### PR TITLE
Fix so wallet row is unmounted after disconnecting the wallet

### DIFF
--- a/src/components/ManageWallets/ManageWallets.tsx
+++ b/src/components/ManageWallets/ManageWallets.tsx
@@ -7,7 +7,7 @@ import { USER_SIGNIN_ADDRESS_LOCAL_STORAGE_KEY } from 'constants/storageKeys';
 import { useAuthenticatedUserAddresses } from 'hooks/api/users/useUser';
 import useAddWalletModal from 'hooks/useAddWalletModal';
 import usePersistedState from 'hooks/usePersistedState';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import ManageWalletsRow from './ManageWalletsRow';
 
@@ -17,7 +17,9 @@ type Props = {
 
 function ManageWallets({ newAddress }: Props) {
   const addresses = useAuthenticatedUserAddresses();
+  const [removedAddress, setRemovedAddress] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [notification, setNotification] = useState('');
 
   const showAddWalletModal = useAddWalletModal();
 
@@ -28,6 +30,14 @@ function ManageWallets({ newAddress }: Props) {
   const addWalletDisabled = useMemo(() => addresses.length >= 5, [addresses]);
   const [userSigninAddress] = usePersistedState(USER_SIGNIN_ADDRESS_LOCAL_STORAGE_KEY, '');
 
+  useEffect(() => {
+    setNotification(`Wallet ${removedAddress} has been removed.`);
+  }, [removedAddress]);
+
+  useEffect(() => {
+    setNotification(`Wallet ${newAddress} has been added.`);
+  }, [newAddress]);
+
   return (
     <StyledManageWallets>
       <BodyMedium>Manage Accounts</BodyMedium>
@@ -36,10 +46,10 @@ function ManageWallets({ newAddress }: Props) {
       <BodyRegular color={colors.gray50}>
         You&apos;ll also be able to sign in using any connected wallet.
       </BodyRegular>
-      {newAddress && (
+      {notification && (
         <>
           <Spacer height={16} />
-          <BodyRegular>Wallet {newAddress} was added.</BodyRegular>
+          <BodyRegular>{notification}</BodyRegular>
         </>
       )}
       {errorMessage ? <StyledErrorText message={errorMessage} /> : <Spacer height={16} />}
@@ -49,6 +59,7 @@ function ManageWallets({ newAddress }: Props) {
           address={address}
           setErrorMessage={setErrorMessage}
           userSigninAddress={userSigninAddress}
+          setRemovedAddress={setRemovedAddress}
         />
       ))}
       <StyledButton text="+ Add new wallet" onClick={handleSubmit} disabled={addWalletDisabled} />

--- a/src/components/ManageWallets/ManageWalletsRow.tsx
+++ b/src/components/ManageWallets/ManageWalletsRow.tsx
@@ -13,9 +13,15 @@ type Props = {
   address: string;
   userSigninAddress: string;
   setErrorMessage: (message: string) => void;
+  setRemovedAddress: (address: string) => void;
 };
 
-function ManageWalletsRow({ address, userSigninAddress, setErrorMessage }: Props) {
+function ManageWalletsRow({
+  address,
+  userSigninAddress,
+  setErrorMessage,
+  setRemovedAddress,
+}: Props) {
   const removeUserAddress = useRemoveUserAddress();
   const [isDisconnecting, setIsDisconnecting] = useState(false);
 
@@ -25,7 +31,7 @@ function ManageWalletsRow({ address, userSigninAddress, setErrorMessage }: Props
       setErrorMessage('');
       setIsDisconnecting(true);
       await removeUserAddress(address);
-      setIsDisconnecting(false);
+      setRemovedAddress(address);
     } catch (error: unknown) {
       setIsDisconnecting(false);
       if (isWeb3Error(error)) {

--- a/src/hooks/api/users/useRemoveUserAddress.ts
+++ b/src/hooks/api/users/useRemoveUserAddress.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useSWRConfig } from 'swr';
 import { User } from 'types/User';
 import usePost from '../_rest/usePost';
-import { getUserCacheKey, useAuthenticatedUser } from './useUser';
+import { useAuthenticatedUser } from './useUser';
 
 type RemoveUserAddressRequest = {
   addresses: string[];
@@ -24,18 +24,8 @@ export default function useRemoveUserAddress() {
         { addresses: [addressToRemove] }
       );
 
-      // Optimistically update both user caches by username, ID
       await mutate(
-        getUserCacheKey({ username: user.username }),
-        (user: User) => {
-          const addresses = user.addresses.filter((address) => address !== addressToRemove);
-          return { ...user, addresses };
-        },
-        false
-      );
-
-      await mutate(
-        getUserCacheKey({ id: user.id }),
+        ['/users/get/current', 'get current user'],
         (user: User) => {
           const addresses = user?.addresses.filter((address) => address !== addressToRemove);
           return { ...user, addresses };


### PR DESCRIPTION
**Summary**
This fixes a bug where upon disconnecting a wallet from a user account, the wallet row remained on screen. The expected behavior is that the wallet row is unmounted so that there is visual feedback that the wallet was removed.

As a bonus I also added a notification that says `Wallet ${removedAddress} has been removed.` upon successful removal, since we already have a notification upon successful addition.
