### PR TITLE
Fix stale bio

### DIFF
--- a/src/hooks/api/users/useUpdateUser.ts
+++ b/src/hooks/api/users/useUpdateUser.ts
@@ -16,6 +16,8 @@ export default function useUpdateUser() {
         bio,
       });
 
+      await mutate(['/users/get/current', 'get current user']);
+
       // Optimistically update both user caches by username, ID
       await mutate(
         getUserCacheKey({ username }),


### PR DESCRIPTION
Users were seeing outdated bios if they re-opened the modal immediately after editing their bio