### PR TITLE
Prevent accidental image selection when editing collections/galleries

### DIFF
--- a/src/flows/shared/steps/OrganizeCollection/Editor/SortableStagedNft.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/SortableStagedNft.tsx
@@ -87,6 +87,8 @@ export const StyledSortableNft = styled.div`
   cursor: grab;
   margin: 24px;
 
+  user-select: none;
+
   &:hover ${StyledUnstageButton} {
     opacity: 1;
   }

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
@@ -99,6 +99,8 @@ const StyledOutline = styled.div<SelectedProps>`
   left: 0;
 
   border: ${({ isSelected }) => (isSelected ? 1 : 0)}px solid ${colors.activeBlue};
+
+  user-select: none;
 `;
 
 const StyledImage = styled.img<SelectedProps>`

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
@@ -156,6 +156,9 @@ const BigNftContainer = styled.div`
 
   width: ${BIG_NFT_SIZE_PX}px;
   height: ${BIG_NFT_SIZE_PX}px;
+
+  user-select: none;
+  pointer-events: none;
 `;
 
 const BigNftVideoPreview = styled.video`


### PR DESCRIPTION
This prevents accidental highlighting of NFT preview images while in editing contexts, by adding `user-select: none` to three places:

### Gallery editor

Here we add `user-select: none` and `pointer-events: none` to the individual images so that the user does not accidentally drag the **image** when they intend to drag the **row**.

https://user-images.githubusercontent.com/13339581/164994892-fa334480-57dd-46cf-a34e-5512ef77765a.mov

### Collection sidebar

Here we add `user-select: none` to individual images so that a user who tries to drag images (thinking dragging is a functionality here, which it is not) do not see highlighting of the other NFTs:

https://user-images.githubusercontent.com/13339581/164995045-e38e6a48-76a7-4849-b924-ccc0565cee02.mov

### Collection editor main view

Finally we add a `user-select: none` to each individual image so that the user does not accidentally select the inner text while trying to reorganize NFT order:

https://user-images.githubusercontent.com/13339581/164995181-60c94036-d0fe-4239-804b-5a9c47c411a7.mov





