### PR TITLE
Set user id using mixpanel identify function

### DIFF
--- a/src/contexts/analytics/AnalyticsContext.tsx
+++ b/src/contexts/analytics/AnalyticsContext.tsx
@@ -1,6 +1,7 @@
 import useAuthenticatedUserId from 'contexts/auth/useAuthenticatedUserId';
 import mixpanel from 'mixpanel-browser';
 import { createContext, memo, ReactNode, useCallback, useContext, useRef } from 'react';
+import { captureException } from '@sentry/nextjs';
 
 type EventProps = Record<string, unknown>;
 
@@ -28,8 +29,18 @@ export const _track = (eventName: string, eventProps: EventProps, userId?: strin
     });
   } catch (error: unknown) {
     // mixpanel errors shouldn't disrupt app
-    // TODO: send reporting errror to Sentry
-    console.error(error);
+    captureException(error);
+  }
+};
+
+export const _identify = (userId: string) => {
+  if (!mixpanelEnabled) return;
+
+  try {
+    mixpanel.identify(userId);
+  } catch (error: unknown) {
+    // mixpanel errors shouldn't disrupt app
+    captureException(error);
   }
 };
 

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -19,6 +19,7 @@ import {
 } from 'constants/storageKeys';
 import { useToastActions } from 'contexts/toast/ToastContext';
 import { User } from 'types/User';
+import { _identify } from 'contexts/analytics/AnalyticsContext';
 
 export type AuthState = LOGGED_IN | typeof LOGGED_OUT | typeof LOADING | typeof UNKNOWN;
 
@@ -99,6 +100,7 @@ const AuthProvider = memo(({ children }: Props) => {
       try {
         setAuthState({ type: 'LOGGED_IN', userId });
         setUserSigninAddress(address.toLowerCase());
+        _identify(userId);
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
         setLoggedOut();
@@ -124,6 +126,7 @@ const AuthProvider = memo(({ children }: Props) => {
         if (authenticatedUser) {
           setAuthState({ type: 'LOGGED_IN', userId: authenticatedUser.id });
           setIsLoggedInLocally(true);
+          _identify(authenticatedUser.id);
           return;
         }
 


### PR DESCRIPTION
We want to set the user's id as the `distinct_id` field in mixpanel when possible. This is done by calling mixpanel.identify() when the user logs in, or on page load and they are already logged in. 

Includes a bonus change to add Sentry logging when there's a Mixpanel error.
