### PR TITLE
[GAL-211] Fix spacing between NFT detail image and collector's note

### DIFF
--- a/src/scenes/NftDetailPage/NftDetailNote.tsx
+++ b/src/scenes/NftDetailPage/NftDetailNote.tsx
@@ -127,24 +127,29 @@ function NoteEditor({ nftCollectorsNote, nftId, collectionId }: NoteEditorProps)
       )}
       {generalError && (
         <>
-          <Spacer height={8} />
           <ErrorText message={generalError} />
+          <Spacer height={8} />
         </>
       )}
 
-      <Spacer height={16} />
       <StyledBottomButtonContainer>
         {isEditing ? (
-          <SaveNoteButton
-            disabled={unescapedCollectorsNote.length > MAX_CHAR_COUNT}
-            text="Save Note"
-            onClick={handleSubmitCollectorsNote}
-          />
+          <>
+            <Spacer height={12} />
+            <SaveNoteButton
+              disabled={unescapedCollectorsNote.length > MAX_CHAR_COUNT}
+              text="Save Note"
+              onClick={handleSubmitCollectorsNote}
+            />
+          </>
         ) : (
-          <EditNoteButton
-            text={hasCollectorsNote ? 'Edit note' : 'Add Note'}
-            onClick={handleEditCollectorsNote}
-          />
+          <>
+            <Spacer height={hasCollectorsNote ? 8 : 0} />
+            <EditNoteButton
+              text={hasCollectorsNote ? 'Edit' : 'Add Note'}
+              onClick={handleEditCollectorsNote}
+            />
+          </>
         )}
       </StyledBottomButtonContainer>
     </div>
@@ -157,7 +162,8 @@ const StyledBottomButtonContainer = styled.div`
 `;
 
 const SaveNoteButton = styled(TextButton)`
-  align-self: end;
+  display: flex;
+  justify-content: end;
 `;
 
 const EditNoteButton = styled(TextButton)`
@@ -195,7 +201,7 @@ function NftDetailNote({
 }: Props) {
   return (
     <StyledContainer footerHeight={GLOBAL_FOOTER_HEIGHT}>
-      <Spacer height={24} />
+      <Spacer height={12} />
       {authenticatedUserOwnsAsset ? (
         <NoteEditor
           nftCollectorsNote={nftCollectorsNote}

--- a/src/scenes/NftDetailPage/NftDetailNote.tsx
+++ b/src/scenes/NftDetailPage/NftDetailNote.tsx
@@ -249,7 +249,6 @@ const StyledTextAreaWithCharCount = styled(AutoResizingTextAreaWithCharCount)<Te
   scrollbar-width: none;
 
   textarea {
-    color: #808080;
     margin: 0;
     line-height: 20px;
     font-size: 14px;
@@ -271,7 +270,6 @@ type CollectorsNoteProps = {
 
 const StyledCollectorsNote = styled(BaseM)<CollectorsNoteProps>`
   height: 100%;
-  color: #808080;
 
   :last-child {
     margin-bottom: 40px; /* line-height * 2, because textarea leaves one line at bottom + char count */


### PR DESCRIPTION
sync'd with Jess offline and got approval. also made sure to make the text off-black (which isn't pictured)

<img width="825" alt="Screen Shot 2022-06-06 at 3 50 05 PM" src="https://user-images.githubusercontent.com/12162433/172238200-eca6e805-4c04-4ebc-8f18-cb4ae2dfc2ec.png">
<img width="833" alt="Screen Shot 2022-06-06 at 3 49 55 PM" src="https://user-images.githubusercontent.com/12162433/172238205-0505145f-e35d-4a18-aa91-a870a8ae16c5.png">
<img width="879" alt="Screen Shot 2022-06-06 at 3 49 48 PM" src="https://user-images.githubusercontent.com/12162433/172238207-dae63064-4195-4cf6-80a8-6c2ceca62f69.png">
