### PR TITLE
Welcome page optimization & tweaks

### DIFF
--- a/src/scenes/Auth/Auth.tsx
+++ b/src/scenes/Auth/Auth.tsx
@@ -28,12 +28,7 @@ function Auth() {
   const username = user?.username;
 
   // Before the welcome screen, we should preload images so that the animation is smooth
-  // NOTE: This means that we preload images for *all* users on /auth, not just new users
-  // This is a necessary tradeoff because the Welcome screen is the first screen for new users,
-  // So there is no 'buffer' screen where we could preload images
-  useEffect(() => {
-    preloadImages();
-  });
+  useEffect(preloadImages, []);
 
   if (isAuthenticated) {
     // If user exists in DB, send them to their profile

--- a/src/scenes/Auth/Auth.tsx
+++ b/src/scenes/Auth/Auth.tsx
@@ -17,7 +17,7 @@ import { animatedImages } from 'src/scenes/WelcomeAnimation/Images';
 const preloadImages = () => {
   animatedImages.forEach((image) => {
     const img = new Image();
-    img.src = image.src;
+    img.src = image.src ?? '';
   });
 };
 

--- a/src/scenes/Auth/Auth.tsx
+++ b/src/scenes/Auth/Auth.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 
 import WalletSelector from 'components/WalletSelector/WalletSelector';
 import Page from 'components/core/Page/Page';
@@ -11,11 +11,29 @@ import GalleryRedirect from 'scenes/_Router/GalleryRedirect';
 import breakpoints from 'components/core/breakpoints';
 import Spacer from 'components/core/Spacer/Spacer';
 
+// Preloading images for the welcome screen
+import { animatedImages } from 'src/scenes/WelcomeAnimation/Images';
+
+const preloadImages = () => {
+  animatedImages.forEach((image) => {
+    const img = new Image();
+    img.src = image.src;
+  });
+};
+
 function Auth() {
   // Whether the user is web3-authenticated
   const isAuthenticated = useIsAuthenticated();
   const user = usePossiblyAuthenticatedUser();
   const username = user?.username;
+
+  // Before the welcome screen, we should preload images so that the animation is smooth
+  // NOTE: This means that we preload images for *all* users on /auth, not just new users
+  // This is a necessary tradeoff because the Welcome screen is the first screen for new users,
+  // So there is no 'buffer' screen where we could preload images
+  useEffect(() => {
+    preloadImages();
+  });
 
   if (isAuthenticated) {
     // If user exists in DB, send them to their profile

--- a/src/scenes/WelcomeAnimation/Image.tsx
+++ b/src/scenes/WelcomeAnimation/Image.tsx
@@ -1,5 +1,4 @@
 import styled, { css, Keyframes } from 'styled-components';
-import { useState } from 'react';
 
 type Props = {
   src: string;
@@ -20,9 +19,6 @@ function Image({
   fadeOutGrow,
   imagesFaded,
 }: Props) {
-  const [xRotation, setXRotation] = useState(0);
-  const [yRotation, setYRotation] = useState(0);
-
   const StyledImage = styled.img<{
     width?: number;
     fadeInDelay: number;
@@ -31,8 +27,6 @@ function Image({
     width: ${({ width }) => width}px;
     box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
     opacity: 1;
-
-    transform-style: preserve-3d;
 
     /* After creating <Image />, the fade in animation ran twice (once on load and once on explosion) This prevents that and only applies fade animation if images have not already faded in */
     animation: ${imagesFaded ? null : fadeInGrow} 1000ms forwards ${fadeInDelay}ms;
@@ -46,38 +40,13 @@ function Image({
   `;
 
   return (
-    <div
-      className="hover-listener"
-      onMouseMove={(e) => {
-        const x = e.nativeEvent.offsetX;
-        const y = e.nativeEvent.offsetY;
-
-        const width = e.target.width;
-        const height = e.target.height;
-
-        const MAX_X_ROTATION = 10;
-        const MAX_Y_ROTATION = 10;
-
-        const xDistance = (Math.abs(x - width / 2) / (width / 2)) * (x < width / 2 ? -1 : 1);
-        const yDistance = (Math.abs(y - height / 2) / (height / 2)) * (y < height / 2 ? 1 : -1);
-
-        setXRotation(xDistance * MAX_X_ROTATION);
-        setYRotation(yDistance * MAX_Y_ROTATION);
-      }}
-      onMouseLeave={() => {
-        setXRotation(0);
-        setYRotation(0);
-      }}
-    >
-      <StyledImage
-        style={{ transform: `rotateX(${yRotation}deg) rotateY(${xRotation}deg) scale3d(1, 1, 1)` }}
-        src={src}
-        width={width}
-        className="rotatable"
-        shouldFadeOut={shouldFadeOut}
-        fadeInDelay={fadeInDelay}
-      />
-    </div>
+    <StyledImage
+      src={src}
+      width={width}
+      className="rotatable"
+      shouldFadeOut={shouldFadeOut}
+      fadeInDelay={fadeInDelay}
+    />
   );
 }
 

--- a/src/scenes/WelcomeAnimation/Image.tsx
+++ b/src/scenes/WelcomeAnimation/Image.tsx
@@ -1,5 +1,5 @@
 import styled, { css, Keyframes } from 'styled-components';
-import { useState, useRef } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { animated, useSpring } from 'react-spring';
 
 type Props = {
@@ -48,6 +48,15 @@ const calc = (
 const trans = (x: number, y: number, s: number): string =>
   `perspective(600px) rotateX(${x}deg) rotateY(${y}deg) scale(${s})`;
 
+const config = {
+  mass: 1,
+  tension: 170,
+  friction: 75,
+  clamp: false,
+  precision: 0.01,
+  velocity: 0,
+};
+
 function Image({
   width,
   src,
@@ -57,31 +66,28 @@ function Image({
   fadeOutGrow,
   imagesFaded,
 }: Props) {
+  const [xys, setXys] = useState([0, 0, 1]);
+
+  const handleMouseLeave = useCallback(() => {
+    setXys([0, 0, 1]);
+  }, []);
+
+  const handleMouseMove = useCallback((e) => {
+    if (ref.current) {
+      const rect = ref.current.getBoundingClientRect();
+      setXys(calc(e.clientX, e.clientY, rect));
+    }
+  }, []);
+
   const ref = useRef<HTMLDivElement>(null);
-  const [xys, set] = useState([0, 0, 1]);
-  const config = {
-    mass: 1,
-    tension: 170,
-    friction: 75,
-    clamp: false,
-    precision: 0.01,
-    velocity: 0,
-  };
   const props = useSpring({ xys, config });
 
   return (
     <div
       className="hover-listener"
       ref={ref}
-      onMouseLeave={() => {
-        set([0, 0, 1]);
-      }}
-      onMouseMove={(e) => {
-        if (ref.current) {
-          const rect = ref.current.getBoundingClientRect();
-          set(calc(e.clientX, e.clientY, rect));
-        }
-      }}
+      onMouseLeave={handleMouseLeave}
+      onMouseMove={handleMouseMove}
     >
       <animated.div className="rotatable" style={{ transform: props.xys.to(trans) }}>
         <StyledImage

--- a/src/scenes/WelcomeAnimation/Image.tsx
+++ b/src/scenes/WelcomeAnimation/Image.tsx
@@ -57,7 +57,7 @@ function Image({
   fadeOutGrow,
   imagesFaded,
 }: Props) {
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
   const [xys, set] = useState([0, 0, 1]);
   const config = {
     mass: 1,
@@ -66,7 +66,6 @@ function Image({
     clamp: false,
     precision: 0.01,
     velocity: 0,
-    easing: (t) => t,
   };
   const props = useSpring({ xys, config });
 
@@ -78,8 +77,10 @@ function Image({
         set([0, 0, 1]);
       }}
       onMouseMove={(e) => {
-        const rect = ref.current.getBoundingClientRect();
-        set(calc(e.clientX, e.clientY, rect));
+        if (ref.current) {
+          const rect = ref.current.getBoundingClientRect();
+          set(calc(e.clientX, e.clientY, rect));
+        }
       }}
     >
       <animated.div className="rotatable" style={{ transform: props.xys.to(trans) }}>

--- a/src/scenes/WelcomeAnimation/Image.tsx
+++ b/src/scenes/WelcomeAnimation/Image.tsx
@@ -40,11 +40,26 @@ const StyledImage = styled.img<{
     `};
 `;
 
-const calc = (
+function calc(
   x: number,
   y: number,
   rect: { top: number; left: number; width: number; height: number }
-): number[] => [-(y - rect.top - rect.height / 2) / 8, (x - rect.left - rect.width / 2) / 8, 1.05];
+): number[] {
+  const rotationCeiling = 5; // Maximum degrees to rotate on both axes
+
+  // Do not let xRotation or yRotation go over the ceiling
+  const yRotationUnscaled = (y - rect.top - rect.height / 2) / 10;
+  const xRotationUnscaled = (x - rect.left - rect.width / 2) / 10;
+
+  const ceiling = function (rotation: number): number {
+    return rotation < 0
+      ? Math.max(rotation, rotationCeiling * -1)
+      : Math.min(rotation, rotationCeiling);
+  };
+
+  return [ceiling(yRotationUnscaled) * -1, ceiling(xRotationUnscaled), 1.05];
+}
+
 const trans = (x: number, y: number, s: number): string =>
   `perspective(600px) rotateX(${x}deg) rotateY(${y}deg) scale(${s})`;
 

--- a/src/scenes/WelcomeAnimation/Image.tsx
+++ b/src/scenes/WelcomeAnimation/Image.tsx
@@ -23,7 +23,8 @@ const StyledImage = styled.img<{
   box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
   opacity: 1;
 
-  /* After creating <Image />, the fade in animation ran twice (once on load and once on explosion) This prevents that and only applies fade animation if images have not already faded in */
+  /*  We only want to apply the animation to fade in the images, and then we can remove the animation
+   We need to remove animation property once faded in, so that transform can be modified in hover events */
   ${({ imagesFaded, fadeInGrow, fadeInDelay }) =>
     !imagesFaded &&
     css`

--- a/src/scenes/WelcomeAnimation/Image.tsx
+++ b/src/scenes/WelcomeAnimation/Image.tsx
@@ -1,0 +1,84 @@
+import styled, { css, Keyframes } from 'styled-components';
+import { useState } from 'react';
+
+type Props = {
+  src: string;
+  width: number;
+  fadeInDelay: number;
+  shouldFadeOut: boolean;
+  imagesFaded: boolean;
+  fadeInGrow: Keyframes;
+  fadeOutGrow: Keyframes;
+};
+
+function Image({
+  width,
+  src,
+  fadeInDelay,
+  shouldFadeOut,
+  fadeInGrow,
+  fadeOutGrow,
+  imagesFaded,
+}: Props) {
+  const [xRotation, setXRotation] = useState(0);
+  const [yRotation, setYRotation] = useState(0);
+
+  const StyledImage = styled.img<{
+    width?: number;
+    fadeInDelay: number;
+    shouldFadeOut?: boolean;
+  }>`
+    width: ${({ width }) => width}px;
+    box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
+    opacity: 1;
+
+    transform-style: preserve-3d;
+
+    /* After creating <Image />, the fade in animation ran twice (once on load and once on explosion) This prevents that and only applies fade animation if images have not already faded in */
+    animation: ${imagesFaded ? null : fadeInGrow} 1000ms forwards ${fadeInDelay}ms;
+
+    ${({ shouldFadeOut, fadeInDelay }) =>
+      shouldFadeOut &&
+      css`
+        animation: ${fadeOutGrow} 500ms forwards ${fadeInDelay}ms;
+        opacity: 0;
+      `};
+  `;
+
+  return (
+    <div
+      className="hover-listener"
+      onMouseMove={(e) => {
+        const x = e.nativeEvent.offsetX;
+        const y = e.nativeEvent.offsetY;
+
+        const width = e.target.width;
+        const height = e.target.height;
+
+        const MAX_X_ROTATION = 10;
+        const MAX_Y_ROTATION = 10;
+
+        const xDistance = (Math.abs(x - width / 2) / (width / 2)) * (x < width / 2 ? -1 : 1);
+        const yDistance = (Math.abs(y - height / 2) / (height / 2)) * (y < height / 2 ? 1 : -1);
+
+        setXRotation(xDistance * MAX_X_ROTATION);
+        setYRotation(yDistance * MAX_Y_ROTATION);
+      }}
+      onMouseLeave={() => {
+        setXRotation(0);
+        setYRotation(0);
+      }}
+    >
+      <StyledImage
+        style={{ transform: `rotateX(${yRotation}deg) rotateY(${xRotation}deg) scale3d(1, 1, 1)` }}
+        src={src}
+        width={width}
+        className="rotatable"
+        shouldFadeOut={shouldFadeOut}
+        fadeInDelay={fadeInDelay}
+      />
+    </div>
+  );
+}
+
+export default Image;

--- a/src/scenes/WelcomeAnimation/Image.tsx
+++ b/src/scenes/WelcomeAnimation/Image.tsx
@@ -48,16 +48,13 @@ function calc(
   const rotationCeiling = 5; // Maximum degrees to rotate on both axes
 
   // Do not let xRotation or yRotation go over the ceiling
-  const yRotationUnscaled = (y - rect.top - rect.height / 2) / 10;
-  const xRotationUnscaled = (x - rect.left - rect.width / 2) / 10;
+  const ceiling = (num: number) => Math.min(Math.max(num, rotationCeiling * -1), rotationCeiling);
 
-  const ceiling = function (rotation: number): number {
-    return rotation < 0
-      ? Math.max(rotation, rotationCeiling * -1)
-      : Math.min(rotation, rotationCeiling);
-  };
-
-  return [ceiling(yRotationUnscaled) * -1, ceiling(xRotationUnscaled), 1.05];
+  return [
+    ceiling((y - rect.top - rect.height / 2) / 10) * -1,
+    ceiling((x - rect.left - rect.width / 2) / 10),
+    1.05,
+  ];
 }
 
 const trans = (x: number, y: number, s: number): string =>

--- a/src/scenes/WelcomeAnimation/Image.tsx
+++ b/src/scenes/WelcomeAnimation/Image.tsx
@@ -1,4 +1,5 @@
 import styled, { css, Keyframes } from 'styled-components';
+import { useState } from 'react';
 
 type Props = {
   src: string;
@@ -10,6 +11,33 @@ type Props = {
   fadeOutGrow: Keyframes;
 };
 
+const StyledImage = styled.img<{
+  width?: number;
+  fadeInDelay: number;
+  fadeInGrow?: Keyframes;
+  fadeOutGrow?: Keyframes;
+  shouldFadeOut?: boolean;
+  imagesFaded?: boolean;
+}>`
+  width: ${({ width }) => width}px;
+  box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
+  opacity: 1;
+
+  /* After creating <Image />, the fade in animation ran twice (once on load and once on explosion) This prevents that and only applies fade animation if images have not already faded in */
+  ${({ imagesFaded, fadeInGrow, fadeInDelay }) =>
+    !imagesFaded &&
+    css`
+      animation: ${fadeInGrow} 1000ms forwards ${fadeInDelay} ms;
+    `}
+
+  ${({ shouldFadeOut, fadeInDelay, fadeOutGrow }) =>
+    shouldFadeOut &&
+    css`
+      animation: ${fadeOutGrow} 500ms forwards ${fadeInDelay}ms;
+      opacity: 0;
+    `};
+`;
+
 function Image({
   width,
   src,
@@ -19,34 +47,45 @@ function Image({
   fadeOutGrow,
   imagesFaded,
 }: Props) {
-  const StyledImage = styled.img<{
-    width?: number;
-    fadeInDelay: number;
-    shouldFadeOut?: boolean;
-  }>`
-    width: ${({ width }) => width}px;
-    box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
-    opacity: 1;
-
-    /* After creating <Image />, the fade in animation ran twice (once on load and once on explosion) This prevents that and only applies fade animation if images have not already faded in */
-    animation: ${imagesFaded ? null : fadeInGrow} 1000ms forwards ${fadeInDelay}ms;
-
-    ${({ shouldFadeOut, fadeInDelay }) =>
-      shouldFadeOut &&
-      css`
-        animation: ${fadeOutGrow} 500ms forwards ${fadeInDelay}ms;
-        opacity: 0;
-      `};
-  `;
+  const [xRotation, setXRotation] = useState(0);
+  const [yRotation, setYRotation] = useState(0);
 
   return (
-    <StyledImage
-      src={src}
-      width={width}
-      className="rotatable"
-      shouldFadeOut={shouldFadeOut}
-      fadeInDelay={fadeInDelay}
-    />
+    <div
+      className="hover-listener"
+      onMouseMove={(e) => {
+        const x = e.nativeEvent.offsetX;
+        const y = e.nativeEvent.offsetY;
+
+        const width = e.target.width;
+        const height = e.target.height;
+
+        const MAX_X_ROTATION = 12.5;
+        const MAX_Y_ROTATION = 12.5;
+
+        const xDistance = (Math.abs(x - width / 2) / (width / 2)) * (x < width / 2 ? -1 : 1);
+        const yDistance = (Math.abs(y - height / 2) / (height / 2)) * (y < height / 2 ? 1 : -1);
+
+        setXRotation(xDistance * MAX_X_ROTATION);
+        setYRotation(yDistance * MAX_Y_ROTATION);
+      }}
+      onMouseLeave={() => {
+        setXRotation(0);
+        setYRotation(0);
+      }}
+    >
+      <StyledImage
+        src={src}
+        width={width}
+        style={{ transform: `rotateX(${yRotation}deg) rotateY(${xRotation}deg) scale3d(1, 1, 1)` }}
+        className="rotatable"
+        shouldFadeOut={shouldFadeOut}
+        fadeInDelay={fadeInDelay}
+        fadeInGrow={fadeInGrow}
+        fadeOutGrow={fadeOutGrow}
+        imagesFaded={imagesFaded}
+      />
+    </div>
   );
 }
 

--- a/src/scenes/WelcomeAnimation/Images.tsx
+++ b/src/scenes/WelcomeAnimation/Images.tsx
@@ -1,0 +1,139 @@
+export type AnimatedImage = {
+  src?: string;
+  width: number;
+  // ZIndex is the "depth" of image from viewer's pov.
+  // It is used to calculate how the image will move based on mousemovement.
+  // z-index of 0 is essentially the axis of movement.
+  // values can be -100 to 100, with -100 being the furthest from viewer and 100 being closest.
+  // positive values move the image in one direction on mouse movement, negative values move in opposite.
+  zIndex: number;
+  // Offset is the x or y position of the image after the explosion and they fan out
+  offsetX: number;
+  offsetY: number;
+  // Offset start is the x or y position of the image when they first load in
+  offsetXStart: number;
+  offsetYStart: number;
+  // Delay in ms so that images don't all appear at once
+  fadeInDelay: number;
+  // Some images have a moveOnVertical property so that they appear in different places on vertical screens
+  moveOnVertical?: boolean;
+  verticalX?: number;
+  verticalY?: number;
+};
+
+export const animatedImages: AnimatedImage[] = [
+  {
+    src: 'https://lh3.googleusercontent.com/AqK0M5EcGCytypy6t5VBclg2Pm66npq4Qpf-MlNox_l1BD8uhDhlircZ5mPCrKch3FAgacTbRO61Ur722W3g-ANWiTMQU6owrnOukQ', // Chair
+    width: 180,
+    zIndex: -40,
+    offsetX: 180,
+    offsetY: -370,
+    offsetXStart: 0,
+    offsetYStart: 0,
+    fadeInDelay: 800,
+    moveOnVertical: true,
+    verticalX: 280,
+    verticalY: -180,
+  },
+  {
+    src: 'https://lh3.googleusercontent.com/sxCl9E-dvfOq7UidBi-dO8TDXtU7QmbpVj8x4nXnJpDAujj2c74F1cTqvX5alvInLh9NkaoGFL1aFIvx8M2mRtqQ', // Punk
+    width: 100,
+    zIndex: -13,
+    offsetX: -105,
+    offsetY: 210,
+    offsetXStart: 0,
+    offsetYStart: 0,
+    fadeInDelay: 0,
+    moveOnVertical: true,
+    verticalX: -400,
+    verticalY: 30,
+  },
+  {
+    src: 'https://lh3.googleusercontent.com/CpwTm306giMTU90lJrdEqs_SuUWa9DPT7r6CzDJZErJAdbLC8RoB-3GEh_QBtcmPrr6SmsywUPjbO9IN0i6VmwpteirK5ptSePYPzQ=w335', // Fidenza
+    width: 280,
+    zIndex: -18,
+    offsetX: 370,
+    offsetY: 80,
+    offsetXStart: -20,
+    offsetYStart: -12,
+    fadeInDelay: 300,
+    moveOnVertical: true,
+    verticalX: 200,
+    verticalY: 100,
+  },
+  {
+    src: 'https://lh3.googleusercontent.com/kghKAvKiZ6dCQaPtfcyuNKnNDNtijiwoalY3ZGeo4WwOyLIZvDeX7auYyiVX2vNKI_GU8Wrt88pLTNNAi5n3ENwsaJ5y2ZWvH0rzMw=w335', // Squiggle
+    width: 200,
+    zIndex: 20,
+    offsetX: -150,
+    offsetY: -390,
+    offsetXStart: 0,
+    offsetYStart: 0,
+    fadeInDelay: 0,
+    moveOnVertical: true,
+    verticalX: 150,
+    verticalY: -450,
+  },
+  {
+    src: 'https://lh3.googleusercontent.com/dvrP8rJNswBrdAo4eYia2y808Od_vjtmxn3-41-WDxs2K5jElLUQEsIUGw7X0uGVLe8ywqrUg-70OlrpjIGKiiK4FBy1SyMCmpmIaA=w336', // Elementals
+    width: 200,
+    zIndex: 11,
+    offsetX: -550,
+    offsetY: -340,
+    offsetXStart: 0,
+    offsetYStart: 0,
+    fadeInDelay: 1200,
+  },
+  {
+    src: 'https://lh3.googleusercontent.com/kOnoQtIQslGFMlxXXGxPtnjCbUvOr1EuIePKC0DJsTsvvV__ytpVoywQ9Fkl8KAxWAwKP2coUj7N-Pk_e_hyTXEKgyzYPJKRcBrULQ=s500', // Brushpops
+    width: 250,
+    zIndex: 37,
+    offsetX: -510,
+    offsetY: 110,
+    offsetXStart: 0,
+    offsetYStart: 30,
+    fadeInDelay: 500,
+    moveOnVertical: true,
+    verticalX: -510,
+    verticalY: 210,
+  },
+  {
+    src: 'https://lh3.googleusercontent.com/eseF_p4TBPq0Jauf99fkm32n13Xde_Zgsjdfy6L450YZaEUorYtDmUUHBxcxnC21Sq8mzBJ6uW8uUwYCKckyChysBRNvrWyZ6uSx', // Doge
+    width: 220,
+    zIndex: 25,
+    offsetX: 440,
+    offsetY: -240,
+    offsetXStart: -40,
+    offsetYStart: 0,
+    fadeInDelay: 0,
+    moveOnVertical: true,
+    verticalX: -100,
+    verticalY: -700,
+  },
+  {
+    src: 'https://lh3.googleusercontent.com/eg2EsokhN7VkPzzHgO6QHYZHsUaGwhhagLiRhYVIi30Fw2WwudM0NFiGdTAZsLEY99dPuCEo0hdrK6BxZzy6EGXsgSdLL3wA4UMz=w500', // Wheatstacks
+    width: 200,
+    zIndex: 30,
+    offsetX: 80,
+    offsetY: 150,
+    offsetXStart: 0,
+    offsetYStart: -40,
+    fadeInDelay: 300,
+    moveOnVertical: true,
+    verticalX: -150,
+    verticalY: 160,
+  },
+  {
+    src: 'https://lh3.googleusercontent.com/G6eilbjTdOHxUcZC3y_O96beaUu_DGzyiduK3HB_7ki94QuZx02xQSz4S-KaDIg-Pw-0YkV1KgC3ECmflEzWq0HoZw', // Rebirth of Venus
+    width: 230,
+    zIndex: -11,
+    offsetX: -660,
+    offsetY: -120,
+    offsetXStart: 0,
+    offsetYStart: 0,
+    fadeInDelay: 0,
+    moveOnVertical: true,
+    verticalX: -230,
+    verticalY: -400,
+  },
+];

--- a/src/scenes/WelcomeAnimation/Images.tsx
+++ b/src/scenes/WelcomeAnimation/Images.tsx
@@ -45,8 +45,8 @@ export const animatedImages: AnimatedImage[] = [
     offsetYStart: 0,
     fadeInDelay: 0,
     moveOnVertical: true,
-    verticalX: -400,
-    verticalY: 30,
+    verticalX: -350,
+    verticalY: 50,
   },
   {
     src: 'https://lh3.googleusercontent.com/CpwTm306giMTU90lJrdEqs_SuUWa9DPT7r6CzDJZErJAdbLC8RoB-3GEh_QBtcmPrr6SmsywUPjbO9IN0i6VmwpteirK5ptSePYPzQ=w335', // Fidenza
@@ -71,8 +71,8 @@ export const animatedImages: AnimatedImage[] = [
     offsetYStart: 0,
     fadeInDelay: 0,
     moveOnVertical: true,
-    verticalX: 150,
-    verticalY: -450,
+    verticalX: 130,
+    verticalY: -430,
   },
   {
     src: 'https://lh3.googleusercontent.com/dvrP8rJNswBrdAo4eYia2y808Od_vjtmxn3-41-WDxs2K5jElLUQEsIUGw7X0uGVLe8ywqrUg-70OlrpjIGKiiK4FBy1SyMCmpmIaA=w336', // Elementals
@@ -95,7 +95,7 @@ export const animatedImages: AnimatedImage[] = [
     fadeInDelay: 500,
     moveOnVertical: true,
     verticalX: -510,
-    verticalY: 210,
+    verticalY: 310,
   },
   {
     src: 'https://lh3.googleusercontent.com/eseF_p4TBPq0Jauf99fkm32n13Xde_Zgsjdfy6L450YZaEUorYtDmUUHBxcxnC21Sq8mzBJ6uW8uUwYCKckyChysBRNvrWyZ6uSx', // Doge
@@ -107,7 +107,7 @@ export const animatedImages: AnimatedImage[] = [
     offsetYStart: 0,
     fadeInDelay: 0,
     moveOnVertical: true,
-    verticalX: -100,
+    verticalX: 50,
     verticalY: -700,
   },
   {

--- a/src/scenes/WelcomeAnimation/Images.tsx
+++ b/src/scenes/WelcomeAnimation/Images.tsx
@@ -45,8 +45,8 @@ export const animatedImages: AnimatedImage[] = [
     offsetYStart: 0,
     fadeInDelay: 0,
     moveOnVertical: true,
-    verticalX: -350,
-    verticalY: 50,
+    verticalX: -375,
+    verticalY: -50,
   },
   {
     src: 'https://lh3.googleusercontent.com/CpwTm306giMTU90lJrdEqs_SuUWa9DPT7r6CzDJZErJAdbLC8RoB-3GEh_QBtcmPrr6SmsywUPjbO9IN0i6VmwpteirK5ptSePYPzQ=w335', // Fidenza
@@ -58,7 +58,7 @@ export const animatedImages: AnimatedImage[] = [
     offsetYStart: -12,
     fadeInDelay: 300,
     moveOnVertical: true,
-    verticalX: 200,
+    verticalX: 150,
     verticalY: 100,
   },
   {
@@ -71,8 +71,8 @@ export const animatedImages: AnimatedImage[] = [
     offsetYStart: 0,
     fadeInDelay: 0,
     moveOnVertical: true,
-    verticalX: 130,
-    verticalY: -430,
+    verticalX: -200,
+    verticalY: 400,
   },
   {
     src: 'https://lh3.googleusercontent.com/dvrP8rJNswBrdAo4eYia2y808Od_vjtmxn3-41-WDxs2K5jElLUQEsIUGw7X0uGVLe8ywqrUg-70OlrpjIGKiiK4FBy1SyMCmpmIaA=w336', // Elementals
@@ -83,6 +83,9 @@ export const animatedImages: AnimatedImage[] = [
     offsetXStart: 0,
     offsetYStart: 0,
     fadeInDelay: 1200,
+    moveOnVertical: true,
+    verticalX: 0,
+    verticalY: -350,
   },
   {
     src: 'https://lh3.googleusercontent.com/kOnoQtIQslGFMlxXXGxPtnjCbUvOr1EuIePKC0DJsTsvvV__ytpVoywQ9Fkl8KAxWAwKP2coUj7N-Pk_e_hyTXEKgyzYPJKRcBrULQ=s500', // Brushpops
@@ -94,8 +97,8 @@ export const animatedImages: AnimatedImage[] = [
     offsetYStart: 30,
     fadeInDelay: 500,
     moveOnVertical: true,
-    verticalX: -510,
-    verticalY: 310,
+    verticalX: -400,
+    verticalY: 100,
   },
   {
     src: 'https://lh3.googleusercontent.com/eseF_p4TBPq0Jauf99fkm32n13Xde_Zgsjdfy6L450YZaEUorYtDmUUHBxcxnC21Sq8mzBJ6uW8uUwYCKckyChysBRNvrWyZ6uSx', // Doge
@@ -108,7 +111,7 @@ export const animatedImages: AnimatedImage[] = [
     fadeInDelay: 0,
     moveOnVertical: true,
     verticalX: 50,
-    verticalY: -700,
+    verticalY: -600,
   },
   {
     src: 'https://lh3.googleusercontent.com/eg2EsokhN7VkPzzHgO6QHYZHsUaGwhhagLiRhYVIi30Fw2WwudM0NFiGdTAZsLEY99dPuCEo0hdrK6BxZzy6EGXsgSdLL3wA4UMz=w500', // Wheatstacks
@@ -120,8 +123,8 @@ export const animatedImages: AnimatedImage[] = [
     offsetYStart: -40,
     fadeInDelay: 300,
     moveOnVertical: true,
-    verticalX: -150,
-    verticalY: 160,
+    verticalX: -100,
+    verticalY: 150,
   },
   {
     src: 'https://lh3.googleusercontent.com/G6eilbjTdOHxUcZC3y_O96beaUu_DGzyiduK3HB_7ki94QuZx02xQSz4S-KaDIg-Pw-0YkV1KgC3ECmflEzWq0HoZw', // Rebirth of Venus
@@ -133,7 +136,7 @@ export const animatedImages: AnimatedImage[] = [
     offsetYStart: 0,
     fadeInDelay: 0,
     moveOnVertical: true,
-    verticalX: -230,
-    verticalY: -400,
+    verticalX: -300,
+    verticalY: -350,
   },
 ];

--- a/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
+++ b/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
@@ -49,10 +49,17 @@ export default function WelcomeAnimation({ next }: Props) {
   }));
 
   // Check for vertical screens and render images in different positions if so
-  const [aspectRatio, setAspectRatio] = useState(0);
+  type AspectRatio = 'vertical' | 'horizontal' | undefined;
+  const [aspectRatio, setAspectRatio] = useState<AspectRatio>(undefined);
   const windowSize = useWindowSize();
+
   useEffect(() => {
-    setAspectRatio(windowSize.width / windowSize.height);
+    if (windowSize.width / windowSize.height < 1) {
+      setAspectRatio('vertical');
+      return;
+    }
+
+    setAspectRatio('horizontal');
   }, [windowSize]);
 
   // If we want to use transitions instead of keyframes, we could add a class to each image after X seconds
@@ -168,7 +175,7 @@ const StyledTextContainer = styled.div<{
 
 const StyledMovementWrapper = styled.div<{
   shouldExplode: boolean;
-  aspectRatio: number;
+  aspectRatio: AspectRatio;
   animatedImage: AnimatedImage;
 }>`
   position: relative;
@@ -177,11 +184,11 @@ const StyledMovementWrapper = styled.div<{
   ${({ shouldExplode, animatedImage, aspectRatio }) =>
     shouldExplode
       ? `transform: translate(${
-          aspectRatio < 1 && animatedImage.moveOnVertical
+          aspectRatio === 'vertical' && animatedImage.moveOnVertical
             ? animatedImage.verticalX
             : animatedImage.offsetX
         }px, ${
-          aspectRatio < 1 && animatedImage.moveOnVertical
+          aspectRatio === 'vertical' && animatedImage.moveOnVertical
             ? animatedImage.verticalY
             : animatedImage.offsetY
         }px);`

--- a/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
+++ b/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
@@ -4,126 +4,20 @@ import Button from 'components/core/Button/Button';
 import colors from 'components/core/colors';
 import Spacer from 'components/core/Spacer/Spacer';
 
+import Image from './Image';
+import { AnimatedImage, animatedImages } from './Images';
+
 import styled, { css, keyframes } from 'styled-components';
 import { animated, useSpring } from 'react-spring';
 import Mixpanel from 'utils/mixpanel';
 import { useAuthenticatedUsername } from 'hooks/api/users/useUser';
 import { useRouter } from 'next/router';
+import useWindowSize from 'src/hooks/useWindowSize';
 
+const FADE_DURATION = 2000;
 // The calc function allows us to control the effect of onMouseMove's x and y movement values on the resulting parallax.
 // example usage: https://codesandbox.io/embed/r5x34869vq
 const calc = (x: number, y: number) => [(x - window.innerWidth) / 2, (y - window.innerHeight) / 2];
-type AnimatedImage = {
-  src?: string;
-  width: number;
-  // ZIndex is the "depth" of image from viewer's pov.
-  // It is used to calculate how the image will move based on mousemovement.
-  // z-index of 0 is essentially the axis of movement.
-  // values can be -100 to 100, with -100 being the furthest from viewer and 100 being closest.
-  // positive values move the image in one direction on mouse movement, negative values move in opposite.
-  zIndex: number;
-  // Offset is the x or y position of the image after the explosion and they fan out
-  offsetX: number;
-  offsetY: number;
-  // Offset start is the x or y position of the image when they first load in
-  offsetXStart: number;
-  offsetYStart: number;
-  // Delay in ms so that images don't all appear at once
-  fadeInDelay: number;
-};
-
-const animatedImages: AnimatedImage[] = [
-  {
-    src: 'https://lh3.googleusercontent.com/AqK0M5EcGCytypy6t5VBclg2Pm66npq4Qpf-MlNox_l1BD8uhDhlircZ5mPCrKch3FAgacTbRO61Ur722W3g-ANWiTMQU6owrnOukQ', // Chair
-    width: 180,
-    zIndex: -40,
-    offsetX: 180,
-    offsetY: -370,
-    offsetXStart: 0,
-    offsetYStart: 0,
-    fadeInDelay: 800,
-  },
-  {
-    src: 'https://lh3.googleusercontent.com/sxCl9E-dvfOq7UidBi-dO8TDXtU7QmbpVj8x4nXnJpDAujj2c74F1cTqvX5alvInLh9NkaoGFL1aFIvx8M2mRtqQ', // Punk
-    width: 100,
-    zIndex: -13,
-    offsetX: -105,
-    offsetY: 210,
-    offsetXStart: 0,
-    offsetYStart: 0,
-    fadeInDelay: 0,
-  },
-  {
-    src: 'https://lh3.googleusercontent.com/CpwTm306giMTU90lJrdEqs_SuUWa9DPT7r6CzDJZErJAdbLC8RoB-3GEh_QBtcmPrr6SmsywUPjbO9IN0i6VmwpteirK5ptSePYPzQ=w335', // Fidenza
-    width: 280,
-    zIndex: -18,
-    offsetX: 370,
-    offsetY: 80,
-    offsetXStart: -20,
-    offsetYStart: -12,
-    fadeInDelay: 300,
-  },
-  {
-    src: 'https://lh3.googleusercontent.com/kghKAvKiZ6dCQaPtfcyuNKnNDNtijiwoalY3ZGeo4WwOyLIZvDeX7auYyiVX2vNKI_GU8Wrt88pLTNNAi5n3ENwsaJ5y2ZWvH0rzMw=w335', // Squiggle
-    width: 200,
-    zIndex: 20,
-    offsetX: -150,
-    offsetY: -390,
-    offsetXStart: 0,
-    offsetYStart: 0,
-    fadeInDelay: 0,
-  },
-  {
-    src: 'https://lh3.googleusercontent.com/dvrP8rJNswBrdAo4eYia2y808Od_vjtmxn3-41-WDxs2K5jElLUQEsIUGw7X0uGVLe8ywqrUg-70OlrpjIGKiiK4FBy1SyMCmpmIaA=w336', // Elementals
-    width: 200,
-    zIndex: 11,
-    offsetX: -550,
-    offsetY: -340,
-    offsetXStart: 0,
-    offsetYStart: 0,
-    fadeInDelay: 1200,
-  },
-  {
-    src: 'https://lh3.googleusercontent.com/kOnoQtIQslGFMlxXXGxPtnjCbUvOr1EuIePKC0DJsTsvvV__ytpVoywQ9Fkl8KAxWAwKP2coUj7N-Pk_e_hyTXEKgyzYPJKRcBrULQ=s500', // Brushpops
-    width: 250,
-    zIndex: 37,
-    offsetX: -510,
-    offsetY: 110,
-    offsetXStart: 0,
-    offsetYStart: 30,
-    fadeInDelay: 500,
-  },
-  {
-    src: 'https://lh3.googleusercontent.com/eseF_p4TBPq0Jauf99fkm32n13Xde_Zgsjdfy6L450YZaEUorYtDmUUHBxcxnC21Sq8mzBJ6uW8uUwYCKckyChysBRNvrWyZ6uSx', // Doge
-    width: 220,
-    zIndex: 25,
-    offsetX: 440,
-    offsetY: -240,
-    offsetXStart: -40,
-    offsetYStart: 0,
-    fadeInDelay: 0,
-  },
-  {
-    src: 'https://lh3.googleusercontent.com/eg2EsokhN7VkPzzHgO6QHYZHsUaGwhhagLiRhYVIi30Fw2WwudM0NFiGdTAZsLEY99dPuCEo0hdrK6BxZzy6EGXsgSdLL3wA4UMz=w500', // Wheatstacks
-    width: 200,
-    zIndex: 30,
-    offsetX: 80,
-    offsetY: 150,
-    offsetXStart: 0,
-    offsetYStart: -40,
-    fadeInDelay: 300,
-  },
-  {
-    src: 'https://lh3.googleusercontent.com/G6eilbjTdOHxUcZC3y_O96beaUu_DGzyiduK3HB_7ki94QuZx02xQSz4S-KaDIg-Pw-0YkV1KgC3ECmflEzWq0HoZw', // Rebirth of Venus
-    width: 230,
-    zIndex: -11,
-    offsetX: -660,
-    offsetY: -120,
-    offsetXStart: 0,
-    offsetYStart: 0,
-    fadeInDelay: 0,
-  },
-];
 
 const textAnimationOptions = {
   width: 300,
@@ -154,20 +48,30 @@ export default function WelcomeAnimation({ next }: Props) {
     config: { mass: 10, tension: 550, friction: 140 },
   }));
 
+  // Check for vertical screens and render images in different positions if so
+  const [aspectRatio, setAspectRatio] = useState(0);
+  const windowSize = useWindowSize();
+  useEffect(() => {
+    setAspectRatio(windowSize.width / windowSize.height);
+  }, [windowSize]);
+
   // If we want to use transitions instead of keyframes, we could add a class to each image after X seconds
   // to trigger the transition. Using a transition allows us to not have to add keyframes for each image.
 
   // const [isTextDisplayed, setIsTextDisplayed] = useState(false);
   const [shouldFadeOut, setShouldFadeOut] = useState(false);
   const [shouldExplode, setShouldExplode] = useState(false);
-  const username = useAuthenticatedUsername();
+  const [imagesFaded, setImagesFaded] = useState(false);
+  // const username = useAuthenticatedUsername();
   const { push } = useRouter();
 
   useEffect(() => {
     setTimeout(() => {
       setShouldExplode(true);
-    }, 2000);
-  }, [setShouldExplode]);
+      setImagesFaded(true);
+    }, FADE_DURATION);
+  }, [setShouldExplode, setImagesFaded]);
+
   const handleClick = useCallback(() => {
     Mixpanel.track('Click through welcome page');
     if (username) {
@@ -179,8 +83,8 @@ export default function WelcomeAnimation({ next }: Props) {
     setShouldFadeOut(true);
     setTimeout(() => {
       next();
-    }, 2000);
-  }, [next, username, push]);
+    }, FADE_DURATION);
+  }, [next, push]);
 
   return (
     <StyledContainer onMouseMove={({ clientX: x, clientY: y }) => set({ xy: calc(x, y) })}>
@@ -202,7 +106,12 @@ export default function WelcomeAnimation({ next }: Props) {
         </StyledTextContainer>
       </animated.div>
       {animatedImages.map((animatedImage) => (
-        <StyledMovementWrapper shouldExplode={shouldExplode} animatedImage={animatedImage}>
+        <StyledMovementWrapper
+          shouldExplode={shouldExplode}
+          aspectRatio={aspectRatio}
+          animatedImage={animatedImage}
+          key={animatedImage.src}
+        >
           <animated.div
             className="animate"
             style={{
@@ -214,6 +123,9 @@ export default function WelcomeAnimation({ next }: Props) {
               src={animatedImage.src}
               fadeInDelay={animatedImage.fadeInDelay}
               shouldFadeOut={shouldFadeOut}
+              fadeInGrow={fadeInGrow}
+              fadeOutGrow={fadeOutGrow}
+              imagesFaded={imagesFaded}
             />
           </animated.div>
         </StyledMovementWrapper>
@@ -245,7 +157,7 @@ const StyledTextContainer = styled.div<{
   align-items: center;
   opacity: 0;
   animation: ${fadeInGrow} 1s forwards;
-  animation-delay: 2s;
+  animation-delay: ${FADE_DURATION}ms;
 
   ${({ shouldFadeOut }) =>
     shouldFadeOut &&
@@ -256,16 +168,26 @@ const StyledTextContainer = styled.div<{
 
 const StyledMovementWrapper = styled.div<{
   shouldExplode: boolean;
+  aspectRatio: number;
   animatedImage: AnimatedImage;
 }>`
   position: relative;
   transition: transform 1000ms cubic-bezier(0, 0, 0, 1.07);
-  ${({ shouldExplode, animatedImage }) =>
+
+  ${({ shouldExplode, animatedImage, aspectRatio }) =>
     shouldExplode
-      ? `transform: translate(${animatedImage.offsetX}px, ${animatedImage.offsetY}px)`
+      ? `transform: translate(${
+          aspectRatio < 1 && animatedImage.moveOnVertical
+            ? animatedImage.verticalX
+            : animatedImage.offsetX
+        }px, ${
+          aspectRatio < 1 && animatedImage.moveOnVertical
+            ? animatedImage.verticalY
+            : animatedImage.offsetY
+        }px);`
       : `transform: translate(${animatedImage.offsetXStart - 120}px, ${
           animatedImage.offsetYStart - 150
-        }px)`};
+        }px);`}
 `;
 
 const StyledContainer = styled.div`
@@ -276,24 +198,6 @@ const StyledContainer = styled.div`
   justify-content: center;
   animation: ${fadeInGrow} 2s;
   overflow: hidden;
-`;
-
-const Image = styled.img<{
-  width?: number;
-  fadeInDelay: number;
-  shouldFadeOut?: boolean;
-}>`
-  width: ${({ width }) => width}px;
-  box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
-  opacity: 0;
-  animation: ${fadeInGrow} 2s forwards ${({ fadeInDelay }) => fadeInDelay}ms;
-
-  ${({ shouldFadeOut, fadeInDelay }) =>
-    shouldFadeOut &&
-    css`
-      animation: ${fadeOutGrow} 500ms forwards ${fadeInDelay / 3}ms;
-      opacity: 1;
-    `}
 `;
 
 const StyledBodyText = styled(BodyRegular)`

--- a/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
+++ b/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
@@ -62,7 +62,7 @@ export default function WelcomeAnimation({ next }: Props) {
   const [shouldFadeOut, setShouldFadeOut] = useState(false);
   const [shouldExplode, setShouldExplode] = useState(false);
   const [imagesFaded, setImagesFaded] = useState(false);
-  // const username = useAuthenticatedUsername();
+  const username = useAuthenticatedUsername();
   const { push } = useRouter();
 
   useEffect(() => {
@@ -84,7 +84,7 @@ export default function WelcomeAnimation({ next }: Props) {
     setTimeout(() => {
       next();
     }, FADE_DURATION);
-  }, [next, push]);
+  }, [next, username, push]);
 
   return (
     <StyledContainer onMouseMove={({ clientX: x, clientY: y }) => set({ xy: calc(x, y) })}>

--- a/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
+++ b/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
@@ -275,6 +275,7 @@ const StyledContainer = styled.div`
   align-items: center;
   justify-content: center;
   animation: ${fadeInGrow} 2s;
+  overflow: hidden;
 `;
 
 const Image = styled.img<{

--- a/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
+++ b/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
@@ -42,6 +42,8 @@ type Props = {
   next: () => void;
 };
 
+type AspectRatio = 'vertical' | 'horizontal' | undefined;
+
 export default function WelcomeAnimation({ next }: Props) {
   const [props, set] = useSpring(() => ({
     xy: [0, 0],
@@ -49,7 +51,6 @@ export default function WelcomeAnimation({ next }: Props) {
   }));
 
   // Check for vertical screens and render images in different positions if so
-  type AspectRatio = 'vertical' | 'horizontal' | undefined;
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>(undefined);
   const windowSize = useWindowSize();
 

--- a/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
+++ b/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
@@ -120,7 +120,7 @@ export default function WelcomeAnimation({ next }: Props) {
           >
             <Image
               width={animatedImage.width}
-              src={animatedImage.src}
+              src={animatedImage.src ?? ''}
               fadeInDelay={animatedImage.fadeInDelay}
               shouldFadeOut={shouldFadeOut}
               fadeInGrow={fadeInGrow}

--- a/src/scenes/WelcomeAnimation/intro.css
+++ b/src/scenes/WelcomeAnimation/intro.css
@@ -5,27 +5,8 @@
 
 .hover-listener {
   perspective: 400px;
-  /* cursor: crosshair; */
 }
 
 .rotatable {
   transform-style: preserve-3d;
-}
-
-.hover-listener .rotatable {
-  transition: transform 400ms ease-in-out;
-  -webkit-transition: transform 400ms ease-in-out;
-  -moz-transition: transform 400ms ease-in-out;
-  -ms-transition: transform 400ms ease-in-out;
-  -o-transition: transform 400ms ease-in-out;
-}
-
-/* If the user is already hovering on the card, we want the transform to respond near-immediately 
-We don't want 0ms because this makes it look choppy when you first hover */
-.hover-listener:hover .rotatable {
-  transition: transform 100ms linear;
-  -webkit-transition: transform 100ms linear;
-  -moz-transition: transform 100ms linear;
-  -ms-transition: transform 100ms linear;
-  -o-transition: transform 100ms linear;
 }

--- a/src/scenes/WelcomeAnimation/intro.css
+++ b/src/scenes/WelcomeAnimation/intro.css
@@ -1,4 +1,20 @@
 .animate {
   position: absolute;
   will-change: transform;
+  perspective: 400px;
+}
+
+.rotatable {
+  transform-style: preserve-3d;
+  transition: all 1000ms ease;
+  -webkit-transition: all 1000ms ease;
+  -moz-transition: all 1000ms ease;
+  -ms-transition: all 1000ms ease;
+  -o-transition: all 1000ms ease;
+}
+
+.hover-listener {
+  perspective: 400px;
+  width: 100%;
+  height: 100%;
 }

--- a/src/scenes/WelcomeAnimation/intro.css
+++ b/src/scenes/WelcomeAnimation/intro.css
@@ -5,23 +5,27 @@
 
 .hover-listener {
   perspective: 400px;
+  /* cursor: crosshair; */
 }
 
 .rotatable {
   transform-style: preserve-3d;
-  transition: transform 600ms ease;
-  -webkit-transition: transform 600ms ease;
-  -moz-transition: transform 600ms ease;
-  -ms-transition: transform 600ms ease;
-  -o-transition: transform 600ms ease;
+}
+
+.hover-listener .rotatable {
+  transition: transform 400ms ease-in-out;
+  -webkit-transition: transform 400ms ease-in-out;
+  -moz-transition: transform 400ms ease-in-out;
+  -ms-transition: transform 400ms ease-in-out;
+  -o-transition: transform 400ms ease-in-out;
 }
 
 /* If the user is already hovering on the card, we want the transform to respond near-immediately 
 We don't want 0ms because this makes it look choppy when you first hover */
-.rotatable:hover {
-  transition: transform 100ms ease;
-  -webkit-transition: transform 100ms ease;
-  -moz-transition: transform 100ms ease;
-  -ms-transition: transform 100ms ease;
-  -o-transition: transform 100ms ease;
+.hover-listener:hover .rotatable {
+  transition: transform 100ms linear;
+  -webkit-transition: transform 100ms linear;
+  -moz-transition: transform 100ms linear;
+  -ms-transition: transform 100ms linear;
+  -o-transition: transform 100ms linear;
 }

--- a/src/scenes/WelcomeAnimation/intro.css
+++ b/src/scenes/WelcomeAnimation/intro.css
@@ -1,20 +1,4 @@
 .animate {
   position: absolute;
   will-change: transform;
-  perspective: 400px;
-}
-
-.rotatable {
-  transform-style: preserve-3d;
-  transition: all 1000ms ease;
-  -webkit-transition: all 1000ms ease;
-  -moz-transition: all 1000ms ease;
-  -ms-transition: all 1000ms ease;
-  -o-transition: all 1000ms ease;
-}
-
-.hover-listener {
-  perspective: 400px;
-  width: 100%;
-  height: 100%;
 }

--- a/src/scenes/WelcomeAnimation/intro.css
+++ b/src/scenes/WelcomeAnimation/intro.css
@@ -2,3 +2,26 @@
   position: absolute;
   will-change: transform;
 }
+
+.hover-listener {
+  perspective: 400px;
+}
+
+.rotatable {
+  transform-style: preserve-3d;
+  transition: transform 600ms ease;
+  -webkit-transition: transform 600ms ease;
+  -moz-transition: transform 600ms ease;
+  -ms-transition: transform 600ms ease;
+  -o-transition: transform 600ms ease;
+}
+
+/* If the user is already hovering on the card, we want the transform to respond near-immediately 
+We don't want 0ms because this makes it look choppy when you first hover */
+.rotatable:hover {
+  transition: transform 100ms ease;
+  -webkit-transition: transform 100ms ease;
+  -moz-transition: transform 100ms ease;
+  -ms-transition: transform 100ms ease;
+  -o-transition: transform 100ms ease;
+}


### PR DESCRIPTION
## Image optimization

Images are preloaded on `/auth` now. For users who auth but do not yet have an account (and are sent to welcome page), this means that images are already loaded and jankiness is prevented. 

The videos below shows onboarding flows for users with "Good 3G" connection before and after preloading:

https://user-images.githubusercontent.com/13339581/149637045-479610c3-24e5-4bcf-aa22-c96221a05e3e.mov

https://user-images.githubusercontent.com/13339581/149637062-302e16d8-9461-4edb-b8e6-3cdbdea3cf6e.mov

The loading of each screen is slow regardless (~11 sec), but when preloading the images are fully loaded as soon as `/welcome` loads, and they do not blink/flicker in

**Note**: This does mean that we're loading images for any user who visits `/auth`, but I don't think this is an issue; the sum of all files is ~1200kb and I don't think (?) loading these images in `useEffect` blocks render

## Vertical screen optimization

Images now have different `x` and `y` positions on vertical screens (screens with a `width/height` aspect ratio of < 1).

Before and after: 

<div style="display: flex;">
<img width="49%" src="https://user-images.githubusercontent.com/13339581/149637237-020a8591-fce8-4bda-bad2-b93a606b8903.png"/>
<img width="49%" src="https://user-images.githubusercontent.com/13339581/149637240-2150f27d-89fd-4c42-80f8-2bbfa6a770ae.png" />
</div>

This is also true on super-tall screens/for users who have zoomed out their display:

<div style="display: flex;">
<img width="49%" src="https://user-images.githubusercontent.com/13339581/149637359-020fe2f3-b1f4-4344-8728-e90064baa5f4.png"/>
<img width="49%" src="https://user-images.githubusercontent.com/13339581/149637316-1c116e6a-78c1-490d-a3f6-3a6c1dee1804.png"/>
</div>

(Minor but related, we also removed scrollbars on welcome by adding `overflow: hidden`)

## Bonus interactivity

Tbh we can do with or without this change, but I added a lil rotation on hover effect to each individual image. (This meant creating an `<Image />` component for each etc)

It looks like this:

https://user-images.githubusercontent.com/13339581/149637468-e2194772-ea7e-4554-9063-d17cb1922572.mov

I will not be offended if we do not include this lol, was just playing around to learn React and now it exists. 

Feel free to review this a bit more critically because this is my first time ever using React