### PR TITLE
lowercase address before querying ENS name

### DIFF
--- a/src/components/EnsOrAddress.tsx
+++ b/src/components/EnsOrAddress.tsx
@@ -9,10 +9,11 @@ type Props = {
 
 export const EnsOrAddress = ({ address }: Props) => {
   const { data } = useSWR(
-    `https://api.ensideas.com/ens/resolve/${encodeURIComponent(address)}`,
+    `https://api.ensideas.com/ens/resolve/${encodeURIComponent(address.toLowerCase())}`,
     fetcher
   );
-  if (data) {
+
+  if (data?.address) {
     return <span title={data.address}>{data.name || data.address}</span>;
   }
 


### PR DESCRIPTION
Meant to do this in #561. This ensures a consistent cache key in SWR and avoids a redirect/round trip at the API.

Also went ahead and did the more defensive check for `data.address` in case the request fails or returns bad JSON for any reason.