### PR TITLE
Update poster deadline and make it based on EST

### DIFF
--- a/src/constants/poster.ts
+++ b/src/constants/poster.ts
@@ -1,1 +1,1 @@
-export const MINT_DATE = '2022-05-19T00:00:00';
+export const MINT_DATE = '2022-05-18T23:00:00-04:00'; // time is in EST (GMT-04:00)


### PR DESCRIPTION
This PR updates the Poster Page's deadline to be 11PM(EST) on 5/18 wed.
previously the time left was localized so users would see different hours remaining, but it should now show the remaining time until 11PMEST for everyone.
