### PR TITLE
fix default notification message

### DIFF
--- a/src/components/ManageWallets/ManageWallets.tsx
+++ b/src/components/ManageWallets/ManageWallets.tsx
@@ -31,11 +31,15 @@ function ManageWallets({ newAddress }: Props) {
   const [userSigninAddress] = usePersistedState(USER_SIGNIN_ADDRESS_LOCAL_STORAGE_KEY, '');
 
   useEffect(() => {
-    setNotification(`Wallet ${removedAddress} has been removed.`);
+    if (removedAddress) {
+      setNotification(`Wallet ${removedAddress} has been removed.`);
+    }
   }, [removedAddress]);
 
   useEffect(() => {
-    setNotification(`Wallet ${newAddress} has been added.`);
+    if (newAddress) {
+      setNotification(`Wallet ${newAddress} has been added.`);
+    }
   }, [newAddress]);
 
   return (


### PR DESCRIPTION
This PR fixes a default notification message being incorrectly displayed when viewing the multi wallet modal.
![Screen Shot 2022-03-29 at 18 52 59](https://user-images.githubusercontent.com/80802871/160585329-207c97b6-ab2b-445f-a5e5-d7fb17664c44.png)

