### PR TITLE
Disable SSR on members page

### DIFF
--- a/pages/members.tsx
+++ b/pages/members.tsx
@@ -1,13 +1,8 @@
-import GalleryRoute from 'scenes/_Router/GalleryRoute';
-import MemberListPage from 'scenes/MemberListPage/MemberListPage';
-import { fetchQuery, graphql } from 'relay-runtime';
-import { useLazyLoadQuery } from 'react-relay';
-import { membersQuery } from '../__generated__/membersQuery.graphql';
-import { GetServerSideProps } from 'next';
-import {
-  createServerSideRelayEnvironment,
-  serializeRelayEnvironment,
-} from 'contexts/relay/RelayProvider';
+import GalleryRoute from "scenes/_Router/GalleryRoute";
+import MemberListPage from "scenes/MemberListPage/MemberListPage";
+import { graphql } from "relay-runtime";
+import { useLazyLoadQuery } from "react-relay";
+import { membersQuery } from "../__generated__/membersQuery.graphql";
 
 const pageQuery = graphql`
   query membersQuery {
@@ -26,15 +21,3 @@ export default function Members() {
     />
   );
 }
-
-export const getServerSideProps: GetServerSideProps = async () => {
-  const relayEnvironment = createServerSideRelayEnvironment();
-
-  await fetchQuery<membersQuery>(relayEnvironment, pageQuery, {}).toPromise();
-
-  return {
-    props: {
-      __relayCache: serializeRelayEnvironment(relayEnvironment),
-    },
-  };
-};


### PR DESCRIPTION
Sounds like we had consensus that the SSR version of the members page felt slow. We can profile this stuff later to see what we can do to make it faster, but for now let's just turn it off.