### PR TITLE
Improve appearance of mobile list/grid toggle icons

### DIFF
--- a/public/icons/grid_layout.svg
+++ b/public/icons/grid_layout.svg
@@ -1,7 +1,7 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M15 3V21" stroke="black" stroke-miterlimit="10"/>
-<path d="M9 3V21" stroke="black" stroke-miterlimit="10"/>
-<path d="M21 3H3V21H21V3Z" stroke="black"/>
-<path d="M21 15H3" stroke="black" stroke-miterlimit="10"/>
-<path d="M21 9H3" stroke="black" stroke-miterlimit="10"/>
-</svg>
+ <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path stroke='black' d="M15 3V21" strokeMiterlimit="10" />
+    <path stroke='black' d="M9 3V21" strokeMiterlimit="10" />
+    <path stroke='black' d="M21 3H3V21H21V3Z" />
+    <path stroke='black' d="M21 15H3" strokeMiterlimit="10" />
+    <path stroke='black' d="M21 9H3" strokeMiterlimit="10" />
+  </svg>

--- a/public/icons/grid_layout.svg
+++ b/public/icons/grid_layout.svg
@@ -1,11 +1,7 @@
-<svg width="184" height="184" viewBox="0 0 184 184" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="1" y="1" width="46" height="46" fill="black" stroke="black" stroke-width="2"/>
-<rect x="69" y="1" width="46" height="46" fill="black" stroke="black" stroke-width="2"/>
-<rect x="137" y="1" width="46" height="46" fill="black" stroke="black" stroke-width="2"/>
-<rect x="1" y="69" width="46" height="46" fill="black" stroke="black" stroke-width="2"/>
-<rect x="69" y="69" width="46" height="46" fill="black" stroke="black" stroke-width="2"/>
-<rect x="137" y="69" width="46" height="46" fill="black" stroke="black" stroke-width="2"/>
-<rect x="1" y="137" width="46" height="46" fill="black" stroke="black" stroke-width="2"/>
-<rect x="69" y="137" width="46" height="46" fill="black" stroke="black" stroke-width="2"/>
-<rect x="137" y="137" width="46" height="46" fill="black" stroke="black" stroke-width="2"/>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 3V21" stroke="black" stroke-miterlimit="10"/>
+<path d="M9 3V21" stroke="black" stroke-miterlimit="10"/>
+<path d="M21 3H3V21H21V3Z" stroke="black"/>
+<path d="M21 15H3" stroke="black" stroke-miterlimit="10"/>
+<path d="M21 9H3" stroke="black" stroke-miterlimit="10"/>
 </svg>

--- a/public/icons/list_layout.svg
+++ b/public/icons/list_layout.svg
@@ -1,7 +1,7 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g>
-    <path id="Vector" d="M21 3H3V21H21V3Z" />
-    <path id="Vector_2" d="M21 15H3" stroke-miterlimit="10"/>
-    <path id="Vector_3" d="M21 9H3" stroke-miterlimit="10"/>
-</g>
+    <g>
+        <path stroke='black' d="M21 3H3V21H21V3Z" />
+        <path stroke='black' d="M21 15H3" strokeMiterlimit="10" />
+        <path stroke='black' d="M21 9H3" strokeMiterlimit="10" />
+    </g>
 </svg>

--- a/public/icons/list_layout.svg
+++ b/public/icons/list_layout.svg
@@ -1,5 +1,7 @@
-<svg width="184" height="184" viewBox="0 0 184 184" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="1" y="137" width="182" height="46" fill="black" stroke="black" stroke-width="2"/>
-<rect x="1" y="69" width="182" height="46" fill="black" stroke="black" stroke-width="2"/>
-<rect x="1" y="1" width="182" height="46" fill="black" stroke="black" stroke-width="2"/>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g>
+    <path id="Vector" d="M21 3H3V21H21V3Z" />
+    <path id="Vector_2" d="M21 15H3" stroke-miterlimit="10"/>
+    <path id="Vector_3" d="M21 9H3" stroke-miterlimit="10"/>
+</g>
 </svg>

--- a/src/scenes/UserGalleryPage/MobileLayoutToggle.tsx
+++ b/src/scenes/UserGalleryPage/MobileLayoutToggle.tsx
@@ -1,11 +1,36 @@
 import { DisplayLayout } from 'components/core/enums';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 type Props = {
   mobileLayout: DisplayLayout;
   setMobileLayout: (layout: DisplayLayout) => void;
 };
+
+const ListLayout = ({ stroke }: { stroke: string }) => (
+  // Although the svg has a height and width of 24, it is actually 18px (per Figma)
+  // Notice how the path elements begin at 21; there is simply padding around the icon
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g>
+      <path stroke={stroke} d="M21 3H3V21H21V3Z" />
+      <path stroke={stroke} d="M21 15H3" strokeMiterlimit="10" />
+      <path stroke={stroke} d="M21 9H3" strokeMiterlimit="10" />
+    </g>
+  </svg>
+);
+
+const GridLayout = ({ stroke }: { stroke: string }) => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M15 3V21" stroke={stroke} strokeMiterlimit="10" />
+    <path d="M9 3V21" stroke={stroke} strokeMiterlimit="10" />
+    <path d="M21 3H3V21H21V3Z" stroke={stroke} />
+    <path d="M21 15H3" stroke={stroke} strokeMiterlimit="10" />
+    <path d="M21 9H3" stroke={stroke} strokeMiterlimit="10" />
+  </svg>
+);
+
+const HOVERED_COLOR = '#000000';
+const UNHOVERED_COLOR = '#808080';
 
 function MobileLayoutToggle({ mobileLayout, setMobileLayout }: Props) {
   const handleGridClick = useCallback(() => {
@@ -16,13 +41,34 @@ function MobileLayoutToggle({ mobileLayout, setMobileLayout }: Props) {
     setMobileLayout(DisplayLayout.GRID);
   }, [setMobileLayout]);
 
+  const [stroke, setStroke] = useState(UNHOVERED_COLOR);
+
+  const handleMouseOver = useCallback(() => {
+    setStroke(HOVERED_COLOR);
+  }, [setStroke]);
+  const handleMouseOut = useCallback(() => {
+    setStroke(UNHOVERED_COLOR);
+  }, [setStroke]);
+
   return mobileLayout === DisplayLayout.GRID ? (
-    <StyledToggleButton onClick={handleGridClick} title="Grid view">
-      <Icon src="/icons/list_layout.svg" />
+    <StyledToggleButton
+      onClick={handleGridClick}
+      onMouseOver={handleMouseOver}
+      onMouseOut={handleMouseOut}
+      title="Grid view"
+    >
+      {/* <Icon src="/icons/list_layout.svg" /> */}
+      <ListLayout stroke={stroke} />
     </StyledToggleButton>
   ) : (
-    <StyledToggleButton onClick={handleListClick} title="List view">
-      <Icon src="/icons/grid_layout.svg" />
+    <StyledToggleButton
+      onClick={handleListClick}
+      onMouseOver={handleMouseOver}
+      onMouseOut={handleMouseOut}
+      title="List view"
+    >
+      {/* <Icon src="/icons/grid_layout.svg" /> */}
+      <GridLayout stroke={stroke} />
     </StyledToggleButton>
   );
 }
@@ -31,15 +77,12 @@ const StyledToggleButton = styled.button`
   background: none;
   border: 0;
   margin-top: 12px;
-`;
+  cursor: pointer;
+  padding: 0;
 
-const Icon = styled.img`
-  width: 20px;
-  height: 20px;
-  opacity: 0.25;
-  pointer-events: none;
-  // prevent "save image" popup when holding down on icon
-  -webkit-touch-callout: none;
+  & svg path {
+    transition: stroke 300ms ease;
+  }
 `;
 
 export default MobileLayoutToggle;

--- a/src/scenes/UserGalleryPage/MobileLayoutToggle.tsx
+++ b/src/scenes/UserGalleryPage/MobileLayoutToggle.tsx
@@ -1,5 +1,5 @@
 import { DisplayLayout } from 'components/core/enums';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import styled from 'styled-components';
 
 type Props = {
@@ -7,30 +7,27 @@ type Props = {
   setMobileLayout: (layout: DisplayLayout) => void;
 };
 
-const ListLayout = ({ stroke }: { stroke: string }) => (
+const ListLayout = () => (
   // Although the svg has a height and width of 24, it is actually 18px (per Figma)
   // Notice how the path elements begin at 21; there is simply padding around the icon
   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <g>
-      <path stroke={stroke} d="M21 3H3V21H21V3Z" />
-      <path stroke={stroke} d="M21 15H3" strokeMiterlimit="10" />
-      <path stroke={stroke} d="M21 9H3" strokeMiterlimit="10" />
+      <path d="M21 3H3V21H21V3Z" />
+      <path d="M21 15H3" strokeMiterlimit="10" />
+      <path d="M21 9H3" strokeMiterlimit="10" />
     </g>
   </svg>
 );
 
-const GridLayout = ({ stroke }: { stroke: string }) => (
+const GridLayout = () => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M15 3V21" stroke={stroke} strokeMiterlimit="10" />
-    <path d="M9 3V21" stroke={stroke} strokeMiterlimit="10" />
-    <path d="M21 3H3V21H21V3Z" stroke={stroke} />
-    <path d="M21 15H3" stroke={stroke} strokeMiterlimit="10" />
-    <path d="M21 9H3" stroke={stroke} strokeMiterlimit="10" />
+    <path d="M15 3V21" strokeMiterlimit="10" />
+    <path d="M9 3V21" strokeMiterlimit="10" />
+    <path d="M21 3H3V21H21V3Z" />
+    <path d="M21 15H3" strokeMiterlimit="10" />
+    <path d="M21 9H3" strokeMiterlimit="10" />
   </svg>
 );
-
-const HOVERED_COLOR = '#000000';
-const UNHOVERED_COLOR = '#808080';
 
 function MobileLayoutToggle({ mobileLayout, setMobileLayout }: Props) {
   const handleGridClick = useCallback(() => {
@@ -41,34 +38,13 @@ function MobileLayoutToggle({ mobileLayout, setMobileLayout }: Props) {
     setMobileLayout(DisplayLayout.GRID);
   }, [setMobileLayout]);
 
-  const [stroke, setStroke] = useState(UNHOVERED_COLOR);
-
-  const handleMouseOver = useCallback(() => {
-    setStroke(HOVERED_COLOR);
-  }, [setStroke]);
-  const handleMouseOut = useCallback(() => {
-    setStroke(UNHOVERED_COLOR);
-  }, [setStroke]);
-
   return mobileLayout === DisplayLayout.GRID ? (
-    <StyledToggleButton
-      onClick={handleGridClick}
-      onMouseOver={handleMouseOver}
-      onMouseOut={handleMouseOut}
-      title="Grid view"
-    >
-      {/* <Icon src="/icons/list_layout.svg" /> */}
-      <ListLayout stroke={stroke} />
+    <StyledToggleButton onClick={handleGridClick} title="Grid view">
+      <ListLayout />
     </StyledToggleButton>
   ) : (
-    <StyledToggleButton
-      onClick={handleListClick}
-      onMouseOver={handleMouseOver}
-      onMouseOut={handleMouseOut}
-      title="List view"
-    >
-      {/* <Icon src="/icons/grid_layout.svg" /> */}
-      <GridLayout stroke={stroke} />
+    <StyledToggleButton onClick={handleListClick} title="List view">
+      <GridLayout />
     </StyledToggleButton>
   );
 }
@@ -82,6 +58,10 @@ const StyledToggleButton = styled.button`
 
   & svg path {
     transition: stroke 300ms ease;
+    stroke: #808080;
+  }
+  & svg:hover path {
+    stroke: #000000;
   }
 `;
 


### PR DESCRIPTION
This updates the icons used for the list/grid toggle buttons. The icons are directly exported from Figma.

Spacing is also in line with expectations as laid out by Figma:

<div style="display: flex;">
<img width="47%" src='https://user-images.githubusercontent.com/13339581/158069965-74adcb07-3f39-4832-81b2-9e5cae332dbe.png'>
<img width="47%" src='https://user-images.githubusercontent.com/13339581/158069944-0e89c074-9921-4b1e-af08-a1a04ea7e6d4.png'>

(As a quick note, if we want pixel-precision on the entire page, that should be a more diligent effort; there are things in our current layout that make it difficult to measure exact px distances between elements, such as the line-height of text elements.)

Behind the scenes, I moved away from imports of the SVG icons as images and instead wrote the SVG [directly](https://github.com/gallery-so/gallery/compare/connor/mobile-grid-toggle?expand=1#diff-189e82c4c56e01bd3b60d712b732ac0b632eb686cb63d7bab28f5d4c74de4cdbR10-R30). This enables hover events on the stroke, which wouldn't be possible if we referenced a static image. Now, when you hover over the icon, the color changes. (I still replaced the icons in the `icons/` folder with the updated SVGs, in the rare event that we would use them elsewhere; we could probably delete these files entirely.)