### PR TITLE
disable another umbrella contract + adjust description clamping:

### DIFF
--- a/pages/community/[contractAddress]/index.tsx
+++ b/pages/community/[contractAddress]/index.tsx
@@ -16,6 +16,7 @@ export const DISABLED_CONTRACTS = [
   '0x495f947276749ce646f68ac8c248420045cb7b5e', // OS
   '0xf6793da657495ffeff9ee6350824910abc21356c', // Rarible
   '0x3b3ee1931dc30c1957379fac9aba94d1c48a5405', // Foundation
+  '0xdfde78d2baec499fe18f2be74b6c287eed9511d7', // Braindrops
 ];
 
 export default function CommunityPage({ contractAddress }: CommunityPageProps) {

--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -94,7 +94,9 @@ const StyledBaseM = styled(BaseM)<{ showExpandedDescription: boolean }>`
   display: -webkit-box;
 
   // allows descriptions with multiple paragraphs to be line clamped properly
-  p {
+  p,
+  ol,
+  li {
     display: contents;
   }
 `;


### PR DESCRIPTION
now that we're opening community pages up, I checked out a few pages to try to find any edge cases and issues.

This PR does the following
- adds Braindrops to the list of disabled contracts. It's another umbrella contract
- fixes a bug where markdown lists were not clamped/hidden properly on safari. affected certain community pages that are now available, like Bob the Bean Farmer `0x2079812353e2c9409a788fbf5f383fa62ad85be8`

Before
![Screen Shot 2022-04-28 at 19 08 30](https://user-images.githubusercontent.com/80802871/165736787-20f582ce-947e-4eda-a759-8e8d5fad16ea.png)

After
![Screen Shot 2022-04-28 at 19 08 22](https://user-images.githubusercontent.com/80802871/165736805-12eec91c-14dd-49d5-86e0-efb1cc034a74.png)

