### PR TITLE
Dont fetch collection in CollectionRowWrapper to fix post-delete error

### DIFF
--- a/src/flows/shared/steps/OrganizeGallery/CollectionDnd.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionDnd.tsx
@@ -20,20 +20,17 @@ import {
 
 import CollectionRowWrapper from './CollectionRowWrapper';
 import CollectionRowDragging from './CollectionRowDragging';
-import { Collection } from 'types/Collection';
+import useAuthenticatedGallery from 'hooks/api/galleries/useAuthenticatedGallery';
 
 const defaultDropAnimationConfig: DropAnimation = {
   ...defaultDropAnimation,
   dragSourceOpacity: 0.2,
 };
 
-type Props = {
-  collections: Collection[];
-};
-
 const modifiers = [restrictToVerticalAxis, restrictToWindowEdges];
 
-function CollectionDnd({ collections }: Props) {
+function CollectionDnd() {
+  const { collections } = useAuthenticatedGallery();
   const [activeId, setActiveId] = useState<string | undefined>(undefined);
   const [sortedCollections, setSortedCollections] = useState(collections);
 
@@ -86,10 +83,7 @@ function CollectionDnd({ collections }: Props) {
         strategy={verticalListSortingStrategy}
       >
         {sortedCollections.map((collection) => (
-          <CollectionRowWrapper
-            key={collection.id}
-            collectionId={collection.id}
-          />
+          <CollectionRowWrapper key={collection.id} collection={collection} />
         ))}
       </SortableContext>
       <DragOverlay dropAnimation={defaultDropAnimationConfig}>

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowWrapper.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowWrapper.tsx
@@ -3,17 +3,13 @@ import styled from 'styled-components';
 import SortableCollectionRow from './SortableCollectionRow';
 import Spacer from 'components/core/Spacer/Spacer';
 import CollectionRowSettings from './CollectionRowSettings';
-import useCollectionById from 'hooks/api/collections/useCollectionById';
+import { Collection } from 'types/Collection';
 
 type Props = {
-  collectionId: string;
+  collection: Collection;
 };
 
-function CollectionRowWrapper({ collectionId }: Props) {
-  // get the latest collection from the cache, since the parent is using a local
-  // (and possibly stale) state of collections to keep track of sort order
-  const collection = useCollectionById(collectionId);
-
+function CollectionRowWrapper({ collection }: Props) {
   return (
     <StyledCollectionRowWrapper>
       <CollectionRowSettings collection={collection} />

--- a/src/flows/shared/steps/OrganizeGallery/OrganizeGallery.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/OrganizeGallery.tsx
@@ -8,7 +8,6 @@ import Spacer from 'components/core/Spacer/Spacer';
 import { useAuthenticatedUser } from 'hooks/api/users/useUser';
 import CollectionDnd from './CollectionDnd';
 import Header from './Header';
-import useAuthenticatedGallery from 'hooks/api/galleries/useAuthenticatedGallery';
 import { WizardContext } from 'react-albus';
 import { useWizardId } from 'contexts/wizard/WizardDataProvider';
 
@@ -53,15 +52,13 @@ function OrganizeGallery({ next }: WizardContext) {
     onPrevious: returnToProfile,
   });
 
-  const { collections } = useAuthenticatedGallery();
-
   return (
     <StyledOrganizeGallery>
       <Content>
         <Spacer height={80} />
         <Header />
         <Spacer height={16} />
-        <CollectionDnd collections={collections} />
+        <CollectionDnd />
         <Spacer height={120} />
       </Content>
     </StyledOrganizeGallery>


### PR DESCRIPTION
`CollectionRowWrapper` tries to get the latest collection from the cache by id, so after the user deletes a collection, the error `Collection by ID not found` is thrown, because the collection is no longer in the cached gallery. 

To fix this, I passed in the collections from the parent component `CollectionDnd` directly into the child component, `CollectionRowWrapper`. This prevents `CollectionRowWrapper` from trying to retrieve a collection that isn't in the gallery anymore.

I also verified that this change didn't break editing the collection name. I was able to edit the collection name and see it immediately reflected in the DnD UI.
