### PR TITLE
configure sentry tunnel with new proxy

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -22,5 +22,5 @@ Sentry.init({
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
   environment: SENTRY_ENV || 'local',
-  tunnel: 'https://monitoring.gallery.so//bugs',
+  tunnel: 'https://monitoring.gallery.so/bugs',
 });

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -22,4 +22,5 @@ Sentry.init({
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
   environment: SENTRY_ENV || 'local',
+  tunnel: 'https://monitoring.gallery.so//bugs',
 });


### PR DESCRIPTION
This PR enables the tunnel option during Sentry.init to to use our Sentry proxy.

official docs:
https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option


bug successfully submitted on brave:
![Screen Shot 2022-03-10 at 18 02 03](https://user-images.githubusercontent.com/80802871/157627485-61501610-265f-4094-be31-eca5aa2cfb10.png)


bug received in sentry:
![Screen Shot 2022-03-10 at 17 58 42](https://user-images.githubusercontent.com/80802871/157627287-40095b7c-5f04-4666-9009-60ba5a4bb716.png)

