### PR TITLE
Place navbar and its dropdowns above asset on nft detail page

### DIFF
--- a/src/components/core/Page/GlobalNavbar/GlobalNavbar.tsx
+++ b/src/components/core/Page/GlobalNavbar/GlobalNavbar.tsx
@@ -23,7 +23,7 @@ const StyledGlobalNavbar = styled.div`
   justify-content: flex-end;
 
   position: relative;
-  z-index: 1;
+  z-index: 3;
 
   padding: 0 ${pageGutter.mobile}px;
 


### PR DESCRIPTION
fixes dat z-index bug (before/after):

<div style="display: flex;">
<img src="https://user-images.githubusercontent.com/13339581/156670079-825e6587-23e4-4c9b-8bf6-1ed694739b3d.png" width="48%"/>
<img src="https://user-images.githubusercontent.com/13339581/156670051-2be475f9-38e9-4c70-894c-ff4ac3097f20.png" width="48%"/>
</div>