### PR TITLE
tweaks to AnimatedModal and Delete confirm

### DIFF
--- a/src/components/core/Button/Button.tsx
+++ b/src/components/core/Button/Button.tsx
@@ -42,7 +42,7 @@ function Button({
       {loading ? (
         <Loader inverted size={mini ? 'mini' : 'small'} />
       ) : (
-        <ButtonText color={type === 'primary' ? colors.white : colors.black}>
+        <ButtonText color={type === 'primary' ? colors.white : colors.gray80}>
           {text}
         </ButtonText>
       )}

--- a/src/contexts/modal/AnimatedModal.tsx
+++ b/src/contexts/modal/AnimatedModal.tsx
@@ -84,7 +84,7 @@ const Overlay = styled.div`
   height: 100vh;
   width: 100vw;
   background: white;
-  opacity: 0.8;
+  opacity: 0.95;
 
   // should appear above rest of site
   z-index: 1;
@@ -102,7 +102,7 @@ const StyledContentContainer = styled.div`
   // should appear above the overlay
   z-index: 2;
 
-  border: 1px solid ${colors.gray50};
+  border: 1px solid ${colors.gray30};
 `;
 
 const StyledContent = styled.div`
@@ -115,7 +115,7 @@ const StyledClose = styled.span`
   position: absolute;
   right: 30px;
   top: 28px;
-  padding: 10px;
+  padding: 12px 10px;
   cursor: pointer;
 `;
 

--- a/src/flows/shared/steps/OrganizeGallery/DeleteCollectionConfirmation.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/DeleteCollectionConfirmation.tsx
@@ -30,11 +30,10 @@ function DeleteCollectionConfirmation({ collectionId }: Props) {
       <BodyMedium>Are you sure you want to delete your collection?</BodyMedium>
       <Spacer height={8} />
       <BodyRegular color={colors.gray50}>
-        This action is irreversible and will remove this collection from your
-        gallery. All NFTs in this collection will be unassigned and available to
+        All NFTs in this collection will be unassigned and available to
         place in other collections.
       </BodyRegular>
-      <Spacer height={40} />
+      <Spacer height={20} />
       <ButtonContainer>
         <StyledCancelButton
           mini


### PR DESCRIPTION
Changes:
- increased AnimatedModal's background's opacity (see less of background content)
- tweak "X" close modal button alignment
- adjust Modal border color
- shorten Delete Collection confirmation copy


before

<img width="572" alt="modal before" src="https://user-images.githubusercontent.com/80802871/139967059-90cd5a59-7168-4fe8-a546-0bd762b3ecb5.png">


after

<img width="536" alt="modal after" src="https://user-images.githubusercontent.com/80802871/139967066-e8442400-5ccf-4f36-b950-aba35534a8a1.png">


