### PR TITLE
Fix community page filter

### DIFF
--- a/src/scenes/CommunityPage/CommunityPageList.tsx
+++ b/src/scenes/CommunityPage/CommunityPageList.tsx
@@ -87,8 +87,6 @@ export default function CommunityPageList({ communityRef }: Props) {
   const sortedOwners = useMemo(() => {
     const nonNullOwners = removeNullValues(owners ?? []);
 
-    // nonNullOwners.sort((a, b) => a.username.toLowerCase().localeCompare(b.username.toLowerCase()));
-
     nonNullOwners.sort((a, b) => {
       const usernameA = a.username.toLowerCase();
       const usernameB = b.username.toLowerCase();
@@ -117,7 +115,7 @@ export default function CommunityPageList({ communityRef }: Props) {
   return (
     <StyledCommunityPageList>
       {filteredOwners.map((owner) => (
-        <CommunityPageUser key={owner.username} username={owner.username} />
+        <CommunityPageUser key={owner.address} username={owner.username} />
       ))}
     </StyledCommunityPageList>
   );

--- a/src/scenes/CommunityPage/CommunityPageList.tsx
+++ b/src/scenes/CommunityPage/CommunityPageList.tsx
@@ -75,6 +75,7 @@ export default function CommunityPageList({ communityRef }: Props) {
     graphql`
       fragment CommunityPageListFragment on Community {
         owners {
+          address @required(action: NONE)
           username @required(action: NONE)
         }
       }


### PR DESCRIPTION
This PR fixes a bug where the search filter on the community page didn't properly update the list of users. Changing the value used as the key worked.