### PR TITLE
Add more detailed events for authentication flow to discern attempt, success, and error cases

### DIFF
--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
@@ -25,9 +25,6 @@ import Mixpanel from 'utils/mixpanel';
 import { addWallet, fetchNonce } from '../authRequestUtils';
 import { DEFAULT_WALLET_TYPE_ID, signMessageWithEOA } from '../walletUtils';
 
-// for mixpanel
-const CONNECTION_MODE = 'Add Wallet';
-
 type Props = {
   pendingWallet: AbstractConnector;
   userFriendlyWalletName: string;
@@ -74,7 +71,7 @@ function AddWalletPendingDefault({
       try {
         setIsConnecting(true);
         setPendingState(PROMPT_SIGNATURE);
-        Mixpanel.trackConnectWalletAttempt(userFriendlyWalletName, CONNECTION_MODE);
+        Mixpanel.trackAddWalletAttempt(userFriendlyWalletName);
         const { nonce, user_exists: userExists } = await fetchNonce(address, fetcher);
 
         if (userExists) {
@@ -89,14 +86,14 @@ function AddWalletPendingDefault({
         };
         const { signatureValid } = await addWallet(payload, fetcher);
 
-        Mixpanel.trackConnectWalletOutcomeSuccess(userFriendlyWalletName, CONNECTION_MODE);
+        Mixpanel.trackAddWalletSuccess(userFriendlyWalletName);
         openManageWalletsModal(address);
         setIsConnecting(false);
 
         return signatureValid;
       } catch (error: unknown) {
         setIsConnecting(false);
-        Mixpanel.trackConnectWalletOutcomeError(userFriendlyWalletName, CONNECTION_MODE, error);
+        Mixpanel.trackAddWalletError(userFriendlyWalletName, error);
         if (isWeb3Error(error)) {
           setDetectedError(error);
         }

--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
@@ -25,6 +25,9 @@ import Mixpanel from 'utils/mixpanel';
 import { addWallet, fetchNonce } from '../authRequestUtils';
 import { DEFAULT_WALLET_TYPE_ID, signMessageWithEOA } from '../walletUtils';
 
+// for mixpanel
+const CONNECTION_MODE = 'Add Wallet';
+
 type Props = {
   pendingWallet: AbstractConnector;
   userFriendlyWalletName: string;
@@ -71,6 +74,7 @@ function AddWalletPendingDefault({
       try {
         setIsConnecting(true);
         setPendingState(PROMPT_SIGNATURE);
+        Mixpanel.trackConnectWalletAttempt(userFriendlyWalletName, CONNECTION_MODE);
         const { nonce, user_exists: userExists } = await fetchNonce(address, fetcher);
 
         if (userExists) {
@@ -85,13 +89,14 @@ function AddWalletPendingDefault({
         };
         const { signatureValid } = await addWallet(payload, fetcher);
 
-        Mixpanel.trackConnectWallet(userFriendlyWalletName, 'Add Wallet');
+        Mixpanel.trackConnectWalletOutcomeSuccess(userFriendlyWalletName, CONNECTION_MODE);
         openManageWalletsModal(address);
         setIsConnecting(false);
 
         return signatureValid;
       } catch (error: unknown) {
         setIsConnecting(false);
+        Mixpanel.trackConnectWalletOutcomeError(userFriendlyWalletName, CONNECTION_MODE, error);
         if (isWeb3Error(error)) {
           setDetectedError(error);
         }

--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
@@ -30,9 +30,6 @@ import {
 import { getLocalStorageItem } from 'utils/localStorage';
 import { GNOSIS_NONCE_STORAGE_KEY } from 'constants/storageKeys';
 
-// for mixpanel
-const CONNECTION_MODE = 'Add Wallet';
-
 type Props = {
   pendingWallet: AbstractConnector;
   userFriendlyWalletName: string;
@@ -67,7 +64,7 @@ function AddWalletPendingGnosisSafe({
 
   const handleError = useCallback(
     (error: unknown) => {
-      Mixpanel.trackConnectWalletOutcomeError('Gnosis Safe', CONNECTION_MODE, error);
+      Mixpanel.trackAddWalletError('Gnosis Safe', error);
       if (isWeb3Error(error)) {
         setDetectedError(error);
       }
@@ -95,7 +92,7 @@ function AddWalletPendingGnosisSafe({
         throw new Error('Signature is not valid');
       }
 
-      Mixpanel.trackConnectWalletOutcomeSuccess('Gnosis Safe', CONNECTION_MODE);
+      Mixpanel.trackAddWalletSuccess('Gnosis Safe');
       openManageWalletsModal(address);
     },
     [fetcher, openManageWalletsModal]
@@ -111,7 +108,7 @@ function AddWalletPendingGnosisSafe({
         }
 
         setPendingState(PROMPT_SIGNATURE);
-        Mixpanel.trackConnectWalletAttempt('Gnosis Safe', CONNECTION_MODE);
+        Mixpanel.trackAddWalletAttempt('Gnosis Safe');
         await signMessageWithContractAccount(address, nonce, pendingWallet, library);
         window.localStorage.setItem(GNOSIS_NONCE_STORAGE_KEY, JSON.stringify(nonce));
 

--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
@@ -30,6 +30,9 @@ import {
 import { getLocalStorageItem } from 'utils/localStorage';
 import { GNOSIS_NONCE_STORAGE_KEY } from 'constants/storageKeys';
 
+// for mixpanel
+const CONNECTION_MODE = 'Add Wallet';
+
 type Props = {
   pendingWallet: AbstractConnector;
   userFriendlyWalletName: string;
@@ -64,6 +67,7 @@ function AddWalletPendingGnosisSafe({
 
   const handleError = useCallback(
     (error: unknown) => {
+      Mixpanel.trackConnectWalletOutcomeError('Gnosis Safe', CONNECTION_MODE, error);
       if (isWeb3Error(error)) {
         setDetectedError(error);
       }
@@ -91,10 +95,10 @@ function AddWalletPendingGnosisSafe({
         throw new Error('Signature is not valid');
       }
 
-      Mixpanel.trackConnectWallet(userFriendlyWalletName, 'Add Wallet');
+      Mixpanel.trackConnectWalletOutcomeSuccess('Gnosis Safe', CONNECTION_MODE);
       openManageWalletsModal(address);
     },
-    [fetcher, openManageWalletsModal, userFriendlyWalletName]
+    [fetcher, openManageWalletsModal]
   );
 
   // Initiates the full authentication flow including signing the message, listening for the signature, validating it. then calling the backend
@@ -107,6 +111,7 @@ function AddWalletPendingGnosisSafe({
         }
 
         setPendingState(PROMPT_SIGNATURE);
+        Mixpanel.trackConnectWalletAttempt('Gnosis Safe', CONNECTION_MODE);
         await signMessageWithContractAccount(address, nonce, pendingWallet, library);
         window.localStorage.setItem(GNOSIS_NONCE_STORAGE_KEY, JSON.stringify(nonce));
 

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingDefault.tsx
@@ -14,9 +14,6 @@ import Spacer from 'components/core/Spacer/Spacer';
 import { fetchNonce, loginOrCreateUser } from '../authRequestUtils';
 import { signMessageWithEOA } from '../walletUtils';
 
-// for mixpanel
-const CONNECTION_MODE = 'Sign In';
-
 type Props = {
   pendingWallet: AbstractConnector;
   userFriendlyWalletName: string;
@@ -49,7 +46,7 @@ function AuthenticateWalletPendingDefault({
   const attemptAuthentication = useCallback(
     async (address: string, signer: JsonRpcSigner) => {
       setPendingState(PROMPT_SIGNATURE);
-      Mixpanel.trackConnectWalletAttempt(userFriendlyWalletName, CONNECTION_MODE);
+      Mixpanel.trackSignInAttempt(userFriendlyWalletName);
 
       const { nonce, user_exists: userExists } = await fetchNonce(address, fetcher);
 
@@ -63,7 +60,7 @@ function AuthenticateWalletPendingDefault({
       };
 
       const { jwt, userId } = await loginOrCreateUser(userExists, payload, fetcher);
-      Mixpanel.trackConnectWalletOutcomeSuccess(userFriendlyWalletName, CONNECTION_MODE);
+      Mixpanel.trackSignInSuccess(userFriendlyWalletName);
       logIn({ jwt, userId }, address);
     },
     [fetcher, logIn, pendingWallet, userFriendlyWalletName]
@@ -75,7 +72,7 @@ function AuthenticateWalletPendingDefault({
         try {
           await attemptAuthentication(account.toLowerCase(), signer);
         } catch (error: unknown) {
-          Mixpanel.trackConnectWalletOutcomeError(userFriendlyWalletName, CONNECTION_MODE, error);
+          Mixpanel.trackSignInError(userFriendlyWalletName, error);
           if (isWeb3Error(error)) {
             setDetectedError(error);
           }

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
@@ -18,6 +18,9 @@ import {
 import { GNOSIS_NONCE_STORAGE_KEY } from 'constants/storageKeys';
 import { getLocalStorageItem } from 'utils/localStorage';
 
+// for mixpanel
+const CONNECTION_MODE = 'Sign In';
+
 type Props = {
   pendingWallet: AbstractConnector;
   userFriendlyWalletName: string;
@@ -51,14 +54,15 @@ function AuthenticateWalletPendingGnosisSafe({
       const { jwt, userId } = await loginOrCreateUser(userExists, payload, fetcher);
       window.localStorage.removeItem(GNOSIS_NONCE_STORAGE_KEY);
 
-      Mixpanel.trackConnectWallet(userFriendlyWalletName, 'Sign In');
+      Mixpanel.trackConnectWalletOutcomeSuccess('Gnosis Safe', CONNECTION_MODE);
       logIn({ jwt, userId }, address);
     },
-    [fetcher, logIn, userExists, userFriendlyWalletName]
+    [fetcher, logIn, userExists]
   );
 
   const handleError = useCallback(
     (error: unknown) => {
+      Mixpanel.trackConnectWalletOutcomeError('Gnosis Safe', CONNECTION_MODE, error);
       if (isWeb3Error(error)) {
         setDetectedError(error);
       }
@@ -140,6 +144,7 @@ function AuthenticateWalletPendingGnosisSafe({
       if (account) {
         setAuthenticationFlowStarted(true);
         try {
+          Mixpanel.trackConnectWalletAttempt('Gnosis Safe', 'Sign In');
           const { nonce, user_exists: userExists } = await fetchNonce(account, fetcher);
           setNonce(nonce);
           setUserExists(userExists);

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
@@ -18,9 +18,6 @@ import {
 import { GNOSIS_NONCE_STORAGE_KEY } from 'constants/storageKeys';
 import { getLocalStorageItem } from 'utils/localStorage';
 
-// for mixpanel
-const CONNECTION_MODE = 'Sign In';
-
 type Props = {
   pendingWallet: AbstractConnector;
   userFriendlyWalletName: string;
@@ -54,7 +51,7 @@ function AuthenticateWalletPendingGnosisSafe({
       const { jwt, userId } = await loginOrCreateUser(userExists, payload, fetcher);
       window.localStorage.removeItem(GNOSIS_NONCE_STORAGE_KEY);
 
-      Mixpanel.trackConnectWalletOutcomeSuccess('Gnosis Safe', CONNECTION_MODE);
+      Mixpanel.trackSignInSuccess('Gnosis Safe');
       logIn({ jwt, userId }, address);
     },
     [fetcher, logIn, userExists]
@@ -62,7 +59,7 @@ function AuthenticateWalletPendingGnosisSafe({
 
   const handleError = useCallback(
     (error: unknown) => {
-      Mixpanel.trackConnectWalletOutcomeError('Gnosis Safe', CONNECTION_MODE, error);
+      Mixpanel.trackSignInError('Gnosis Safe', error);
       if (isWeb3Error(error)) {
         setDetectedError(error);
       }
@@ -144,7 +141,7 @@ function AuthenticateWalletPendingGnosisSafe({
       if (account) {
         setAuthenticationFlowStarted(true);
         try {
-          Mixpanel.trackConnectWalletAttempt('Gnosis Safe', 'Sign In');
+          Mixpanel.trackSignInAttempt('Gnosis Safe');
           const { nonce, user_exists: userExists } = await fetchNonce(account, fetcher);
           setNonce(nonce);
           setUserExists(userExists);

--- a/src/types/Error.ts
+++ b/src/types/Error.ts
@@ -1,5 +1,5 @@
 export type ErrorCode = string;
-export type Web3Error = Error & { code: ErrorCode };
+export type Web3Error = Error & { code: ErrorCode; customMessage?: string };
 
 export function isWeb3Error(error: unknown): error is Web3Error {
   return typeof error === 'object' && error !== null && 'code' in error;

--- a/src/utils/mixpanel.ts
+++ b/src/utils/mixpanel.ts
@@ -1,4 +1,5 @@
 import mixpanel from 'mixpanel-browser';
+import { isWeb3Error } from 'types/Error';
 
 if (process.env.NEXT_PUBLIC_MIXPANEL_TOKEN && process.env.NEXT_PUBLIC_ANALYTICS_API_URL) {
   mixpanel.init(process.env.NEXT_PUBLIC_MIXPANEL_TOKEN, {
@@ -11,10 +12,20 @@ type EventProps = Record<string, unknown>;
 const mixpanelEnabled =
   process.env.NEXT_PUBLIC_MIXPANEL_TOKEN && process.env.NEXT_PUBLIC_ANALYTICS_API_URL;
 
+type ConnectWalletOutcomeDetails = {
+  success: boolean;
+  error?: string;
+};
+
 const Mixpanel = {
   track: (eventname: string, props: EventProps = {}) => {
     if (mixpanelEnabled) {
-      mixpanel.track(eventname, props);
+      // mixpanel errors shouldn't disrupt app
+      try {
+        mixpanel.track(eventname, props);
+      } catch (error: unknown) {
+        console.error(error);
+      }
     }
   },
 
@@ -22,6 +33,47 @@ const Mixpanel = {
     Mixpanel.track('Connect wallet', {
       wallet_provider: walletName,
       connection_mode: connectionMode,
+    });
+  },
+
+  trackConnectWalletAttempt: (walletName: string, connectionMode: string) => {
+    Mixpanel.track('Connect Wallet - Attempt', {
+      wallet_provider: walletName,
+      connection_mode: connectionMode,
+    });
+  },
+
+  trackConnectWalletOutcome: (
+    walletName: string,
+    connectionMode: string,
+    outcomeDetails: ConnectWalletOutcomeDetails
+  ) => {
+    Mixpanel.track(`Connect Wallet - ${outcomeDetails.success ? 'Success' : 'Error'}`, {
+      wallet_provider: walletName,
+      connection_mode: connectionMode,
+      ...outcomeDetails,
+    });
+  },
+
+  trackConnectWalletOutcomeSuccess: (walletName: string, connectionMode: string) => {
+    Mixpanel.trackConnectWalletOutcome(walletName, connectionMode, {
+      success: true,
+    });
+  },
+
+  trackConnectWalletOutcomeError: (walletName: string, connectionMode: string, error: unknown) => {
+    let errorMessage;
+    if (isWeb3Error(error)) {
+      errorMessage = `Web3 Error: ${error.customMessage}`;
+    } else if (error instanceof Error) {
+      errorMessage = error.message;
+    } else {
+      errorMessage = 'Unknown';
+    }
+
+    Mixpanel.trackConnectWalletOutcome(walletName, connectionMode, {
+      success: false,
+      error: errorMessage,
     });
   },
 };

--- a/src/utils/mixpanel.ts
+++ b/src/utils/mixpanel.ts
@@ -7,15 +7,27 @@ if (process.env.NEXT_PUBLIC_MIXPANEL_TOKEN && process.env.NEXT_PUBLIC_ANALYTICS_
   });
 }
 
-type EventProps = Record<string, unknown>;
-
 const mixpanelEnabled =
   process.env.NEXT_PUBLIC_MIXPANEL_TOKEN && process.env.NEXT_PUBLIC_ANALYTICS_API_URL;
 
-type ConnectWalletOutcomeDetails = {
-  success: boolean;
-  error?: string;
-};
+// CONSTS
+const AUTH_MODE_SIGN_IN = 'Sign In';
+const AUTH_MODE_ADD_WALLET = 'Add Wallet';
+
+// Types
+type EventProps = Record<string, unknown>;
+
+function getAuthErrorMessage(error: unknown) {
+  if (isWeb3Error(error)) {
+    return `Web3 Error: ${error.customMessage}`;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Unknown';
+}
 
 const Mixpanel = {
   track: (eventname: string, props: EventProps = {}) => {
@@ -29,52 +41,51 @@ const Mixpanel = {
     }
   },
 
-  trackConnectWallet: (walletName: string, connectionMode: string) => {
-    Mixpanel.track('Connect wallet', {
-      wallet_provider: walletName,
-      connection_mode: connectionMode,
-    });
-  },
-
-  trackConnectWalletAttempt: (walletName: string, connectionMode: string) => {
-    Mixpanel.track('Connect Wallet - Attempt', {
-      wallet_provider: walletName,
-      connection_mode: connectionMode,
-    });
-  },
-
-  trackConnectWalletOutcome: (
+  trackAuthEvent: (
+    eventName: string,
     walletName: string,
     connectionMode: string,
-    outcomeDetails: ConnectWalletOutcomeDetails
+    errorMessage?: string
   ) => {
-    Mixpanel.track(`Connect Wallet - ${outcomeDetails.success ? 'Success' : 'Error'}`, {
+    Mixpanel.track(eventName, {
       wallet_provider: walletName,
       connection_mode: connectionMode,
-      ...outcomeDetails,
+      ...(errorMessage && { error: errorMessage }),
     });
   },
 
-  trackConnectWalletOutcomeSuccess: (walletName: string, connectionMode: string) => {
-    Mixpanel.trackConnectWalletOutcome(walletName, connectionMode, {
-      success: true,
-    });
+  trackSignInAttempt: (walletName: string) => {
+    Mixpanel.trackAuthEvent('Sign In - Attempt', walletName, AUTH_MODE_SIGN_IN);
   },
 
-  trackConnectWalletOutcomeError: (walletName: string, connectionMode: string, error: unknown) => {
-    let errorMessage;
-    if (isWeb3Error(error)) {
-      errorMessage = `Web3 Error: ${error.customMessage}`;
-    } else if (error instanceof Error) {
-      errorMessage = error.message;
-    } else {
-      errorMessage = 'Unknown';
-    }
+  trackSignInSuccess: (walletName: string) => {
+    Mixpanel.trackAuthEvent('Sign In - Success', walletName, AUTH_MODE_SIGN_IN);
+  },
 
-    Mixpanel.trackConnectWalletOutcome(walletName, connectionMode, {
-      success: false,
-      error: errorMessage,
-    });
+  trackSignInError: (walletName: string, error: unknown) => {
+    Mixpanel.trackAuthEvent(
+      'Sign In - Error',
+      walletName,
+      AUTH_MODE_SIGN_IN,
+      getAuthErrorMessage(error)
+    );
+  },
+
+  trackAddWalletAttempt: (walletName: string) => {
+    Mixpanel.trackAuthEvent('Add Wallet - Attempt', walletName, AUTH_MODE_ADD_WALLET);
+  },
+
+  trackAddWalletSuccess: (walletName: string) => {
+    Mixpanel.trackAuthEvent('Add Wallet - Success', walletName, AUTH_MODE_ADD_WALLET);
+  },
+
+  trackAddWalletError: (walletName: string, error: unknown) => {
+    Mixpanel.trackAuthEvent(
+      'Add Wallet - Error',
+      walletName,
+      AUTH_MODE_ADD_WALLET,
+      getAuthErrorMessage(error)
+    );
   },
 };
 


### PR DESCRIPTION
We currently only track one event during the whole auth flow - when it's successful. 
This alone isn't very useful for us to measure how the flow is performing.

This PR introduces more detailed events:
`trackSignInAttempt`
`trackSignInSuccess`
`trackSignInError`
and equivalent for `AddWallet`


these get recorded for Logging In and Multi Wallet for both EOA and Contract Accounts. 
no PII such as address is recorded.