### PR TITLE
Show tall assets on small screens/mobile devices

### DIFF
--- a/src/contexts/swr/useFetcher.ts
+++ b/src/contexts/swr/useFetcher.ts
@@ -4,7 +4,7 @@ import { JWT_LOCAL_STORAGE_KEY } from 'contexts/auth/constants';
 import RequestAction from 'hooks/api/_rest/RequestAction';
 import { ApiError } from 'errors/types';
 
-const baseurl = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000';
+const baseurl = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'https://api.gallery.so';
 
 const ERR_UNAUTHORIZED = 401;
 

--- a/src/contexts/swr/useFetcher.ts
+++ b/src/contexts/swr/useFetcher.ts
@@ -4,7 +4,7 @@ import { JWT_LOCAL_STORAGE_KEY } from 'contexts/auth/constants';
 import RequestAction from 'hooks/api/_rest/RequestAction';
 import { ApiError } from 'errors/types';
 
-const baseurl = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'https://api.gallery.so';
+const baseurl = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000';
 
 const ERR_UNAUTHORIZED = 401;
 

--- a/src/scenes/NftDetailPage/NftDetailAnimation.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAnimation.tsx
@@ -18,7 +18,6 @@ function NftDetailAnimation({ nft }: Props) {
 
 const StyledNftDetailAnimation = styled.div`
   width: 100%;
-  height: 100%;
 `;
 const StyledIframe = styled.iframe`
   width: 100%;

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -74,8 +74,13 @@ function NftDetailAsset({ nft }: Props) {
 
   const { aspectRatioType } = useContentState();
   const breakpoint = useBreakpoint();
+
+  // We do not want to enforce square aspect ratio for iframes https://github.com/gallery-so/gallery/pull/536
+  const isIframe = getMediaType(nft) === NftMediaType.ANIMATION;
   const shouldEnforceSquareAspectRatio =
-    breakpoint === size.desktop || breakpoint === size.tablet || aspectRatioType === 'square';
+    breakpoint === size.desktop ||
+    breakpoint === size.tablet ||
+    (aspectRatioType !== 'wide' && !isIframe);
 
   return (
     <StyledAssetContainer

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -75,7 +75,7 @@ function NftDetailAsset({ nft }: Props) {
   const { aspectRatioType } = useContentState();
   const breakpoint = useBreakpoint();
   const shouldEnforceSquareAspectRatio =
-    breakpoint === size.desktop || breakpoint === size.tablet || aspectRatioType !== 'wide';
+    breakpoint === size.desktop || breakpoint === size.tablet || aspectRatioType === 'square';
 
   return (
     <StyledAssetContainer


### PR DESCRIPTION
The issue here was `StyledNftDetailAnimation` containing iframes. Tall assets that are not iframes don't seem to have the same overlap issue ([example image](https://gallery.so/mikey/22euUUNhWUZuJoHkqU402V6p9Bj/22euRj0cL6PxPKjcu1pqihhHwRs), [example GIF](https://gallery.so/mikey/1zVE7ilCacNz0IL35AhlKbW0956/1zVDDGiS1plOeZtxC5rFzuT6Jc2)). 

In cases where the embedded asset was recorded as having an aspect ratio other than 'wide', we passed an `aspectRatio: 1` to the parent container (derived from [this code](https://github.com/gallery-so/gallery/blob/main/src/scenes/NftDetailPage/NftDetailAsset.tsx#L77)). 

This is problematic on small screens because the iframe height will always be `500px`; this is because `StyledIframe` has a `min-height` rule of 500px and a `height` rule of 100%. But because of the aspect ratio we apply to the parent container, **the container height will always be equal to the it's width** (e.g., basically the screen width).

Because of this, the iframe height will exceed its parent height anytime window width is less than 500px. (And therefore text will appear under it because it only cares about the parent container's size.)

![image](https://user-images.githubusercontent.com/13339581/150659410-e38644a1-7abf-4970-a376-29c4b7e69d6f.png)

The best way to make these assets show correctly on all screen sizes is to 1. remove the `height: 100%` rule on the parent container and 2. never set `shouldEnforceSquareAspectRatio` to true for iframes.

Before/after:

<div style="display: flex;">
<img src="https://user-images.githubusercontent.com/13339581/150658854-49f40e70-f807-48c2-8bbb-4b2d8e2ee32e.png" width="49%" />
<img src="https://user-images.githubusercontent.com/13339581/150658846-a10701c5-40de-4a77-8bf2-62f30a446ac3.png" width="49%" />
</div>

---

The `height: 100%` change also solves the issue of there being dead space on tablet-sized screens. Before/after:

<div style="display: flex;">
<img src="https://user-images.githubusercontent.com/13339581/150694481-d02c2a9c-bdbf-4a14-9565-26b3d95bffb0.png" width="49%" />
<img src="https://user-images.githubusercontent.com/13339581/150694464-62a03b58-1f4f-446c-9c88-535cb2583e68.png" width="49%" />
</div>

## Tldr

Applying `aspect-ratio: 1` to the parent container of an iframe—which will always have a height of 500px due to our CSS—will lead the iframe to exceed its parent height on screen sizes less than 500px. The solution is to remove aspect ratio declarations on iframes and to remove `height: 100%` on the parent container.