### PR TITLE
update mirror link to new publication

### DIFF
--- a/src/components/core/Page/GlobalFooter.tsx
+++ b/src/components/core/Page/GlobalFooter.tsx
@@ -10,7 +10,7 @@ import {
   GALLERY_DISCORD,
   GALLERY_MEMBERSHIP_OPENSEA,
   GALLERY_TWITTER,
-  GALLERY_MIRROR,
+  GALLERY_BLOG,
 } from 'constants/urls';
 
 function GlobalFooter() {
@@ -29,15 +29,11 @@ function GlobalFooter() {
             <StyledLinkText color={colors.gray40}>Discord</StyledLinkText>
           </StyledLink>
           <Spacer width={8} />
-          <StyledLink href={GALLERY_MIRROR} target="_blank" rel="noreferrer">
-            <StyledLinkText color={colors.gray40}>Mirror</StyledLinkText>
+          <StyledLink href={GALLERY_BLOG} target="_blank" rel="noreferrer">
+            <StyledLinkText color={colors.gray40}>Blog</StyledLinkText>
           </StyledLink>
           <Spacer width={8} />
-          <StyledLink
-            href={GALLERY_MEMBERSHIP_OPENSEA}
-            target="_blank"
-            rel="noreferrer"
-          >
+          <StyledLink href={GALLERY_MEMBERSHIP_OPENSEA} target="_blank" rel="noreferrer">
             <StyledLinkText color={colors.gray40}>OpenSea</StyledLinkText>
           </StyledLink>
           <Spacer width={8} />

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -2,7 +2,5 @@ export const GALLERY_JOBS =
   'https://gallery-so.notion.site/Careers-e8d78dea54834630928f075f4a4ccdba';
 export const GALLERY_TWITTER = 'https://twitter.com/usegallery';
 export const GALLERY_DISCORD = 'https://discord.gg/BM4qhEy3Qj';
-export const GALLERY_MEMBERSHIP_OPENSEA =
-  'https://opensea.io/collection/gallery-membership-cards';
-export const GALLERY_MIRROR =
-  'https://mirror.xyz/0x16c6C19329cBb46218d51B07c994468a5aF864A7';
+export const GALLERY_MEMBERSHIP_OPENSEA = 'https://opensea.io/collection/gallery-membership-cards';
+export const GALLERY_BLOG = 'https://gallery.mirror.xyz';


### PR DESCRIPTION
- renamed `GALLERY_MIRROR` constant to `GALLERY_BLOG`
- updated URL to new gallery.mirror.xyz publication
- changed footer to say `Blog` instead of `Mirror` (generalize in case we move off Mirror in future)