### PR TITLE
Fix fade transition with suspense jank

### DIFF
--- a/src/components/FadeTransitioner/FadeTransitioner.tsx
+++ b/src/components/FadeTransitioner/FadeTransitioner.tsx
@@ -38,9 +38,9 @@ function FadeTransitioner({ locationKey, children }: Props) {
       <CSSTransition key={locationKey} timeout={timeoutConfig} classNames="fade">
         {/* Placing the Suspense boundary here (within the TransitionGroup) allows the scroll position
             to remain uninterrupted upon navigation */}
-        <Suspense fallback={<FullPageLoader />}>
-          <div style={childNodeStyles as CSSProperties}>{children}</div>
-        </Suspense>
+        <div style={childNodeStyles as CSSProperties}>
+          <Suspense fallback={<FullPageLoader />}>{children}</Suspense>
+        </div>
       </CSSTransition>
     </TransitionGroup>
   );


### PR DESCRIPTION
There was some pretty gross jank when transitioning to a route which suspended while waiting for data.

The root cause here was the `FullScreenLoader` wasn't getting the same transition styles as the actual route, so it just looked really sudden / jarring.

**Before / After**

On the right, you're not seeing the fallback since the API resolves faster than the transition finishes. I tested it out with a component which suspends forever and the functionality looks right.

https://user-images.githubusercontent.com/6754223/152666156-01b6d6fb-87f0-449b-91df-66c036103f2f.mp4


