### PR TITLE
Replace instances of overflow: scroll with overflow: auto

### DIFF
--- a/src/flows/shared/steps/OrganizeCollection/Editor/StagingArea.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/StagingArea.tsx
@@ -129,7 +129,7 @@ const StyledStagingArea = styled.div`
 
   padding: 100px 80px;
 
-  overflow: scroll;
+  overflow: auto;
 
   &::-webkit-scrollbar {
     display: none;

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
@@ -120,7 +120,7 @@ const StyledSidebar = styled.div`
 
   padding: 32px;
 
-  overflow: scroll;
+  overflow: auto;
 
   &::-webkit-scrollbar {
     display: none;

--- a/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -92,7 +92,7 @@ const StyledDetailLabel = styled.div<{ horizontalLayout: boolean }>`
     horizontalLayout
       ? `
     max-height: ${fullPageHeightWithoutNavbarAndFooter};
-    overflow: scroll;
+    overflow: auto;
     padding-right: 16px;
     `
       : `


### PR DESCRIPTION
This PR removes extraneous scrollbars by replacing `overflow: scroll` with `overflow: auto`. It affects three elements:

### 1. Sidebar on collection editing page (before/after):

<div style="display: flex;">
<img src="https://user-images.githubusercontent.com/13339581/154352664-c985bc47-3f35-4440-b81f-76c24e69596e.png" width="49%" />
<img src="https://user-images.githubusercontent.com/13339581/154352597-07b225d5-98d2-4a2c-bd04-dd7b31730a40.png" width="49%" />
</div>


### 2. Staging area

<div style="display: flex;">
<img src="https://user-images.githubusercontent.com/13339581/154352860-652ef2fe-da0e-4b36-98b9-c341e342e097.png" width="49%" />
<img src="https://user-images.githubusercontent.com/13339581/154352805-fdff8fcf-151a-4f49-b029-34f6aa6c0ac3.png" width="49%" />
</div>


### 3. NFT detail text


<div style="display: flex;">
<img src="https://user-images.githubusercontent.com/13339581/154352972-c075eb3d-cc48-4d85-ba45-8e111b73f436.png" width="49%" />
<img src="https://user-images.githubusercontent.com/13339581/154353017-c79051b9-9f75-4a9a-b29f-aabd2c7b78b5.png" width="49%" />
</div>

---

These scrollbars will still appear if **there is overflow**, but in events where content does not overflow no scrollbars appear.

For those interested, us Mac OSX were likely being tricked because trackpads automatically hide scrollbars. This is also why plugging in an external mouse would cause the scrollbars to reappear: https://kilianvalkhof.com/2021/css-html/you-want-overflow-auto-not-overflow-scroll/