### PR TITLE
e2e auth and error handling improvements

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,11 @@
 # Local Proxy
 BASEURL_LOCAL=http://localhost:4000
 
-# Development Backend
-BASEURL_DEVELOPMENT=https://api.dev.gallery.so
-# BASEURL_DEVELOPMENT=http://58b07ba0ec71.ngrok.io
+# Local Network (Separate Machine)
+BASEURL_HACK=http://58b07ba0ec71.ngrok.io
 
-# Production Backend
-BASEURL_PRODUCTION=https://some/prod/AWS/environment
+# Development AWS Backend
+BASEURL_DEVELOPMENT=https://api.dev.gallery.so
+
+# Production AWS Backend
+BASEURL_PRODUCTION=https://api.gallery.so

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 BASEURL_LOCAL=http://localhost:4000
-BASEURL_DEVELOPMENT=https://some/dev/AWS/environment
+BASEURL_DEVELOPMENT=https://api.dev.gallery.so
 BASEURL_PRODUCTION=https://some/prod/AWS/environment

--- a/.env
+++ b/.env
@@ -1,3 +1,9 @@
+# Local Proxy
 BASEURL_LOCAL=http://localhost:4000
+
+# Development Backend
 BASEURL_DEVELOPMENT=https://api.dev.gallery.so
+# BASEURL_DEVELOPMENT=http://58b07ba0ec71.ngrok.io
+
+# Production Backend
 BASEURL_PRODUCTION=https://some/prod/AWS/environment

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   },
   "scripts": {
     "start": "ENV=local node scripts/start.js",
+    "start:hack": "ENV=hack node scripts/start.js",
     "start:dev": "ENV=dev node scripts/start.js",
     "start:prod": "ENV=production node scripts/start.js",
     "build": "CI=false node scripts/build.js",

--- a/src/components/WalletSelector/WalletSelector.tsx
+++ b/src/components/WalletSelector/WalletSelector.tsx
@@ -72,7 +72,7 @@ function WalletSelector() {
   // to manually set error. since not all errors come with an
   // error code, we'll add them as they come up case-by-case
   const displayedError = useMemo(() => {
-    console.log('login error from provider', {
+    console.error('login error from provider', {
       error,
       // @ts-ignore
       code: error?.code,

--- a/src/components/WalletSelector/authRequestUtils.ts
+++ b/src/components/WalletSelector/authRequestUtils.ts
@@ -53,7 +53,7 @@ async function fetchNonce(address: string): Promise<NonceResponse> {
   try {
     return await fetcher<NonceResponse>(`/auth/get_preflight?addr=${address}`);
   } catch (err) {
-    console.log('error while retrieving nonce', err);
+    console.error('error while retrieving nonce', err);
     err.code = 'GALLERY_SERVER_ERROR';
     throw err;
   }
@@ -73,7 +73,7 @@ async function signMessage(
   try {
     return await signer.signMessage(nonce);
   } catch (err) {
-    console.log('error while signing message', err);
+    console.error('error while signing message', err);
     err.code = 'REJECTED_SIGNATURE';
     throw err;
   }
@@ -97,7 +97,7 @@ async function loginUser(body: LoginUserRequest): Promise<LoginUserResponse> {
   try {
     return await fetcher<LoginUserResponse>('/users/login', body);
   } catch (err) {
-    console.log('error while attempting user login', err);
+    console.error('error while attempting user login', err);
     err.code = 'GALLERY_SERVER_ERROR';
     throw err;
   }
@@ -124,7 +124,7 @@ async function createUser(
   try {
     return await fetcher<CreateUserResponse>('/users/create', body);
   } catch (err) {
-    console.log('error while attempting user creation', err);
+    console.error('error while attempting user creation', err);
     err.code = 'GALLERY_SERVER_ERROR';
     throw err;
   }

--- a/src/components/WalletSelector/authRequestUtils.ts
+++ b/src/components/WalletSelector/authRequestUtils.ts
@@ -1,0 +1,131 @@
+import { JsonRpcSigner } from '@ethersproject/providers';
+import fetcher from 'contexts/swr/fetcher';
+
+/**
+ * Auth Pipeline:
+ * 1. Fetch nonce from server with provided wallet address
+ * 2. Sign nonce with wallet (metamask / walletconnect / etc.)
+ * 3a. If wallet exists, log user in
+ * 3b. If wallet is new, sign user up
+ */
+type AuthPipelineProps = {
+  address: string;
+  signer: JsonRpcSigner;
+};
+
+type AuthResult = {
+  jwt: string;
+  userId: string;
+};
+
+export default async function initializeAuthPipeline({
+  address,
+  signer,
+}: AuthPipelineProps): Promise<AuthResult> {
+  const { nonce, user_exists: userExists } = await fetchNonce(address);
+
+  const signature = await signMessage(nonce, signer);
+
+  if (userExists) {
+    const res = await loginUser({ signature, address });
+    return { jwt: res.jwt_token, userId: res.user_id };
+  }
+
+  const res = await createUser({
+    signature,
+    address,
+    nonce,
+  });
+  return { jwt: res.jwt_token, userId: res.user_id };
+}
+
+/**
+ * Retrieve a nonce for the client to sign given a wallet address.
+ * Endpoint will also notify whether the user exists or not, so the
+ * client can login or signup accordingly
+ */
+type NonceResponse = {
+  nonce: string;
+  user_exists: boolean;
+};
+
+async function fetchNonce(address: string): Promise<NonceResponse> {
+  try {
+    return await fetcher<NonceResponse>(`/auth/get_preflight?addr=${address}`);
+  } catch (err) {
+    console.log('error while retrieving nonce', err);
+    err.code = 'GALLERY_SERVER_ERROR';
+    throw err;
+  }
+}
+
+/**
+ * Once we receive a nonce from gallery servers, we'll ask the
+ * client to sign it. The method will hang here until a signature
+ * is provided or denied (example: Metamask pop-up)
+ */
+type Signature = string;
+
+async function signMessage(
+  nonce: string,
+  signer: JsonRpcSigner
+): Promise<Signature> {
+  try {
+    return await signer.signMessage(nonce);
+  } catch (err) {
+    console.log('error while signing message', err);
+    err.code = 'REJECTED_SIGNATURE';
+    throw err;
+  }
+}
+
+/**
+ * Log in user with signature if user already exists
+ */
+type LoginUserRequest = {
+  signature: string;
+  address: string;
+};
+
+type LoginUserResponse = {
+  sig_valid: boolean;
+  jwt_token: string;
+  user_id: string;
+};
+
+async function loginUser(body: LoginUserRequest): Promise<LoginUserResponse> {
+  try {
+    return await fetcher<LoginUserResponse>('/users/login', body);
+  } catch (err) {
+    console.log('error while attempting user login', err);
+    err.code = 'GALLERY_SERVER_ERROR';
+    throw err;
+  }
+}
+
+/**
+ * Create user with signature if user doesn't exist yet
+ */
+type CreateUserRequest = {
+  signature: string;
+  address: string;
+  nonce: string;
+};
+
+type CreateUserResponse = {
+  sig_valid: boolean;
+  jwt_token: string;
+  user_id: string;
+};
+
+async function createUser(
+  body: CreateUserRequest
+): Promise<CreateUserResponse> {
+  try {
+    return await fetcher<CreateUserResponse>('/users/create', body);
+  } catch (err) {
+    console.log('error while attempting user creation', err);
+    err.code = 'GALLERY_SERVER_ERROR';
+    throw err;
+  }
+}

--- a/src/contexts/swr/SwrContext.tsx
+++ b/src/contexts/swr/SwrContext.tsx
@@ -1,23 +1,12 @@
-import { JWT_LOCAL_STORAGE_KEY } from 'contexts/auth/constants';
 import React from 'react';
 import { SWRConfig } from 'swr';
 import { MINUTE } from 'utils/time';
+import fetcher from './fetcher';
 import { syncWithLocalStorage } from './swr-sync-storage';
 
-const baseurl =
-  process.env.ENV === 'production'
-    ? 'https://api.gallery.so'
-    : 'http://localhost:3000/api';
-
 export const SwrProvider = React.memo(({ children }) => {
-  const localJwt = window.localStorage.getItem(JWT_LOCAL_STORAGE_KEY);
-
-  const requestOptions: RequestInit = localJwt
-    ? { headers: { Authentication: `Bearer: ${localJwt}` } }
-    : {};
   const value = {
-    fetcher: (path: string) =>
-      fetch(`${baseurl}/glry/v1${path}`, requestOptions).then((r) => r.json()),
+    fetcher,
     refreshInterval: 5 * MINUTE,
     suspense: true,
   };

--- a/src/contexts/swr/fetcher.ts
+++ b/src/contexts/swr/fetcher.ts
@@ -1,17 +1,31 @@
 import { JWT_LOCAL_STORAGE_KEY } from 'contexts/auth/constants';
+import { isErrorResponse } from 'types/ApiResponse';
 
 const baseurl =
   process.env.ENV === 'production'
     ? 'https://api.gallery.so'
     : 'http://localhost:3000/api';
 
-export default async function fetcher(path: string) {
+export default async function fetcher<ResponseData, RequestBody = {}>(
+  path: string,
+  body?: RequestBody
+): Promise<ResponseData> {
   const localJwt = window.localStorage.getItem(JWT_LOCAL_STORAGE_KEY);
 
   const requestOptions: RequestInit = localJwt
     ? { headers: { Authentication: `Bearer: ${localJwt}` } }
     : {};
 
+  if (body) {
+    requestOptions.method = 'POST';
+    requestOptions.body = JSON.stringify(body);
+  }
+
   const res = await fetch(`${baseurl}/glry/v1${path}`, requestOptions);
-  return await res.json();
+  const payload = await res.json();
+
+  if (isErrorResponse(payload)) {
+    throw new Error(payload.data.handler_error_user_msg);
+  }
+  return payload.data;
 }

--- a/src/contexts/swr/fetcher.ts
+++ b/src/contexts/swr/fetcher.ts
@@ -1,0 +1,17 @@
+import { JWT_LOCAL_STORAGE_KEY } from 'contexts/auth/constants';
+
+const baseurl =
+  process.env.ENV === 'production'
+    ? 'https://api.gallery.so'
+    : 'http://localhost:3000/api';
+
+export default async function fetcher(path: string) {
+  const localJwt = window.localStorage.getItem(JWT_LOCAL_STORAGE_KEY);
+
+  const requestOptions: RequestInit = localJwt
+    ? { headers: { Authentication: `Bearer: ${localJwt}` } }
+    : {};
+
+  const res = await fetch(`${baseurl}/glry/v1${path}`, requestOptions);
+  return await res.json();
+}

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -190,7 +190,7 @@ function initializeMockServer() {
     if (query.id) {
       const user = MOCK_DB.users.find((user) => user.id === query.id);
       if (user) {
-        res.json(user);
+        res.json({ data: user });
         return;
       }
     }
@@ -199,14 +199,14 @@ function initializeMockServer() {
         (user) => user.username === query.username
       );
       if (user) {
-        res.json(user);
+        res.json({ data: user });
         return;
       }
     }
     if (query.address) {
       const user = MOCK_DB.users.find((user) => user.address === query.address);
       if (user) {
-        res.json(user);
+        res.json({ data: user });
         return;
       }
     }
@@ -231,7 +231,9 @@ function initializeMockServer() {
     );
     if (collectionsForUser.length) {
       res.json({
-        collections: collectionsForUser,
+        data: {
+          collections: collectionsForUser,
+        },
       });
       return;
     }
@@ -250,6 +252,42 @@ function initializeMockServer() {
       return;
     }
     res.json(nft);
+    return;
+  });
+
+  mockServer.get('/auth/get_preflight', (req, res) => {
+    const { query } = req;
+    console.log(query);
+    res.json({
+      data: {
+        nonce: '1234',
+        user_exists: false,
+      },
+    });
+    return;
+  });
+
+  mockServer.post('/users/login', (req, res) => {
+    const { query } = req;
+    res.json({
+      data: {
+        sig_valid: true,
+        jwt_token: 'token',
+        user_id: 'PAoGbFB6OQtZ6mWI/BYyLA==',
+      },
+    });
+    return;
+  });
+
+  mockServer.post('/users/create', (req, res) => {
+    const { query } = req;
+    res.json({
+      data: {
+        sig_valid: true,
+        jwt_token: 'token',
+        user_id: 'PAoGbFB6OQtZ6mWI/BYyLA==',
+      },
+    });
     return;
   });
 }

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -13,13 +13,13 @@ function getBaseUrl() {
 }
 
 function getPathRewrite() {
-  return process.env.ENV === process.env.BASEURL_LOCAL
+  return process.env.ENV === 'local'
     ? {
-        // when hitting local express proxy from localhost, drop `/api/glry/v1` from path prefix
-        '^/api/glry/v1': '/',
+        // when localhost => local express proxy, drop `/api/glry/v1` from path prefix
+        '^/api/glry/v1/': '/',
       }
     : {
-        // when hitting dev or production from localhost, drop `/api` from path prefix
+        // when localhost => dev or production, drop `/api` from path prefix
         '^/api': '/',
       };
 }

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -6,6 +6,8 @@ function getBaseUrl() {
       return process.env.BASEURL_PRODUCTION;
     case 'dev':
       return process.env.BASEURL_DEVELOPMENT;
+    case 'hack':
+      return process.env.BASEURL_HACK;
     case 'local':
     default:
       return process.env.BASEURL_LOCAL;

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -12,6 +12,18 @@ function getBaseUrl() {
   }
 }
 
+function getPathRewrite() {
+  return process.env.ENV === process.env.BASEURL_LOCAL
+    ? {
+        // when hitting local express proxy from localhost, drop `/api/glry/v1` from path prefix
+        '^/api/glry/v1': '/',
+      }
+    : {
+        // when hitting dev or production from localhost, drop `/api` from path prefix
+        '^/api': '/',
+      };
+}
+
 const baseurl = getBaseUrl();
 
 module.exports = function (app) {
@@ -20,10 +32,7 @@ module.exports = function (app) {
     createProxyMiddleware({
       target: baseurl,
       changeOrigin: true,
-      pathRewrite: {
-        // drop `/api/glry/v1` from path prefix
-        '^/api/glry/v1': '/',
-      },
+      pathRewrite: getPathRewrite(),
     })
   );
 };

--- a/src/types/ApiResponse.ts
+++ b/src/types/ApiResponse.ts
@@ -1,0 +1,38 @@
+/**
+ * GALLERY SERVER RESPONSE FORMAT
+ *
+ * Example success response:
+ *   {
+ *     data: {
+ *       env: 'dev',
+ *       msg: 'gallery operational',
+ *     },
+ *     status: 'OK',
+ *   }
+ *
+ * Example error response:
+ *   {
+ *     data: {
+ *       handler_error_user_msg:
+ *         'handler /glry/v1/auth/get_preflight failed unexpectedly',
+ *     },
+ *     status: 'ERROR',
+ *   }
+ */
+type SuccessResponse<T = {}> = {
+  data: T;
+  status: 'OK';
+};
+
+type ErrorResponse = {
+  data: {
+    handler_error_user_msg: string;
+  };
+  status: 'ERROR';
+};
+
+export type ApiResponse<T = {}> = SuccessResponse<T> | ErrorResponse;
+
+export function isErrorResponse(res: ApiResponse): res is ErrorResponse {
+  return res.status === 'ERROR';
+}


### PR DESCRIPTION
- improved authentication pipeline
  - fetch nonce => sign message => login user OR signup user
- generic `fetcher` function to make network requests imperatively (outside of hooks)
- updated .env to connect to AWS dev services
- support for "hack" environment (ngrok proxied on ivan's machine)
- improved gallery-specific ApiResponse type, error handling

**Known Issues**
- after signing up, app makes a request to `/users?id=${userId}`, but this endpoint does not yet support `userId` query param (as well as `username`)
- preflight endpoint is returning `user_exists: false` even after user has been created. this prompts the app to sign up user, instead of login
- auth endpoints aren't mocked in local proxy, so merging this PR will break development on local + dev