### PR TITLE
Fix broken analytics context

### DIFF
--- a/src/contexts/analytics/AnalyticsContext.tsx
+++ b/src/contexts/analytics/AnalyticsContext.tsx
@@ -1,6 +1,7 @@
 import useAuthenticatedUserId from 'contexts/auth/useAuthenticatedUserId';
 import mixpanel from 'mixpanel-browser';
 import { createContext, memo, ReactNode, useCallback, useContext, useRef } from 'react';
+import noop from 'utils/noop';
 
 type EventProps = Record<string, unknown>;
 
@@ -36,7 +37,8 @@ export const _track = (eventName: string, eventProps: EventProps, userId?: strin
 export const useTrack = () => {
   const track = useContext(AnalyticsContext);
   if (!track) {
-    throw new Error('Attempted to use AnalyticsContext without a provider!');
+    console.error('Attempted to use AnalyticsContext without a provider!');
+    return noop;
   }
 
   return track;

--- a/src/contexts/errorReporting/ErrorReportingContext.tsx
+++ b/src/contexts/errorReporting/ErrorReportingContext.tsx
@@ -2,6 +2,7 @@ import { createContext, memo, ReactNode, useCallback, useContext, useRef } from 
 import { captureException, captureMessage, setUser } from '@sentry/nextjs';
 import { ScopeContext } from '@sentry/types';
 import useAuthenticatedUserId from 'contexts/auth/useAuthenticatedUserId';
+import noop from 'utils/noop';
 
 type AdditionalContext = Partial<Pick<ScopeContext, 'tags' | 'level'>>;
 
@@ -53,7 +54,8 @@ const ErrorReportingContext = createContext<ReportFn | undefined>(undefined);
 export const useReportError = () => {
   const reportError = useContext(ErrorReportingContext);
   if (!reportError) {
-    throw new Error('Attempted to use ErrorReportingContext without a provider!');
+    console.error('Attempted to use ErrorReportingContext without a provider!');
+    return noop;
   }
 
   return reportError;


### PR DESCRIPTION
Any error triggering the top-level error boundary would trigger a cascade of `AnalyticsContext` errors due to it trying to render `GalleryLink` outside of the analytics context – when it's in fact a dependency and must be rendered within.

This PR updates the tracking function to revert to a no-op should a situation like this arise in the future.

![image](https://user-images.githubusercontent.com/12162433/158677664-1f4e093b-8dfd-4017-900f-677997372948.png)
