### PR TITLE
Improve gallerylink markdown resiliency

### DIFF
--- a/src/components/core/GalleryLink/GalleryLink.tsx
+++ b/src/components/core/GalleryLink/GalleryLink.tsx
@@ -18,7 +18,7 @@ export default function GalleryLink({
   underlineOnHover = false,
 }: Props) {
   if (!to && !href) {
-    throw new Error('no link provided for GalleryLink');
+    console.error('no link provided for GalleryLink');
   }
 
   if (to) {

--- a/src/components/core/Markdown/Markdown.tsx
+++ b/src/components/core/Markdown/Markdown.tsx
@@ -9,10 +9,15 @@ export default function Markdown({ text }: Props) {
   return (
     <ReactMarkdown
       components={{
-        // TODO: come up with a sane default if NFT doesn't have an href provided
-        a: ({ href, children }) => (
-          <GalleryLink href={href ?? window.location.origin}>{children}</GalleryLink>
-        ),
+        a: ({ href, children }) =>
+          href ? (
+            <GalleryLink href={href}>{children}</GalleryLink>
+          ) : (
+            // if href is blank, we must render the empty string this way;
+            // simply rendering `children` causes the markdown library to crash
+            // eslint-disable-next-line react/jsx-no-useless-fragment
+            <>{children}</>
+          ),
       }}
     >
       {text}


### PR DESCRIPTION
rather than crashing, we now handle broken URLs.

the screenshot uses the following bio:
```
aaa
[]()
bbb
ccc
```

![image](https://user-images.githubusercontent.com/12162433/150611480-98a69886-d589-4ad4-aac8-e005d32f5179.png)
