### PR TITLE
[GAL-173] fix membership success state to not show ineligible message

### DIFF
--- a/src/scenes/MembershipMintPage/MembershipMintPage.tsx
+++ b/src/scenes/MembershipMintPage/MembershipMintPage.tsx
@@ -81,8 +81,8 @@ export function MembershipMintPage({
   );
 
   const directUserToSecondary = useMemo(
-    () => membershipNft.tokenId === 6 || (active && !canMintToken),
-    [active, canMintToken, membershipNft.tokenId]
+    () => membershipNft.tokenId === 6 || (active && !canMintToken && transactionStatus === null),
+    [active, canMintToken, membershipNft.tokenId, transactionStatus]
   );
 
   const handleConnectWalletButtonClick = useCallback(() => {
@@ -199,7 +199,7 @@ export function MembershipMintPage({
           <Spacer height={32} />
           <HorizontalBreak />
           <Spacer height={32} />
-          {active && !canMintToken && (
+          {active && !canMintToken && transactionStatus === null && (
             <>
               <StyledIneligibleMessageWrapper>
                 <BaseXL>You are ineligible for this mint.</BaseXL>


### PR DESCRIPTION
Fixes a bug on the membership mint page where upon a successful mint, we also showed the user the "Ineligible to mint" message since technically they are no longer eligible. 
We now only show the success state message and link to onboarding

![Screen Shot 2022-05-18 at 17 19 14](https://user-images.githubusercontent.com/80802871/168993358-4bec1d44-6dfc-41bb-bcc3-0314c40dedaa.png)


full video in threads.
.