### PR TITLE
Wrap ENS handler in error boundary

### DIFF
--- a/src/components/EnsOrAddress.tsx
+++ b/src/components/EnsOrAddress.tsx
@@ -1,4 +1,5 @@
 import useSWR from 'swr';
+import { PlainErrorBoundary } from './PlainErrorBoundary';
 
 const fetcher = async (...args: Parameters<typeof fetch>) =>
   fetch(...args).then(async (res) => res.json());
@@ -7,7 +8,7 @@ type Props = {
   address?: string;
 };
 
-export const EnsOrAddress = ({ address }: Props) => {
+const EnsName = ({ address }: Props) => {
   const { data } = useSWR(
     address
       ? `https://api.ensideas.com/ens/resolve/${encodeURIComponent(address.toLowerCase())}`
@@ -21,3 +22,9 @@ export const EnsOrAddress = ({ address }: Props) => {
 
   return <span title={address}>{address}</span>;
 };
+
+export const EnsOrAddress = ({ address }: Props) => (
+  <PlainErrorBoundary fallback={<span title={address}>{address}</span>}>
+    <EnsName address={address} />
+  </PlainErrorBoundary>
+);

--- a/src/components/PlainErrorBoundary.tsx
+++ b/src/components/PlainErrorBoundary.tsx
@@ -1,0 +1,31 @@
+import React, { ErrorInfo } from 'react';
+
+type Props = {
+  fallback: React.ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+};
+
+export class PlainErrorBoundary extends React.Component<Props, State> {
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  state = {
+    hasError: false,
+  };
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('PlainErrorBoundary:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
This should protect against all sorts of errors: 404s, malformed JSON, etc.
