### PR TITLE
Add EnsOrAddress component

### DIFF
--- a/src/components/EnsOrAddress.tsx
+++ b/src/components/EnsOrAddress.tsx
@@ -1,0 +1,20 @@
+import useSWR from 'swr';
+
+const fetcher = async (...args: Parameters<typeof fetch>) =>
+  fetch(...args).then(async (res) => res.json());
+
+type Props = {
+  address: string;
+};
+
+export const EnsOrAddress = ({ address }: Props) => {
+  const { data } = useSWR(
+    `https://api.ensideas.com/ens/resolve/${encodeURIComponent(address)}`,
+    fetcher
+  );
+  if (data) {
+    return <span title={data.address}>{data.name || data.address}</span>;
+  }
+
+  return <span title={address}>{address}</span>;
+};

--- a/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -10,6 +10,7 @@ import { useMemo } from 'react';
 import NftAdditionalDetails from './NftAdditionalDetails';
 import { fullPageHeightWithoutNavbarAndFooter } from 'components/core/Page/constants';
 import { useBreakpoint } from 'hooks/useWindowSize';
+import { EnsOrAddress } from 'components/EnsOrAddress';
 
 type Props = {
   nft: Nft;
@@ -38,7 +39,9 @@ function NftDetailText({ nft }: Props) {
       <NftOwnerLink owner={currentOwner} ownerAddress={nft.owner_address} />
       <Spacer height={16} />
       <BodyRegular color={colors.gray50}>Created By</BodyRegular>
-      <BodyRegular>{nft.creator_name || nft.creator_address}</BodyRegular>
+      <BodyRegular>
+        {nft.creator_name || <EnsOrAddress address={nft.creator_address} />}
+      </BodyRegular>
       <Spacer height={32} />
       <NftAdditionalDetails nft={nft} />
     </StyledDetailLabel>
@@ -64,7 +67,9 @@ function NftOwnerLink({ owner, ownerAddress }: NftOwnerProps) {
 
   return (
     <StyledLink href={`https://etherscan.io/address/${address}`} target="_blank" rel="noreferrer">
-      <BodyRegular>{address}</BodyRegular>
+      <BodyRegular>
+        <EnsOrAddress address={address} />
+      </BodyRegular>
     </StyledLink>
   );
 }


### PR DESCRIPTION
This quickly translates an address to an ENS name (where available) using [a highly cached API I built](https://ensideas.com/about).

The results look like this:
![image](https://user-images.githubusercontent.com/508855/152112448-bf5b7e43-c442-4dfe-832d-7d912ae5c255.png)

This could be optionally coupled with some lightweight frontend caching that stores the last ~day of queries in localStorage, but not strictly necessary - Cloudflare edge cache is very fast (~50ms for me).

I only swapped out the address for one page/component, but happy to do more if you like this approach!