### PR TITLE
GAL-55 enable Community Pages for every collection except umbrella contracts like art blocks and foundation

### DIFF
--- a/pages/community/[contractAddress]/index.tsx
+++ b/pages/community/[contractAddress]/index.tsx
@@ -11,12 +11,8 @@ type CommunityPageProps = MetaTagProps & {
   contractAddress: string;
 };
 
-export const ENABLED_CONTRACTS = [
-  '0x5180db8f5c931aae63c74266b211f580155ecac8', // Crypto Coven
-  '0xb228d7b6e099618ca71bd5522b3a8c3788a8f172', // Poolsuite Exec
-  '0x123214ef2bb526d1b3fb84a6d448985f537d9763', // Poolsuite Pool
-  // '0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270', // Crypto Citizens
-  '0xf64e6fb725f04042b5197e2529b84be4a925902c', // Zen Academy
+export const DISABLED_CONTRACTS = [
+  '0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270', // Art Blocks
 ];
 
 export default function CommunityPage({ contractAddress }: CommunityPageProps) {
@@ -35,7 +31,7 @@ export default function CommunityPage({ contractAddress }: CommunityPageProps) {
     return <GalleryRedirect to="/" />;
   }
 
-  if (!ENABLED_CONTRACTS.includes(contractAddress)) {
+  if (DISABLED_CONTRACTS.includes(contractAddress)) {
     return <GalleryRedirect to="/" />;
   }
 

--- a/pages/community/[contractAddress]/index.tsx
+++ b/pages/community/[contractAddress]/index.tsx
@@ -13,6 +13,9 @@ type CommunityPageProps = MetaTagProps & {
 
 export const DISABLED_CONTRACTS = [
   '0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270', // Art Blocks
+  '0x495f947276749ce646f68ac8c248420045cb7b5e', // OS
+  '0xf6793da657495ffeff9ee6350824910abc21356c', // Rarible
+  '0x3b3ee1931dc30c1957379fac9aba94d1c48a5405', // Foundation
 ];
 
 export default function CommunityPage({ contractAddress }: CommunityPageProps) {

--- a/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -10,7 +10,7 @@ import { useBreakpoint } from 'hooks/useWindowSize';
 import { EnsOrAddress } from 'components/EnsOrAddress';
 import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 import { useMemo, useRef } from 'react';
-import { ENABLED_CONTRACTS } from 'pages/community/[contractAddress]';
+import { DISABLED_CONTRACTS } from 'pages/community/[contractAddress]';
 
 type Props = {
   name: string | null;
@@ -41,7 +41,7 @@ function NftDetailText({
   const username = useRef(ownerUsername);
 
   const showCommunityLink = useMemo(
-    () => !!contractAddress && ENABLED_CONTRACTS.includes(contractAddress),
+    () => !!contractAddress && !DISABLED_CONTRACTS.includes(contractAddress),
     [contractAddress]
   );
 


### PR DESCRIPTION
This PR enables Community Pages for every collection except Art Blocks, which we need custom support for due to their collections existing on a single contract.