### PR TITLE
Track collector's note events

### DIFF
--- a/src/scenes/NftDetailPage/NftDetailNote.tsx
+++ b/src/scenes/NftDetailPage/NftDetailNote.tsx
@@ -11,6 +11,7 @@ import breakpoints from 'components/core/breakpoints';
 import ErrorText from 'components/core/Text/ErrorText';
 import formatError from 'errors/formatError';
 import { GLOBAL_FOOTER_HEIGHT } from 'components/core/Page/constants';
+import Mixpanel from 'utils/mixpanel';
 
 const MAX_CHAR_COUNT = 1200;
 const MIN_NOTE_HEIGHT = 150;
@@ -70,6 +71,10 @@ function NoteEditor({ nftCollectorsNote, nftId }: NoteEditorProps) {
 
     try {
       await updateNft(nftId, collectorsNote);
+      Mixpanel.track('Save NFT collectors note', {
+        added_note: unescapedCollectorsNote.length > 0,
+        num_chars: unescapedCollectorsNote.length,
+      });
     } catch (error: unknown) {
       if (error instanceof Error) {
         setGeneralError(formatError(error));


### PR DESCRIPTION
Adds Mixpanel tracking to collector's note saves, indicating whether the note was added (`note_added`, returning `false` if the user has deleted their note) and the length of the note `num_chars`