### PR TITLE
remove share button from Reorder Gallery page

### DIFF
--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
@@ -12,8 +12,6 @@ import { Collection } from 'types/Collection';
 import noop from 'utils/noop';
 import CollectionCreateOrEditForm from '../OrganizeCollection/CollectionCreateOrEditForm';
 import DeleteCollectionConfirmation from './DeleteCollectionConfirmation';
-import CopyToClipboard from 'components/CopyToClipboard/CopyToClipboard';
-import { useAuthenticatedUsername } from 'hooks/api/users/useUser';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 
 type Props = {
@@ -23,11 +21,8 @@ type Props = {
 function CollectionRowSettings({ collection, wizard: { push } }: Props & WizardComponentProps) {
   const { showModal } = useModal();
   const { setCollectionIdBeingEdited } = useCollectionWizardActions();
-  const username = useAuthenticatedUsername();
 
   const { id, name, collectors_note, hidden } = collection;
-
-  const collectionUrl = `${window.location.origin}/${username}/${id}`;
 
   const track = useTrack();
 

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
@@ -72,10 +72,6 @@ function CollectionRowSettings({ collection, wizard: { push } }: Props & WizardC
         <Spacer height={12} />
         <TextButton onClick={handleToggleHiddenClick} text={hidden ? 'Show' : 'Hide'} />
         <Spacer height={12} />
-        <CopyToClipboard textToCopy={collectionUrl}>
-          <TextButton text="Share" />
-        </CopyToClipboard>
-        <Spacer height={12} />
         <TextButton onClick={handleDeleteClick} text="Delete" />
       </Dropdown>
     </StyledCollectionRowSettings>


### PR DESCRIPTION
This PR removes the "Share" option from each collection on the /edit page.
![Screen Shot 2022-04-08 at 0 00 09](https://user-images.githubusercontent.com/80802871/162229893-abae9d99-4932-453f-86ce-685c5b59a904.png)

