### PR TITLE
use browser native lazy load sto improve page bandwidth

### DIFF
--- a/src/components/ImageWithLoading/ImageWithLoading.tsx
+++ b/src/components/ImageWithLoading/ImageWithLoading.tsx
@@ -11,7 +11,7 @@ type Props = {
 export default function ImageWithLoading({ className, src, alt }: Props) {
   const setContentIsLoaded = useSetContentIsLoaded();
 
-  return <StyledImg className={className} src={src} alt={alt} onLoad={setContentIsLoaded}/>;
+  return <StyledImg className={className} src={src} alt={alt} loading="lazy" onLoad={setContentIsLoaded}/>;
 }
 
 const StyledImg = styled.img`


### PR DESCRIPTION
Changes
- use loading="lazy" to lazy load images on the Gallery profile page
- only works on Chromium based browsers, but it's an improvement