### PR TITLE
Fix modal close regression

### DIFF
--- a/src/contexts/modal/ModalContext.tsx
+++ b/src/contexts/modal/ModalContext.tsx
@@ -88,7 +88,9 @@ function ModalProvider({ children }: Props) {
   const hideModal = useCallback((bypassOnClose = false) => {
     setIsActive(false);
     isModalOpenRef.current = false;
-    if (!bypassOnClose) {
+    // need to explicitly check for true, because if this function
+    // is passed into an onClick, it'll be given a truthy MouseEvent
+    if (bypassOnClose !== true) {
       onCloseRef.current?.();
     }
     setTimeout(() => {


### PR DESCRIPTION
Currently, clicking "X" on the modal explicitly will keep your URL at the NFT detail route, rather than returning you to the homepage.

This is because the desired `onClose` wasn't getting called, since the callback was being passed a truthy MouseEvent.