### PR TITLE
Show 'More Info' button on assets that have external_url

### DIFF
--- a/src/scenes/NftDetailPage/NftAdditionalDetails.tsx
+++ b/src/scenes/NftDetailPage/NftAdditionalDetails.tsx
@@ -62,14 +62,21 @@ function NftAdditionalDetails({ nft }: Props) {
           <BodyRegular color={colors.gray50}>Token ID</BodyRegular>
           <BodyRegular>{hexHandler(nft.opensea_token_id)}</BodyRegular>
           <Spacer height={16} />
-          {hasContractAddress && (
-            <StyledLinkContainer>
-              <StyledLink href={getOpenseaExternalUrl(nft)} target="_blank" rel="noreferrer">
-                <ActionText color={colors.gray50}>View on OpenSea</ActionText>
+          <StyledLinkContainer>
+            {hasContractAddress && (
+              <>
+                <StyledLink href={getOpenseaExternalUrl(nft)} target="_blank" rel="noreferrer">
+                  <ActionText color={colors.gray50}>View on OpenSea</ActionText>
+                </StyledLink>
+                <Spacer width={16} />
+              </>
+            )}
+            {nft?.external_url !== '' && (
+              <StyledLink href={nft.external_url} target="_blank" rel="noreferrer">
+                <ActionText color={colors.gray50}>More Info</ActionText>
               </StyledLink>
-              <Spacer width={16} />
-            </StyledLinkContainer>
-          )}
+            )}
+          </StyledLinkContainer>
         </div>
       )}
     </StyledNftAdditionalDetails>


### PR DESCRIPTION
Looks like this ([example](https://gallery-n3d8zs5s1-gallery-so.vercel.app/connorr/23d4gAV1jK7EorGmfphDTTD7tuK/23sellWLGTpApQwMi7Vslgj3mqR)): 

<img width="224" alt="image" src="https://user-images.githubusercontent.com/13339581/150654590-6247a1b9-91be-4dda-93fc-09c2ef7ff9ea.png">
