### PR TITLE
Fix sidebar alignment issue for NFTs

### DIFF
--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
@@ -137,7 +137,7 @@ function Sidebar({ nftsRef, sidebarNfts }: Props) {
           />
         )}
       </StyledSelectButtonWrapper>
-      <Spacer height={8} />
+      <Spacer height={16} />
       <Selection>
         <StyledAddBlankBlock onClick={handleAddBlankBlockClick}>
           <StyledAddBlankBlockText>Add Blank Space</StyledAddBlankBlockText>
@@ -210,7 +210,7 @@ const Selection = styled.div`
   display: flex;
   flex-wrap: wrap;
   width: 218px;
-  justify-content: space-between;
+  grid-gap: 19px;
 `;
 
 export default memo(Sidebar);

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
@@ -83,7 +83,6 @@ export const StyledSidebarNftIcon = styled.div<{ backgroundColorOverride: string
   width: 60px;
   height: 60px;
   overflow: hidden;
-  margin-bottom: 16px;
 
   display: flex;
   justify-content: center;


### PR DESCRIPTION
`justify-content: space-between` was spreading out sidebar content if users had an uneven number of NFTs. fixed with `grid-gap`.

before vs. after

![Screen Shot 2022-05-28 at 2 26 47 AM](https://user-images.githubusercontent.com/12162433/170813492-860edaec-acff-458d-9851-3a57a1636d0b.png)

before vs. after

![Screen Shot 2022-05-28 at 2 27 35 AM](https://user-images.githubusercontent.com/12162433/170813528-257d5180-ec78-4156-9e6f-7724a2962cac.png)

ensure no regressions (top of sidebar)

![Screen Shot 2022-05-28 at 2 27 24 AM](https://user-images.githubusercontent.com/12162433/170813538-398b7ab9-c481-45fd-9105-2ba93cdbb5d4.png)

property is well supported

![Screen Shot 2022-05-28 at 2 28 59 AM](https://user-images.githubusercontent.com/12162433/170813541-61f05b99-7fdb-4389-b572-8ff4c9174c98.png)