### PR TITLE
Imgix + SSR proof of concept

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@dnd-kit/utilities": "^2.0.0",
     "@ethersproject/contracts": "^5.4.1",
     "@ethersproject/providers": "^5.0.24",
+    "@imgix/js-core": "^3.5.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@web3-react/abstract-connector": "^6.0.7",
     "@web3-react/core": "^6.1.9",

--- a/pages/[username]/[collectionId]/[nftId]/index.tsx
+++ b/pages/[username]/[collectionId]/[nftId]/index.tsx
@@ -4,26 +4,42 @@ import { GetServerSideProps } from 'next';
 import GalleryRedirect from 'scenes/_Router/GalleryRedirect';
 import { MetaTagProps } from 'pages/_app';
 import { openGraphMetaTags } from 'utils/openGraphMetaTags';
+import { Nft } from 'types/Nft';
+import { getImageSrcSet } from 'utils/imageSrcSet';
 
 type NftDetailPageProps = MetaTagProps & {
-  nftId?: string;
+  nft?: Nft;
 };
 
-export default function NftDetailPage({ nftId }: NftDetailPageProps) {
-  if (!nftId) {
+export default function NftDetailPage({ nft }: NftDetailPageProps) {
+  if (!nft) {
     // Something went horribly wrong
     return <GalleryRedirect to="/" />;
   }
 
-  return <GalleryRoute element={<NftDetailPageScene nftId={nftId} />} footerIsFixed />;
+  return <GalleryRoute element={<NftDetailPageScene nft={nft} />} footerIsFixed />;
 }
 
 export const getServerSideProps: GetServerSideProps<NftDetailPageProps> = async ({ params }) => {
   const username = params?.username ? (params.username as string) : undefined;
   const nftId = params?.nftId ? (params.nftId as string) : undefined;
+
+  // retrieve nft from db
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/glry/v1/nfts/get?id=${nftId}`);
+  const data = await res.json();
+
+  if (!data?.nft) {
+    return {
+      notFound: true,
+    };
+  }
+
+  // generate srcset for image resizing
+  const imageSrcSet = getImageSrcSet(data.nft.image_original_url, 600);
+
   return {
     props: {
-      nftId,
+      nft: { ...data.nft, imageSrcSet },
       metaTags: nftId
         ? openGraphMetaTags({
             title: `${username} | Gallery`,

--- a/src/components/ImageWithLoading/ImageWithLoading.tsx
+++ b/src/components/ImageWithLoading/ImageWithLoading.tsx
@@ -1,5 +1,6 @@
 import { useSetContentIsLoaded } from 'contexts/shimmer/ShimmerContext';
 import styled from 'styled-components';
+import { ImageSrcSet } from 'utils/imageSrcSet';
 
 type ContentWidthType =
   | 'fullWidth' // fill container
@@ -13,6 +14,7 @@ type Props = {
   alt: string;
   widthType?: ContentWidthType;
   heightType?: ContentHeightType;
+  srcSet: ImageSrcSet['srcSet'];
 };
 
 export default function ImageWithLoading({
@@ -21,8 +23,24 @@ export default function ImageWithLoading({
   heightType,
   src,
   alt,
+  srcSet,
 }: Props) {
   const setContentIsLoaded = useSetContentIsLoaded();
+
+  if (srcSet) {
+    return (
+      <StyledImg
+        className={className}
+        widthType={widthType}
+        heightType={heightType}
+        src={src}
+        srcSet={srcSet}
+        alt={alt}
+        loading="lazy"
+        onLoad={setContentIsLoaded}
+      />
+    );
+  }
 
   return (
     <StyledImg

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -3,7 +3,7 @@ import { NftMediaType } from 'components/core/enums';
 import styled from 'styled-components';
 import ImageWithLoading from 'components/ImageWithLoading/ImageWithLoading';
 import { Nft } from 'types/Nft';
-import { getMediaType, getResizedNftImageUrlWithFallback } from 'utils/nft';
+import { getMediaType } from 'utils/nft';
 import { GLOBAL_FOOTER_HEIGHT, GLOBAL_NAVBAR_HEIGHT } from 'components/core/Page/constants';
 import NftDetailAnimation from './NftDetailAnimation';
 import NftDetailVideo from './NftDetailVideo';
@@ -25,7 +25,8 @@ function NftDetailAssetComponent({ nft, maxHeight }: NftDetailAssetComponentProp
   const resizableImage = useMemo(
     () => (
       <ImageWithLoading
-        src={getResizedNftImageUrlWithFallback(nft, 1200)}
+        srcSet={nft.imageSrcSet.srcSet}
+        src={nft.imageSrcSet.src}
         alt={nft.name}
         widthType="maxWidth"
         heightType={breakpoint === size.desktop ? 'maxHeightScreen' : undefined}

--- a/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -40,7 +40,6 @@ function NftDetailPage({ nft }: Props) {
 
   const handleBackClick = useBackButton({ username });
 
-  // const nft = useNft({ id: nftId ?? '' });
   const headTitle = useMemo(() => `${nft?.name} - ${username} | Gallery`, [nft, username]);
 
   useEffect(() => {

--- a/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -20,12 +20,13 @@ import { usePossiblyAuthenticatedUser } from 'src/hooks/api/users/useUser';
 import { isFeatureEnabled } from 'utils/featureFlag';
 import { FeatureFlag } from 'components/core/enums';
 import { useIsMobileWindowWidth } from 'hooks/useWindowSize';
+import { Nft } from 'types/Nft';
 
 type Props = {
-  nftId: string;
+  nft: Nft;
 };
 
-function NftDetailPage({ nftId }: Props) {
+function NftDetailPage({ nft }: Props) {
   const { query } = useRouter();
 
   const username = window.location.pathname.split('/')[1];
@@ -39,12 +40,12 @@ function NftDetailPage({ nftId }: Props) {
 
   const handleBackClick = useBackButton({ username });
 
-  const nft = useNft({ id: nftId ?? '' });
+  // const nft = useNft({ id: nftId ?? '' });
   const headTitle = useMemo(() => `${nft?.name} - ${username} | Gallery`, [nft, username]);
 
   useEffect(() => {
-    Mixpanel.track('Page View: NFT Detail', { nftId });
-  }, [nftId]);
+    Mixpanel.track('Page View: NFT Detail', { nftId: nft.id });
+  }, [nft.id]);
 
   const assetHasNote = nft?.collectors_note !== '';
   const isCollectorsNoteEnabled = isFeatureEnabled(FeatureFlag.COLLECTORS_NOTE);

--- a/src/types/Nft.ts
+++ b/src/types/Nft.ts
@@ -1,3 +1,4 @@
+import { ImageSrcSet } from 'utils/imageSrcSet';
 import { User } from './User';
 
 export type Nft = {
@@ -36,6 +37,7 @@ export type Nft = {
   token_metadata_url: string;
   user_id: string;
   ownership_history: OwnershipHistory;
+  imageSrcSet: ImageSrcSet;
 };
 
 type OwnershipHistory = {

--- a/src/utils/imageSrcSet.ts
+++ b/src/utils/imageSrcSet.ts
@@ -1,0 +1,29 @@
+import ImgixClient from '@imgix/js-core';
+
+export type ImageSrcSet = {
+  srcSet: string;
+  src: string;
+};
+
+const IMGIX_DOMAIN = 'assets.gallery.so';
+
+// Generates the srcset for an image so we can display different sizes of the image.
+// Must be called server side, or it won't be signed with the token.
+export function getImageSrcSet(url: string, width: number): ImageSrcSet {
+  const client = new ImgixClient({
+    domain: IMGIX_DOMAIN,
+    secureURLToken: process.env.IMGIX_TOKEN,
+  });
+
+  const srcSet = client.buildSrcSet(
+    url,
+    {
+      w: width,
+    },
+    {
+      devicePixelRatios: [1, 2],
+    }
+  );
+
+  return { srcSet, src: url };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2420,6 +2420,14 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@imgix/js-core@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@imgix/js-core/-/js-core-3.5.1.tgz#00482a6469d55e424899101eb89ba9b0a8d49f18"
+  integrity sha512-5gfOuyC0drq9TdEVR0+fR/PRZx4MqymsiTY38ZJoTXHz5D5IpnQhreroj7F4+VBKLdv96aCU9UyPGVjzSlzYIw==
+  dependencies:
+    js-base64 "~3.7.0"
+    md5 "^2.2.1"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -6213,6 +6221,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 check-more-types@2.24.0, check-more-types@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
@@ -6893,6 +6906,11 @@ cross-zip@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cross-zip/-/cross-zip-4.0.0.tgz#c29bfb2c001659a6d480ae9596f3bee83b48a230"
   integrity sha512-MEzGfZo0rqE10O/B+AEcCSJLZsrWuRUvmqJTqHNqBtALhaJc3E3ixLGLJNTRzEA2K34wbmOHC4fwYs9sVsdcCA==
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-addr-codec@^0.1.7:
   version "0.1.7"
@@ -10276,7 +10294,7 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-buffer@^1.1.0, is-buffer@^1.1.5:
+is-buffer@^1.1.0, is-buffer@^1.1.5, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -11171,6 +11189,11 @@ joi@^17.4.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+js-base64@~3.7.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.2.tgz#816d11d81a8aff241603d19ce5761e13e41d7745"
+  integrity sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==
+
 js-levenshtein@^1.1.3, js-levenshtein@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
@@ -11906,6 +11929,15 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+md5@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
+  dependencies:
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
 
 mdast-util-definitions@^5.0.0:
   version "5.1.0"


### PR DESCRIPTION
This PR introduces using Imgix to get resized + scaled versions of images to prepare us for the indexer switch.

To serve as proof of concept and agree with the team on the implementation pattern before making the change across the whole app, I got it working with the Nft Detail Page only. We don't have to merge this, I can use it as the foundation for the rest of the conversion.

changes:
- updated the Nft Detail Page route to retrieve the nft from the backend in server side props
- added an `getImageSrcSet` util function to generate a signed srcset of the image's source url using imgix's library and token. imgix requires the url to be signed when using their web proxy to resize any public image. the token is not exposed to the browser because we are using it in serversideprops only and it does not have the `NEXT_PUBLIC_` env var prefix
- updated `ImageWithLoading` to take an optional srcset prop which will render the Imgix-provided image. The srcset includes two versions of the image, for 1x and 2x resolution to support normal resolution screens as well as high resolution ones such as retina displays. Using `srcset` allows us to tell the `img` tag what versions of the image it can use for different settings such as screen resolution or size. More info about `srcset` and `size` attributes: https://medium.com/@woutervanderzee/responsive-images-with-srcset-and-sizes-fc434845e948


considerations for implementing this across the app
- on other pages such as the Gallery and Collection pages, the srcset will include multiple versions of the image at varying widths. Imgix supports this. 
- we can do this page by page before we switch to the indexer. However, we must convert all pages where we use nft images before we switch to our indexer.
- this means we'll have to re-enable SSR for the members page, which we had turned off because it felt a bit slow.

