### PR TITLE
Make touch target for nft preview label link tighter

### DIFF
--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -28,9 +28,11 @@ function NftPreviewLabel({ className, title, collectionName, contractAddress }: 
       )}
       {collectionName &&
         (showCommunityLink ? (
-          <StyledInteractiveLink to={`/community/${contractAddress}`}>
-            {collectionName}
-          </StyledInteractiveLink>
+          <div>
+            <StyledInteractiveLink to={`/community/${contractAddress}`}>
+              {collectionName}
+            </StyledInteractiveLink>
+          </div>
         ) : (
           <StyledBaseM color={colors.white} lines={2}>
             {collectionName}
@@ -94,6 +96,7 @@ const StyledBaseM = styled(BaseM)<{ lines: number }>`
 
 const StyledInteractiveLink = styled(InteractiveLink)`
   color: ${colors.white};
+  width: fit-content;
 
   &:hover {
     color: ${colors.white};

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -29,9 +29,11 @@ function NftPreviewLabel({ className, title, collectionName, contractAddress }: 
       {collectionName &&
         (showCommunityLink ? (
           <div>
-            <StyledInteractiveLink to={`/community/${contractAddress}`}>
-              {collectionName}
-            </StyledInteractiveLink>
+            <StyledBaseM lines={2}>
+              <StyledInteractiveLink to={`/community/${contractAddress}`}>
+                {collectionName}
+              </StyledInteractiveLink>
+            </StyledBaseM>
           </div>
         ) : (
           <StyledBaseM color={colors.white} lines={2}>


### PR DESCRIPTION
Make touch target for nft preview label link smaller so that only the text is clickable.
also matches the link's text style with the text above
![CleanShot 2022-05-04 at 17 19 03](https://user-images.githubusercontent.com/80802871/166645504-a46130db-2ecc-4dc7-90cd-ae4de35c825c.png)
 