### PR TITLE
Fix button positioning regression

### DIFF
--- a/src/components/core/Button/TextButton.tsx
+++ b/src/components/core/Button/TextButton.tsx
@@ -44,7 +44,6 @@ const StyledButton = styled.button<Pick<Props, 'underlineOnHover' | 'disabled'>>
   border-style: none;
   cursor: pointer;
   background: none;
-  width: 100%;
   text-align: left;
 
   pointer-events: ${({ disabled }) => (disabled ? 'none' : 'inherit')};


### PR DESCRIPTION
fix a recent regression that messes with button positioning

**current**
<img width="249" alt="image" src="https://user-images.githubusercontent.com/12162433/172259531-79780e90-dda5-4487-b197-e2bfeda78266.png">

**new**
<img width="247" alt="image" src="https://user-images.githubusercontent.com/12162433/172259505-7b4fdb90-26fd-4bcd-b1a0-021f627fd076.png">
