### PR TITLE
Handle error http codes in fetcher

### DIFF
--- a/src/contexts/swr/fetcher.ts
+++ b/src/contexts/swr/fetcher.ts
@@ -1,5 +1,4 @@
 import { JWT_LOCAL_STORAGE_KEY } from 'contexts/auth/constants';
-import { isErrorResponse } from 'types/ApiResponse';
 
 const baseurl = process.env.REACT_APP_API_BASE_URL;
 
@@ -24,12 +23,11 @@ export default async function fetcher<ResponseData, RequestBody = {}>(
     requestOptions.method = 'POST';
     requestOptions.body = JSON.stringify(body);
   }
-
   const res = await fetch(`${baseurl}/glry/v1${path}`, requestOptions);
   const payload = await res.json();
 
-  if (isErrorResponse(payload)) {
-    throw new Error(payload.data.handler_error_user_msg);
+  if (!res.ok) {
+    throw new Error(payload.error);
   }
   return payload;
 }

--- a/src/contexts/swr/fetcher.ts
+++ b/src/contexts/swr/fetcher.ts
@@ -31,5 +31,5 @@ export default async function fetcher<ResponseData, RequestBody = {}>(
   if (isErrorResponse(payload)) {
     throw new Error(payload.data.handler_error_user_msg);
   }
-  return payload.data;
+  return payload;
 }

--- a/src/types/ApiResponse.ts
+++ b/src/types/ApiResponse.ts
@@ -32,7 +32,3 @@ type ErrorResponse = {
 };
 
 export type ApiResponse<T = {}> = SuccessResponse<T> | ErrorResponse;
-
-export function isErrorResponse(res: ApiResponse): res is ErrorResponse {
-  return res.status === 'ERROR';
-}


### PR DESCRIPTION
Since we changed our http responses to use error codes (4xx, 5xx) rather than embed the error message inside a successful response, our Fetcher should be able to detect these cases and throw an error when appropriate.