### PR TITLE
set z-index on dropdown

### DIFF
--- a/src/components/core/Dropdown/Dropdown.tsx
+++ b/src/components/core/Dropdown/Dropdown.tsx
@@ -104,6 +104,8 @@ const StyledDropdownBox = styled.div<StyledDropdownProps>`
   position: absolute;
   right: 0;
 
+  z-index: 1;
+
   padding: 12px;
   border: 1px solid ${colors.gray50};
   width: auto;


### PR DESCRIPTION
The mobile toggle was appearing over the dropdown. This PR fixes it by setting a z-index on the dropdown.

before:
![Screen Shot 2022-01-31 at 19 06 42](https://user-images.githubusercontent.com/80802871/151774524-9dcda06c-dfc7-482b-ba66-f2dbc0a3338b.png)


after:
![Screen Shot 2022-01-31 at 19 06 10](https://user-images.githubusercontent.com/80802871/151774606-bd08ea6f-e626-408f-a9cc-8f0d9af052b5.png)

