### PR TITLE
capture web3error and error separately during wallet actions

### DIFF
--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
@@ -104,14 +104,15 @@ function AddWalletPendingDefault({
         return signatureValid;
       } catch (error: unknown) {
         setIsConnecting(false);
-        captureException(error);
         trackAddWalletError(userFriendlyWalletName, error);
         if (isWeb3Error(error)) {
+          captureException(error.message);
           setDetectedError(error);
         }
 
         // Fall back to generic error message
         if (error instanceof Error) {
+          captureException(error);
           const web3Error: Web3Error = { code: 'AUTHENTICATION_ERROR', ...error };
           setDetectedError(web3Error);
         }

--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
@@ -73,14 +73,15 @@ function AddWalletPendingGnosisSafe({
 
   const handleError = useCallback(
     (error: unknown) => {
-      captureException(error);
       trackAddWalletError('Gnosis Safe', error);
       if (isWeb3Error(error)) {
+        captureException(error.message);
         setDetectedError(error);
       }
 
       // Fall back to generic error message
       if (error instanceof Error) {
+        captureException(error);
         const web3Error: Web3Error = { code: 'AUTHENTICATION_ERROR', ...error };
         setDetectedError(web3Error);
       }

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingDefault.tsx
@@ -95,15 +95,16 @@ function AuthenticateWalletPendingDefault({
         try {
           await attemptAuthentication(account.toLowerCase(), signer);
         } catch (error: unknown) {
-          captureException(error);
           trackSignInError(userFriendlyWalletName, error);
 
           if (isWeb3Error(error)) {
+            captureException(error.message);
             setDetectedError(error);
           }
 
           // Fall back to generic error message
           if (error instanceof Error) {
+            captureException(error);
             const web3Error: Web3Error = { code: 'AUTHENTICATION_ERROR', ...error };
             setDetectedError(web3Error);
           }

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
@@ -72,14 +72,15 @@ function AuthenticateWalletPendingGnosisSafe({
 
   const handleError = useCallback(
     (error: unknown) => {
-      captureException(error);
       trackSignInError('Gnosis Safe', error);
       if (isWeb3Error(error)) {
+        captureException(error.message);
         setDetectedError(error);
       }
 
       // Fall back to generic error message
       if (error instanceof Error) {
+        captureException(error);
         const web3Error: Web3Error = { code: 'AUTHENTICATION_ERROR', ...error };
         setDetectedError(web3Error);
       }


### PR DESCRIPTION
This tries to address the following issue:
https://sentry.io/organizations/usegallery/issues/3122657620/events/ce4b0f3370a04bdcb13a559a69111561/?project=6187637

We aren't capturing web3 errors correctly because they are not Error types. The suggested solution is to just capture the message. If we find that isn't sufficient we can dig deeper on how to capture the full error.
