### PR TITLE
Fix broken 404s

### DIFF
--- a/src/scenes/UserGalleryPage/UserGalleryPageErrorBoundary.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryPageErrorBoundary.tsx
@@ -10,7 +10,10 @@ class UserGalleryPageErrorBoundary extends Component {
   state: { error: null | Error | ApiError } = { error: null };
 
   render() {
-    if (this.state.error instanceof ApiError && this.state.error.code === 404) {
+    if (
+      (this.state.error instanceof ApiError && this.state.error.code === 404) ||
+      this.state.error?.message.toLowerCase().includes('not found')
+    ) {
       return <NotFound />;
     }
 


### PR DESCRIPTION
We ran into a regression where 404 pages are now showing this:

![image](https://user-images.githubusercontent.com/12162433/150610439-13f4dc38-f6ac-49ed-a043-af8fe8d6da4f.png)

New:

![image](https://user-images.githubusercontent.com/12162433/150610455-13d934cd-7347-45e7-b2a0-a8c82905a344.png)
