### PR TITLE
Add new Error Boundary for Gallery Page and handle 404 correctly

### DIFF
--- a/src/contexts/boundary/ErrorBoundary.tsx
+++ b/src/contexts/boundary/ErrorBoundary.tsx
@@ -13,6 +13,7 @@ class ErrorBoundary extends Component {
   render() {
     if (this.state.error !== null) {
       const { header, description } = formatDetailedError(this.state.error);
+
       return (
         <Page centered withRoomForFooter={false}>
           <Subdisplay>{header}</Subdisplay>

--- a/src/contexts/swr/useFetcher.ts
+++ b/src/contexts/swr/useFetcher.ts
@@ -54,7 +54,7 @@ export const _fetch: FetcherType = async (path, action, parameters = {}) => {
 
     // Attach custom error message if provided
     if (action && error instanceof Error) {
-      throw new ApiError(error.message, action);
+      throw new ApiError(error.message, action, response.status);
     }
 
     throw error;
@@ -69,8 +69,7 @@ export const _fetch: FetcherType = async (path, action, parameters = {}) => {
     const errorResponseBody = responseBody as GalleryErrorResponseBody;
     const serverErrorMessage = errorResponseBody?.error ?? 'Server Error';
     if (action) {
-      const apiError = new ApiError(serverErrorMessage, action);
-      throw apiError;
+      throw new ApiError(serverErrorMessage, action, response.status);
     }
 
     throw new Error(serverErrorMessage);

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -1,9 +1,11 @@
 export class ApiError extends Error {
   customMessage = '';
+  code = -1;
 
-  constructor(message: string, customMessage: string) {
+  constructor(message: string, customMessage: string, code: number) {
     super(message);
     this.name = 'ApiError';
     this.customMessage = customMessage;
+    this.code = code;
   }
 }

--- a/src/scenes/NotFound/NotFound.tsx
+++ b/src/scenes/NotFound/NotFound.tsx
@@ -1,17 +1,16 @@
-import { memo } from 'react';
-import { Link, RouteComponentProps } from '@reach/router';
+import { Link } from '@reach/router';
 import styled from 'styled-components';
 import { Display, BodyRegular } from 'components/core/Text/Text';
 import Button from 'components/core/Button/Button';
 import Spacer from 'components/core/Spacer/Spacer';
 import Page from 'components/core/Page/Page';
 
-function NotFound(_: RouteComponentProps) {
+function NotFound() {
   return (
     <Page centered>
       <Display>404</Display>
       <Spacer height={8} />
-      <BodyRegular>Unfortunately, there's not much to see here.</BodyRegular>
+      <StyledBody>This user doesn't exist yet. If you think they should,<br/>share their collection in a tweet and tag us @usegallery.</StyledBody>
       <Spacer height={24} />
       <Link to="/">
         <StyledButton text="Take me back" />
@@ -20,8 +19,13 @@ function NotFound(_: RouteComponentProps) {
   );
 }
 
+const StyledBody = styled(BodyRegular)`
+  white-space: pre-wrap;;
+  text-align: center;
+`;
+
 const StyledButton = styled(Button)`
   padding: 0px 24px;
 `;
 
-export default memo(NotFound);
+export default NotFound;

--- a/src/scenes/NotFound/NotFound.tsx
+++ b/src/scenes/NotFound/NotFound.tsx
@@ -10,7 +10,9 @@ function NotFound() {
     <Page centered>
       <Display>404</Display>
       <Spacer height={8} />
-      <StyledBody>This user doesn't exist yet. If you think they should,<br/>share their collection in a tweet and tag us @usegallery.</StyledBody>
+      <StyledBody>This user doesn't exist yet. If you think they should,<br/>{'share their collection in a tweet and tag us '}
+        <StyledInlineLink href="https://twitter.com/usegallery" target="_blank" rel="noreferrer">@usegallery</StyledInlineLink>.
+      </StyledBody>
       <Spacer height={24} />
       <Link to="/">
         <StyledButton text="Take me back" />
@@ -19,8 +21,17 @@ function NotFound() {
   );
 }
 
+const StyledInlineLink = styled.a`
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
 const StyledBody = styled(BodyRegular)`
-  white-space: pre-wrap;;
+  white-space: pre-wrap;
   text-align: center;
 `;
 

--- a/src/scenes/Routes.tsx
+++ b/src/scenes/Routes.tsx
@@ -8,7 +8,6 @@ import EditGalleryFlow from 'flows/EditGalleryFlow/EditGalleryFlow';
 import Home from './Home/Home';
 import Auth from './Auth/Auth';
 import Password from './Password/Password';
-import NotFound from './NotFound/NotFound';
 import NftDetailPage from './NftDetailPage/NftDetailPage';
 import Nuke from './Nuke/Nuke';
 import UserGalleryPage from './UserGalleryPage/UserGalleryPage';
@@ -50,7 +49,6 @@ export default function Routes() {
               <Password path="/password" />
               <AuthenticatedRoute Component={OnboardingFlow} path="/welcome" />
               <AuthenticatedRoute Component={EditGalleryFlow} path="/edit" />
-              <NotFound path="/404" />
               <Nuke path="/nuke" />
               <NftDetailPage path="/:userName/:collectionId/:nftId" />
               <UserGalleryPage path="/:username" />

--- a/src/scenes/UserGalleryPage/UserGallery.tsx
+++ b/src/scenes/UserGalleryPage/UserGallery.tsx
@@ -1,19 +1,30 @@
 import { contentSize } from 'components/core/breakpoints';
 import styled from 'styled-components';
 import Spacer from 'components/core/Spacer/Spacer';
-import { Gallery } from 'types/Gallery';
-import { User } from 'types/User';
+import useUser, { usePossiblyAuthenticatedUser } from 'hooks/api/users/useUser';
+import useGalleries from 'hooks/api/galleries/useGalleries';
+import NotFound from 'scenes/NotFound/NotFound';
 import UserGalleryCollections from './UserGalleryCollections';
 import UserGalleryHeader from './UserGalleryHeader';
 import EmptyGallery from './EmptyGallery';
 
 type Props = {
-  user: User;
-  gallery: Gallery;
-  isAuthenticatedUsersPage: boolean;
+  username?: string;
 };
 
-function UserGallery({ user, gallery, isAuthenticatedUsersPage }: Props) {
+function UserGallery({ username }: Props) {
+  const user = useUser({ username });
+  const galleries = useGalleries({ userId: user?.id ?? '' }) ?? [];
+  const gallery = galleries[0];
+  const authenticatedUser = usePossiblyAuthenticatedUser();
+
+  if (!user) {
+    return <NotFound/>;
+  }
+
+  const isAuthenticatedUsersPage
+    = user.username === authenticatedUser?.username;
+
   const collectionsView = gallery ? (
     <UserGalleryCollections
       collections={gallery.collections}

--- a/src/scenes/UserGalleryPage/UserGallery.tsx
+++ b/src/scenes/UserGalleryPage/UserGallery.tsx
@@ -14,8 +14,7 @@ type Props = {
 
 function UserGallery({ username }: Props) {
   const user = useUser({ username });
-  const galleries = useGalleries({ userId: user?.id ?? '' }) ?? [];
-  const gallery = galleries[0];
+  const [gallery] = useGalleries({ userId: user?.id ?? '' }) ?? [];
   const authenticatedUser = usePossiblyAuthenticatedUser();
 
   if (!user) {

--- a/src/scenes/UserGalleryPage/UserGalleryPage.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryPage.tsx
@@ -1,38 +1,25 @@
 import breakpoints, { pageGutter } from 'components/core/breakpoints';
-import { Redirect, RouteComponentProps } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
 import Page from 'components/core/Page/Page';
-import useGalleries from 'hooks/api/galleries/useGalleries';
-import useUser, { usePossiblyAuthenticatedUser } from 'hooks/api/users/useUser';
 import styled from 'styled-components';
 import UserGallery from './UserGallery';
+import UserGalleryPageErrorBoundary from './UserGalleryPageErrorBoundary';
 
 type Parameters_ = {
   username: string;
 };
 
 function UserGalleryPage({ username }: RouteComponentProps<Parameters_>) {
-  const user = useUser({ username });
-  const galleries = useGalleries({ userId: user?.id ?? '' }) ?? [];
-  const authenticatedUser = usePossiblyAuthenticatedUser();
-
-  if (!user) {
-    return <Redirect to="/404" noThrow />;
-  }
-
-  // Consider turning into a hook
-  const isAuthenticatedUsersPage
-    = user.username === authenticatedUser?.username;
-
   return (
-    <Page>
-      <StyledUserGalleryWrapper>
-        <UserGallery
-          user={user}
-          gallery={galleries[0]}
-          isAuthenticatedUsersPage={isAuthenticatedUsersPage}
-        />
-      </StyledUserGalleryWrapper>
-    </Page>
+    <UserGalleryPageErrorBoundary>
+      <Page>
+        <StyledUserGalleryWrapper>
+          <UserGallery
+            username={username}
+          />
+        </StyledUserGalleryWrapper>
+      </Page>
+    </UserGalleryPageErrorBoundary>
   );
 }
 

--- a/src/scenes/UserGalleryPage/UserGalleryPageErrorBoundary.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryPageErrorBoundary.tsx
@@ -1,0 +1,20 @@
+import { ApiError } from 'errors/types';
+import { Component } from 'react';
+import NotFound from 'scenes/NotFound/NotFound';
+
+class UserGalleryPageErrorBoundary extends Component {
+  state: { error: null | Error | ApiError } = { error: null };
+  static getDerivedStateFromError(error: Error | ApiError) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error instanceof ApiError && this.state.error.code === 404) {
+      return <NotFound/>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default UserGalleryPageErrorBoundary;


### PR DESCRIPTION
Changes:
- Added new Error Boundary for Gallery Page to specifically handle 404 case
- Updated ApiError class to include response code
- 404 view is now rendered without redirecting to /404 route
- Updated 404 view message