### PR TITLE
specify which elements we allow in markdown

### DIFF
--- a/src/components/core/Markdown/Markdown.tsx
+++ b/src/components/core/Markdown/Markdown.tsx
@@ -19,6 +19,8 @@ export default function Markdown({ text }: Props) {
             <>{children}</>
           ),
       }}
+      allowedElements={['a', 'strong', 'em', 'ol', 'ul', 'li', 'p']}
+      unwrapDisallowed
     >
       {text}
     </ReactMarkdown>


### PR DESCRIPTION
Changes:
This PR updates the markdown component to specify which elements we allow via markdown. 

For now we will allow users to use the following elements in their bio and collection+nft collectors notes: `['a', 'strong', 'em', 'ol', 'ul', 'li', 'p']` 