### PR TITLE
Fix dangling toast

### DIFF
--- a/src/contexts/toast/ToastContext.tsx
+++ b/src/contexts/toast/ToastContext.tsx
@@ -64,8 +64,8 @@ const ToastProvider = memo(({ children }: Props) => {
 
   return (
     <ToastActionsContext.Provider value={value}>
-      {toasts.map(({ message, onDismiss }) => (
-        <AnimatedToast key={message} message={message} onClose={onDismiss} />
+      {toasts.map(({ message }) => (
+        <AnimatedToast key={message} message={message} onClose={dismissToast} />
       ))}
       {children}
     </ToastActionsContext.Provider>


### PR DESCRIPTION
Toast would never actually be dismissed, preventing the user from being able to click on any elements behind it (even post-dismissal)