### PR TITLE
Disable new user sign up

### DIFF
--- a/src/components/WalletSelector/WalletSelector.tsx
+++ b/src/components/WalletSelector/WalletSelector.tsx
@@ -44,6 +44,11 @@ const ERROR_MESSAGES: Record<ErrorCode, ErrorMessage> = {
     heading: 'Signature required',
     body: 'Please sign the message with your wallet to log in.',
   },
+  USER_SIGNUP_DISABLED: {
+    heading: 'Could not sign in',
+    body: 'The wallet you tried to connect with is not associated with an existing Gallery user.\n\n New sign ups are limited while we invite more users.\n\n'
+    + 'If you have used Gallery before, please check that you are connecting with the same wallet.',
+  },
   UNKNOWN_ERROR: {
     heading: 'There was an error connecting',
     body: 'Please try again.',
@@ -220,6 +225,7 @@ const StyledTitleMedium = styled(TitleMedium)`
 
 const StyledBody = styled(BodyRegular)`
   margin-bottom: 30px;
+  white-space: pre-wrap;
 `;
 
 const StyledRetryButton = styled(Button)`

--- a/src/components/WalletSelector/authRequestUtils.ts
+++ b/src/components/WalletSelector/authRequestUtils.ts
@@ -3,6 +3,8 @@ import { FetcherType } from 'contexts/swr/useFetcher';
 import { OpenseaSyncResponse } from 'hooks/api/nfts/useOpenseaSync';
 import { Web3Error } from 'types/Error';
 
+const USER_SIGNUP_ENABLED = false;
+
 /**
  * Auth Pipeline:
  * 1. Fetch nonce from server with provided wallet address
@@ -33,6 +35,10 @@ export default async function initializeAuthPipeline({
   if (userExists) {
     const response = await loginUser({ signature, address }, fetcher);
     return { jwt: response.jwt_token, userId: response.user_id };
+  }
+
+  if (!USER_SIGNUP_ENABLED) {
+    throw { code: 'USER_SIGNUP_DISABLED' } as Web3Error;
   }
 
   const response = await createUser(


### PR DESCRIPTION
Disable new user sign up for now, and show an appropriate error message if someone tries to connect a wallet that is not associated with an existing Gallery user.