### PR TITLE
Always reset the walletconnect provider to allow multiple subsequent connections

### DIFF
--- a/src/components/WalletSelector/WalletButton.tsx
+++ b/src/components/WalletSelector/WalletButton.tsx
@@ -38,17 +38,14 @@ function WalletButton({ walletName, activate, connector, setToPendingState }: Wa
   const handleClick = useCallback(() => {
     if (connector) {
       if (connector instanceof WalletConnectConnector) {
-        // Walletconnect "remembers" what address you recently connected with. We don't want this for multi-wallet
+        // Walletconnect "remembers" what address you recently connected with. We don't want this for multi-wallet.
+        // if the connector is walletconnect and the user has already tried to connect, manually reset the connector.
+        connector.walletConnectProvider = undefined;
         window.localStorage.removeItem('walletconnect');
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (connector.walletConnectProvider?.wc?.uri) {
-          // if the connector is walletconnect and the user has already tried to connect, manually reset the connector
-          connector.walletConnectProvider = undefined;
-        }
       }
 
       setToPendingState(connector, walletSymbol);
+      console.log('connector', connector);
 
       void activate(connector);
     }

--- a/src/hooks/api/users/useRemoveUserAddress.ts
+++ b/src/hooks/api/users/useRemoveUserAddress.ts
@@ -37,7 +37,7 @@ export default function useRemoveUserAddress() {
       await mutate(
         getUserCacheKey({ id: user.id }),
         (user: User) => {
-          const addresses = user.addresses.filter((address) => address !== addressToRemove);
+          const addresses = user?.addresses.filter((address) => address !== addressToRemove);
           return { ...user, addresses };
         },
         false


### PR DESCRIPTION
This PR fixes a regression where the user was not able to connect a wallet using WalletConnect more than once. This meant they could not add another wallet to their account using WalletConnect if they had signed in with WalletConnect.

The fix is to reset the wallet connect provider every time the user clicks the WC option. Previously, we had only reset it if the user had encountered an error or otherwise aborted the WC flow previously.

This previously worked with us just removing the WC data from local storage every time the user clicked the WC option, but it appears something changed.
The solutions are from https://github.com/NoahZinsmeister/web3-react/issues/217

In the medium term, it looks like the beta of the next version of web3-react is out and the author suggests upgrading for a better dev experience. https://github.com/NoahZinsmeister/web3-react/tree/main#web3-react-beta


