### PR TITLE
GAL-42 Add image background override to let us set backgrounds for certain contracts

### DIFF
--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -11,6 +11,7 @@ import { useCollectionColumns } from 'hooks/useCollectionColumns';
 import Gradient from 'components/core/Gradient/Gradient';
 import styled from 'styled-components';
 import NftPreviewLabel from './NftPreviewLabel';
+import { getBackgroundColorOverrideForContract } from 'utils/nft';
 
 type Props = {
   galleryNftRef: NftPreviewFragment$key;
@@ -45,6 +46,7 @@ function NftPreview({ galleryNftRef }: Props) {
           dbid
           name
           openseaCollectionName
+          contractAddress
           ...NftPreviewAssetFragment
         }
         collection @required(action: THROW) {
@@ -97,8 +99,13 @@ function NftPreview({ galleryNftRef }: Props) {
     }
   }, [columns, aspectRatioType, isMobile]);
 
+  const backgroundColorOverride = useMemo(
+    () => getBackgroundColorOverrideForContract(nft.contractAddress ?? ''),
+    [nft.contractAddress]
+  );
+
   return (
-    <StyledNftPreview width={nftPreviewWidth}>
+    <StyledNftPreview width={nftPreviewWidth} backgroundColorOverride={backgroundColorOverride}>
       <StyledLinkWrapper onClick={handleNftClick}>
         {/* // we'll request images at double the size of the element so that it looks sharp on retina */}
         <NftPreviewAsset nftRef={nft} size={previewSize * 2} />
@@ -138,13 +145,16 @@ const StyledNftFooter = styled.div`
   opacity: 0;
 `;
 
-const StyledNftPreview = styled.div<{ width?: string }>`
+const StyledNftPreview = styled.div<{ width?: string; backgroundColorOverride: string }>`
   display: flex;
   justify-content: center;
   align-items: center;
   position: relative;
   height: fit-content;
   overflow: hidden;
+
+  ${({ backgroundColorOverride }) =>
+    backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 
   max-height: 80vh;
   max-width: ${({ width }) => width};

--- a/src/flows/shared/steps/OrganizeCollection/Editor/SortableStagedNft.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/SortableStagedNft.tsx
@@ -10,6 +10,7 @@ import StagedNftImage from './StagedNftImage';
 import UnstageButton from './UnstageButton';
 import { graphql, useFragment } from 'react-relay';
 import { SortableStagedNftFragment$key } from '__generated__/SortableStagedNftFragment.graphql';
+import { getBackgroundColorOverrideForContract } from 'utils/nft';
 
 type Props = {
   nftRef: SortableStagedNftFragment$key;
@@ -21,6 +22,7 @@ function SortableStagedNft({ nftRef, size }: Props) {
     graphql`
       fragment SortableStagedNftFragment on Nft {
         dbid @required(action: THROW)
+        contractAddress
         ...StagedNftImageFragment
       }
     `,
@@ -42,12 +44,18 @@ function SortableStagedNft({ nftRef, size }: Props) {
     [isDragging, transform, transition]
   );
 
+  const backgroundColorOverride = useMemo(
+    () => getBackgroundColorOverrideForContract(nft.contractAddress ?? ''),
+    [nft.contractAddress]
+  );
+
   return (
     <StyledSortableNft
       id={id}
       active={isDragging}
       // @ts-expect-error force overload
       style={style}
+      backgroundColorOverride={backgroundColorOverride}
     >
       <StagedNftImage
         nftRef={nft}
@@ -77,7 +85,7 @@ const StyledUnstageButton = styled(UnstageButton)`
   transition: opacity ${transitions.cubic};
 `;
 
-export const StyledSortableNft = styled.div`
+export const StyledSortableNft = styled.div<{ backgroundColorOverride: string }>`
   position: relative;
   -webkit-backface-visibility: hidden;
   &:focus {
@@ -86,6 +94,10 @@ export const StyledSortableNft = styled.div`
   }
   cursor: grab;
   margin: 24px;
+
+  ${({ backgroundColorOverride }) =>
+    backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
+  
 
   user-select: none;
 

--- a/src/flows/shared/steps/OrganizeCollection/Editor/StagedNftImageDragging.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/StagedNftImageDragging.tsx
@@ -1,8 +1,10 @@
+import colors from 'components/core/colors';
 import useMouseUp from 'hooks/useMouseUp';
 import { useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled, { keyframes } from 'styled-components';
 import getVideoOrImageUrlForNftPreview from 'utils/graphql/getVideoOrImageUrlForNftPreview';
+import { getBackgroundColorOverrideForContract } from 'utils/nft';
 import { StagedNftImageDraggingFragment$key } from '__generated__/StagedNftImageDraggingFragment.graphql';
 
 type Props = {
@@ -14,6 +16,7 @@ function StagedNftImageDragging({ nftRef, size }: Props) {
   const nft = useFragment(
     graphql`
       fragment StagedNftImageDraggingFragment on Nft {
+        contractAddress
         ...getVideoOrImageUrlForNftPreviewFragment
       }
     `,
@@ -27,6 +30,11 @@ function StagedNftImageDragging({ nftRef, size }: Props) {
 
   const result = getVideoOrImageUrlForNftPreview(nft);
 
+  const backgroundColorOverride = useMemo(
+    () => getBackgroundColorOverrideForContract(nft.contractAddress ?? ''),
+    [nft.contractAddress]
+  );
+
   if (!result || !result.urls.large) {
     throw new Error('Image URL not found for StagedNftImageDragging');
   }
@@ -36,7 +44,7 @@ function StagedNftImageDragging({ nftRef, size }: Props) {
       <StyledDraggingVideo src={result.urls.large} />
     </VideoContainer>
   ) : (
-    <ImageContainer size={zoomedSize}>
+    <ImageContainer size={zoomedSize} backgroundColorOverride={backgroundColorOverride}>
       <StyledDraggingImage srcUrl={result.urls.large} isMouseUp={isMouseUp} size={zoomedSize} />
     </ImageContainer>
   );
@@ -62,8 +70,9 @@ const StyledDraggingVideo = styled.video`
   width: 100%;
 `;
 
-const ImageContainer = styled.div<{ size: number }>`
-  background: white;
+const ImageContainer = styled.div<{ size: number; backgroundColorOverride: string }>`
+  background-color: ${({ backgroundColorOverride }) =>
+    backgroundColorOverride ? backgroundColorOverride : colors.white};
   height: ${({ size }) => size}px;
   width: ${({ size }) => size}px;
 `;

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
@@ -2,10 +2,11 @@ import colors from 'components/core/colors';
 import transitions from 'components/core/transitions';
 import { useCollectionEditorActions } from 'contexts/collectionEditor/CollectionEditorContext';
 import { useReportError } from 'contexts/errorReporting/ErrorReportingContext';
-import { memo, useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 import getVideoOrImageUrlForNftPreview from 'utils/graphql/getVideoOrImageUrlForNftPreview';
+import { getBackgroundColorOverrideForContract } from 'utils/nft';
 import { SidebarNftIconFragment$key } from '__generated__/SidebarNftIconFragment.graphql';
 import { EditModeNft } from '../types';
 
@@ -18,6 +19,7 @@ function SidebarNftIcon({ nftRef, editModeNft }: SidebarNftIconProps) {
   const nft = useFragment(
     graphql`
       fragment SidebarNftIconFragment on Nft {
+        contractAddress
         ...getVideoOrImageUrlForNftPreviewFragment
       }
     `,
@@ -56,8 +58,13 @@ function SidebarNftIcon({ nftRef, editModeNft }: SidebarNftIconProps) {
     throw new Error('Image URL not found for SidebarNftIcon');
   }
 
+  const backgroundColorOverride = useMemo(
+    () => getBackgroundColorOverrideForContract(nft.contractAddress ?? ''),
+    [nft.contractAddress]
+  );
+
   return (
-    <StyledSidebarNftIcon>
+    <StyledSidebarNftIcon backgroundColorOverride={backgroundColorOverride}>
       {
         // Some OpenSea assets dont have an image url, so render a freeze frame of the video instead
         result.type === 'video' ? (
@@ -71,7 +78,7 @@ function SidebarNftIcon({ nftRef, editModeNft }: SidebarNftIconProps) {
   );
 }
 
-export const StyledSidebarNftIcon = styled.div`
+export const StyledSidebarNftIcon = styled.div<{ backgroundColorOverride: string }>`
   position: relative;
   width: 64px;
   height: 64px;
@@ -81,6 +88,8 @@ export const StyledSidebarNftIcon = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  ${({ backgroundColorOverride }) =>
+    backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 
   &:hover {
     cursor: pointer;

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
@@ -4,7 +4,10 @@ import unescape from 'utils/unescape';
 import { BaseM } from 'components/core/Text/Text';
 import Spacer from 'components/core/Spacer/Spacer';
 import colors from 'components/core/colors';
-import { graphqlGetResizedNftImageUrlWithFallback } from 'utils/nft';
+import {
+  getBackgroundColorOverrideForContract,
+  graphqlGetResizedNftImageUrlWithFallback,
+} from 'utils/nft';
 import Markdown from 'components/core/Markdown/Markdown';
 import Settings from 'public/icons/ellipses.svg';
 import { graphql, useFragment } from 'react-relay';
@@ -35,6 +38,7 @@ function CollectionRow({ collectionRef, className }: Props) {
         nfts {
           id
           nft @required(action: NONE) {
+            contractAddress
             ...getVideoOrImageUrlForNftPreviewFragment
             ...CollectionRowCompactNftsFragment
           }
@@ -99,7 +103,12 @@ function CollectionRow({ collectionRef, className }: Props) {
               {result.type === 'video' ? (
                 <BigNftVideoPreview src={imageUrl} />
               ) : (
-                <BigNftImagePreview src={imageUrl} />
+                <BigNftImagePreview
+                  src={imageUrl}
+                  backgroundColorOverride={getBackgroundColorOverrideForContract(
+                    nft.nft.contractAddress ?? ''
+                  )}
+                />
               )}
             </BigNftContainer>
           );
@@ -166,9 +175,11 @@ const BigNftVideoPreview = styled.video`
   max-height: 100%;
 `;
 
-const BigNftImagePreview = styled.img`
+const BigNftImagePreview = styled.img<{ backgroundColorOverride: string }>`
   max-width: 100%;
   max-height: 100%;
+  ${({ backgroundColorOverride }) =>
+    backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 `;
 
 const Body = styled.div`
@@ -195,6 +206,7 @@ function CompactNfts({ nftRefs }: { nftRefs: CollectionRowCompactNftsFragment$ke
     graphql`
       fragment CollectionRowCompactNftsFragment on Nft @relay(plural: true) {
         id
+        contractAddress
         ...getVideoOrImageUrlForNftPreviewFragment
       }
     `,
@@ -235,7 +247,12 @@ function CompactNfts({ nftRefs }: { nftRefs: CollectionRowCompactNftsFragment$ke
                   {result.type === 'video' ? (
                     <SmolNftVideoPreview src={imageUrl} />
                   ) : (
-                    <SmolNftImagePreview src={imageUrl} />
+                    <SmolNftImagePreview
+                      src={imageUrl}
+                      backgroundColorOverride={getBackgroundColorOverrideForContract(
+                        nft.contractAddress ?? ''
+                      )}
+                    />
                   )}
                 </SmolNftContainer>
               );
@@ -261,7 +278,12 @@ function CompactNfts({ nftRefs }: { nftRefs: CollectionRowCompactNftsFragment$ke
                 {result.type === 'video' ? (
                   <SmolNftVideoPreview src={imageUrl} />
                 ) : (
-                  <SmolNftImagePreview src={imageUrl} />
+                  <SmolNftImagePreview
+                    src={imageUrl}
+                    backgroundColorOverride={getBackgroundColorOverrideForContract(
+                      nft.contractAddress ?? ''
+                    )}
+                  />
                 )}
               </SmolNftContainer>
             );
@@ -296,9 +318,11 @@ const SmolNftVideoPreview = styled.video`
   max-height: 100%;
 `;
 
-const SmolNftImagePreview = styled.img`
+const SmolNftImagePreview = styled.img<{ backgroundColorOverride: string }>`
   max-width: 100%;
   max-height: 100%;
+  ${({ backgroundColorOverride }) =>
+    backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 `;
 
 const Content = styled.div`

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -11,6 +11,8 @@ import { NftDetailAssetFragment$key } from '__generated__/NftDetailAssetFragment
 import { NftDetailAssetComponentFragment$key } from '__generated__/NftDetailAssetComponentFragment.graphql';
 import NftDetailImage from './NftDetailImage';
 import NftDetailModel from './NftDetailModel';
+import { useMemo } from 'react';
+import { getBackgroundColorOverrideForContract } from 'utils/nft';
 
 type NftDetailAssetComponentProps = {
   nftRef: NftDetailAssetComponentFragment$key;
@@ -90,6 +92,7 @@ function NftDetailAsset({ nftRef, hasExtraPaddingForNote }: Props) {
       fragment NftDetailAssetFragment on CollectionNft {
         id
         nft @required(action: THROW) {
+          contractAddress
           media @required(action: THROW) {
             ... on HtmlMedia {
               __typename
@@ -100,6 +103,11 @@ function NftDetailAsset({ nftRef, hasExtraPaddingForNote }: Props) {
       }
     `,
     nftRef
+  );
+
+  const backgroundColorOverride = useMemo(
+    () => getBackgroundColorOverrideForContract(nft.nft.contractAddress ?? ''),
+    [nft.nft.contractAddress]
   );
 
   const maxHeight = Math.min(
@@ -125,6 +133,7 @@ function NftDetailAsset({ nftRef, hasExtraPaddingForNote }: Props) {
       maxHeight={maxHeight}
       shouldEnforceSquareAspectRatio={shouldEnforceSquareAspectRatio}
       hasExtraPaddingForNote={hasExtraPaddingForNote}
+      backgroundColorOverride={backgroundColorOverride}
     >
       <NftDetailAssetComponent nftRef={nft} maxHeight={maxHeight} />
     </StyledAssetContainer>
@@ -136,6 +145,7 @@ type AssetContainerProps = {
   maxHeight: number;
   shouldEnforceSquareAspectRatio: boolean;
   hasExtraPaddingForNote: boolean;
+  backgroundColorOverride: string;
 };
 
 const StyledAssetContainer = styled.div<AssetContainerProps>`
@@ -148,6 +158,9 @@ const StyledAssetContainer = styled.div<AssetContainerProps>`
 
   ${({ shouldEnforceSquareAspectRatio }) =>
     shouldEnforceSquareAspectRatio ? 'aspect-ratio: 1' : ''};
+
+  ${({ backgroundColorOverride }) =>
+    backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 
   @media only screen and ${breakpoints.tablet} {
     width: 100%;

--- a/src/utils/nft.ts
+++ b/src/utils/nft.ts
@@ -18,3 +18,11 @@ export function graphqlGetResizedNftImageUrlWithFallback(url: string | null, siz
 
   return url || FALLBACK_URL;
 }
+
+const backgroundColorOverrides: Record<string, string> = {
+  '0x30cdac3871c41a63767247c8d1a2de59f5714e78': '#E0E0E0', // Obits
+};
+
+export function getBackgroundColorOverrideForContract(contractAddress: string) {
+  return backgroundColorOverrides[contractAddress] || '';
+}


### PR DESCRIPTION
This PR adds a background color override mechanism that allows us to specify a background color for nfts from specific contracts.


This was requested by Obits to set the background of their nfts which have a transparent background to #E0E0E0.

Gallery page:
![Screen Shot 2022-04-28 at 16 28 33](https://user-images.githubusercontent.com/80802871/165701095-f331a077-bf33-44ec-8eaf-cee749613946.png)


Editor dnd:
![Screen Shot 2022-04-28 at 16 29 02](https://user-images.githubusercontent.com/80802871/165700992-2064d27e-e86c-4181-89e2-446c010cb480.png)

Editor sidebar:
![Screen Shot 2022-04-28 at 16 29 06](https://user-images.githubusercontent.com/80802871/165701104-41739b30-630d-4877-b3bd-acc2171f4de4.png)

/edit collection rows
![Screen Shot 2022-04-28 at 16 29 30](https://user-images.githubusercontent.com/80802871/165701130-256958f7-9639-4354-a8f3-dfe5d3549014.png)

