### PR TITLE
Remove unnecessary username check for welcome flow

### DIFF
--- a/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
+++ b/src/scenes/WelcomeAnimation/WelcomeAnimation.tsx
@@ -8,8 +8,6 @@ import { AnimatedImage, animatedImages } from './Images';
 
 import styled, { css, keyframes } from 'styled-components';
 import { animated, useSpring } from 'react-spring';
-import { useAuthenticatedUsername } from 'hooks/api/users/useUser';
-import { useRouter } from 'next/router';
 import useWindowSize from 'src/hooks/useWindowSize';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 
@@ -69,8 +67,6 @@ export default function WelcomeAnimation({ next }: Props) {
   const [shouldFadeOut, setShouldFadeOut] = useState(false);
   const [shouldExplode, setShouldExplode] = useState(false);
   const [imagesFaded, setImagesFaded] = useState(false);
-  const username = useAuthenticatedUsername();
-  const { push } = useRouter();
 
   useEffect(() => {
     setTimeout(() => {
@@ -83,17 +79,13 @@ export default function WelcomeAnimation({ next }: Props) {
 
   const handleClick = useCallback(() => {
     track('Click through welcome page');
-    if (username) {
-      void push(`/${username}`);
-      return;
-    }
 
     // Delay next so we can show a transition animation
     setShouldFadeOut(true);
     setTimeout(() => {
       next();
     }, FADE_DURATION);
-  }, [track, username, push, next]);
+  }, [track, next]);
 
   return (
     <StyledContainer onMouseMove={({ clientX: x, clientY: y }) => set({ xy: calc(x, y) })}>


### PR DESCRIPTION
The welcome page has logic where if you already have a username, it would push you to your user profile, rather than continuing you through the onboarding flow.

This seems like an unnecessary check, as the only way one could end up in this state is to visit `/welcome` directly as an authenticated user. Furthermore, if they do choose to go through the welcome flow again, it works just fine (their username/bio is pre-populated in the next step, and they can create a new collection in the next, etc).

Honestly the other cool thing about this is it's one less place to handle graphql migration lolll