### PR TITLE
Fix broken proxy

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-ENV=development
-BASEURL_DEVELOPMENT=http://localhost:4000
-BASEURL_PRODUCTION=https://api.gallery.so
+BASEURL_LOCAL=http://localhost:4000
+BASEURL_DEVELOPMENT=https://some/dev/AWS/environment
+BASEURL_PRODUCTION=https://some/prod/AWS/environment

--- a/package.json
+++ b/package.json
@@ -89,8 +89,9 @@
     "workbox-webpack-plugin": "5.1.4"
   },
   "scripts": {
-    "start": "node scripts/start.js",
-    "start:mock": "MOCK=true node scripts/start.js",
+    "start": "ENV=local node scripts/start.js",
+    "start:dev": "ENV=dev node scripts/start.js",
+    "start:prod": "ENV=production node scripts/start.js",
     "build": "CI=false node scripts/build.js",
     "test": "node scripts/test.js"
   },

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,9 +1,18 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-const baseurl =
-  process.env.ENV === 'production'
-    ? process.env.BASEURL_PRODUCTION
-    : process.env.BASEURL_DEVELOPMENT;
+function getBaseUrl() {
+  switch (process.env.ENV) {
+    case 'production':
+      return process.env.BASEURL_PRODUCTION;
+    case 'dev':
+      return process.env.BASEURL_DEVELOPMENT;
+    case 'local':
+    default:
+      return process.env.BASEURL_LOCAL;
+  }
+}
+
+const baseurl = getBaseUrl();
 
 module.exports = function (app) {
   app.use(
@@ -29,7 +38,7 @@ module.exports = function (app) {
  * TODO: allow local development to communicate directly with production AWS servers.
  *       this will probably just be an extra flag when starting the app
  */
-if (process.env.MOCK === 'true') {
+if (process.env.ENV === 'local') {
   initializeMockServer();
 }
 


### PR DESCRIPTION
deprecate `$ yarn start:mock` in favor of:

```
$ yarn start      => develop against local mock server
$ yarn start:dev  => develop against AWS dev (coming soon)
$ yarn start:prod => develop against AWS prod (coming soon)
```