### PR TITLE
GAL-61 Move hide details to the bottom of nft details and update copy

### DIFF
--- a/src/scenes/NftDetailPage/NftAdditionalDetails.tsx
+++ b/src/scenes/NftDetailPage/NftAdditionalDetails.tsx
@@ -35,9 +35,9 @@ const getOpenseaExternalUrl = (contractAddress: string, tokenId: string) => {
 const GALLERY_OS_ADDRESS = '0x8914496dc01efcc49a2fa340331fb90969b6f1d2';
 
 function NftAdditionalDetails({ contractAddress, tokenId, externalUrl }: Props) {
-  const [showAdditionalDetails, setShowAdditionalDetails] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
   const handleToggleClick = useCallback(() => {
-    setShowAdditionalDetails((value) => !value);
+    setShowDetails((value) => !value);
   }, []);
 
   // Check for contract address befor rendering additional details
@@ -45,12 +45,8 @@ function NftAdditionalDetails({ contractAddress, tokenId, externalUrl }: Props) 
 
   return (
     <StyledNftAdditionalDetails>
-      <TextButton
-        text={showAdditionalDetails ? 'Hide Details' : 'Additional Details'}
-        onClick={handleToggleClick}
-      />
-      <Spacer height={12} />
-      {showAdditionalDetails && (
+      {!showDetails && <TextButton text="Show Details" onClick={handleToggleClick} />}
+      {showDetails && (
         <div>
           {hasContractAddress && (
             <>
@@ -75,6 +71,8 @@ function NftAdditionalDetails({ contractAddress, tokenId, externalUrl }: Props) 
             )}
             {externalUrl && <InteractiveLink href={externalUrl}>More Info</InteractiveLink>}
           </StyledLinkContainer>
+          <Spacer height={12} />
+          <TextButton text="Hide Details" onClick={handleToggleClick} />
         </div>
       )}
     </StyledNftAdditionalDetails>

--- a/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -78,7 +78,7 @@ function NftDetailText({
           <BaseM>{<EnsOrAddress address={addressToUse} />}</BaseM>
         </>
       )}
-      <Spacer height={32} />
+      <Spacer height={16} />
       <NftAdditionalDetails
         contractAddress={contractAddress}
         tokenId={tokenId}


### PR DESCRIPTION
This PR updates two things:
- Move "HIDE DETAILS" button to the bottom of nft detail description
- Change button copy from "ADDITIONAL DETAILS" -> "SHOW DETAILS" 

SHOW DETAILS
![Screen Shot 2022-04-28 at 18 12 24](https://user-images.githubusercontent.com/80802871/165719863-29a1de31-d7ae-4b79-947f-2ebbfc172a32.png)

HIDE DETAILS
![Screen Shot 2022-04-28 at 18 12 27](https://user-images.githubusercontent.com/80802871/165719897-e3f639bc-3d55-443c-8c94-5eda569a0908.png)

