### PR TITLE
Truncate collectors_note with ellpises in dnd view

### DIFF
--- a/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
@@ -27,14 +27,15 @@ function CollectionRow({ collection, className }: Props) {
 
   const isHidden = useMemo(() => Boolean(hidden), [hidden]);
 
+  const truncatedCollectorsNote = useMemo(() => collectors_note.length > 100 ? collectors_note.slice(0, 100) + ('...') : collectors_note, [collectors_note]);
+
   return (
     <StyledCollectionRow className={className} isHidden={isHidden}>
       <Header>
         <TextContainer>
           <BodyRegular>{name}</BodyRegular>
           <Spacer height={4} />
-          {/* TODO__v1: make sure this truncates with ellipses if too long */}
-          <Caption color={colors.gray50}>{collectors_note}</Caption>
+          <Caption color={colors.gray50}>{truncatedCollectorsNote}</Caption>
         </TextContainer>
         <Settings />
       </Header>

--- a/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -50,7 +50,7 @@ const StyledCollectionHeader = styled.div`
   width: 100%;
 
   @media only screen and ${breakpoints.tablet} {
-    width: 50%;
+    width: 70%;
   }
 `;
 


### PR DESCRIPTION
This PR updates the dnd collection view to truncate the collection_note if it's more than 100 characters

![truncate note dnd collection ](https://user-images.githubusercontent.com/80802871/133358558-c20f74e9-68f2-41f5-8a1f-a731fdc7fd1f.png)

I also increased the width of the collectors_note in the main gallery view from 50% to 70% - I think it looks better that way

![decrease width note gallery view](https://user-images.githubusercontent.com/80802871/133358570-a8c31a7d-8e21-4a9a-8628-8d6991ce4fa3.png)
