### PR TITLE
Polish items for markdown, add to collection desc and edit gallery pages

### DIFF
--- a/src/components/Profile/UserInfoForm.tsx
+++ b/src/components/Profile/UserInfoForm.tsx
@@ -84,7 +84,7 @@ function UserInfoForm({
         errorMessage={usernameError}
         autoFocus={shouldAutofocusUsername}
       />
-      <Spacer height={24} />
+      <Spacer height={16} />
       <StyledTextAreaWithCharCount
         onChange={handleBioChange}
         placeholder="Tell us about yourself..."
@@ -92,8 +92,8 @@ function UserInfoForm({
         currentCharCount={unescapedBio.length}
         maxCharCount={BIO_MAX_CHAR_COUNT}
         autoFocus={shouldAutofocusBio}
-        showMarkdownShortcuts={true}
-        hasPadding={true}
+        showMarkdownShortcuts
+        hasPadding
       />
     </StyledForm>
   );

--- a/src/components/core/BigInput/BigInput.tsx
+++ b/src/components/core/BigInput/BigInput.tsx
@@ -1,6 +1,7 @@
 import { ChangeEventHandler } from 'react';
 import styled from 'styled-components';
 import noop from 'utils/noop';
+import colors from '../colors';
 import Spacer from '../Spacer/Spacer';
 import ErrorText from '../Text/ErrorText';
 
@@ -42,17 +43,17 @@ function BigInput({
 }
 
 const StyledBigInput = styled.input`
-  padding: 0 2px;
+  padding: 12px;
   border: 0;
   font-size: 32px;
   font-family: 'GT Alpina';
   line-height: 36px;
   letter-spacing: -0.03em;
+  background: ${colors.offWhite};
 
   ::placeholder {
     opacity: 0.5;
   }
-  background: none;
 `;
 
 export default BigInput;

--- a/src/components/core/Markdown/Bold.tsx
+++ b/src/components/core/Markdown/Bold.tsx
@@ -5,15 +5,11 @@ import { setValueAndTriggerOnChange } from './MarkdownShortcuts';
 export default function Bold({
   selectedRange,
   textAreaRef,
-  setUserDragged,
 }: {
   selectedRange: number[];
   textAreaRef: React.RefObject<HTMLTextAreaElement>;
-  setUserDragged: (value: boolean) => void;
 }) {
   const handleClick = useCallback(() => {
-    setUserDragged(false);
-
     const textArea = textAreaRef.current;
     if (!textArea) return;
 
@@ -59,7 +55,7 @@ export default function Bold({
       setValueAndTriggerOnChange(textArea, newText, [start + 2, start + 2]); // Bold ([0, 0]) -> **Bold** ([2, 2])
       return;
     }
-  }, [textAreaRef, selectedRange, setUserDragged]);
+  }, [textAreaRef, selectedRange]);
 
   return (
     <IconContainer

--- a/src/components/core/Markdown/IconContainer.tsx
+++ b/src/components/core/Markdown/IconContainer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import colors from '../colors';
 
 export default function IconContainer({ icon }: { icon: React.ReactElement }) {
   return (
@@ -16,17 +17,13 @@ export default function IconContainer({ icon }: { icon: React.ReactElement }) {
 
 const StyledIcon = styled.div`
   cursor: pointer;
+  height: 24px;
 
-  & svg rect {
-    transition: fill 300ms ease;
-    fill: rgba(254, 254, 254, 1);
+  &:hover {
+    background: ${colors.porcelain};
   }
 
-  &:hover svg rect {
-    fill: rgba(249, 249, 249, 1);
-  }
-
-  &:active svg rect {
-    fill: rgba(226, 226, 226, 1);
+  &:active {
+    background: ${colors.metal};
   }
 `;

--- a/src/components/core/Markdown/Link.tsx
+++ b/src/components/core/Markdown/Link.tsx
@@ -5,15 +5,11 @@ import { setValueAndTriggerOnChange } from './MarkdownShortcuts';
 export default function Bold({
   selectedRange,
   textAreaRef,
-  setUserDragged,
 }: {
   selectedRange: number[];
   textAreaRef: React.RefObject<HTMLTextAreaElement>;
-  setUserDragged: (value: boolean) => void;
 }) {
   const handleClick = useCallback(() => {
-    setUserDragged(false);
-
     const textArea = textAreaRef.current;
     if (!textArea) return;
 
@@ -46,7 +42,7 @@ export default function Bold({
       setValueAndTriggerOnChange(textArea, newText, [start + 1, start + 1]); // [0, 0] -> []() ([1, 1])
       return;
     }
-  }, [textAreaRef, selectedRange, setUserDragged]);
+  }, [textAreaRef, selectedRange]);
 
   return (
     <IconContainer

--- a/src/components/core/Markdown/List.tsx
+++ b/src/components/core/Markdown/List.tsx
@@ -5,15 +5,11 @@ import { setValueAndTriggerOnChange } from './MarkdownShortcuts';
 export default function List({
   selectedRange,
   textAreaRef,
-  setUserDragged,
 }: {
   selectedRange: number[];
   textAreaRef: React.RefObject<HTMLTextAreaElement>;
-  setUserDragged: (value: boolean) => void;
 }) {
   const handleClick = useCallback(() => {
-    setUserDragged(false);
-
     const textArea = textAreaRef.current;
     if (!textArea) return;
 
@@ -84,7 +80,7 @@ export default function List({
         setValueAndTriggerOnChange(textArea, newText, [start + 2, end + selectedLines.length * 2]); // List ([0, 4]) -> * List ([2, 6])
       }
     }
-  }, [textAreaRef, selectedRange, setUserDragged]);
+  }, [textAreaRef, selectedRange]);
 
   return (
     <IconContainer

--- a/src/components/core/Markdown/MarkdownShortcuts.tsx
+++ b/src/components/core/Markdown/MarkdownShortcuts.tsx
@@ -42,15 +42,11 @@ export default function MarkdownShortcuts({ textAreaRef }: Props) {
     textAreaRef?.current?.selectionEnd || 0,
   ]);
 
-  // We track whether the selection updated via user drag, or something external (e.g. a Markdown addition)
-  const [userDragged, setUserDragged] = useState(false);
-
   // Anytime the user selects new text, setSelectedRange to equal the indexes of that text
   useEffect(() => {
     const textArea = textAreaRef?.current;
     if (textArea) {
       const onSelectionChange = () => {
-        setUserDragged(true);
         setSelectedRange([textArea.selectionStart, textArea.selectionEnd]);
       };
 
@@ -63,37 +59,11 @@ export default function MarkdownShortcuts({ textAreaRef }: Props) {
     }
   }, [textAreaRef, textAreaRef?.current?.value]);
 
-  // Whenever selectedRange updates, set the textarea.current.selectionStart and selectionEnd to match
-  // This means that we can apply markdown to selected text, but preserve selection afterwards
-  useEffect(() => {
-    // We do not want to run if the selectedRange updated because of user cursor dragging
-    // This leads to a bug in Chrome where the user cannot drag text from the end backwards
-    // if (userDragged) return;
-
-    const textArea = textAreaRef?.current;
-    if (textArea) {
-      textArea.selectionStart = selectedRange[0];
-      textArea.selectionEnd = selectedRange[1];
-    }
-  }, [textAreaRef, selectedRange, userDragged]);
-
   return (
     <StyledMarkdownShortcutsContainer data-testid="markdown-shortcuts-container">
-      <Bold
-        selectedRange={selectedRange}
-        textAreaRef={textAreaRef}
-        setUserDragged={setUserDragged}
-      />
-      <List
-        selectedRange={selectedRange}
-        textAreaRef={textAreaRef}
-        setUserDragged={setUserDragged}
-      />
-      <Link
-        selectedRange={selectedRange}
-        textAreaRef={textAreaRef}
-        setUserDragged={setUserDragged}
-      />
+      <Bold selectedRange={selectedRange} textAreaRef={textAreaRef} />
+      <List selectedRange={selectedRange} textAreaRef={textAreaRef} />
+      <Link selectedRange={selectedRange} textAreaRef={textAreaRef} />
     </StyledMarkdownShortcutsContainer>
   );
 }

--- a/src/components/core/TextArea/TextArea.tsx
+++ b/src/components/core/TextArea/TextArea.tsx
@@ -63,10 +63,10 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 const StyledTextArea = styled.textarea<TextAreaProps>`
   width: 100%;
   height: 100%;
-  padding: 16px;
+  padding: 12px;
   font-family: ABC Diatype;
   border: none;
-  border-bottom: 28px solid ${colors.white};
+  border-bottom: 36px solid transparent;
   resize: none;
   font-size: 14px;
   line-height: 20px;
@@ -88,10 +88,11 @@ export function TextAreaWithCharCount({
   maxCharCount,
   ...textAreaProps
 }: TextAreaWithCharCountProps) {
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
   return (
     <>
       <StyledTextAreaWithCharCount className={className}>
-        <TextArea {...textAreaProps} />
+        <TextArea ref={textAreaRef} {...textAreaProps} />
         <StyledCharacterCounter
           error={currentCharCount > maxCharCount}
           hasPadding={textAreaProps?.hasPadding || false}
@@ -174,7 +175,7 @@ export function AutoResizingTextAreaWithCharCount({
 
 const StyledTextAreaWithCharCount = styled.div`
   position: relative;
-  border: 1px solid ${colors.metal};
+  background: ${colors.offWhite};
   padding-bottom: 1px; /* This fixes a FF bug where the bottom border does not appear */
 `;
 
@@ -192,6 +193,7 @@ const StyledCharacterCounter = styled(BaseM)<{ error: boolean; hasPadding: boole
 
 const StyledMarkdownContainer = styled.div<{ hasPadding: boolean }>`
   position: absolute;
-  bottom: ${({ hasPadding }) => (hasPadding ? '8px' : '0')};
+  background: none;
+  bottom: ${({ hasPadding }) => (hasPadding ? '12px' : '0')};
   left: ${({ hasPadding }) => (hasPadding ? '8px' : '0')};
 `;

--- a/src/contexts/modal/AnimatedModal.tsx
+++ b/src/contexts/modal/AnimatedModal.tsx
@@ -121,7 +121,7 @@ const StyledContentContainer = styled.div`
 
 const StyledContent = styled.div<{ noPadding: boolean }>`
   position: relative;
-  padding: ${({ noPadding }) => (noPadding ? 0 : 40)}px;
+  padding: ${({ noPadding }) => (noPadding ? 0 : 24)}px;
   background: ${colors.white};
 
   // allows for scrolling within child components

--- a/src/flows/shared/steps/OrganizeCollection/CollectionCreateOrEditForm.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/CollectionCreateOrEditForm.tsx
@@ -159,6 +159,8 @@ function CollectionCreateOrEditForm({
         defaultValue={unescapedCollectorsNote}
         currentCharCount={description.length}
         maxCharCount={COLLECTION_DESCRIPTION_MAX_CHAR_COUNT}
+        showMarkdownShortcuts
+        hasPadding
       />
       {generalError && (
         <>

--- a/src/scenes/NftDetailPage/NftDetailNote.tsx
+++ b/src/scenes/NftDetailPage/NftDetailNote.tsx
@@ -232,14 +232,6 @@ const StyledContainer = styled.div<{ footerHeight: number }>`
   }
 `;
 
-const StyledTitleAndButtonContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  z-index: 2; /* Above footer so user can click buttons on very small vertical screens */
-  position: relative;
-`;
-
 type TextAreaProps = {
   footerHeight: number;
 };

--- a/src/scenes/NftDetailPage/NftDetailNote.tsx
+++ b/src/scenes/NftDetailPage/NftDetailNote.tsx
@@ -105,35 +105,6 @@ function NoteEditor({ nftCollectorsNote, nftId, collectionId }: NoteEditorProps)
 
   return (
     <div onKeyDown={handleKeyDown} ref={collectorsNoteRef}>
-      <StyledTitleAndButtonContainer>
-        {/* We also include isEditing as an option here so the user can click save with an empty note (e.g. delete their note) */}
-        {hasCollectorsNote || isEditing ? (
-          <>
-            <BaseM>Collector&rsquo;s Note</BaseM>
-            {isEditing ? (
-              <TextButton
-                disabled={unescapedCollectorsNote.length > MAX_CHAR_COUNT}
-                text="Save"
-                onClick={handleSubmitCollectorsNote}
-              />
-            ) : (
-              <TextButton text="Edit" onClick={handleEditCollectorsNote} />
-            )}
-          </>
-        ) : (
-          <TextButton text={"+ Add Collector's Note"} onClick={handleEditCollectorsNote} />
-        )}
-      </StyledTitleAndButtonContainer>
-
-      {generalError && (
-        <>
-          <Spacer height={8} />
-          <ErrorText message={generalError} />
-        </>
-      )}
-
-      <Spacer height={8} />
-
       {/* Create a dummy textbox of the same height so that, when the element switches from the above to this one, there is not a jump to the top of the screen before scrollDown applies */}
       {isEditing ? (
         <StyledTextAreaWithCharCount
@@ -143,8 +114,8 @@ function NoteEditor({ nftCollectorsNote, nftId, collectionId }: NoteEditorProps)
           defaultValue={unescapedCollectorsNote}
           currentCharCount={unescapedCollectorsNote.length}
           maxCharCount={MAX_CHAR_COUNT}
-          showMarkdownShortcuts={true}
-          hasPadding={false}
+          showMarkdownShortcuts
+          hasPadding
         />
       ) : (
         <StyledCollectorsNote
@@ -154,9 +125,44 @@ function NoteEditor({ nftCollectorsNote, nftId, collectionId }: NoteEditorProps)
           <Markdown text={collectorsNote} />
         </StyledCollectorsNote>
       )}
+      {generalError && (
+        <>
+          <Spacer height={8} />
+          <ErrorText message={generalError} />
+        </>
+      )}
+
+      <Spacer height={16} />
+      <StyledBottomButtonContainer>
+        {isEditing ? (
+          <SaveNoteButton
+            disabled={unescapedCollectorsNote.length > MAX_CHAR_COUNT}
+            text="Save Note"
+            onClick={handleSubmitCollectorsNote}
+          />
+        ) : (
+          <EditNoteButton
+            text={hasCollectorsNote ? 'Edit note' : 'Add Note'}
+            onClick={handleEditCollectorsNote}
+          />
+        )}
+      </StyledBottomButtonContainer>
     </div>
   );
 }
+
+const StyledBottomButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const SaveNoteButton = styled(TextButton)`
+  align-self: end;
+`;
+
+const EditNoteButton = styled(TextButton)`
+  align-self: start;
+`;
 
 type NoteViewerProps = {
   nftCollectorsNote: string;
@@ -247,7 +253,6 @@ const StyledTextAreaWithCharCount = styled(AutoResizingTextAreaWithCharCount)<Te
   textarea {
     color: #808080;
     margin: 0;
-    padding: 0;
     line-height: 20px;
     font-size: 14px;
     display: block;

--- a/src/scenes/UserGalleryPage/EditUserInfoModal.tsx
+++ b/src/scenes/UserGalleryPage/EditUserInfoModal.tsx
@@ -119,8 +119,8 @@ const StyledEditUserInfoModal = styled.div`
 `;
 
 const StyledButton = styled(Button)`
-  height: 30px;
-  width: 80px;
+  height: 40px;
+  width: 150px;
   align-self: flex-end;
 `;
 


### PR DESCRIPTION
This PR addresses remaining design+polish items described here: https://github.com/gallery-so/gallery/pull/748#issuecomment-1126583289

Additionally, it enables Markdown for the Collection description editor on the Edit Gallery page, and fixes undefined text refs wherever we used `TextAreaWithCharCount`.  also made som changes to the Collectors Note editor to match the updated specs.

detailed list of changes:

- [x] update input background to offwhite, and markdown button hover/active colors to match
- [x] resize button, padding, spacing in text editor
- [x] match markdown button spacing from edge of text area
- [x] enable markdown editor for Edit Gallery page
- [x] fix undefined ref in uses of `TextAreaWithCharCount`
- [x] updated NFT Collector Note editor to match new spec


Markdown Buttons (before)
![Screen Shot 2022-05-25 at 22 52 57](https://user-images.githubusercontent.com/80802871/170279016-e3494d18-fd5d-4b84-a33e-4ee47de07ae9.png)


Markdown Buttons (after)
![Screen Shot 2022-05-25 at 22 42 00](https://user-images.githubusercontent.com/80802871/170278359-b904e751-562f-4b5c-865d-d6477ae21dc2.png)

Modal Editor (before)
![Screen Shot 2022-05-25 at 22 52 20](https://user-images.githubusercontent.com/80802871/170279178-e9b2beb8-f079-45a6-af95-d3f51743ef7a.png)


Modal Editor (after)
![Screen Shot 2022-05-25 at 22 52 08](https://user-images.githubusercontent.com/80802871/170279152-a8143676-e7fa-47c2-a2eb-c0a04b349be1.png)


Collectors Note Editor (before)
![Screen Shot 2022-05-25 at 22 52 30](https://user-images.githubusercontent.com/80802871/170278978-4af094c4-7d5f-4de9-9a4f-19d98b5206a2.png)


Collectors Note Editor (after)
![Screen Shot 2022-05-25 at 22 41 34](https://user-images.githubusercontent.com/80802871/170278320-b986c817-7c1d-4b65-b0ea-2f649883557d.png)


