### PR TITLE
Make user + nft page titles dynamic

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -19,6 +19,8 @@ const App: FC<{
     <Head>
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <meta name="description" content="Show your collection to the world." />
+      <meta property="og:title" content="Gallery" key="og:title" />
+      <meta name="twitter:title" content="Gallery" key="twitter:title" />
 
       <title>Gallery</title>
     </Head>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -19,8 +19,27 @@ const App: FC<{
     <Head>
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <meta name="description" content="Show your collection to the world." />
+      <meta name="msapplication-TileColor" content="#da532c" />
+      <meta name="theme-color" content="#ffffff" />
+
+      <meta property="og:type" content="website" />
       <meta property="og:title" content="Gallery" key="og:title" />
+      <meta property="og:description" content="Show your collection to the world." />
+      <meta
+        property="og:image"
+        content="https://storage.googleapis.com/gallery-prod-325303.appspot.com/gallery_full_logo.png"
+      />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content="@usegallery" />
       <meta name="twitter:title" content="Gallery" key="twitter:title" />
+      <meta name="twitter:description" content="Show your collection to the world." />
+      <meta
+        name="twitter:image"
+        content="https://storage.googleapis.com/gallery-prod-325303.appspot.com/gallery_full_logo.png"
+      />
 
       <title>Gallery</title>
     </Head>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -40,7 +40,6 @@ export default class MyDocument extends Document {
           <meta name="theme-color" content="#ffffff" />
 
           <meta property="og:type" content="website" />
-          <meta property="og:title" content="Gallery" />
           <meta property="og:description" content="Show your collection to the world." />
           <meta
             property="og:image"
@@ -51,7 +50,6 @@ export default class MyDocument extends Document {
 
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="twitter:site" content="@usegallery" />
-          <meta name="twitter:title" content="Gallery" />
           <meta name="twitter:description" content="Show your collection to the world." />
           <meta
             name="twitter:image"

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -36,25 +36,6 @@ export default class MyDocument extends Document {
           <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
           <link rel="manifest" href="/site.webmanifest" />
           <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#000000" />
-          <meta name="msapplication-TileColor" content="#da532c" />
-          <meta name="theme-color" content="#ffffff" />
-
-          <meta property="og:type" content="website" />
-          <meta property="og:description" content="Show your collection to the world." />
-          <meta
-            property="og:image"
-            content="https://storage.googleapis.com/gallery-prod-325303.appspot.com/gallery_full_logo.png"
-          />
-          <meta property="og:image:width" content="1200" />
-          <meta property="og:image:height" content="630" />
-
-          <meta name="twitter:card" content="summary_large_image" />
-          <meta name="twitter:site" content="@usegallery" />
-          <meta name="twitter:description" content="Show your collection to the world." />
-          <meta
-            name="twitter:image"
-            content="https://storage.googleapis.com/gallery-prod-325303.appspot.com/gallery_full_logo.png"
-          />
           <script
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{

--- a/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -59,6 +59,8 @@ function NftDetailPage({ username, nftId }: RouteComponentProps<Props>) {
     <>
       <Head>
         <title>{headTitle}</title>
+        <meta property="og:title" content={headTitle} key="og:title" />
+        <meta name="twitter:title" content={headTitle} key="twitter:title" />
       </Head>
       <StyledNftDetailPage centered fixedFullPageHeight>
         <StyledBackLink>

--- a/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { navigate, RouteComponentProps } from '@reach/router';
 import styled from 'styled-components';
 
@@ -12,18 +12,20 @@ import { useGalleryNavigationActions } from 'contexts/navigation/GalleryNavigati
 import GalleryRedirect from 'scenes/_Router/GalleryRedirect';
 import NftDetailAsset from './NftDetailAsset';
 import NftDetailText from './NftDetailText';
+import Head from 'next/head';
 
 type Props = {
   collectionId: string;
   nftId: string;
+  username: string;
 };
 
-function NftDetailPage({ nftId }: RouteComponentProps<Props>) {
+function NftDetailPage({ username, nftId }: RouteComponentProps<Props>) {
   const { getVisitedPagesLength } = useGalleryNavigationActions();
 
   const handleBackClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
-      const username = window.location.pathname.split('/')[1];
+      // const username = window.location.pathname.split('/')[1];
 
       if (event.metaKey) {
         window.open(`/${username}`);
@@ -45,41 +47,47 @@ function NftDetailPage({ nftId }: RouteComponentProps<Props>) {
       // position is maintained when going back (see: GalleryNavigationContext.tsx)
       void navigate(-1);
     },
-    [getVisitedPagesLength]
+    [getVisitedPagesLength, username]
   );
 
   const nft = useNft({ id: nftId ?? '' });
+  const headTitle = useMemo(() => `${nft?.name} - ${username} | Gallery`, [nft, username]);
 
   if (!nft) {
     return <GalleryRedirect to="/404" />;
   }
 
   return (
-    <StyledNftDetailPage centered fixedFullPageHeight>
-      <StyledBackLink>
-        <ActionText onClick={handleBackClick}>← Back to gallery</ActionText>
-      </StyledBackLink>
-      <StyledBody>
-        {/* {prevNftId && (
+    <>
+      <Head>
+        <title>{headTitle}</title>
+      </Head>
+      <StyledNftDetailPage centered fixedFullPageHeight>
+        <StyledBackLink>
+          <ActionText onClick={handleBackClick}>← Back to gallery</ActionText>
+        </StyledBackLink>
+        <StyledBody>
+          {/* {prevNftId && (
           <NavigationHandle
             direction={Directions.LEFT}
             nftId={prevNftId}
           ></NavigationHandle>
         )} */}
-        <StyledContentContainer>
-          <ShimmerProvider>
-            <NftDetailAsset nft={nft} />
-          </ShimmerProvider>
-          <NftDetailText nft={nft} />
-        </StyledContentContainer>
-        {/* {nextNftId && (
+          <StyledContentContainer>
+            <ShimmerProvider>
+              <NftDetailAsset nft={nft} />
+            </ShimmerProvider>
+            <NftDetailText nft={nft} />
+          </StyledContentContainer>
+          {/* {nextNftId && (
           <NavigationHandle
             direction={Directions.RIGHT}
             nftId={nextNftId}
           ></NavigationHandle>
         )} */}
-      </StyledBody>
-    </StyledNftDetailPage>
+        </StyledBody>
+      </StyledNftDetailPage>
+    </>
   );
 }
 

--- a/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -25,8 +25,6 @@ function NftDetailPage({ username, nftId }: RouteComponentProps<Props>) {
 
   const handleBackClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
-      // const username = window.location.pathname.split('/')[1];
-
       if (event.metaKey) {
         window.open(`/${username}`);
         return;

--- a/src/scenes/UserGalleryPage/UserGalleryPage.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryPage.tsx
@@ -58,10 +58,14 @@ function useSuggestion() {
 function UserGalleryPage({ username }: RouteComponentProps<Props>) {
   useSuggestion();
 
+  const headTitle = `${username} | Gallery`;
+
   return (
     <UserGalleryPageErrorBoundary>
       <Head>
-        <title>{username} | Gallery</title>
+        <title>{headTitle}</title>
+        <meta property="og:title" content={headTitle} key="og:title" />
+        <meta name="twitter:title" content={headTitle} key="twitter:title" />
       </Head>
       <Page>
         <StyledUserGalleryWrapper>

--- a/src/scenes/UserGalleryPage/UserGalleryPage.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryPage.tsx
@@ -10,6 +10,7 @@ import { useBreakpoint } from 'hooks/useWindowSize';
 import usePrevious from 'hooks/usePrevious';
 import UserGallery from './UserGallery';
 import UserGalleryPageErrorBoundary from './UserGalleryPageErrorBoundary';
+import Head from 'next/head';
 
 type Props = {
   username: string;
@@ -59,6 +60,9 @@ function UserGalleryPage({ username }: RouteComponentProps<Props>) {
 
   return (
     <UserGalleryPageErrorBoundary>
+      <Head>
+        <title>{username} | Gallery</title>
+      </Head>
       <Page>
         <StyledUserGalleryWrapper>
           <UserGallery username={username} />

--- a/src/scenes/_Router/Router.tsx
+++ b/src/scenes/_Router/Router.tsx
@@ -43,7 +43,7 @@ export default function Routes() {
                 navbar={false}
               />
               <GalleryRoute path="/nuke" component={Nuke} navbar={false} />
-              <GalleryRoute path="/:userName/:collectionId/:nftId" component={NftDetailPage} />
+              <GalleryRoute path="/:username/:collectionId/:nftId" component={NftDetailPage} />
               <GalleryRoute path="/:username" component={UserGalleryPage} />
             </Router>
           </FadeTransitioner>


### PR DESCRIPTION
Make the Page title dynamic, so that we include the username on the Gallery Page, and username+artwork name on the Detail Page.

- [x] title, og:title and twitter:title are dynamic on the User Gallery Page, displaying the username. Tab says "Kaito | Gallery" for example
- [x] title, og:title and twitter:title are dynamic on the NFT Detail Page, displaying the artwork name + username. Tab says "Obit #1 - Kaito | Gallery"  for example


example:
![Screen Shot 2022-01-04 at 19 37 22](https://user-images.githubusercontent.com/80802871/148508532-d6c6753b-c28e-4da8-80b5-7ddbaa099f44.png)

