### PR TITLE
Convert hexadecimals for all token IDs

### DIFF
--- a/src/scenes/NftDetailPage/NftAdditionalDetails.tsx
+++ b/src/scenes/NftDetailPage/NftAdditionalDetails.tsx
@@ -11,10 +11,9 @@ type Props = {
   nft: Nft;
 };
 
-// If the address contains alphabetical characters, it is hexidecimal, and we convert it
+// The backend converts all token IDs to hexadecimals; here, we convert back
 // TODO: Fix parseInt() for long strings (> 21 characters?), when JS converts to scientific https://gallery.so/robin/21Qt76R6bIyM7fIDsBsgU9DrKCg/21R0nPXR1nlqXP9UD8hn7CQUsUP
-// TODO: This currently fails to convert token IDs that have hexes with 3 digits https://gallery.so/robin/20qynDqailFfmP5VlVHhB2AYrAN/20qyZkjvBh3fxYyY1zryrvKH4pC
-const hexHandler = (str: string) => (/[a-zA-Z]/.test(str) ? parseInt(str, 16) : str);
+const hexHandler = (str: string) => parseInt(str, 16);
 
 const getOpenseaExternalUrl = (nft: Nft) => {
   const contractAddress = nft.asset_contract.address;


### PR DESCRIPTION
This amends a previous change https://github.com/gallery-so/gallery/pull/531 where we converted all token IDs with alphabet from hexadecimal -> decimal.

This change removes the alphabetical check and converts **all token IDs** to decimal. Any token IDs that seem to be correct are actually artifacts of old data; once we update Opensea data for that asset/user, they will be properly converted to hexadecimal (and then back to decimal on the frontend).

This means that any bugs related to improper token IDs are not related to our code, but rather should be fixed through manually updating Opensea data for that user.