### PR TITLE
fix image ratio on safari

### DIFF
--- a/src/components/ImageWithLoading/ImageWithLoading.tsx
+++ b/src/components/ImageWithLoading/ImageWithLoading.tsx
@@ -2,10 +2,6 @@ import { useSetContentIsLoaded } from 'contexts/shimmer/ShimmerContext';
 import { useMemo } from 'react';
 import styled from 'styled-components';
 
-type ContentWidthType =
-  | 'fullWidth' // fill container
-  | 'maxWidth'; // fill up to container
-
 type ContentHeightType =
   | 'maxHeightScreen' // fill up to screen
   | 'inherit';
@@ -14,17 +10,10 @@ type Props = {
   className?: string;
   src: string;
   alt: string;
-  widthType?: ContentWidthType;
   heightType?: ContentHeightType;
 };
 
-export default function ImageWithLoading({
-  className,
-  widthType = 'fullWidth',
-  heightType,
-  src,
-  alt,
-}: Props) {
+export default function ImageWithLoading({ className, heightType, src, alt }: Props) {
   const setContentIsLoaded = useSetContentIsLoaded();
 
   const maxHeight = useMemo(() => {
@@ -40,7 +29,6 @@ export default function ImageWithLoading({
   return (
     <StyledImg
       className={className}
-      widthType={widthType}
       maxHeight={maxHeight}
       src={src}
       alt={alt}
@@ -51,12 +39,11 @@ export default function ImageWithLoading({
 }
 
 type StyledImgProps = {
-  widthType: ContentWidthType;
   maxHeight: string;
 };
 
 const StyledImg = styled.img<StyledImgProps>`
   display: block;
-  ${({ widthType }) => (widthType === 'fullWidth' ? 'width' : 'max-width')}: 100%;
+  max-width: 100%;
   max-height: ${({ maxHeight }) => maxHeight};
 `;

--- a/src/scenes/NftDetailPage/NftDetailImage.tsx
+++ b/src/scenes/NftDetailPage/NftDetailImage.tsx
@@ -43,7 +43,6 @@ function NftDetailImage({ nftRef }: Props) {
     <ImageWithLoading
       src={graphqlGetResizedNftImageUrlWithFallback(contentRenderURL, 1200)}
       alt={nft.name ?? ''}
-      widthType="maxWidth"
       heightType={breakpoint === size.desktop ? 'maxHeightScreen' : undefined}
     />
   );

--- a/src/scenes/NftDetailPage/NftDetailVideo.tsx
+++ b/src/scenes/NftDetailPage/NftDetailVideo.tsx
@@ -15,6 +15,7 @@ function NftDetailVideo({ mediaRef, maxHeight }: Props) {
       fragment NftDetailVideoFragment on VideoMedia {
         contentRenderURLs @required(action: THROW) {
           raw @required(action: THROW)
+          large @required(action: THROW)
         }
       }
     `,
@@ -24,7 +25,7 @@ function NftDetailVideo({ mediaRef, maxHeight }: Props) {
 
   return (
     <StyledVideo
-      src={nft.contentRenderURLs.raw}
+      src={nft.contentRenderURLs.large}
       muted
       autoPlay
       loop


### PR DESCRIPTION
this PR fixes image ratio bug for safari

before
<img width="1144" alt="Screen Shot 2022-04-20 at 12 03 27" src="https://user-images.githubusercontent.com/80802871/164304040-6b880f3c-a5e4-472d-b910-b1e09f417e91.png">

after
<img width="867" alt="Screen Shot 2022-04-20 at 12 04 18" src="https://user-images.githubusercontent.com/80802871/164304051-b8578fe6-251e-4abc-bd80-3bd2af330b87.png">

