### PR TITLE
refactor gallery to use display:grid instead of flex

### DIFF
--- a/src/components/NftGallery/NftGallery.tsx
+++ b/src/components/NftGallery/NftGallery.tsx
@@ -30,7 +30,6 @@ function NftGallery({ collection, mobileLayout }: Props) {
   );
 }
 
-// grid-template-columns: repeat(${({ columns }) => columns}, minmax(auto, 50%));
 const StyledCollectionNfts = styled.div<{ columns: number; mobileLayout: DisplayLayout }>`
   display: grid;
   grid-template-columns: ${({ columns, mobileLayout }) =>

--- a/src/components/NftGallery/NftGallery.tsx
+++ b/src/components/NftGallery/NftGallery.tsx
@@ -1,4 +1,4 @@
-import { DEFAULT_COLUMNS, LAYOUT_GAP_BREAKPOINTS } from 'constants/layout';
+import { DEFAULT_COLUMNS } from 'constants/layout';
 import breakpoints from 'components/core/breakpoints';
 import { DisplayLayout } from 'components/core/enums';
 import NftPreview from 'components/NftPreview/NftPreview';
@@ -24,36 +24,23 @@ function NftGallery({ collection, mobileLayout }: Props) {
   return (
     <StyledCollectionNfts columns={columns} mobileLayout={mobileLayout}>
       {collection.nfts.map((nft) => (
-        <NftPreview
-          key={nft.id}
-          nft={nft}
-          collectionId={collection.id}
-          columns={columns}
-          mobileLayout={mobileLayout}
-        />
+        <NftPreview key={nft.id} nft={nft} collectionId={collection.id} columns={columns} />
       ))}
     </StyledCollectionNfts>
   );
 }
 
+// grid-template-columns: repeat(${({ columns }) => columns}, minmax(auto, 50%));
 const StyledCollectionNfts = styled.div<{ columns: number; mobileLayout: DisplayLayout }>`
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: ${({ columns, mobileLayout }) =>
+    mobileLayout === DisplayLayout.LIST ? '1fr' : `repeat(${columns},  minmax(auto, 50%))`};
+  grid-gap: 20px 20px;
   align-items: center;
-  justify-content: ${({ columns }) => (columns === 1 ? 'center' : 'initial')};
+  justify-content: center;
 
-  // Can't use these for now due to lack of Safari support
-  // column-gap: px;
-  // row-gap: px;
-  margin-left: ${({ mobileLayout }) =>
-    mobileLayout === DisplayLayout.GRID ? `-${LAYOUT_GAP_BREAKPOINTS.mobileSmall / 2}px` : '0px'};
-
-  @media only screen and ${breakpoints.mobileLarge} {
-    margin-left: -${LAYOUT_GAP_BREAKPOINTS.mobileLarge / 2}px;
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    margin-left: -${LAYOUT_GAP_BREAKPOINTS.desktop / 2}px;
+  @media only screen and ${breakpoints.tablet} {
+    grid-gap: 40px 40px;
   }
 `;
 

--- a/src/components/NftGallery/NftGallery.tsx
+++ b/src/components/NftGallery/NftGallery.tsx
@@ -35,11 +35,15 @@ const StyledCollectionNfts = styled.div<{ columns: number; mobileLayout: Display
   display: grid;
   grid-template-columns: ${({ columns, mobileLayout }) =>
     mobileLayout === DisplayLayout.LIST ? '1fr' : `repeat(${columns},  minmax(auto, 50%))`};
-  grid-gap: 20px 20px;
+  grid-gap: 10px 10px;
   align-items: center;
   justify-content: center;
 
   @media only screen and ${breakpoints.tablet} {
+    grid-gap: 20px 20px;
+  }
+
+  @media only screen and ${breakpoints.desktop} {
     grid-gap: 40px 40px;
   }
 `;

--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -1,6 +1,5 @@
-import { LAYOUT_GAP_BREAKPOINTS } from 'constants/layout';
 import styled from 'styled-components';
-import breakpoints, { size } from 'components/core/breakpoints';
+import { size } from 'components/core/breakpoints';
 import Gradient from 'components/core/Gradient/Gradient';
 import transitions from 'components/core/transitions';
 import { useCallback, useMemo } from 'react';
@@ -10,13 +9,11 @@ import { useNavigateToUrl } from 'utils/navigate';
 import { useBreakpoint } from 'hooks/useWindowSize';
 import NftPreviewLabel from './NftPreviewLabel';
 import NftPreviewAsset from './NftPreviewAsset';
-import { DisplayLayout } from 'components/core/enums';
 
 type Props = {
   nft: Nft;
   collectionId: string;
   columns: number;
-  mobileLayout: DisplayLayout;
 };
 
 const SINGLE_COLUMN_NFT_WIDTH = 600;
@@ -31,7 +28,7 @@ const LAYOUT_DIMENSIONS: Record<number, number> = {
   6: 134,
 };
 
-function NftPreview({ nft, collectionId, columns, mobileLayout }: Props) {
+function NftPreview({ nft, collectionId, columns }: Props) {
   const navigateToUrl = useNavigateToUrl();
 
   const username = window.location.pathname.split('/')[1];
@@ -44,7 +41,7 @@ function NftPreview({ nft, collectionId, columns, mobileLayout }: Props) {
       if (storage) storage.setItem('prevPage', window.location.pathname);
       navigateToUrl(`/${username}/${collectionId}/${nft.id}`, event);
     },
-    [collectionId, navigateToUrl, nft.id, username]
+    [collectionId, navigateToUrl, nft.id, storage, username]
   );
   const screenWidth = useBreakpoint();
 
@@ -54,16 +51,8 @@ function NftPreview({ nft, collectionId, columns, mobileLayout }: Props) {
     [columns, screenWidth]
   );
 
-  const NftPreviewComponent = useMemo(() => {
-    if (screenWidth === size.mobile && mobileLayout === DisplayLayout.LIST) {
-      return StyledNftPreviewList;
-    }
-
-    return StyledNftPreviewGrid;
-  }, [mobileLayout, screenWidth]);
-
   return (
-    <NftPreviewComponent key={nft.id} columns={columns}>
+    <StyledNftPreview key={nft.id} columns={columns}>
       <StyledLinkWrapper onClick={handleNftClick}>
         <ShimmerProvider>
           {/* // we'll request images at double the size of the element so that it looks sharp on retina */}
@@ -74,7 +63,7 @@ function NftPreview({ nft, collectionId, columns, mobileLayout }: Props) {
           </StyledNftFooter>
         </ShimmerProvider>
       </StyledLinkWrapper>
-    </NftPreviewComponent>
+    </StyledNftPreview>
   );
 }
 
@@ -119,39 +108,6 @@ const StyledNftPreview = styled.div<{ columns: number }>`
   &:hover ${StyledNftFooter} {
     opacity: 1;
   }
-
-  margin-bottom: 40px;
-`;
-
-const StyledNftPreviewGrid = styled(StyledNftPreview)`
-  // width looks complex but it allows us to conditionally apply different width rules based on the # of columns in the collection:
-  // - if single columm, use hardcoded width because the NFT isnt as wide as the whole page (unless on mobile, in which case we use the mobile width)
-  // - if more columns, use calc to automatically set width based on column #
-  // this is important because while we *could* use hardcoded widths for desktop, we need to use dynamic widths for tablet
-
-  width: ${({ columns }) =>
-    `calc((100% - ${LAYOUT_GAP_BREAKPOINTS.mobileSmall * columns}px) / ${columns});`}
-  margin: ${LAYOUT_GAP_BREAKPOINTS.mobileSmall / 2}px;
-
-  @media only screen and ${breakpoints.mobileLarge} {
-    width: ${({ columns }) =>
-      columns === 1
-        ? `${SINGLE_COLUMN_NFT_WIDTH}px;`
-        : `calc((100% - ${LAYOUT_GAP_BREAKPOINTS.mobileLarge * columns}px) / ${columns});`}
-    margin: ${LAYOUT_GAP_BREAKPOINTS.mobileLarge / 2}px;
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    width: ${({ columns }) =>
-      columns === 1
-        ? `${SINGLE_COLUMN_NFT_WIDTH}px;`
-        : `calc((100% - ${LAYOUT_GAP_BREAKPOINTS.desktop * columns}px) / ${columns});`}
-    margin: ${LAYOUT_GAP_BREAKPOINTS.desktop / 2}px;
-  }
-`;
-
-const StyledNftPreviewList = styled(StyledNftPreview)`
-  width: 100%;
 `;
 
 export default NftPreview;

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,9 +1,3 @@
 export const DEFAULT_COLUMNS = 3;
 export const MIN_COLUMNS = 1;
 export const MAX_COLUMNS = 6;
-
-export const LAYOUT_GAP_BREAKPOINTS: Record<string, number> = {
-  mobileSmall: 10,
-  mobileLarge: 20,
-  desktop: 40,
-};


### PR DESCRIPTION
This is a refactor PR to change our Gallery layout to use display: grid instead of display: flex.

This allows column widths to be automatically calculated while preserving the desired behavior of evenly spacing the nfts on rows that are complete(using space-between) while left-aligning rows that are incomplete.
Being able to use space-between to automatically space nfts apart means we don't have to use margin, which means we don't have to then use negative margin to re-align the row with the parent container.


This also fixes an issue where the right side of the collection wasn't flush with the parent container.

before:
<img width="1105" alt="Screen Shot 2022-02-01 at 22 38 06" src="https://user-images.githubusercontent.com/80802871/151978440-e8f404b5-3a1e-4942-8091-e2f6f263adbc.png">

after:
<img width="1110" alt="Screen Shot 2022-02-01 at 22 37 48" src="https://user-images.githubusercontent.com/80802871/151978457-21e57122-f969-4dfe-a51b-e3b733b8b64e.png">



Confirmed the following:
- works on Brave (chrome) , Safari, Firefox
- works for 1-6 column collections (1 column layouts are displayed at 50% width)
- works on Gallery and Single Collection Page
