### PR TITLE
Add API calls for creating first collection and saving collection name

### DIFF
--- a/src/flows/OnboardingFlow/OnboardingFlow.tsx
+++ b/src/flows/OnboardingFlow/OnboardingFlow.tsx
@@ -12,6 +12,7 @@ import Welcome from './steps/Welcome';
 import CreateFirstCollection from './steps/CreateFirstCollection';
 import AddUserInfo from './steps/AddUserInfo';
 import Congratulations from './steps/Congratulations';
+import OrganizeCollectionWrapper from 'flows/shared/steps/OrganizeCollection/OrganizeCollectionWrapper';
 
 const footerButtonTextMap: GalleryWizardProps['footerButtonTextMap'] = {
   addUserInfo: 'Save',
@@ -33,7 +34,10 @@ function OnboardingFlow(_: RouteComponentProps) {
                     <Step id="welcome" render={Welcome} />
                     <Step id="addUserInfo" render={AddUserInfo} />
                     <Step id="create" render={CreateFirstCollection} />
-                    <Step id="organizeCollection" render={OrganizeCollection} />
+                    <Step
+                      id="organizeCollection"
+                      render={OrganizeCollectionWrapper}
+                    />
                     <Step id="organizeGallery" render={OrganizeGallery} />
                     <Step id="congratulations" render={Congratulations} />
                   </Steps>

--- a/src/flows/shared/steps/OrganizeCollection/CollectionNamingForm.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/CollectionNamingForm.tsx
@@ -12,6 +12,7 @@ import ErrorText from 'components/core/Text/ErrorText';
 import { useModal } from 'contexts/modal/ModalContext';
 import { Collection } from 'types/Collection';
 import { pause } from 'utils/time';
+import fetcher from 'contexts/swr/fetcher';
 
 type Props = {
   onNext: WizardContext['next'];
@@ -64,7 +65,12 @@ function CollectionNamingForm({ onNext, collection }: Props) {
 
     setIsLoading(true);
     try {
-      // TODO__v1: send request to server to UPDATE user's collection name, description
+      // TODO this endpoint only updates name. Change endpoint to also update description
+      await fetcher('/collections/update/name', {
+        id: collection.id,
+        name: collectionName,
+      });
+
       if (collectionDescription === 'invalid_desc') {
         await pause(700);
         throw { type: 'ERROR_SOMETHING_GENERIC' };
@@ -81,7 +87,7 @@ function CollectionNamingForm({ onNext, collection }: Props) {
     }
     setIsLoading(false);
     return;
-  }, [collectionDescription, goToNextStep]);
+  }, [collection.id, collectionDescription, collectionName, goToNextStep]);
 
   return (
     <StyledCollectionNamingForm>

--- a/src/flows/shared/steps/OrganizeCollection/CollectionNamingForm.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/CollectionNamingForm.tsx
@@ -16,33 +16,39 @@ import fetcher from 'contexts/swr/fetcher';
 
 type Props = {
   onNext: WizardContext['next'];
-  collection: Collection;
+  // collection: Collection;
+  collectionId: Collection['id'];
+  collectionTitle?: Collection['title'];
+  collectionDescription?: Collection['description'];
 };
 
 export const COLLECTION_DESCRIPTION_MAX_CHAR_COUNT = 300;
 
-function CollectionNamingForm({ onNext, collection }: Props) {
+function CollectionNamingForm({
+  onNext,
+  collectionId,
+  collectionTitle,
+  collectionDescription,
+}: Props) {
   const { hideModal } = useModal();
 
-  const [collectionName, setCollectionName] = useState(collection.title || '');
-  const [collectionDescription, setCollectionDescription] = useState(
-    collection.description || ''
-  );
+  const [title, setTitle] = useState(collectionTitle || '');
+  const [description, setDescription] = useState(collectionDescription || '');
 
   // generic error that doesn't belong to username / bio
   const [generalError, setGeneralError] = useState('');
 
   const handleNameChange = useCallback((event) => {
-    setCollectionName(event.target.value);
+    setTitle(event.target.value);
   }, []);
 
   const handleDescriptionChange = useCallback((event) => {
-    setCollectionDescription(event.target.value);
+    setDescription(event.target.value);
   }, []);
 
   const hasEnteredValue = useMemo(() => {
-    return collectionName.length || collectionDescription.length;
-  }, [collectionName, collectionDescription]);
+    return title.length || description.length;
+  }, [title, description]);
 
   const buttonText = useMemo(() => {
     return hasEnteredValue ? 'save' : 'skip';
@@ -58,7 +64,7 @@ function CollectionNamingForm({ onNext, collection }: Props) {
   const handleClick = useCallback(async () => {
     setGeneralError('');
 
-    if (collectionDescription.length > COLLECTION_DESCRIPTION_MAX_CHAR_COUNT) {
+    if (description.length > COLLECTION_DESCRIPTION_MAX_CHAR_COUNT) {
       // no need to handle error here, since the form will mark the text as red
       return;
     }
@@ -67,11 +73,11 @@ function CollectionNamingForm({ onNext, collection }: Props) {
     try {
       // TODO this endpoint only updates name. Change endpoint to also update description
       await fetcher('/collections/update/name', {
-        id: collection.id,
-        name: collectionName,
+        id: collectionId,
+        name: title,
       });
 
-      if (collectionDescription === 'invalid_desc') {
+      if (description === 'invalid_desc') {
         await pause(700);
         throw { type: 'ERROR_SOMETHING_GENERIC' };
       }
@@ -87,7 +93,7 @@ function CollectionNamingForm({ onNext, collection }: Props) {
     }
     setIsLoading(false);
     return;
-  }, [collection.id, collectionDescription, collectionName, goToNextStep]);
+  }, [collectionId, description, goToNextStep, title]);
 
   return (
     <StyledCollectionNamingForm>
@@ -99,7 +105,7 @@ function CollectionNamingForm({ onNext, collection }: Props) {
       <Spacer height={16} />
       <BigInput
         onChange={handleNameChange}
-        defaultValue={collectionName}
+        defaultValue={title}
         placeholder="Collection name"
         autoFocus
       />
@@ -107,8 +113,8 @@ function CollectionNamingForm({ onNext, collection }: Props) {
       <StyledTextAreaWithCharCount
         onChange={handleDescriptionChange}
         placeholder="Tell us about your collection..."
-        defaultValue={collectionDescription}
-        currentCharCount={collectionDescription.length}
+        defaultValue={description}
+        currentCharCount={description.length}
         maxCharCount={COLLECTION_DESCRIPTION_MAX_CHAR_COUNT}
       />
       {generalError && (

--- a/src/flows/shared/steps/OrganizeCollection/OrganizeCollection.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/OrganizeCollection.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { WizardContext } from 'react-albus';
 import styled from 'styled-components';
 
@@ -6,50 +6,69 @@ import CollectionNamingForm from './CollectionNamingForm';
 import CollectionEditor from './Editor/CollectionEditor';
 
 import { useWizardCallback } from 'contexts/wizard/WizardCallbackContext';
-import CollectionEditorProvider from 'contexts/collectionEditor/CollectionEditorContext';
+import { useStagedNftsState } from 'contexts/collectionEditor/CollectionEditorContext';
 import { useModal } from 'contexts/modal/ModalContext';
 import { useWizardId } from 'contexts/wizard/WizardDataProvider';
+import fetcher from 'contexts/swr/fetcher';
+import { EditModeNft } from 'types/Nft';
+import { CreateCollectionResponse } from 'types/Collection';
 
 type ConfigProps = {
   onNext: WizardContext['next'];
 };
 
 type Props = {
-  step?: any;
+  next?: any;
 };
+
+function mapStagedNftsToNftIds(stagedNfts: EditModeNft[]) {
+  return stagedNfts.map((stagedNft: EditModeNft) => stagedNft.nft.id);
+}
 
 function useWizardConfig({ onNext }: ConfigProps) {
   const wizardId = useWizardId();
   const { setOnNext } = useWizardCallback();
   const { showModal } = useModal();
+  const stagedNfts = useStagedNftsState();
+
+  const getStagedNfts = useCallback(() => stagedNfts, [stagedNfts]);
 
   useEffect(() => {
     // if the user is part of the onboarding flow, prompt them
     // to name their collection before moving onto the next step
     if (wizardId === 'onboarding') {
-      setOnNext(() =>
+      setOnNext(async () => {
+        let nftIdsToSave = mapStagedNftsToNftIds(getStagedNfts());
+
+        const createdCollection = await fetcher<CreateCollectionResponse>(
+          '/collections/create',
+          {
+            nfts: nftIdsToSave,
+          }
+        );
+
         showModal(
           <CollectionNamingForm
             onNext={onNext}
-            // TODO: pass in the actual collection being organized
-            collection={{ id: '', nfts: [] }}
+            // TODO: pass in only id, or actual collection
+            collection={{ id: createdCollection.collection_id, nfts: [] }}
           />
-        )
-      );
+        );
+      });
     }
 
     return () => setOnNext(undefined);
-  }, [setOnNext, showModal, onNext, wizardId]);
+  }, [setOnNext, showModal, onNext, wizardId, getStagedNfts]);
 }
 
-function OrganizeCollection({ next }: WizardContext & Props) {
+function OrganizeCollection({ next }: Props) {
   useWizardConfig({ onNext: next });
 
   return (
     <StyledOrganizeCollection>
-      <CollectionEditorProvider>
-        <CollectionEditor />
-      </CollectionEditorProvider>
+      {/* <CollectionEditorProvider> */}
+      <CollectionEditor />
+      {/* </CollectionEditorProvider> */}
     </StyledOrganizeCollection>
   );
 }

--- a/src/flows/shared/steps/OrganizeCollection/OrganizeCollection.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/OrganizeCollection.tsx
@@ -66,9 +66,7 @@ function OrganizeCollection({ next }: Props) {
 
   return (
     <StyledOrganizeCollection>
-      {/* <CollectionEditorProvider> */}
       <CollectionEditor />
-      {/* </CollectionEditorProvider> */}
     </StyledOrganizeCollection>
   );
 }

--- a/src/flows/shared/steps/OrganizeCollection/OrganizeCollectionWrapper.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/OrganizeCollectionWrapper.tsx
@@ -1,0 +1,20 @@
+// The sole purpose of this component is to wrap the OrganizeCollection step with the Collection Editor Context Provider
+// so that the OrganizeCollection step can access the collection being edited
+
+import CollectionEditorProvider from 'contexts/collectionEditor/CollectionEditorContext';
+import { WizardContext } from 'react-albus';
+import OrganizeCollection from './OrganizeCollection';
+
+type Props = {
+  step?: any;
+};
+
+function OrganizeCollectionWrapper({ next }: WizardContext & Props) {
+  return (
+    <CollectionEditorProvider>
+      <OrganizeCollection></OrganizeCollection>
+    </CollectionEditorProvider>
+  );
+}
+
+export default OrganizeCollectionWrapper;

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
@@ -31,7 +31,13 @@ function CollectionRowSettings({
 
   const handleEditNameClick = useCallback(() => {
     showModal(
-      <CollectionNamingForm onNext={() => {}} collection={collection} />
+      <CollectionNamingForm
+        // No need for onNext because this isn't part of a wizard
+        onNext={() => {}}
+        collectionId={collection.id}
+        collectionTitle={collection.title}
+        collectionDescription={collection.description}
+      />
     );
   }, [collection, showModal]);
 

--- a/src/types/Collection.ts
+++ b/src/types/Collection.ts
@@ -12,6 +12,10 @@ type CollectionsNotFoundError = {
   error: 'ERR_NO_COLLECTIONS_FOUND_FOR_USER';
 };
 
+export type CreateCollectionResponse = {
+  collection_id: string;
+};
+
 export type CollectionsResponse =
   | { collections: Collection[] }
   | CollectionsNotFoundError;


### PR DESCRIPTION
- Wrapped OrganizeCollection step with new component, `OrganizeCollectionWrapper` to provide access to collection context during wizard onNext()
- Added Create Collection response type (for create collection endpoint)
- Add API call to Create 1st Collection (called when user clicks "Create Collection", before modal appears)
- Add API call to save collection name (called when user clicks "Save" in modal)