### PR TITLE
GAL-128 Make Collection Name in Nft Preview clickable to link to community page

### DIFF
--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -110,7 +110,11 @@ function NftPreview({ galleryNftRef }: Props) {
         {/* // we'll request images at double the size of the element so that it looks sharp on retina */}
         <NftPreviewAsset nftRef={nft} size={previewSize * 2} />
         <StyledNftFooter>
-          <StyledNftLabel title={nft.name} collectionName={nft.openseaCollectionName} />
+          <StyledNftLabel
+            title={nft.name}
+            collectionName={nft.openseaCollectionName}
+            contractAddress={nft.contractAddress}
+          />
           <StyledGradient type="bottom" direction="down" />
         </StyledNftFooter>
       </StyledLinkWrapper>

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -2,15 +2,23 @@ import colors from 'components/core/colors';
 import styled from 'styled-components';
 import { BaseM } from 'components/core/Text/Text';
 import breakpoints from 'components/core/breakpoints';
+import { DISABLED_CONTRACTS } from 'pages/community/[contractAddress]';
+import { useMemo } from 'react';
+import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 
 type Props = {
   className?: string;
   title?: string | null;
   collectionName?: string | null;
+  contractAddress?: string | null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function NftPreviewLabel({ className, title, collectionName }: Props) {
+function NftPreviewLabel({ className, title, collectionName, contractAddress }: Props) {
+  const showCommunityLink = useMemo(
+    () => !!contractAddress && !DISABLED_CONTRACTS.includes(contractAddress),
+    [contractAddress]
+  );
   return (
     <StyledNftPreviewLabel className={className}>
       {title && (
@@ -18,11 +26,16 @@ function NftPreviewLabel({ className, title, collectionName }: Props) {
           {title}
         </StyledBaseM>
       )}
-      {collectionName && (
-        <StyledBaseM color={colors.white} lines={2}>
-          {collectionName}
-        </StyledBaseM>
-      )}
+      {collectionName &&
+        (showCommunityLink ? (
+          <StyledInteractiveLink to={`/community/${contractAddress}`}>
+            {collectionName}
+          </StyledInteractiveLink>
+        ) : (
+          <StyledBaseM color={colors.white} lines={2}>
+            {collectionName}
+          </StyledBaseM>
+        ))}
     </StyledNftPreviewLabel>
   );
 }
@@ -77,6 +90,14 @@ const StyledBaseM = styled(BaseM)<{ lines: number }>`
     text-overflow: unset;
   }
 }
+`;
+
+const StyledInteractiveLink = styled(InteractiveLink)`
+  color: ${colors.white};
+
+  &:hover {
+    color: ${colors.white};
+  }
 `;
 
 export default NftPreviewLabel;

--- a/src/components/core/InteractiveLink/InteractiveLink.tsx
+++ b/src/components/core/InteractiveLink/InteractiveLink.tsx
@@ -18,15 +18,20 @@ type Props = {
 export default function InteractiveLink({ to, href, children, className, onClick }: Props) {
   const track = useTrack();
 
-  const handleClick = useCallback(() => {
-    track('Link Click', {
-      to: to || href,
-    });
+  const handleClick = useCallback(
+    (event) => {
+      event.stopPropagation();
 
-    if (onClick) {
-      onClick();
-    }
-  }, [href, onClick, to, track]);
+      track('Link Click', {
+        to: to || href,
+      });
+
+      if (onClick) {
+        onClick();
+      }
+    },
+    [href, onClick, to, track]
+  );
 
   if (!to && !href) {
     console.error('no link provided for InteractiveLink');


### PR DESCRIPTION
This PR makes the Collection Name in Nft Previews clickable , and they link to the community page.

![Screen Shot 2022-05-03 at 18 32 09](https://user-images.githubusercontent.com/80802871/166431946-2140688c-cfeb-4706-9c25-51e0897c392b.png)
