### PR TITLE
Hide your hidden collections when on your own page as an authenticated user

### DIFF
--- a/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import Spacer from 'components/core/Spacer/Spacer';
 
 import { Collection } from 'types/Collection';
+import { useMemo } from 'react';
 import EmptyGallery from './EmptyGallery';
 import UserGalleryCollection from './UserGalleryCollection';
 
@@ -14,6 +15,8 @@ function UserGalleryCollections({
   collections,
   isAuthenticatedUsersPage,
 }: Props) {
+  const filteredCollections = useMemo(() => collections.filter(collection => !collection.hidden), [collections]);
+
   if (collections.length === 0) {
     const noCollectionsMessage = isAuthenticatedUsersPage
       ? 'Your gallery is empty. Display your NFTs by creating a collection.'
@@ -25,7 +28,7 @@ function UserGalleryCollections({
   // TODO: Consider extracting 48 and 108 into unit consts
   return (
     <StyledUserGalleryCollections>
-      {collections.map((collection, index) => (
+      {filteredCollections.map((collection, index) => (
         <>
           <Spacer height={index === 0 ? 48 : 108} />
           <UserGalleryCollection collection={collection} />


### PR DESCRIPTION
Currently if you're authenticated and you load your own Gallery page, it shows your hidden collections as well. 
This happens because the hidden collections are included in the GET gallery request because you are authenticated, which in itself is fine.
This PR ensures we don't render the hidden collections. 