### PR TITLE
see if bumping relay-compiler version fixes vercel preview deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint-plugin-unicorn": "^35.0.0",
     "jest": "^27.3.1",
     "prettier": "^2.5.1",
-    "relay-compiler": "^13.0.1",
+    "relay-compiler": "^13.2.0",
     "ts-jest": "^27.0.7",
     "ts-prune": "^0.10.3",
     "typescript": "^4.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14599,10 +14599,10 @@ regjsparser@^0.8.2:
   dependencies:
     jsesc "~0.5.0"
 
-relay-compiler@^13.0.1:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-13.0.1.tgz#09c713647aa7e1d8cf3de9f7fb4ee6a76b32cf26"
-  integrity sha512-C/qJ7IdfZ140b9JaNpuAP6WhV/Odt/tIq4sUZoTwsaOlhs+1Zu3fvIOoWKTnZT5PC6krRuw1hD7GSX6/paVpTQ==
+relay-compiler@^13.2.0:
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-13.2.0.tgz#06dd416e19e1cd22008b89499726ea5eb342c36e"
+  integrity sha512-GGLWTJYqQ5jQLMXlq++Fl17f4gMuvmIi3+xU/TrD4UqWZLI3qhxE0NFAmOvg6xgBQ8xtCMhP066kv+3bhL+7Aw==
 
 relay-runtime@13.0.1, relay-runtime@^13.0.1:
   version "13.0.1"


### PR DESCRIPTION
Vercel previews deploys have been failing with the error:
```/vercel/path0/node_modules/relay-compiler/linux-x64/relay: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory```

this PR bumps `relay-compiler` to `13.2.0` to see if it fixes verbal preview deploys