### PR TITLE
Adjust styling of NFT preview text on small screens

### DIFF
--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -101,11 +101,11 @@ const StyledNftPreview = styled.div<{ columns: number }>`
   height: fit-content;
   overflow: hidden;
 
-  ${StyledNftLabel} {
+  &:hover ${StyledNftLabel} {
     transform: translateY(0px);
   }
 
-  ${StyledNftFooter} {
+  &:hover ${StyledNftFooter} {
     opacity: 1;
   }
 `;

--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -101,11 +101,11 @@ const StyledNftPreview = styled.div<{ columns: number }>`
   height: fit-content;
   overflow: hidden;
 
-  &:hover ${StyledNftLabel} {
+  ${StyledNftLabel} {
     transform: translateY(0px);
   }
 
-  &:hover ${StyledNftFooter} {
+  ${StyledNftFooter} {
     opacity: 1;
   }
 `;

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -40,7 +40,7 @@ export const StyledNftPreviewLabel = styled.div`
 
 const StyledBodyRegular = styled(BodyRegular)<{ lines: number }>`
   margin: 0;
-  text-shadow: 1px 1px 3px rgba(0, 0, 0, 1);
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, .5);
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: ${({ lines }) => lines};

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -39,28 +39,36 @@ export const StyledNftPreviewLabel = styled.div`
 `;
 
 const StyledBodyRegular = styled(BodyRegular)<{ lines: number }>`
+  word-wrap: break-word;
+  word-break: break-all;
+
   margin: 0;
-  text-shadow: 1px 1px 3px rgba(0, 0, 0, .5);
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.7);
   display: -webkit-box;
   -webkit-box-orient: vertical;
+  line-clamp: ${({ lines }) => lines};
   -webkit-line-clamp: ${({ lines }) => lines};
   overflow: hidden;
   font-size: 12px;
   line-height: 16px;
   text-overflow: ellipsis;
-  // word-break: break-word;
-  // word-break: break-all;
 
-    @media only screen and ${breakpoints.tablet} {
-      font-size: 14px;
-      line-height: 20px;
-      display: unset;
-      -webkit-box-orient: unset;
-      -webkit-line-clamp: unset;
-      overflow: visible;
-      text-overflow: unset;
-    }
+  @media only screen and ${breakpoints.mobileLarge} {
+    word-wrap: unset;
+    word-break: unset;
   }
+
+  @media only screen and ${breakpoints.tablet} {
+    font-size: 14px;
+    line-height: 20px;
+    display: unset;
+    -webkit-box-orient: unset;
+    line-clamp: unset;
+    -webkit-line-clamp: unset;
+    overflow: visible;
+    text-overflow: unset;
+  }
+}
 `;
 
 export default NftPreviewLabel;

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -32,7 +32,6 @@ export const StyledNftPreviewLabel = styled.div`
   padding: 8px;
   z-index: 10;
   justify-content: end;
-  // height: 100%;
   // this helps position the label correctly in Safari
   // Safari differs from Chrome in how it renders height: 100% on position: absolute elements
   min-height: 56px;
@@ -52,6 +51,8 @@ const StyledBodyRegular = styled(BodyRegular)<{ lines: number }>`
   font-size: 12px;
   line-height: 16px;
   text-overflow: ellipsis;
+  padding-right: 16px;
+  margin-right: -16px;
 
   @media only screen and ${breakpoints.mobileLarge} {
     word-wrap: unset;
@@ -61,6 +62,8 @@ const StyledBodyRegular = styled(BodyRegular)<{ lines: number }>`
   @media only screen and ${breakpoints.tablet} {
     font-size: 14px;
     line-height: 20px;
+    padding-right: 0;
+    margin-right: 0;
     display: unset;
     -webkit-box-orient: unset;
     line-clamp: unset;

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -2,6 +2,7 @@ import colors from 'components/core/colors';
 import styled from 'styled-components';
 import { BodyRegular } from 'components/core/Text/Text';
 import { Nft } from 'types/Nft';
+import breakpoints from 'components/core/breakpoints';
 
 type Props = {
   nft: Nft;
@@ -11,8 +12,12 @@ type Props = {
 function NftPreviewLabel({ nft, className }: Props) {
   return (
     <StyledNftPreviewLabel className={className}>
-      <StyledBodyRegular color={colors.white}>{nft.name}</StyledBodyRegular>
-      <StyledBodyRegular color={colors.white}>{nft.token_collection_name}</StyledBodyRegular>
+      <StyledBodyRegular color={colors.white} lines={1}>
+        {nft.name}
+      </StyledBodyRegular>
+      <StyledBodyRegular color={colors.white} lines={2}>
+        {nft.token_collection_name}
+      </StyledBodyRegular>
     </StyledNftPreviewLabel>
   );
 }
@@ -27,14 +32,35 @@ export const StyledNftPreviewLabel = styled.div`
   padding: 8px;
   z-index: 10;
   justify-content: end;
-  height: 100%;
+  // height: 100%;
   // this helps position the label correctly in Safari
   // Safari differs from Chrome in how it renders height: 100% on position: absolute elements
   min-height: 56px;
 `;
 
-const StyledBodyRegular = styled(BodyRegular)`
+const StyledBodyRegular = styled(BodyRegular)<{ lines: number }>`
   margin: 0;
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, 1);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: ${({ lines }) => lines};
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  // word-break: break-word;
+  // word-break: break-all;
+
+    @media only screen and ${breakpoints.tablet} {
+      font-size: 14px;
+      line-height: 20px;
+      display: unset;
+      -webkit-box-orient: unset;
+      -webkit-line-clamp: unset;
+      overflow: visible;
+      text-overflow: unset;
+    }
+  }
 `;
 
 export default NftPreviewLabel;


### PR DESCRIPTION
This PR adjusts styling of asset preview text on small screens. It fixes the bug where collection titles/NFT names were cut off on mobile/small screens. Before/after:

<div style="display: flex;">
<img width="49%" alt="image" src="https://user-images.githubusercontent.com/13339581/154816873-3b6fde00-f411-4ed8-83c1-b6526d6b55aa.png">
<img width="49%" alt="image" src="https://user-images.githubusercontent.com/13339581/154816883-fd109c22-2f93-4254-b289-42f99547761d.png">
</div>

---

On screens under our `tablet` breakpoint, we 
1. reduce font size and line height, 
2. hide overflow, and 
3. apply a `text-overflow` property of `ellipsis` which leads to the `...` truncation when overflow begins. 

We use `-webkit-line-clamp` so that the NFT title will be truncated after one line of text, and the collection title will begin truncation after 2 lines of text (as you can see in the screenshot above). We can adjust these numbers, although generally 3 lines of text is the upper limit if we want to preserve the current design of the Nft preview text only taking up a max of ~56px.

You can read more about line clamping overflow [here](https://css-tricks.com/almanac/properties/l/line-clamp/). It has [full browser support](https://caniuse.com/?search=line-clamp) other than IE.

Also, I added a slight `text-shadow` to preview text, no matter the screen size. This makes titles more readable, especially on white assets, and makes the text feel elevated from the background:

<div style="display: flex;">
<img width="212" alt="image" src="https://user-images.githubusercontent.com/13339581/154817285-707de0ee-2344-41d9-b989-ab673cd9586b.png">
<img width="212" alt="image" src="https://user-images.githubusercontent.com/13339581/154817297-754e8c91-5aa3-4b08-8f91-23843f2189e7.png">
</div>

Let me know if you think we should reduce the intensity of the shadow!

---

## Note on browser support 

I've verified that this looks good on desktop Chrome, FF, and Safari. There is a difference in how Chrome and FF render truncated text though -- Chrome, by default, will only show the `...` if there is a break `within` a word; whereas FF will render it no matter what (even breaking after a word, e.g. a space). Firefox/Chrome:

<div style="display: flex;">
<img width="49%" alt="image" src="https://user-images.githubusercontent.com/13339581/154821805-864d161b-3695-40e3-9dcd-837790f2d5b8.png">
<img width="49%" alt="image" src="https://user-images.githubusercontent.com/13339581/154821814-f82e2557-31f5-4401-96c6-410c59123c52.png">
</div>

Of these two, the first (Firefox) seems preferable. I don't like that Chrome ends the string with no visual representation of truncation, so it just looks like the title is wrong.

To mitigate this, I'm applying `word-wrap: break-word` and `word-break: break-all` to the div only on mobile screens. I don't think we want to apply this everywhere because it will break words arbitrarily with no hyphens, making it look a bit goofy:

<img width="110" alt="image" src="https://user-images.githubusercontent.com/13339581/154821697-0b255cfe-99da-495d-a6ce-7eb028139492.png">

By applying only on small screens, we make sure that it only does these odd word breaks when absolutely necessary. There is a bit of a tradeoff here no matter what; we either choose to allow for strings to be cut off on Chrome with no visual representation (no `...`) or we break *within* words.