### PR TITLE
send handled auth errors to sentry

### DIFF
--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
@@ -28,7 +28,7 @@ import {
   useTrackAddWalletError,
   useTrackAddWalletSuccess,
 } from 'contexts/analytics/authUtil';
-import * as Sentry from '@sentry/nextjs';
+import { captureException } from '@sentry/nextjs';
 
 type Props = {
   pendingWallet: AbstractConnector;
@@ -104,7 +104,7 @@ function AddWalletPendingDefault({
         return signatureValid;
       } catch (error: unknown) {
         setIsConnecting(false);
-        Sentry.captureException(error);
+        captureException(error);
         trackAddWalletError(userFriendlyWalletName, error);
         if (isWeb3Error(error)) {
           setDetectedError(error);

--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
@@ -28,6 +28,7 @@ import {
   useTrackAddWalletError,
   useTrackAddWalletSuccess,
 } from 'contexts/analytics/authUtil';
+import * as Sentry from '@sentry/nextjs';
 
 type Props = {
   pendingWallet: AbstractConnector;
@@ -103,6 +104,7 @@ function AddWalletPendingDefault({
         return signatureValid;
       } catch (error: unknown) {
         setIsConnecting(false);
+        Sentry.captureException(error);
         trackAddWalletError(userFriendlyWalletName, error);
         if (isWeb3Error(error)) {
           setDetectedError(error);

--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
@@ -33,6 +33,7 @@ import {
   useTrackAddWalletSuccess,
   useTrackAddWalletError,
 } from 'contexts/analytics/authUtil';
+import * as Sentry from '@sentry/nextjs';
 
 type Props = {
   pendingWallet: AbstractConnector;
@@ -72,6 +73,7 @@ function AddWalletPendingGnosisSafe({
 
   const handleError = useCallback(
     (error: unknown) => {
+      Sentry.captureException(error);
       trackAddWalletError('Gnosis Safe', error);
       if (isWeb3Error(error)) {
         setDetectedError(error);

--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
@@ -33,7 +33,7 @@ import {
   useTrackAddWalletSuccess,
   useTrackAddWalletError,
 } from 'contexts/analytics/authUtil';
-import * as Sentry from '@sentry/nextjs';
+import { captureException } from '@sentry/nextjs';
 
 type Props = {
   pendingWallet: AbstractConnector;
@@ -73,7 +73,7 @@ function AddWalletPendingGnosisSafe({
 
   const handleError = useCallback(
     (error: unknown) => {
-      Sentry.captureException(error);
+      captureException(error);
       trackAddWalletError('Gnosis Safe', error);
       if (isWeb3Error(error)) {
         setDetectedError(error);

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingDefault.tsx
@@ -17,6 +17,7 @@ import {
   useTrackSignInError,
   useTrackSignInSuccess,
 } from 'contexts/analytics/authUtil';
+import * as Sentry from '@sentry/nextjs';
 
 type Props = {
   pendingWallet: AbstractConnector;
@@ -94,6 +95,7 @@ function AuthenticateWalletPendingDefault({
         try {
           await attemptAuthentication(account.toLowerCase(), signer);
         } catch (error: unknown) {
+          Sentry.captureException(error);
           trackSignInError(userFriendlyWalletName, error);
 
           if (isWeb3Error(error)) {

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingDefault.tsx
@@ -17,7 +17,7 @@ import {
   useTrackSignInError,
   useTrackSignInSuccess,
 } from 'contexts/analytics/authUtil';
-import * as Sentry from '@sentry/nextjs';
+import { captureException } from '@sentry/nextjs';
 
 type Props = {
   pendingWallet: AbstractConnector;
@@ -95,7 +95,7 @@ function AuthenticateWalletPendingDefault({
         try {
           await attemptAuthentication(account.toLowerCase(), signer);
         } catch (error: unknown) {
-          Sentry.captureException(error);
+          captureException(error);
           trackSignInError(userFriendlyWalletName, error);
 
           if (isWeb3Error(error)) {

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
@@ -21,6 +21,7 @@ import {
   useTrackSignInError,
   useTrackCreateUserSuccess,
 } from 'contexts/analytics/authUtil';
+import * as Sentry from '@sentry/nextjs';
 
 type Props = {
   pendingWallet: AbstractConnector;
@@ -71,6 +72,7 @@ function AuthenticateWalletPendingGnosisSafe({
 
   const handleError = useCallback(
     (error: unknown) => {
+      Sentry.captureException(error);
       trackSignInError('Gnosis Safe', error);
       if (isWeb3Error(error)) {
         setDetectedError(error);

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
@@ -21,7 +21,7 @@ import {
   useTrackSignInError,
   useTrackCreateUserSuccess,
 } from 'contexts/analytics/authUtil';
-import * as Sentry from '@sentry/nextjs';
+import { captureException } from '@sentry/nextjs';
 
 type Props = {
   pendingWallet: AbstractConnector;
@@ -72,7 +72,7 @@ function AuthenticateWalletPendingGnosisSafe({
 
   const handleError = useCallback(
     (error: unknown) => {
-      Sentry.captureException(error);
+      captureException(error);
       trackSignInError('Gnosis Safe', error);
       if (isWeb3Error(error)) {
         setDetectedError(error);


### PR DESCRIPTION
Send handled auth errors to sentry in the following areas
  - sign in (EOA + Gnosis)
  - add wallet (EOA + Gnosis)