### PR TITLE
Add await to relayFetchFunction

### DIFF
--- a/src/contexts/relay/relayFetchFunction.ts
+++ b/src/contexts/relay/relayFetchFunction.ts
@@ -13,7 +13,7 @@ export const relayFetchFunction: FetchFunction = async (request, variables) => {
   const transaction = initSentryTracing(request);
   // ---------- end pre-request hooks
 
-  const response = _fetch<GraphQLResponse>(`${baseurl}/glry/graphql/query`, {
+  const response = await _fetch<GraphQLResponse>(`${baseurl}/glry/graphql/query`, {
     body: {
       query: request.text,
       variables,


### PR DESCRIPTION
Helps fix an issue in tracing where a span for a request would last a very short amount of time, rather than the length of the request.

More details in comments!