### PR TITLE
Capture error to sentry when refresh nfts returns an error

### DIFF
--- a/src/contexts/wizard/WizardDataProvider.tsx
+++ b/src/contexts/wizard/WizardDataProvider.tsx
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/nextjs';
 import { useToastActions } from 'contexts/toast/ToastContext';
 import { useMutateAllNftsCache } from 'hooks/api/nfts/useAllNfts';
 import { useRefreshOpenseaSync } from 'hooks/api/nfts/useOpenseaSync';
@@ -57,7 +58,8 @@ export default memo(function WizardDataProvider({ id, children }: Props) {
     try {
       await refreshOpenseaSync();
       void mutateAllNftsCache();
-    } catch {
+    } catch (error: unknown) {
+      captureException(error);
       pushToast(
         'Error while fetching latest NFTs. Opensea may be temporarily unavailable. Please try again later.'
       );


### PR DESCRIPTION
This will give us more visibility into how often this issue occurs