### PR TITLE
Migrate useAuthenticatedUser

### DIFF
--- a/src/components/GlobalNavbar/LoggedInNav.tsx
+++ b/src/components/GlobalNavbar/LoggedInNav.tsx
@@ -19,6 +19,7 @@ function LoggedInNav() {
   const { logOut } = useAuthActions();
   const user = useAuthenticatedUser();
   const userAddress = useAuthenticatedUserAddress();
+
   const truncatedUserAddress = useMemo(() => {
     return truncate(userAddress);
   }, [userAddress]);

--- a/src/components/GlobalNavbar/LoggedInNav.tsx
+++ b/src/components/GlobalNavbar/LoggedInNav.tsx
@@ -10,7 +10,6 @@ import {
   useAuthenticatedUser,
   useAuthenticatedUserAddress,
 } from 'hooks/api/users/useUser';
-import { User } from 'types/User';
 
 function truncate(address: string) {
   return `${address.slice(0, 4)}...${address.slice(-4)}`;
@@ -18,7 +17,7 @@ function truncate(address: string) {
 
 function LoggedInNav() {
   const { logOut } = useAuthActions();
-  const user = useAuthenticatedUser() as User;
+  const user = useAuthenticatedUser();
   const userAddress = useAuthenticatedUserAddress();
   const truncatedUserAddress = useMemo(() => {
     return truncate(userAddress);

--- a/src/components/WalletSelector/authRequestUtils.ts
+++ b/src/components/WalletSelector/authRequestUtils.ts
@@ -158,7 +158,7 @@ async function createUser(
 async function triggerOpenseaSync(address: string, fetcher: FetcherType) {
   try {
     await fetcher<OpenseaSyncResponse>(
-      `/nfts/opensea_get?address=${address}`,
+      `/nfts/opensea_get?address=${address}&skip_cache=true`,
       'fetch and sync nfts'
     );
   } catch (e) {

--- a/src/flows/OnboardingFlow/steps/AddUserInfo.tsx
+++ b/src/flows/OnboardingFlow/steps/AddUserInfo.tsx
@@ -9,7 +9,6 @@ import Spacer from 'components/core/Spacer/Spacer';
 
 import useUserInfoForm from 'components/Profile/useUserInfoForm';
 import { useAuthenticatedUser } from 'hooks/api/users/useUser';
-import { User } from 'types/User';
 
 type ConfigProps = {
   onNext: () => Promise<void>;
@@ -26,7 +25,7 @@ function useWizardConfig({ onNext }: ConfigProps) {
 }
 
 function AddUserInfo({ next }: WizardContext) {
-  const user = useAuthenticatedUser() as User;
+  const user = useAuthenticatedUser();
 
   const {
     username,

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
@@ -11,6 +11,7 @@ import DeleteCollectionConfirmation from './DeleteCollectionConfirmation';
 import CollectionEditInfoForm from '../OrganizeCollection/CollectionEditInfoForm';
 import { withWizard, WizardComponentProps } from 'react-albus';
 import { useCollectionWizardActions } from 'contexts/wizard/CollectionWizardContext';
+import useUpdateCollectionHidden from 'hooks/api/collections/useUpdateCollectionHidden';
 import { Collection } from 'types/Collection';
 
 type Props = {
@@ -43,10 +44,11 @@ function CollectionRowSettings({
     );
   }, [collectors_note, id, name, showModal]);
 
+  const toggleHideCollection = useUpdateCollectionHidden();
+
   const handleToggleHiddenClick = useCallback(() => {
-    // make request to update collection
-    // on success, update collection state
-  }, []);
+    toggleHideCollection(id, !hidden);
+  }, [id, hidden, toggleHideCollection]);
 
   const handleDeleteClick = useCallback(() => {
     showModal(<DeleteCollectionConfirmation />);

--- a/src/flows/shared/steps/OrganizeGallery/OrganizeGallery.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/OrganizeGallery.tsx
@@ -8,7 +8,6 @@ import Spacer from 'components/core/Spacer/Spacer';
 import { useAuthenticatedUser } from 'hooks/api/users/useUser';
 import CollectionDnd from './CollectionDnd';
 import Header from './Header';
-import { User } from 'types/User';
 import useAuthenticatedGallery from 'hooks/api/galleries/useAuthenticatedGallery';
 import { WizardContext } from 'react-albus';
 import { useWizardId } from 'contexts/wizard/WizardDataProvider';
@@ -34,7 +33,7 @@ function useWizardConfig({ onNext, onPrevious }: ConfigProps) {
 
 function OrganizeGallery({ next }: WizardContext) {
   const wizardId = useWizardId();
-  const user = useAuthenticatedUser() as User;
+  const user = useAuthenticatedUser();
 
   const returnToProfile = useCallback(() => {
     navigate(`/${user.username}`);

--- a/src/hooks/api/collections/types.ts
+++ b/src/hooks/api/collections/types.ts
@@ -25,3 +25,10 @@ export type UpdateCollectionNftsRequest = {
 };
 
 export type UpdateCollectionNftsResponse = null;
+
+export type UpdateCollectionHiddenRequest = {
+  id: string;
+  hidden: boolean;
+};
+
+export type UpdateCollectionHiddenResponse = null;

--- a/src/hooks/api/collections/useUpdateCollectionHidden.ts
+++ b/src/hooks/api/collections/useUpdateCollectionHidden.ts
@@ -1,28 +1,27 @@
 import { useCallback } from 'react';
 import {
-  UpdateCollectionInfoRequest,
-  UpdateCollectionInfoResponse,
+  UpdateCollectionHiddenRequest,
+  UpdateCollectionHiddenResponse,
 } from './types';
 import usePost from '../_rest/usePost';
 import { useAuthenticatedUser } from '../users/useUser';
 import { mutate } from 'swr';
+import { getGalleriesCacheKey } from '../galleries/useGalleries';
 import { GetGalleriesResponse } from '../galleries/types';
 import cloneDeep from 'lodash.clonedeep';
-import { getGalleriesCacheKey } from '../galleries/useGalleries';
 
-export default function useUpdateCollectionInfo() {
+export default function useUpdateCollectionHidden() {
   const updateCollection = usePost();
   const authenticatedUser = useAuthenticatedUser();
 
   return useCallback(
-    async (collectionId: string, name: string, collectors_note: string) => {
+    async (collectionId: string, hidden: boolean) => {
       await updateCollection<
-        UpdateCollectionInfoResponse,
-        UpdateCollectionInfoRequest
-      >('/collections/update/info', 'update collection info', {
+        UpdateCollectionHiddenResponse,
+        UpdateCollectionHiddenRequest
+      >('/collections/update/hidden', 'update collection hidden', {
         id: collectionId,
-        name: name,
-        collectors_note,
+        hidden,
       });
 
       // optimistically update the collection within gallery cache.
@@ -35,7 +34,7 @@ export default function useUpdateCollectionInfo() {
           const gallery = newVal.galleries[0];
           const newCollections = gallery.collections.map((collection) => {
             if (collection.id === collectionId) {
-              return { ...collection, name, collectors_note };
+              return { ...collection, hidden };
             }
             return collection;
           });
@@ -45,6 +44,6 @@ export default function useUpdateCollectionInfo() {
         false
       );
     },
-    [authenticatedUser, updateCollection]
+    [updateCollection, authenticatedUser]
   );
 }

--- a/src/hooks/api/galleries/useAuthenticatedGallery.ts
+++ b/src/hooks/api/galleries/useAuthenticatedGallery.ts
@@ -1,13 +1,9 @@
 import { Gallery } from 'types/Gallery';
-import { User } from 'types/User';
 import { useAuthenticatedUser } from '../users/useUser';
 import useGalleries from './useGalleries';
 
 export default function useAuthenticatedGallery(): Gallery {
-  const user = useAuthenticatedUser() as User;
-  if (!user) {
-    throw new Error('Authenticated user not found');
-  }
+  const user = useAuthenticatedUser();
 
   const galleries = useGalleries({ userId: user.id });
   if (!galleries?.length) {

--- a/src/hooks/api/nfts/useUnassignedNfts.ts
+++ b/src/hooks/api/nfts/useUnassignedNfts.ts
@@ -1,5 +1,4 @@
 import { Nft } from 'types/Nft';
-import { User } from 'types/User';
 import { useAuthenticatedUser } from '../users/useUser';
 import useGet from '../_rest/useGet';
 
@@ -36,10 +35,7 @@ type Props = {
 export default function useUnassignedNfts({
   skipCache,
 }: Props): Nft[] | undefined {
-  const user = useAuthenticatedUser() as User;
-  if (!user) {
-    throw new Error('Authenticated user not found');
-  }
+  const user = useAuthenticatedUser();
 
   const data = useGet<UnassignedNftsResponse>(
     getUnassignedNftsBaseUrlWithQuery({ userId: user.id, skipCache }),

--- a/src/hooks/api/users/useUpdateUser.ts
+++ b/src/hooks/api/users/useUpdateUser.ts
@@ -10,7 +10,7 @@ export default function useUpdateUser() {
 
   return useCallback(
     async (userId: string, username: string, bio: string) => {
-      const result = await updateUser<UpdateUserResponse, UpdateUserRequest>(
+      await updateUser<UpdateUserResponse, UpdateUserRequest>(
         '/users/update/info',
         'update user',
         { username, bio }
@@ -28,8 +28,6 @@ export default function useUpdateUser() {
         (user: User) => ({ ...user, username, bio }),
         false
       );
-
-      return result;
     },
     [updateUser]
   );

--- a/src/hooks/api/users/useUser.ts
+++ b/src/hooks/api/users/useUser.ts
@@ -38,7 +38,7 @@ export default function useUser(props: Props): User | undefined {
   return data;
 }
 
-export function useAuthenticatedUser() {
+export function usePossiblyAuthenticatedUser() {
   const state = useAuthState();
   const userId = useMemo(() => {
     if (isLoggedInState(state)) {
@@ -50,26 +50,28 @@ export function useAuthenticatedUser() {
   return user;
 }
 
-export function useAuthenticatedUserAddress() {
-  const user = useAuthenticatedUser();
-
+export function useAuthenticatedUser() {
+  const user = usePossiblyAuthenticatedUser();
   if (!user) {
     throw new Error('Authenticated user not found');
   }
+
+  return user;
+}
+
+export function useAuthenticatedUserAddress() {
+  const user = useAuthenticatedUser();
 
   const address = user.addresses?.[0];
   if (!address) {
     throw new Error('No address found on user');
   }
+
   return address;
 }
 
 export function useAuthenticatedUsername() {
   const user = useAuthenticatedUser();
-
-  if (!user) {
-    throw new Error('Authenticated user not found');
-  }
 
   return user.username;
 }

--- a/src/scenes/Auth/Auth.tsx
+++ b/src/scenes/Auth/Auth.tsx
@@ -5,7 +5,7 @@ import useIsPasswordValidated from 'hooks/useIsPasswordValidated';
 import WalletSelector from 'components/WalletSelector/WalletSelector';
 import Page from 'components/core/Page/Page';
 import useIsAuthenticated from 'contexts/auth/useIsAuthenticated';
-import { useAuthenticatedUser } from 'hooks/api/users/useUser';
+import { usePossiblyAuthenticatedUser } from 'hooks/api/users/useUser';
 import { Caption } from 'components/core/Text/Text';
 import colors from 'components/core/colors';
 import styled from 'styled-components';
@@ -16,7 +16,7 @@ function Auth(_: RouteComponentProps) {
   const isPasswordValidated = useIsPasswordValidated();
   // whether the user is web3-authenticated
   const isAuthenticated = useIsAuthenticated();
-  const user = useAuthenticatedUser();
+  const user = usePossiblyAuthenticatedUser();
   const username = user?.username;
 
   if (!isPasswordValidated) {

--- a/src/scenes/Nuke/Nuke.tsx
+++ b/src/scenes/Nuke/Nuke.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect } from 'react';
 import { Link, RouteComponentProps } from '@reach/router';
 import styled from 'styled-components';
-import { Display } from 'components/core/Text/Text';
+import { Heading } from 'components/core/Text/Text';
 import Button from 'components/core/Button/Button';
 import Spacer from 'components/core/Spacer/Spacer';
 import Page from 'components/core/Page/Page';
@@ -15,7 +15,7 @@ function Nuke(_: RouteComponentProps) {
 
   return (
     <Page centered>
-      <Display>Your local data has been nuked</Display>
+      <Heading>Your local cache has been nuked</Heading>
       <Spacer height={32} />
       <Link to="/">
         <StyledButton text="Take me home" />

--- a/src/scenes/UserGalleryPage/EditUserInfoModal.tsx
+++ b/src/scenes/UserGalleryPage/EditUserInfoModal.tsx
@@ -7,11 +7,10 @@ import Button from 'components/core/Button/Button';
 import Spacer from 'components/core/Spacer/Spacer';
 import ErrorText from 'components/core/Text/ErrorText';
 import { useAuthenticatedUser } from 'hooks/api/users/useUser';
-import { User } from 'types/User';
 import { navigate } from '@reach/router';
 
 function EditUserInfoModal() {
-  const existingUser = useAuthenticatedUser() as User;
+  const existingUser = useAuthenticatedUser();
 
   const { hideModal } = useModal();
 

--- a/src/scenes/UserGalleryPage/UserGalleryPage.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryPage.tsx
@@ -2,7 +2,7 @@ import breakpoints, { pageGutter } from 'components/core/breakpoints';
 import { Redirect, RouteComponentProps } from '@reach/router';
 import Page from 'components/core/Page/Page';
 import useGalleries from 'hooks/api/galleries/useGalleries';
-import useUser, { useAuthenticatedUser } from 'hooks/api/users/useUser';
+import useUser, { usePossiblyAuthenticatedUser } from 'hooks/api/users/useUser';
 import styled from 'styled-components';
 import UserGallery from './UserGallery';
 
@@ -13,7 +13,7 @@ type Params = {
 function UserGalleryPage({ username }: RouteComponentProps<Params>) {
   const user = useUser({ username });
   const galleries = useGalleries({ userId: user?.id }) || [];
-  const authenticatedUser = useAuthenticatedUser();
+  const authenticatedUser = usePossiblyAuthenticatedUser();
 
   if (!user) {
     return <Redirect to="/404" noThrow />;


### PR DESCRIPTION
1. remove `as User` when calling `useAuthenticatedUser` by definitively returning a user
2. in areas where an authenticated user may not be present, we call `usePossiblyAuthenticatedUser`