### PR TITLE
Consolidate api base url in .env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,7 @@
 SERVER_PORT=4000
 
 # Local Proxy OR local backend
-REACT_APP_API_BASE_URLL=http://localhost:4000
+REACT_APP_API_BASE_URL=http://localhost:4000
 
 # Local Network (Separate Machine)
 BASEURL_HACK=http://58b07ba0ec71.ngrok.io

--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,7 @@
 SERVER_PORT=4000
 
 # Local Proxy OR local backend
-BASEURL_LOCAL=http://localhost:4000
+API_BASE_URL_LOCAL=http://localhost:4000
 
 # Local Network (Separate Machine)
 BASEURL_HACK=http://58b07ba0ec71.ngrok.io

--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,7 @@
 SERVER_PORT=4000
 
 # Local Proxy OR local backend
-API_BASE_URL_LOCAL=http://localhost:4000
+REACT_APP_API_BASE_URLL=http://localhost:4000
 
 # Local Network (Separate Machine)
 BASEURL_HACK=http://58b07ba0ec71.ngrok.io

--- a/dev_server/server.js
+++ b/dev_server/server.js
@@ -12,7 +12,7 @@ function getBaseUrl() {
       return process.env.BASEURL_HACK;
     case 'local':
     default:
-      return process.env.API_BASE_URL_LOCAL;
+      return process.env.REACT_APP_API_BASE_URLL;
   }
 }
 

--- a/dev_server/server.js
+++ b/dev_server/server.js
@@ -12,7 +12,7 @@ function getBaseUrl() {
       return process.env.BASEURL_HACK;
     case 'local':
     default:
-      return process.env.REACT_APP_API_BASE_URLL;
+      return process.env.REACT_APP_API_BASE_URL;
   }
 }
 

--- a/dev_server/server.js
+++ b/dev_server/server.js
@@ -12,7 +12,7 @@ function getBaseUrl() {
       return process.env.BASEURL_HACK;
     case 'local':
     default:
-      return process.env.BASEURL_LOCAL;
+      return process.env.API_BASE_URL_LOCAL;
   }
 }
 

--- a/src/contexts/swr/useFetcher.ts
+++ b/src/contexts/swr/useFetcher.ts
@@ -4,7 +4,7 @@ import { JWT_LOCAL_STORAGE_KEY } from 'contexts/auth/constants';
 import RequestAction from 'hooks/api/_rest/RequestAction';
 import { ApiError } from 'src/errors/types';
 
-const baseurl = process.env.REACT_APP_API_BASE_URL;
+const baseurl = process.env.API_BASE_URL_LOCAL;
 
 const ERR_UNAUTHORIZED = 401;
 

--- a/src/contexts/swr/useFetcher.ts
+++ b/src/contexts/swr/useFetcher.ts
@@ -4,7 +4,7 @@ import { JWT_LOCAL_STORAGE_KEY } from 'contexts/auth/constants';
 import RequestAction from 'hooks/api/_rest/RequestAction';
 import { ApiError } from 'src/errors/types';
 
-const baseurl = process.env.API_BASE_URL_LOCAL;
+const baseurl = process.env.REACT_APP_API_BASE_URLL;
 
 const ERR_UNAUTHORIZED = 401;
 
@@ -36,6 +36,7 @@ export const _fetch: FetcherType = async (path, action, params = {}) => {
     requestOptions.method = 'POST';
     requestOptions.body = JSON.stringify(body);
   }
+  console.log(baseurl, process.env)
   const res = await fetch(`${baseurl}/glry/v1${path}`, requestOptions);
 
   const responseBody = await res.json().catch((e) => {

--- a/src/contexts/swr/useFetcher.ts
+++ b/src/contexts/swr/useFetcher.ts
@@ -4,7 +4,7 @@ import { JWT_LOCAL_STORAGE_KEY } from 'contexts/auth/constants';
 import RequestAction from 'hooks/api/_rest/RequestAction';
 import { ApiError } from 'src/errors/types';
 
-const baseurl = process.env.REACT_APP_API_BASE_URLL;
+const baseurl = process.env.REACT_APP_API_BASE_URL;
 
 const ERR_UNAUTHORIZED = 401;
 
@@ -36,7 +36,7 @@ export const _fetch: FetcherType = async (path, action, params = {}) => {
     requestOptions.method = 'POST';
     requestOptions.body = JSON.stringify(body);
   }
-  console.log(baseurl, process.env)
+  console.log(baseurl, process.env);
   const res = await fetch(`${baseurl}/glry/v1${path}`, requestOptions);
 
   const responseBody = await res.json().catch((e) => {


### PR DESCRIPTION
This was an older todo, but we have both `BASEURL_LOCAL` and `REACT_APP_API_BASE_URL` in our .env to point to localhost:4000. This PR consolidates them and renames it to `API_BASE_URL_LOCAL`