### PR TITLE
Fix collection hovering bug

### DIFF
--- a/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -70,9 +70,7 @@ function UserGalleryCollection({ collection, mobileLayout }: Props) {
   }, []);
 
   const handleMouseExit = useCallback(() => {
-    setTimeout(() => {
-      setIsHovering(false);
-    }, 200);
+    setIsHovering(false);
   }, []);
 
   const handleEditNameClick = useCallback(() => {


### PR DESCRIPTION
A timeout was preventing the icon from re-appearing when the mouse quickly left and re-entered.

Not sure why the timeout was there in the first place (original [PR](https://github.com/gallery-so/gallery/pull/571/files#diff-32f8df5768976d7f398a2e18a88ccafff55d8ae1aeb11765e8530e5af2ccd022R57-R61))

![image](https://user-images.githubusercontent.com/12162433/162066398-f22febff-98b3-40ac-b400-939ef2ad5a84.png)
