### PR TITLE
make collection name in hover text smaller on mobile

### DIFF
--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -99,9 +99,14 @@ const StyledBaseM = styled(BaseM)<{ lines: number }>`
 const StyledInteractiveLink = styled(InteractiveLink)`
   color: ${colors.white};
   width: fit-content;
+  font-size: 12px;
 
   &:hover {
     color: ${colors.white};
+  }
+
+  @media only screen and ${breakpoints.tablet} {
+    font-size: 14px;
   }
 `;
 


### PR DESCRIPTION
On the label that appears when you hover on an NFT, the collection name was a bit bigger than the name name on mobile.
This PR fixes that so that the sizing is consistent.

Before:
![Screen Shot 2022-05-12 at 17 02 49](https://user-images.githubusercontent.com/80802871/168022163-10005b69-e1e8-4258-8c83-cacd8fd66fa5.png)

After:
![Screen Shot 2022-05-12 at 17 02 43](https://user-images.githubusercontent.com/80802871/168022158-566269f7-ba3c-41eb-8601-3a8abc07116b.png)

