### PR TITLE
Prevent full-page errors on image load failure

### DIFF
--- a/src/flows/shared/steps/OrganizeCollection/Editor/StagedNftImage.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/StagedNftImage.tsx
@@ -4,6 +4,8 @@ import transitions from 'components/core/transitions';
 import { graphql, useFragment } from 'react-relay';
 import { StagedNftImageFragment$key } from '__generated__/StagedNftImageFragment.graphql';
 import getVideoOrImageUrlForNftPreview from 'utils/graphql/getVideoOrImageUrlForNftPreview';
+import { FALLBACK_URL } from 'utils/nft';
+import { useReportError } from 'contexts/errorReporting/ErrorReportingContext';
 
 type Props = {
   nftRef: StagedNftImageFragment$key;
@@ -23,19 +25,25 @@ function StagedNftImage({ nftRef, size, setNodeRef, ...props }: Props) {
     nftRef
   );
 
-  const result = getVideoOrImageUrlForNftPreview(nft);
+  const reportError = useReportError();
+  const result = getVideoOrImageUrlForNftPreview(nft, reportError);
 
   if (!result || !result.urls.large) {
-    throw new Error('Image URL not found for StagedNftImageDragging');
+    reportError('Image URL not found for StagedNftImageDragging');
   }
 
-  return result.type === 'video' ? (
+  return result?.type === 'video' ? (
     <VideoContainer ref={setNodeRef} size={size} {...props}>
-      <StyledGridVideo src={result.urls.large} />
+      <StyledGridVideo src={result?.urls.large ?? FALLBACK_URL} />
       <StyledNftPreviewLabel title={nft.name} collectionName={nft.openseaCollectionName} />
     </VideoContainer>
   ) : (
-    <StyledGridImage srcUrl={result.urls.large} ref={setNodeRef} size={size} {...props}>
+    <StyledGridImage
+      srcUrl={result?.urls.large ?? FALLBACK_URL}
+      ref={setNodeRef}
+      size={size}
+      {...props}
+    >
       <StyledNftPreviewLabel title={nft.name} collectionName={nft.openseaCollectionName} />
     </StyledGridImage>
   );

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
@@ -6,7 +6,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 import getVideoOrImageUrlForNftPreview from 'utils/graphql/getVideoOrImageUrlForNftPreview';
-import { getBackgroundColorOverrideForContract } from 'utils/nft';
+import { FALLBACK_URL, getBackgroundColorOverrideForContract } from 'utils/nft';
 import { SidebarNftIconFragment$key } from '__generated__/SidebarNftIconFragment.graphql';
 import { EditModeNft } from '../types';
 
@@ -55,7 +55,7 @@ function SidebarNftIcon({ nftRef, editModeNft }: SidebarNftIconProps) {
   const result = getVideoOrImageUrlForNftPreview(nft, reportError);
 
   if (!result || !result.urls.small) {
-    throw new Error('Image URL not found for SidebarNftIcon');
+    reportError('Image URL not found for SidebarNftIcon');
   }
 
   const backgroundColorOverride = useMemo(
@@ -67,10 +67,10 @@ function SidebarNftIcon({ nftRef, editModeNft }: SidebarNftIconProps) {
     <StyledSidebarNftIcon backgroundColorOverride={backgroundColorOverride}>
       {
         // Some OpenSea assets dont have an image url, so render a freeze frame of the video instead
-        result.type === 'video' ? (
-          <StyledVideo isSelected={isSelected} src={result.urls.small} />
+        result?.type === 'video' ? (
+          <StyledVideo isSelected={isSelected} src={result?.urls.small ?? FALLBACK_URL} />
         ) : (
-          <StyledImage isSelected={isSelected} src={result.urls.small} alt="nft" />
+          <StyledImage isSelected={isSelected} src={result?.urls.small ?? FALLBACK_URL} alt="nft" />
         )
       }
       <StyledOutline onClick={handleClick} isSelected={isSelected} />


### PR DESCRIPTION
Instead of causing a full-screen error, make the problematic NFT display a fallback image instead (and silently report the error to sentry)