### PR TITLE
reduce max height image size

### DIFF
--- a/src/components/ImageWithLoading/ImageWithLoading.tsx
+++ b/src/components/ImageWithLoading/ImageWithLoading.tsx
@@ -44,8 +44,6 @@ type StyledImgProps = {
 
 const StyledImg = styled.img<StyledImgProps>`
   display: block;
-  ${({ widthType }) =>
-    widthType === 'fullWidth' ? 'width' : 'max-width'}: 100%;
-  max-height: ${({ heightType }) =>
-    heightType === 'maxHeightScreen' ? '100vh' : '100%'};
+  ${({ widthType }) => (widthType === 'fullWidth' ? 'width' : 'max-width')}: 100%;
+  max-height: ${({ heightType }) => (heightType === 'maxHeightScreen' ? '80vh' : '100%')};
 `;


### PR DESCRIPTION
from 100vh to 80vh, that way it doesn't appear to go over the navbar/footer