### PR TITLE
Improve how # of lines in community description are limited and add analytics events

### DIFF
--- a/src/components/core/InteractiveLink/InteractiveLink.tsx
+++ b/src/components/core/InteractiveLink/InteractiveLink.tsx
@@ -12,16 +12,21 @@ type Props = {
   children: ReactNode;
   size?: string; // 'M', 'L', 'XL'
   className?: string;
+  onClick?: () => void;
 };
 
-export default function InteractiveLink({ to, href, children, className }: Props) {
+export default function InteractiveLink({ to, href, children, className, onClick }: Props) {
   const track = useTrack();
 
   const handleClick = useCallback(() => {
     track('Link Click', {
       to: to || href,
     });
-  }, [href, to, track]);
+
+    if (onClick) {
+      onClick();
+    }
+  }, [href, onClick, to, track]);
 
   if (!to && !href) {
     console.error('no link provided for InteractiveLink');

--- a/src/scenes/CommunityPage/CommunityPage.tsx
+++ b/src/scenes/CommunityPage/CommunityPage.tsx
@@ -1,6 +1,8 @@
 import breakpoints, { pageGutter } from 'components/core/breakpoints';
 import Page from 'components/core/Page/Page';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import Head from 'next/head';
+import { useEffect } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import NotFound from 'scenes/NotFound/NotFound';
@@ -31,6 +33,14 @@ export default function CommunityPage({ queryRef }: Props) {
     `,
     queryRef
   );
+
+  const track = useTrack();
+
+  useEffect(() => {
+    if (community && community.__typename === 'Community') {
+      track('Page View: Community', { name: community.name });
+    }
+  }, [community, track]);
 
   if (!community || community.__typename !== 'Community') {
     return <NotFound resource="community" />;

--- a/src/scenes/CommunityPage/CommunityPageList.tsx
+++ b/src/scenes/CommunityPage/CommunityPageList.tsx
@@ -2,6 +2,7 @@ import breakpoints from 'components/core/breakpoints';
 import colors from 'components/core/colors';
 import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 import { BaseXL } from 'components/core/Text/Text';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import {
   useMemberListPageActions,
   useMemberListPageState,
@@ -28,10 +29,20 @@ function CommunityPageUser({ username }: CommunityPageUserProps) {
     setFadeUsernames(false);
   }, [setFadeUsernames]);
 
+  const track = useTrack();
+
+  const handleUsernameClick = useCallback(() => {
+    track('Community Page Username Click', { username });
+  }, [track, username]);
+
   return (
     <StyledOwner>
       <div onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-        <StyledLink href={`/${username}`} fadeUsernames={fadeUsernames}>
+        <StyledLink
+          href={`/${username}`}
+          fadeUsernames={fadeUsernames}
+          onClick={handleUsernameClick}
+        >
           <StyledBaseXL>{username}</StyledBaseXL>
         </StyledLink>
       </div>

--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -90,6 +90,13 @@ const StyledBaseM = styled(BaseM)<{ showExpandedDescription: boolean }>`
   display: -webkit-box;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  line-clamp: 4;
+  display: -webkit-box;
+
+  // allows descriptions with multiple paragraphs to be line clamped properly
+  p {
+    display: contents;
+  }
 `;
 
 const StyledDescriptionWrapper = styled.div`

--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -9,7 +9,7 @@ import Markdown from 'components/core/Markdown/Markdown';
 import { graphql } from 'relay-runtime';
 import { useFragment } from 'react-relay';
 import { CommunityPageViewFragment$key } from '__generated__/CommunityPageViewFragment.graphql';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import TextButton from 'components/core/Button/TextButton';
 import breakpoints from 'components/core/breakpoints';
 


### PR DESCRIPTION
This pr improves how we limit long community descriptions to 4 lines using css rather than by character length.
It also adds 2 mixpanel events for the community page.