### PR TITLE
Build NextJS when on nextjs branch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ $VERCEL_GIT_COMMIT_REF == "nextjs"  ]] ; then
+  yarn next build && yarn next export -o build;
+else
+  CI=false node scripts/build.js
+fi

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node scripts/start.js",
     "start:mock": "ENV=local node scripts/start.js",
-    "build": "CI=false node scripts/build.js",
+    "build": "bash ./build.sh",
     "lint": "eslint . --ext .js,.ts,.tsx,.cjs",
     "test": "node scripts/test.cjs"
   },


### PR DESCRIPTION
Alright so basically, I followed this https://www.storyblok.com/tp/different-build-commands-branch-name-vercel . So NextJS provides us an environment variable telling us what the branch is, we just use that to determine which build command to use. 

If you look at the image below, pretty much the only thing we need to change the build command since all of the other configs are the same across `create-react-app` and `nextjs` other than the development command but I'm pretty sure we don't use that so....

![image](https://user-images.githubusercontent.com/6754223/143178094-2adf2846-5ccd-4867-b89f-1de0bd994b14.png)


**After this merges, I should be able to push up the nextjs branch and things should deploy just fine.**. I think a good way to test this would be to create another project in vercel on the same repo but change the branch to `nextjs` so we have one last confirmation that things are working before we make the big switch.