### PR TITLE
[GAL-190] Fix error flash when hitting `e` on modal

### DIFF
--- a/src/scenes/CollectionGalleryPage/CollectionGalleryPage.tsx
+++ b/src/scenes/CollectionGalleryPage/CollectionGalleryPage.tsx
@@ -10,6 +10,7 @@ import { graphql, useFragment } from 'react-relay';
 import { GLOBAL_NAVBAR_HEIGHT } from 'contexts/globalLayout/GlobalNavbar/GlobalNavbar';
 import useDisplayFullPageNftDetailModal from 'scenes/NftDetailPage/useDisplayFullPageNftDetailModal';
 import { CollectionGalleryPageFragment$key } from '__generated__/CollectionGalleryPageFragment.graphql';
+import { useModalState } from 'contexts/modal/ModalContext';
 
 type CollectionGalleryPageProps = {
   username: string;
@@ -50,14 +51,17 @@ function CollectionGalleryPage({ collectionId, username, queryRef }: CollectionG
   const userOwnsCollection = Boolean(query?.viewer?.user?.username === username);
   const isLoggedIn = Boolean(query?.viewer?.user?.username);
 
+  const { isModalOpenRef } = useModalState();
+
   const navigateToEdit = useCallback(() => {
     if (!isLoggedIn) return;
+    if (isModalOpenRef.current) return;
     if (userOwnsCollection) {
       void push(`/edit?collectionId=${collectionId}`);
     } else {
       void push(`/edit`);
     }
-  }, [push, collectionId, userOwnsCollection, isLoggedIn]);
+  }, [push, collectionId, userOwnsCollection, isLoggedIn, isModalOpenRef]);
 
   useKeyDown('e', navigateToEdit);
 

--- a/src/scenes/UserGalleryPage/UserGallery.tsx
+++ b/src/scenes/UserGalleryPage/UserGallery.tsx
@@ -7,6 +7,7 @@ import { graphql } from 'relay-runtime';
 import { UserGalleryLayout } from 'scenes/UserGalleryPage/UserGalleryLayout';
 import { UserGalleryFragment$key } from '__generated__/UserGalleryFragment.graphql';
 import useDisplayFullPageNftDetailModal from 'scenes/NftDetailPage/useDisplayFullPageNftDetailModal';
+import { useModalState } from 'contexts/modal/ModalContext';
 
 type Props = {
   queryRef: UserGalleryFragment$key;
@@ -47,10 +48,13 @@ function UserGallery({ queryRef }: Props) {
 
   const isLoggedIn = Boolean(query.viewer?.user?.id);
 
+  const { isModalOpenRef } = useModalState();
+
   const navigateToEdit = useCallback(() => {
     if (!isLoggedIn) return;
+    if (isModalOpenRef.current) return;
     void push(`/edit`);
-  }, [push, isLoggedIn]);
+  }, [push, isLoggedIn, isModalOpenRef]);
 
   useKeyDown('e', navigateToEdit);
 


### PR DESCRIPTION
Wanted to use something like `preventDefault` on the modal but the problem is the callback is already registered from the parent by then; seemed cleanest to put the check on the parent