### PR TITLE
[GAL-189] stop key event propagation for big input

### DIFF
--- a/src/components/core/BigInput/BigInput.tsx
+++ b/src/components/core/BigInput/BigInput.tsx
@@ -26,6 +26,7 @@ function BigInput({
         placeholder={placeholder}
         defaultValue={defaultValue}
         onChange={onChange}
+        onKeyUp={(e) => e.stopPropagation()}
         autoComplete="off"
         autoCorrect="off"
         autoCapitalize="off"


### PR DESCRIPTION
Fixes bug where users couldn't enter a username with the letter 'e', otherwise it would trigger the /edit shortcut