### PR TITLE
Put optimistically create collection at top of gallery

### DIFF
--- a/src/hooks/api/collections/useCreateCollection.ts
+++ b/src/hooks/api/collections/useCreateCollection.ts
@@ -56,7 +56,7 @@ export default function useCreateCollection() {
         (value: GetGalleriesResponse) => {
           const newValue = cloneDeep<GetGalleriesResponse>(value);
           const gallery = newValue.galleries[0];
-          const newCollections = [...gallery.collections, optimisticallyCreatedCollection];
+          const newCollections = [optimisticallyCreatedCollection, ...gallery.collections];
           gallery.collections = newCollections;
           gallery.last_updated = now;
           return newValue;


### PR DESCRIPTION
When we optimistically save the newly created collection in the cache, put it at the beginning of your gallery.