### PR TITLE
truncate long community descriptions and reduce width

### DIFF
--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -31,14 +31,16 @@ export default function CommunityPageView({ communityRef }: Props) {
   const { name, description } = community;
   const isMobile = useIsMobileWindowWidth();
 
+  const shouldTruncateDescription = useMemo(
+    () => !!description && description?.length > 330,
+    [description]
+  );
+
   const truncatedDescription = useMemo(() => {
-    if (!description) {
-      return '';
-    }
-    return description.length > 330 ? `${description.slice(0, 327).trim()}...` : description;
+    return !!description ? `${description.slice(0, 327).trim()}...` : '';
   }, [description]);
 
-  const [showFullDescription, setShowFullDescription] = useState(false);
+  const [showFullDescription, setShowFullDescription] = useState(!shouldTruncateDescription);
 
   const handleShowMoreClick = useCallback(() => {
     setShowFullDescription((prev) => !prev);
@@ -56,10 +58,12 @@ export default function CommunityPageView({ communityRef }: Props) {
               <Markdown text={showFullDescription ? description : truncatedDescription} />
             </BaseM>
             <Spacer height={8} />
-            <TextButton
-              text={showFullDescription ? 'Show less' : 'Show More'}
-              onClick={handleShowMoreClick}
-            />
+            {shouldTruncateDescription && (
+              <TextButton
+                text={showFullDescription ? 'Show less' : 'Show More'}
+                onClick={handleShowMoreClick}
+              />
+            )}
           </StyledDescription>
         )}
       </StyledHeader>

--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -1,5 +1,5 @@
 import Spacer from 'components/core/Spacer/Spacer';
-import { BaseM, TitleL, TitleS, TitleXS } from 'components/core/Text/Text';
+import { BaseM, TitleL, TitleS } from 'components/core/Text/Text';
 import MemberListFilter from 'scenes/MemberListPage/MemberListFilter';
 import styled from 'styled-components';
 import MemberListPageProvider from 'contexts/memberListPage/MemberListPageContext';

--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -1,5 +1,5 @@
 import Spacer from 'components/core/Spacer/Spacer';
-import { BaseM, TitleL, TitleS } from 'components/core/Text/Text';
+import { BaseM, TitleL, TitleS, TitleXS } from 'components/core/Text/Text';
 import MemberListFilter from 'scenes/MemberListPage/MemberListFilter';
 import styled from 'styled-components';
 import MemberListPageProvider from 'contexts/memberListPage/MemberListPageContext';
@@ -9,6 +9,9 @@ import Markdown from 'components/core/Markdown/Markdown';
 import { graphql } from 'relay-runtime';
 import { useFragment } from 'react-relay';
 import { CommunityPageViewFragment$key } from '__generated__/CommunityPageViewFragment.graphql';
+import { useCallback, useMemo, useState } from 'react';
+import TextButton from 'components/core/Button/TextButton';
+import breakpoints from 'components/core/breakpoints';
 
 type Props = {
   communityRef: CommunityPageViewFragment$key;
@@ -28,18 +31,36 @@ export default function CommunityPageView({ communityRef }: Props) {
   const { name, description } = community;
   const isMobile = useIsMobileWindowWidth();
 
+  const truncatedDescription = useMemo(() => {
+    if (!description) {
+      return '';
+    }
+    return description.length > 330 ? `${description.slice(0, 327).trim()}...` : description;
+  }, [description]);
+
+  const [showFullDescription, setShowFullDescription] = useState(false);
+
+  const handleShowMoreClick = useCallback(() => {
+    setShowFullDescription((prev) => !prev);
+  }, []);
+
   return (
     <MemberListPageProvider>
       <Spacer height={128} />
       <StyledHeader>
         <TitleL>{name}</TitleL>
         {description && (
-          <>
+          <StyledDescription>
             <Spacer height={8} />
             <BaseM>
-              <Markdown text={description} />
+              <Markdown text={showFullDescription ? description : truncatedDescription} />
             </BaseM>
-          </>
+            <Spacer height={8} />
+            <TextButton
+              text={showFullDescription ? 'Show less' : 'Show More'}
+              onClick={handleShowMoreClick}
+            />
+          </StyledDescription>
         )}
       </StyledHeader>
       <Spacer height={isMobile ? 65 : 96} />
@@ -54,6 +75,12 @@ export default function CommunityPageView({ communityRef }: Props) {
     </MemberListPageProvider>
   );
 }
+
+const StyledDescription = styled.div`
+  @media only screen and ${breakpoints.tablet} {
+    width: 50%;
+  }
+`;
 
 const StyledListWrapper = styled.div`
   display: flex;


### PR DESCRIPTION
This PR truncates long community descriptions so that only 4 lines (approx) of the description are displayed by default.

a "Show More" button will reveal the rest of the description.

Also reduces the width of the description to 50% on non mobile