### PR TITLE
Make Polygon/Unsupported chain error display correctly 

### DIFF
--- a/src/components/WalletSelector/WalletSelector.tsx
+++ b/src/components/WalletSelector/WalletSelector.tsx
@@ -97,6 +97,8 @@ function WalletSelector({ connectionMode = AUTH }: Props) {
       if (error instanceof UserRejectedRequestError) {
         return getErrorMessage('REJECTED_SIGNATURE');
       }
+
+      return getErrorMessage('UNKNOWN_ERROR');
     }
 
     // detectedError is an error we manually set elsewhere in the app

--- a/src/components/WalletSelector/WalletSelector.tsx
+++ b/src/components/WalletSelector/WalletSelector.tsx
@@ -92,7 +92,7 @@ function WalletSelector({ connectionMode = AUTH }: Props) {
   // error code, we'll add them as they come up case-by-case
   const displayedError = useMemo(() => {
     const errorToDisplay = (error as Web3Error | undefined) ?? detectedError;
-    console.log(error, detectedError);
+    console.log(error, detectedError, errorToDisplay?.code, errorToDisplay?.name, errorToDisplay?.message);
     if (!errorToDisplay) {
       return null;
     }

--- a/src/components/WalletSelector/WalletSelector.tsx
+++ b/src/components/WalletSelector/WalletSelector.tsx
@@ -10,6 +10,7 @@ import Spacer from 'components/core/Spacer/Spacer';
 import { ADD_WALLET_TO_USER, AUTH, CONNECT_WALLET_ONLY } from 'types/Wallet';
 import { convertWalletName } from 'utils/wallet';
 import { Web3Provider } from '@ethersproject/providers/lib/web3-provider';
+import { UserRejectedRequestError } from '@web3-react/injected-connector';
 import WalletButton from './WalletButton';
 import AuthenticateWalletPending from './AuthenticateWalletPending';
 import AddWalletPending from './AddWalletPending';
@@ -30,10 +31,6 @@ type ErrorMessage = {
 // TODO: consider making these enums
 const ERROR_MESSAGES: Record<ErrorCode, ErrorMessage> = {
   // Client-side provider errors: https://eips.ethereum.org/EIPS/eip-1193#provider-errors
-  4001: {
-    heading: 'Authorization denied',
-    body: 'Please approve your wallet to connect to Gallery.',
-  },
   UNSUPPORTED_CHAIN: {
     heading: 'Authorization error',
     body: 'The selected chain is unsupported. We currently only support the Ethereum network.',
@@ -91,37 +88,31 @@ function WalletSelector({ connectionMode = AUTH }: Props) {
   // to manually set error. since not all errors come with an
   // error code, we'll add them as they come up case-by-case
   const displayedError = useMemo(() => {
-    const errorToDisplay = (error as Web3Error | undefined) ?? detectedError;
-    if (error instanceof UnsupportedChainIdError) {
-      console.log('UnsupportedChainIdError');
-    }
-
-    console.log(error, detectedError, error?.name, error?.message);
-    if (!errorToDisplay) {
-      return null;
-    }
-
-    // Handle error from server
-    if (errorToDisplay.code === 'GALLERY_SERVER_ERROR') {
-      return {
-        heading: 'Authorization error',
-        body: errorToDisplay.message,
-      };
-    }
-
-    // Handle error from web3 lib
-    if (!errorToDisplay.code) {
-      // Manually handle error cases as we run into them with wallets
-      if (errorToDisplay.name === 'UserRejectedRequestError') {
-        errorToDisplay.code = '4001';
+    // error is an error from the web3 provider
+    if (error) {
+      if (error instanceof UnsupportedChainIdError) {
+        return getErrorMessage('UNSUPPORTED_CHAIN');
       }
 
-      if (errorToDisplay.name === 'UnsupportedChainIdError') {
-        errorToDisplay.code = 'UNSUPPORTED_CHAIN';
+      if (error instanceof UserRejectedRequestError) {
+        return getErrorMessage('REJECTED_SIGNATURE');
       }
     }
 
-    return getErrorMessage(errorToDisplay.code ?? '');
+    // detectedError is an error we manually set elsewhere in the app
+    if (detectedError) {
+      // Handle error from server
+      if (detectedError.code === 'GALLERY_SERVER_ERROR') {
+        return {
+          heading: 'Authorization error',
+          body: detectedError.message,
+        };
+      }
+
+      return getErrorMessage(detectedError.code);
+    }
+
+    return null;
   }, [error, detectedError]);
 
   const setToPendingState = useCallback(

--- a/src/components/WalletSelector/WalletSelector.tsx
+++ b/src/components/WalletSelector/WalletSelector.tsx
@@ -92,7 +92,7 @@ function WalletSelector({ connectionMode = AUTH }: Props) {
   // error code, we'll add them as they come up case-by-case
   const displayedError = useMemo(() => {
     const errorToDisplay = (error as Web3Error | undefined) ?? detectedError;
-    console.log(error, detectedError, errorToDisplay?.code, errorToDisplay?.name, errorToDisplay?.message);
+    console.log(error, detectedError, error?.name, error?.message);
     if (!errorToDisplay) {
       return null;
     }

--- a/src/components/WalletSelector/WalletSelector.tsx
+++ b/src/components/WalletSelector/WalletSelector.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { useWeb3React } from '@web3-react/core';
+import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core';
 import { injected, walletconnect, walletlink } from 'connectors/index';
 import { AbstractConnector } from '@web3-react/abstract-connector';
 import { useCallback, useMemo, useState } from 'react';
@@ -92,6 +92,10 @@ function WalletSelector({ connectionMode = AUTH }: Props) {
   // error code, we'll add them as they come up case-by-case
   const displayedError = useMemo(() => {
     const errorToDisplay = (error as Web3Error | undefined) ?? detectedError;
+    if (error instanceof UnsupportedChainIdError) {
+      console.log('UnsupportedChainIdError');
+    }
+
     console.log(error, detectedError, error?.name, error?.message);
     if (!errorToDisplay) {
       return null;


### PR DESCRIPTION
Changes:
- The error message was displayed as expected locally but not on deployed environments.
- Refactor WalletSelector's displayed error to differentiate web3 provider error types properly
- Use error type instead of error.name to differentiate errors.