### PR TITLE
delete duplicate description

### DIFF
--- a/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -69,14 +69,6 @@ function NftDetailText({
           <Spacer height={32} />
         </>
       )}
-      {description && (
-        <>
-          <StyledNftDescription>
-            <Markdown text={description} />
-          </StyledNftDescription>
-          <Spacer height={32} />
-        </>
-      )}
       <TitleXS>Owner</TitleXS>
       <InteractiveLink to={`/${username.current}`}>{username.current}</InteractiveLink>
       <Spacer height={16} />


### PR DESCRIPTION
The description on the NFT Detail text was rendered twice in a row by accident. This PR removes the redundant one.