### PR TITLE
Ensure number of columns on Edit Page displays correctly despite window width

### DIFF
--- a/src/flows/shared/steps/OrganizeCollection/Editor/StagingArea.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/StagingArea.tsx
@@ -38,11 +38,11 @@ const DND_WIDTHS: Record<number, number> = {
 // Width of draggable image for each Column # setting
 const IMAGE_SIZES: Record<number, number> = {
   1: 400,
-  2: 320,
-  3: 280,
-  4: 207,
-  5: 156,
-  6: 122,
+  2: 330,
+  3: 212,
+  4: 153,
+  5: 122,
+  6: 91,
 };
 
 const defaultDropAnimationConfig: DropAnimation = {
@@ -157,7 +157,7 @@ const StyledStagedNftContainer = styled.div<StyledStagedNftContainerProps>`
   width: calc(100% + 48px);
 
   ${StyledSortableNft} {
-    margin: 24px;
+    margin: 24px 0 0 24px;
   }
   ${StyledSortableNft} * {
     outline: none;

--- a/src/flows/shared/steps/OrganizeCollection/Editor/StagingArea.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/StagingArea.tsx
@@ -29,10 +29,10 @@ import { MENU_HEIGHT } from './EditorMenu';
 const DND_WIDTHS: Record<number, number> = {
   1: 600,
   2: 800,
-  3: 984,
-  4: 1020,
-  5: 1020,
-  6: 1020,
+  3: 720,
+  4: 708,
+  5: 705,
+  6: 690,
 };
 
 // Width of draggable image for each Column # setting
@@ -41,7 +41,7 @@ const IMAGE_SIZES: Record<number, number> = {
   2: 330,
   3: 212,
   4: 153,
-  5: 122,
+  5: 117,
   6: 91,
 };
 


### PR DESCRIPTION
This adjusts the sizes of images when editing collections. It is designed to show the correct number of user-specified columns for users on a desktop device (>= 1100px). Here is a before and after of each number of user-selected columns:

<img width="80%" alt="image" src="https://user-images.githubusercontent.com/13339581/154858936-433f9ff5-fe4d-41ae-9691-e4a70680e162.png">

---

All that's happening here is a reduction in sizes for images in each of the `n-`column layouts. 

The only other notable edit is that I have replaced the `margin: 24px` applied to each image with a `margin: 24px 0 0 24px`. (You can see how the assets in `NEW` above are closer together.) This 
1. allows the images to fill more of the available space
2. prevents rendering of dead space to the right of assets that are on the last column of each row (e.g. below):

<div style="display: flex;">
<img width="46%" alt="image" src="https://user-images.githubusercontent.com/13339581/154859209-1faf604c-fb74-4f45-bd20-d7a3fbedca1d.png">
<img width="48%"" alt="image" src="https://user-images.githubusercontent.com/13339581/154859225-2050a4fa-9852-4eb5-8b6a-44cae813faf1.png">
</div>

This does reduce the margin between elements, but I personally don't think that losing that space between assets is an issue? Happy to undo this change based on the team's thoughts.

---

This is an imperfect and intermediate solution only meant to solve the issue of columns rendering incorrectly for desktop users. Screens under 1100px will still break columns (although this may be a desired behavior?), and there might be a more complete solution in the future. For now, this fixes the user-reported issue and solves layout issues for users who edit their collection on desktop (most likely the vast majority of them).