### PR TITLE
use isSubmitting state to prevent redundant submits

### DIFF
--- a/src/components/Profile/UserInfoForm.tsx
+++ b/src/components/Profile/UserInfoForm.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback } from 'react';
+import { FormEvent, useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import { BodyMedium } from 'components/core/Text/Text';
@@ -31,12 +31,19 @@ function UserInfoForm({
   onBioChange,
   mode = 'Add',
 }: Props) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const handleSubmit = useCallback(
-    (event: FormEvent) => {
+    async (event: FormEvent) => {
       event.preventDefault();
-      onSubmit?.();
+      if (isSubmitting) {
+        return;
+      }
+      setIsSubmitting(true);
+      await onSubmit?.();
+      setIsSubmitting(false);
     },
-    [onSubmit]
+    [isSubmitting, onSubmit]
   );
 
   const handleUsernameChange = useCallback(


### PR DESCRIPTION
Fixes "Pressing enter quickly proceeds through all of the next steps" #258

Add isSubmitting state to UserInfoForm to prevent rapid-hitting Enter from submitting multiple times