### PR TITLE
Fix weird keyboard navigation bug

### DIFF
--- a/src/components/core/TextArea/TextArea.tsx
+++ b/src/components/core/TextArea/TextArea.tsx
@@ -27,6 +27,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         placeholder={placeholder}
         defaultValue={defaultValue}
         onChange={onChange}
+        onKeyUp={(e) => e.stopPropagation()} // To prevent keyboard navigation from triggering while in textarea
         autoFocus={autoFocus}
         autoComplete="off"
         autoCorrect="off"

--- a/src/hooks/useKeyDown.tsx
+++ b/src/hooks/useKeyDown.tsx
@@ -22,11 +22,12 @@ export default function useKeyDown(targetKey: string, callbackFn: () => void) {
     };
   }, [pressHandler]);
 
+  const activeEl = document.activeElement;
+
   // useEffect ensures that the callback function is called once, which is relevant when navigating
   useEffect(() => {
     // If the user is not currently focused on the body, return
-    const activeEl = document.activeElement;
-    if (activeEl?.tagName !== 'BODY') return;
+    if (activeEl?.tagName == 'TEXTAREA') return;
 
     if (keyPressed) {
       callbackFn();
@@ -35,5 +36,5 @@ export default function useKeyDown(targetKey: string, callbackFn: () => void) {
       // This also prevents route-based navigation from duplicating
       setKeyPressed(false);
     }
-  }, [keyPressed, callbackFn]);
+  }, [keyPressed, callbackFn, activeEl]);
 }

--- a/src/hooks/useKeyDown.tsx
+++ b/src/hooks/useKeyDown.tsx
@@ -28,8 +28,8 @@ export default function useKeyDown(targetKey: string, callbackFn: () => void) {
 
   // useEffect ensures that the callback function is called once, which is relevant when navigating
   useEffect(() => {
-    // If the user is currently focused on a textarea, return to prevent accidental navigation
-    if (activeEl?.tagName == 'TEXTAREA') return;
+    // If the user is currently not focused on body, return to prevent accidental navigation
+    if (activeEl?.tagName !== 'BODY') return;
 
     if (keyPressed) {
       callbackFn();

--- a/src/hooks/useKeyDown.tsx
+++ b/src/hooks/useKeyDown.tsx
@@ -20,19 +20,15 @@ export default function useKeyDown(targetKey: string, callbackFn: () => void) {
     };
   }, [pressHandler]);
 
-  const activeEl = document.activeElement;
-
   // useEffect ensures that the callback function is called once, which is relevant when navigating
   useEffect(() => {
-    // If the user is not currently focused on the body, return
-    if (activeEl?.tagName !== 'BODY') return;
-
     if (keyPressed) {
       callbackFn();
+
       // After executing, reset keyPressed to false so that the user can click the same key again on the same page
       // Only currently relevant if user is on /edit -> escapes -> shows modal -> escapes -> clicks escape again
       // This also prevents route-based navigation from duplicating
       setKeyPressed(false);
     }
-  }, [keyPressed, callbackFn, activeEl]);
+  }, [keyPressed, callbackFn]);
 }

--- a/src/hooks/useKeyDown.tsx
+++ b/src/hooks/useKeyDown.tsx
@@ -7,11 +7,7 @@ export default function useKeyDown(targetKey: string, callbackFn: () => void) {
   // If pressed key is our target key then set to true
   const pressHandler = useCallback(
     ({ key }: KeyboardEvent) => {
-      if (key === targetKey) {
-        setKeyPressed(true);
-      } else {
-        setKeyPressed(false);
-      }
+      setKeyPressed(key === targetKey);
     },
     [targetKey]
   );

--- a/src/hooks/useKeyDown.tsx
+++ b/src/hooks/useKeyDown.tsx
@@ -28,7 +28,7 @@ export default function useKeyDown(targetKey: string, callbackFn: () => void) {
 
   // useEffect ensures that the callback function is called once, which is relevant when navigating
   useEffect(() => {
-    // If the user is currently not focused on body, return to prevent accidental navigation
+    // If the user is not currently focused on the body, return
     if (activeEl?.tagName !== 'BODY') return;
 
     if (keyPressed) {

--- a/src/hooks/useKeyDown.tsx
+++ b/src/hooks/useKeyDown.tsx
@@ -9,6 +9,8 @@ export default function useKeyDown(targetKey: string, callbackFn: () => void) {
     ({ key }: KeyboardEvent) => {
       if (key === targetKey) {
         setKeyPressed(true);
+      } else {
+        setKeyPressed(false);
       }
     },
     [targetKey]
@@ -26,7 +28,7 @@ export default function useKeyDown(targetKey: string, callbackFn: () => void) {
 
   // useEffect ensures that the callback function is called once, which is relevant when navigating
   useEffect(() => {
-    // If the user is not currently focused on the body, return
+    // If the user is currently focused on a textarea, return to prevent accidental navigation
     if (activeEl?.tagName == 'TEXTAREA') return;
 
     if (keyPressed) {

--- a/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -100,12 +100,17 @@ export default function NftDetailView({
     [username, collection.dbid, replace]
   );
 
+  // Unsure why, but setTimeout is needed, otherwise next/prevNftId will be null sometimes
   const handleNextPress = useCallback(() => {
-    if (nextNftId) navigateToId(nextNftId);
+    setTimeout(() => {
+      if (nextNftId) navigateToId(nextNftId);
+    }, 0);
   }, [nextNftId, navigateToId]);
 
   const handlePrevPress = useCallback(() => {
-    if (prevNftId) navigateToId(prevNftId);
+    setTimeout(() => {
+      if (prevNftId) navigateToId(prevNftId);
+    }, 0);
   }, [prevNftId, navigateToId]);
 
   useKeyDown('ArrowRight', handleNextPress);

--- a/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -95,6 +95,7 @@ export default function NftDetailView({
 
   const navigateToId = useCallback(
     (nftId: string) => {
+      console.log(collection.dbid, nftId);
       void replace(`/${username}/${collection.dbid}/${nftId}`);
     },
     [username, collection.dbid, replace]
@@ -102,15 +103,11 @@ export default function NftDetailView({
 
   // Unsure why, but setTimeout is needed, otherwise next/prevNftId will be null sometimes
   const handleNextPress = useCallback(() => {
-    setTimeout(() => {
-      if (nextNftId) navigateToId(nextNftId);
-    }, 0);
+    if (nextNftId) navigateToId(nextNftId);
   }, [nextNftId, navigateToId]);
 
   const handlePrevPress = useCallback(() => {
-    setTimeout(() => {
-      if (prevNftId) navigateToId(prevNftId);
-    }, 0);
+    if (prevNftId) navigateToId(prevNftId);
   }, [prevNftId, navigateToId]);
 
   useKeyDown('ArrowRight', handleNextPress);

--- a/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -95,13 +95,11 @@ export default function NftDetailView({
 
   const navigateToId = useCallback(
     (nftId: string) => {
-      console.log(collection.dbid, nftId);
       void replace(`/${username}/${collection.dbid}/${nftId}`);
     },
     [username, collection.dbid, replace]
   );
 
-  // Unsure why, but setTimeout is needed, otherwise next/prevNftId will be null sometimes
   const handleNextPress = useCallback(() => {
     if (nextNftId) navigateToId(nextNftId);
   }, [nextNftId, navigateToId]);


### PR DESCRIPTION
This fixes a bug where if you type a backspace in a textarea and then click right or left arrow key the app navigates to `/{username}` rather than the next/previous NFT id. This was because it was registering the `Backspace` key and "queuing" it up for when the next key press was registered. 

https://user-images.githubusercontent.com/13339581/164838867-8fc6a483-f05c-4c10-a914-ae4149453831.mov

Fixed by resetting `keyPressed` to false when key is released. Also, moved the `activeEl` declaration outside of the useEffect so that we listen for changes in focused element. 