### PR TITLE
Get NftPreview for video thumbnail to render properly on mobile

### DIFF
--- a/src/components/NftPreview/NftPreviewAsset.tsx
+++ b/src/components/NftPreview/NftPreviewAsset.tsx
@@ -15,7 +15,7 @@ function NftPreviewAsset({ nft }: Props) {
   const setContentIsLoaded = useSetContentIsLoaded();
   const nftAssetComponent = useMemo(() => {
     if (getMediaTypeForAssetUrl(nft.image_url) === NftMediaType.VIDEO) {
-      return <StyledVideo src={nft.image_url} onLoadStart={setContentIsLoaded}></StyledVideo>;
+      return <StyledVideo src={`${nft.image_url}#t=0.5`} onLoadStart={setContentIsLoaded} preload="metadata"></StyledVideo>;
     }
 
     const isObit = nft.asset_contract?.name?.toLowerCase() === '0bits';


### PR DESCRIPTION
Changes:
- add preload="metadata" property to video tag to prevent loading the whole video on the profile page
- set src to start from t=0.5, this ensures the thumbnail used is a valid frame from the video

before: 
nothing visible

after
![video thumb on ios](https://user-images.githubusercontent.com/80802871/140003611-92743a7c-f453-466b-aeb4-ec0ef38122a1.png)

