### PR TITLE
Use /update/info to update collection info + and add useGalleries hook

### DIFF
--- a/src/flows/shared/steps/OrganizeCollection/CollectionEditInfoForm.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/CollectionEditInfoForm.tsx
@@ -17,7 +17,6 @@ import formatError from 'src/errors/formatError';
 
 type Props = {
   onNext: WizardContext['next'];
-  // collection: Collection;
   collectionId: Collection['id'];
   collectionTitle?: Collection['title'];
   collectionDescription?: Collection['description'];
@@ -25,7 +24,7 @@ type Props = {
 
 export const COLLECTION_DESCRIPTION_MAX_CHAR_COUNT = 300;
 
-function CollectionNamingForm({
+function CollectionEditInfoForm({
   onNext,
   collectionId,
   collectionTitle,
@@ -74,18 +73,12 @@ function CollectionNamingForm({
 
     setIsLoading(true);
     try {
-      // TODO this endpoint only updates name. Change endpoint to also update description
-      await fetcher('/collections/update/name', {
+      await fetcher('/collections/update/info', {
         id: collectionId,
         name: title,
+        collectors_note: description,
       });
 
-      if (description === 'invalid_desc') {
-        await pause(700);
-        throw { type: 'ERROR_SOMETHING_GENERIC' };
-      }
-
-      await pause(1000);
       goToNextStep();
     } catch (e) {
       setGeneralError(formatError(e));
@@ -95,7 +88,7 @@ function CollectionNamingForm({
   }, [collectionId, description, goToNextStep, title, fetcher]);
 
   return (
-    <StyledCollectionNamingForm>
+    <StyledCollectionEditInfoForm>
       <BodyMedium>Give your collection a name and description</BodyMedium>
       <Spacer height={4} />
       <BodyRegular color={colors.gray50}>
@@ -132,11 +125,11 @@ function CollectionNamingForm({
           loading={isLoading}
         />
       </ButtonContainer>
-    </StyledCollectionNamingForm>
+    </StyledCollectionEditInfoForm>
   );
 }
 
-const StyledCollectionNamingForm = styled.div`
+const StyledCollectionEditInfoForm = styled.div`
   display: flex;
   flex-direction: column;
 
@@ -156,4 +149,4 @@ const StyledButton = styled(Button)`
   width: 90px;
 `;
 
-export default CollectionNamingForm;
+export default CollectionEditInfoForm;

--- a/src/flows/shared/steps/OrganizeCollection/OrganizeCollection.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/OrganizeCollection.tsx
@@ -52,7 +52,6 @@ function useWizardConfig({ onNext }: ConfigProps) {
         );
 
         // TODO: Only need to show modal if this is creation
-        console.log('onNext', onNext);
         showModal(
           <CollectionEditInfoForm
             onNext={onNext}

--- a/src/flows/shared/steps/OrganizeCollection/OrganizeCollection.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/OrganizeCollection.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { WizardContext } from 'react-albus';
 import styled from 'styled-components';
 
-import CollectionNamingForm from './CollectionNamingForm';
+import CollectionEditInfoForm from './CollectionEditInfoForm';
 import CollectionEditor from './Editor/CollectionEditor';
 
 import { useWizardCallback } from 'contexts/wizard/WizardCallbackContext';
@@ -52,8 +52,9 @@ function useWizardConfig({ onNext }: ConfigProps) {
         );
 
         // TODO: Only need to show modal if this is creation
+        console.log('onNext', onNext);
         showModal(
-          <CollectionNamingForm
+          <CollectionEditInfoForm
             onNext={onNext}
             collectionId={createdCollection.collection_id}
           />

--- a/src/flows/shared/steps/OrganizeCollection/OrganizeCollectionWrapper.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/OrganizeCollectionWrapper.tsx
@@ -12,7 +12,7 @@ type Props = {
 function OrganizeCollectionWrapper({ next }: WizardContext & Props) {
   return (
     <CollectionEditorProvider>
-      <OrganizeCollection></OrganizeCollection>
+      <OrganizeCollection next={next} />
     </CollectionEditorProvider>
   );
 }

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
@@ -9,7 +9,7 @@ import TextButton from 'components/core/Button/TextButton';
 import { useModal } from 'contexts/modal/ModalContext';
 import Spacer from 'components/core/Spacer/Spacer';
 import DeleteCollectionConfirmation from './DeleteCollectionConfirmation';
-import CollectionNamingForm from '../OrganizeCollection/CollectionNamingForm';
+import CollectionEditInfoForm from '../OrganizeCollection/CollectionEditInfoForm';
 import { withWizard, WizardComponentProps } from 'react-albus';
 import { useCollectionWizardActions } from 'contexts/wizard/CollectionWizardContext';
 
@@ -31,7 +31,7 @@ function CollectionRowSettings({
 
   const handleEditNameClick = useCallback(() => {
     showModal(
-      <CollectionNamingForm
+      <CollectionEditInfoForm
         // No need for onNext because this isn't part of a wizard
         onNext={() => {}}
         collectionId={collection.id}

--- a/src/flows/shared/steps/OrganizeGallery/OrganizeGallery.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/OrganizeGallery.tsx
@@ -8,8 +8,8 @@ import Spacer from 'components/core/Spacer/Spacer';
 import Header from './Header';
 import CollectionDnd from './CollectionDnd';
 import { useAuthenticatedUser } from 'hooks/api/useUser';
-import useCollections from 'hooks/api/useCollections';
 import { User } from 'types/User';
+import useGalleries from 'hooks/api/useGalleries';
 
 type ConfigProps = {
   onNext: () => void;
@@ -47,7 +47,9 @@ function OrganizeGallery() {
     onPrevious: returnToProfile,
   });
 
-  const collections = useCollections({ userId: user.id }) || [];
+  const galleries = useGalleries({ userId: user.id }) || [];
+  // TODO: handle if galleries array is empty
+  const gallery = galleries[0] || { collections: [] };
 
   return (
     <StyledOrganizeGallery>
@@ -55,7 +57,7 @@ function OrganizeGallery() {
         <Spacer height={80} />
         <Header />
         <Spacer height={16} />
-        <CollectionDnd collections={collections}></CollectionDnd>
+        <CollectionDnd collections={gallery.collections}></CollectionDnd>
         <Spacer height={120} />
       </Content>
     </StyledOrganizeGallery>

--- a/src/hooks/api/useGalleries.ts
+++ b/src/hooks/api/useGalleries.ts
@@ -1,0 +1,19 @@
+import useSwr from 'swr';
+import { Gallery, GetGalleriesResponse } from 'types/Gallery';
+import { User } from 'types/User';
+
+type Props = {
+  userId: User['id'];
+};
+
+export default function useGalleries({ userId }: Props): Gallery[] | null {
+  const { data } = useSwr<GetGalleriesResponse>(
+    `/galleries/user_get?user_id=${userId}`
+  );
+
+  if (!data) {
+    return null;
+  }
+
+  return data.galleries;
+}

--- a/src/types/Gallery.ts
+++ b/src/types/Gallery.ts
@@ -1,0 +1,9 @@
+import { Collection } from './Collection';
+
+export type Gallery = {
+  id: string;
+  collections: Collection[];
+  ownerUserId: string;
+};
+
+export type GetGalleriesResponse = { galleries: Gallery[] };


### PR DESCRIPTION
Collection info form changes:
- Changed the endpoint that's used to save collection info to `/update/info`
- The collection info form now saves the collection name and collectors note (description)
- Renamed `CollectionNamingForm` to `CollectionEditInfoForm` to align with associated endpoint

OrganizeGallery changes (this allows the OrganizeGallery step to load properly)
- Added a `useGalleries` hook to retrieve a user's galleries from `/galleries/user_get`
- Added a `Gallery` type
- updated OrganizeGallery to use the `useGalleries` hook instead of `useCollections`