### PR TITLE
Handle obscenely large images

### DIFF
--- a/src/contexts/swr/SwrContext.tsx
+++ b/src/contexts/swr/SwrContext.tsx
@@ -4,6 +4,7 @@ import { MINUTE, SECOND } from 'utils/time';
 import useFetcher from './useFetcher';
 import Mixpanel from 'utils/mixpanel';
 import ensureLatestGallery from './middleware/ensureLatestGallery';
+import handleObscenelyLargeAssets from './middleware/handleObscenelyLargeAssets';
 
 function localStorageProvider() {
   // When initializing, we restore the data from `localStorage` into a map.
@@ -18,7 +19,9 @@ function localStorageProvider() {
     const arrayMap = Array.from(map.entries()) as Array<[string, any]>;
     // ignore inflight requests (labeled with $req$) and errors (labeled with $err$) in the cache.
     // in fact, aggressively caching an error response can result in pain!
-    const saneArrayMap = arrayMap.filter((arr) => !(arr[0].includes('$req$') || arr[0].includes('$err$')))
+    const saneArrayMap = arrayMap.filter(
+      (arr) => !(arr[0].includes('$req$') || arr[0].includes('$err$'))
+    );
     const appCache = JSON.stringify(saneArrayMap);
     localStorage.setItem('app-cache', appCache);
   });
@@ -27,7 +30,7 @@ function localStorageProvider() {
   return map;
 }
 
-const middleware = [ensureLatestGallery];
+const middleware = [ensureLatestGallery, handleObscenelyLargeAssets];
 
 export const SwrProvider = memo(({ children }) => {
   const fetcher = useFetcher();

--- a/src/contexts/swr/middleware/ensureLatestGallery.ts
+++ b/src/contexts/swr/middleware/ensureLatestGallery.ts
@@ -18,7 +18,7 @@ const ensureLatestGallery: Middleware = (useSWRNext) => (key: Key, fetcher, conf
 
   const currentTimestamp = getTimeFromISOString(
     // @ts-expect-error this route will always return `GetGalleriesResponse` type
-    swr.data.galleries.length > 0 ? swr.data.galleries[0].last_updated : 0
+    swr.data.galleries?.length > 0 ? swr.data.galleries[0].last_updated : 0
   );
 
   const previousTimestamp = getTimeFromISOString(

--- a/src/contexts/swr/middleware/handleObscenelyLargeAssets.ts
+++ b/src/contexts/swr/middleware/handleObscenelyLargeAssets.ts
@@ -1,0 +1,130 @@
+import { GetCollectionResponse } from 'hooks/api/collections/types';
+import { getCollectionByIdAction } from 'hooks/api/collections/useCollectionById';
+import { GetGalleriesResponse } from 'hooks/api/galleries/types';
+import { getGalleriesAction } from 'hooks/api/galleries/useGalleries';
+import { getAllNftsAction, GetAllNFtsResponse } from 'hooks/api/nfts/useAllNfts';
+import { getMembersListAction } from 'hooks/api/users/useMemberList';
+import { Key, Middleware } from 'swr';
+
+const OBSCENELY_LARGE_ASSET_URLS: Record<string, string> = {
+  'https://storage.opensea.io/files/33ab86c2a565430af5e7fb8399876960.png':
+    'https://lh3.googleusercontent.com/pw/AM-JKLVsudnwN97ULF-DgJC1J_AZ8i-1pMjLCVUqswF1_WShId30uP_p_jSRkmVx-XNgKNIGFSglgRojZQrsLOoCM2pVNJwgx5_E4yeYRsMvDQALFKbJk0_6wj64tjLhSIINwGpdNw0MhtWNehKCipDKNeE',
+};
+
+// @ts-expect-error: TODO this is erroring because of `data` type returned by this func
+const handleObscenelyLargeAssets: Middleware = (useSWRNext) => (key: Key, fetcher, config) => {
+  const swr = useSWRNext(key, fetcher, config);
+
+  // gallery requests are identified through a tuple of [endpoint, action_type]
+  if (!Array.isArray(key) || !swr.data) {
+    return swr;
+  }
+
+  const swrAction = key[1];
+  const { data } = swr;
+
+  // help load gallery
+  if (swrAction === getGalleriesAction) {
+    const galleryData = data as unknown as GetGalleriesResponse;
+
+    const meticulouslyConvertedGalleryData = galleryData.galleries?.map((gallery) => {
+      gallery.collections = gallery.collections.map((collection) => {
+        collection.nfts = collection.nfts.map((nft) => {
+          if (nft.image_url in OBSCENELY_LARGE_ASSET_URLS) {
+            nft.image_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_url];
+          }
+
+          if (nft.image_preview_url in OBSCENELY_LARGE_ASSET_URLS) {
+            nft.image_preview_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_preview_url];
+          }
+
+          if (nft.image_thumbnail_url in OBSCENELY_LARGE_ASSET_URLS) {
+            nft.image_thumbnail_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_thumbnail_url];
+          }
+
+          return nft;
+        });
+
+        return collection;
+      });
+
+      return gallery;
+    });
+
+    return {
+      ...swr,
+      data: {
+        ...galleryData,
+        galleries: meticulouslyConvertedGalleryData,
+      },
+    };
+  }
+
+  // help load collection detail
+  if (swrAction === getCollectionByIdAction) {
+    const collectionData = data as unknown as GetCollectionResponse;
+
+    const meticulouslyConvertedCollectionNfts = collectionData.collection.nfts.map((nft) => {
+      if (nft.image_url in OBSCENELY_LARGE_ASSET_URLS) {
+        nft.image_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_url];
+      }
+
+      if (nft.image_preview_url in OBSCENELY_LARGE_ASSET_URLS) {
+        nft.image_preview_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_preview_url];
+      }
+
+      if (nft.image_thumbnail_url in OBSCENELY_LARGE_ASSET_URLS) {
+        nft.image_thumbnail_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_thumbnail_url];
+      }
+
+      return nft;
+    });
+
+    return {
+      ...swr,
+      data: {
+        collection: {
+          ...collectionData.collection,
+          nfts: meticulouslyConvertedCollectionNfts,
+        },
+      },
+    };
+  }
+
+  // help load editor sidebar
+  if (swrAction === getAllNftsAction) {
+    const nftResponseData = data as unknown as GetAllNFtsResponse;
+
+    const meticulouslyConvertedNftData = nftResponseData.nfts.map((nft) => {
+      if (nft.image_url in OBSCENELY_LARGE_ASSET_URLS) {
+        nft.image_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_url];
+      }
+
+      if (nft.image_preview_url in OBSCENELY_LARGE_ASSET_URLS) {
+        nft.image_preview_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_preview_url];
+      }
+
+      if (nft.image_thumbnail_url in OBSCENELY_LARGE_ASSET_URLS) {
+        nft.image_thumbnail_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_thumbnail_url];
+      }
+
+      return nft;
+    });
+
+    return {
+      ...swr,
+      data: {
+        nfts: meticulouslyConvertedNftData,
+      },
+    };
+  }
+
+  // help load members list
+  if (swrAction === getMembersListAction) {
+    return swr;
+  }
+
+  return swr;
+};
+
+export default handleObscenelyLargeAssets;

--- a/src/contexts/swr/middleware/handleObscenelyLargeAssets.ts
+++ b/src/contexts/swr/middleware/handleObscenelyLargeAssets.ts
@@ -1,9 +1,10 @@
+/* eslint-disable max-depth */
 import { GetCollectionResponse } from 'hooks/api/collections/types';
 import { getCollectionByIdAction } from 'hooks/api/collections/useCollectionById';
 import { GetGalleriesResponse } from 'hooks/api/galleries/types';
 import { getGalleriesAction } from 'hooks/api/galleries/useGalleries';
 import { getAllNftsAction, GetAllNFtsResponse } from 'hooks/api/nfts/useAllNfts';
-import { getMembersListAction } from 'hooks/api/users/useMemberList';
+import cloneDeep from 'lodash.clonedeep';
 import { Key, Middleware } from 'swr';
 
 const OBSCENELY_LARGE_ASSET_URLS: Record<string, string> = {
@@ -25,46 +26,64 @@ const handleObscenelyLargeAssets: Middleware = (useSWRNext) => (key: Key, fetche
 
   // help load gallery
   if (swrAction === getGalleriesAction) {
-    const galleryData = data as unknown as GetGalleriesResponse;
+    let galleryData = data as unknown as GetGalleriesResponse;
 
-    const meticulouslyConvertedGalleryData = galleryData.galleries?.map((gallery) => {
-      gallery.collections = gallery.collections.map((collection) => {
-        collection.nfts = collection.nfts.map((nft) => {
-          if (nft.image_url in OBSCENELY_LARGE_ASSET_URLS) {
-            nft.image_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_url];
+    // first detect offender before doing expensive deep clone
+    let foundObscenelyLargeImage = false;
+
+    for (const gallery of galleryData.galleries) {
+      for (const collection of gallery.collections) {
+        for (const nft of collection.nfts) {
+          if (
+            nft.image_url in OBSCENELY_LARGE_ASSET_URLS ||
+            nft.image_preview_url in OBSCENELY_LARGE_ASSET_URLS ||
+            nft.image_thumbnail_url in OBSCENELY_LARGE_ASSET_URLS
+          ) {
+            foundObscenelyLargeImage = true;
           }
+        }
+      }
+    }
 
-          if (nft.image_preview_url in OBSCENELY_LARGE_ASSET_URLS) {
-            nft.image_preview_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_preview_url];
-          }
+    if (foundObscenelyLargeImage) {
+      galleryData = cloneDeep(galleryData);
+      galleryData.galleries = galleryData.galleries?.map((gallery) => {
+        gallery.collections = gallery.collections.map((collection) => {
+          collection.nfts = collection.nfts.map((nft) => {
+            if (nft.image_url in OBSCENELY_LARGE_ASSET_URLS) {
+              nft.image_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_url];
+            }
 
-          if (nft.image_thumbnail_url in OBSCENELY_LARGE_ASSET_URLS) {
-            nft.image_thumbnail_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_thumbnail_url];
-          }
+            if (nft.image_preview_url in OBSCENELY_LARGE_ASSET_URLS) {
+              nft.image_preview_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_preview_url];
+            }
 
-          return nft;
+            if (nft.image_thumbnail_url in OBSCENELY_LARGE_ASSET_URLS) {
+              nft.image_thumbnail_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_thumbnail_url];
+            }
+
+            return nft;
+          });
+
+          return collection;
         });
 
-        return collection;
+        return gallery;
       });
-
-      return gallery;
-    });
+    }
 
     return {
       ...swr,
-      data: {
-        ...galleryData,
-        galleries: meticulouslyConvertedGalleryData,
-      },
+      data: galleryData,
     };
   }
 
   // help load collection detail
   if (swrAction === getCollectionByIdAction) {
-    const collectionData = data as unknown as GetCollectionResponse;
+    // single collections are small and chill to clone
+    const collectionData = cloneDeep(data) as unknown as GetCollectionResponse;
 
-    const meticulouslyConvertedCollectionNfts = collectionData.collection.nfts.map((nft) => {
+    collectionData.collection.nfts = collectionData.collection.nfts.map((nft) => {
       if (nft.image_url in OBSCENELY_LARGE_ASSET_URLS) {
         nft.image_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_url];
       }
@@ -82,46 +101,50 @@ const handleObscenelyLargeAssets: Middleware = (useSWRNext) => (key: Key, fetche
 
     return {
       ...swr,
-      data: {
-        collection: {
-          ...collectionData.collection,
-          nfts: meticulouslyConvertedCollectionNfts,
-        },
-      },
+      data: collectionData,
     };
   }
 
   // help load editor sidebar
   if (swrAction === getAllNftsAction) {
-    const nftResponseData = data as unknown as GetAllNFtsResponse;
+    let nftResponseData = data as unknown as GetAllNFtsResponse;
 
-    const meticulouslyConvertedNftData = nftResponseData.nfts.map((nft) => {
-      if (nft.image_url in OBSCENELY_LARGE_ASSET_URLS) {
-        nft.image_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_url];
+    // first detect offender before doing expensive deep clone
+    let foundObscenelyLargeImage = false;
+
+    for (const nft of nftResponseData.nfts) {
+      if (
+        nft.image_url in OBSCENELY_LARGE_ASSET_URLS ||
+        nft.image_preview_url in OBSCENELY_LARGE_ASSET_URLS ||
+        nft.image_thumbnail_url in OBSCENELY_LARGE_ASSET_URLS
+      ) {
+        foundObscenelyLargeImage = true;
       }
+    }
 
-      if (nft.image_preview_url in OBSCENELY_LARGE_ASSET_URLS) {
-        nft.image_preview_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_preview_url];
-      }
+    if (foundObscenelyLargeImage) {
+      nftResponseData = cloneDeep(nftResponseData);
+      nftResponseData.nfts = nftResponseData.nfts.map((nft) => {
+        if (nft.image_url in OBSCENELY_LARGE_ASSET_URLS) {
+          nft.image_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_url];
+        }
 
-      if (nft.image_thumbnail_url in OBSCENELY_LARGE_ASSET_URLS) {
-        nft.image_thumbnail_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_thumbnail_url];
-      }
+        if (nft.image_preview_url in OBSCENELY_LARGE_ASSET_URLS) {
+          nft.image_preview_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_preview_url];
+        }
 
-      return nft;
-    });
+        if (nft.image_thumbnail_url in OBSCENELY_LARGE_ASSET_URLS) {
+          nft.image_thumbnail_url = OBSCENELY_LARGE_ASSET_URLS[nft.image_thumbnail_url];
+        }
+
+        return nft;
+      });
+    }
 
     return {
       ...swr,
-      data: {
-        nfts: meticulouslyConvertedNftData,
-      },
+      data: nftResponseData,
     };
-  }
-
-  // help load members list
-  if (swrAction === getMembersListAction) {
-    return swr;
   }
 
   return swr;

--- a/src/flows/shared/steps/OrganizeCollection/Editor/CollectionEditor.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/CollectionEditor.tsx
@@ -46,8 +46,6 @@ function CollectionEditor() {
   const { collectionIdBeingEdited } = useCollectionWizardState();
   const { setSidebarNfts, stageNfts, unstageNfts } = useCollectionEditorActions();
 
-  const allNfts = useAllNfts();
-
   const { collections } = useAuthenticatedGallery();
   const collectionIdBeingEditedRef = useRef<string>(collectionIdBeingEdited ?? '');
   const collectionBeingEdited = useMemo(
@@ -78,11 +76,21 @@ function CollectionEditor() {
     sidebarNftsRef.current = sidebarNfts;
   }, [sidebarNfts]);
 
+  const allNfts = useAllNfts();
+
+  // stabilize `allNfts` returned from `useAllNfts`, since SWR middleware can make it referentially unstable
+  const allNftsCacheKey = useMemo(
+    () => allNfts.reduce((prev, curr) => `${prev}-${curr.last_updated}`, ''),
+    [allNfts]
+  );
+
   // decorates NFTs returned from useAllNfts with additional fields for the purpose of editing / dnd
   const allEditModeNfts: SidebarNftsState = useMemo(() => {
     const editModeNfts = convertNftsToEditModeNfts(allNfts);
     return Object.fromEntries(editModeNfts.map((nft) => [nft.id, nft]));
-  }, [allNfts]);
+    // use `allNftsCacheKey` as more stable memo dep. see comment where variable is defined.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allNftsCacheKey]);
 
   // Either initialize sidebar NFTs or refresh sidebar NFTs
   // while retaining the current user selections

--- a/src/hooks/api/collections/useCollectionById.ts
+++ b/src/hooks/api/collections/useCollectionById.ts
@@ -4,9 +4,9 @@ import useGet from '../_rest/useGet';
 
 type Props = {
   id: string;
-}
+};
 
-const getCollectionByIdAction = 'fetch collection by id';
+export const getCollectionByIdAction = 'fetch collection by id';
 const getCollectionByIdBaseUrl = '/collections/get';
 
 function getCollectionByIdBaseUrlWithQuery({ id }: Props) {
@@ -22,7 +22,10 @@ export function getCollectionByIdCacheKey({ id }: Props) {
 }
 
 export default function useCollectionById({ id }: Props): Collection | undefined {
-  const data = useGet<GetCollectionResponse>(id ? getCollectionByIdBaseUrlWithQuery({ id }) : null, getCollectionByIdAction);
+  const data = useGet<GetCollectionResponse>(
+    id ? getCollectionByIdBaseUrlWithQuery({ id }) : null,
+    getCollectionByIdAction
+  );
 
   return data?.collection;
 }

--- a/src/hooks/api/nfts/useAllNfts.ts
+++ b/src/hooks/api/nfts/useAllNfts.ts
@@ -4,7 +4,7 @@ import { Nft } from 'types/Nft';
 import { useAuthenticatedUser } from '../users/useUser';
 import useGet from '../_rest/useGet';
 
-type GetAllNFtsResponse = {
+export type GetAllNFtsResponse = {
   nfts: Nft[];
 };
 
@@ -12,7 +12,7 @@ type QueryProps = {
   userId: string;
 };
 
-const getAllNftsAction = 'fetch all nfts';
+export const getAllNftsAction = 'fetch all nfts';
 
 function getAllNftsCacheKey({ userId }: QueryProps) {
   return [`/nfts/user_get?user_id=${userId}`, getAllNftsAction];

--- a/src/hooks/api/nfts/useAllNfts.ts
+++ b/src/hooks/api/nfts/useAllNfts.ts
@@ -26,7 +26,7 @@ export default function useAllNfts(): Nft[] {
     throw new Error(`No NFTs were found for user id: ${user.id}`);
   }
 
-  return data.nfts || [];
+  return data?.nfts;
 }
 
 // use this hook to force SWR to refetch all nfts for user

--- a/src/hooks/api/users/useMemberList.ts
+++ b/src/hooks/api/users/useMemberList.ts
@@ -7,14 +7,16 @@ type GetMemberListResponse = {
 
 function dedupeOwners(owners: MembershipTier['owners']) {
   const dedupedOwners: Record<string, MembershipOwner> = {};
-  owners.forEach(owner => {
+  owners.forEach((owner) => {
     dedupedOwners[owner.username] = owner;
-  })
+  });
   return Object.values(dedupedOwners);
 }
 
+export const getMembersListAction = 'fetch member list';
+
 export default function useMemberList(): MembershipTier[] {
-  const data = useGet<GetMemberListResponse>('/users/membership', 'fetch member list');
+  const data = useGet<GetMemberListResponse>('/users/membership', getMembersListAction);
 
   if (!data) {
     throw new Error('Error fetching member list');
@@ -25,7 +27,7 @@ export default function useMemberList(): MembershipTier[] {
     if (tier !== null) {
       tier.owners = dedupeOwners(tier.owners);
     }
-  })
+  });
 
   return data.tiers;
 }


### PR DESCRIPTION
Dmitri Cherniak's Dead Ringers NFT, while very beautiful, would borderline crash the gallery experience given its massive dimensions.

![image](https://user-images.githubusercontent.com/12162433/152113622-5e5dd109-ca7c-4e87-8cf1-61beadea5b9c.png)

Opensea should normally resize the image and provide it under `image_url`, but @kaitoo1's suspicion is that _Opensea itself_ is failing to resize the image due to its gargantuan nature. Indeed, uploading the image to various image resizing services online wouldn't work, and we had to resort to manually resizing on figma.

This is a PR I'm certainly not proud of, but will temporarily stop the bleeding to get our app to load.