### PR TITLE
Fix dropdown bug

### DIFF
--- a/src/components/core/Dropdown/Dropdown.tsx
+++ b/src/components/core/Dropdown/Dropdown.tsx
@@ -46,7 +46,7 @@ function Dropdown({ mainText, shouldCloseOnMenuItemClick = false, children }: Pr
         // underlying child element's `onClick` from triggering
         setTimeout(() => {
           setIsDropdownVisible(false);
-        }, 10);
+        }, 200);
       }
     },
     [shouldCloseOnMenuItemClick]


### PR DESCRIPTION
For certain users, the dropdown was closing too quickly for the underlying `onClick` to fire. Made sure to test in various scenarios that there was no jank.