### PR TITLE
[GAL-212] Remove link formatting when clicking on empty link

### DIFF
--- a/src/components/core/Markdown/Link.tsx
+++ b/src/components/core/Markdown/Link.tsx
@@ -16,11 +16,17 @@ export default function Bold({
     const [start, end] = selectedRange;
     const selectedText = textArea.value.substring(start, end);
 
-    // If user is inbetween two brackets, or at the end of (https://), they probably just clicked the link button. Do nothing
-    if (
-      textArea.value.substring(start - 1, end + 1) == '[]' ||
-      textArea.value.substring(start - 1, end + 1) == '/)'
-    ) {
+    // If the user clicks an empty link, remove the [](https://)
+    if (textArea.value.substring(start - 1, end + 11) === '[](https://)') {
+      const newText =
+        textArea.value.substring(0, start - 1) +
+        textArea.value.substring(end + 11, textArea.value.length);
+      setValueAndTriggerOnChange(textArea, newText, [start - 1, start - 1]);
+      return;
+    }
+    // If user is at the end of (https://), they probably just clicked the link button.
+    // Removing the [text](https://) would be difficult because [text] can be any number of chars. For now, just return
+    if (textArea.value.substring(start - 1, end + 1) == '/)') {
       return;
     }
     if (selectedText.length > 0) {


### PR DESCRIPTION
If the user clicks the Link button while their cursor is in a newly created link (`[](https://)`) this will remove that link.

This does not handle the case where a user selects text (`Hello`), creates a link (`[Hello](https://)`) and then clicks again. This is a more difficult problem because the middle text (`Hello`) could be any number of characters; it is difficult to handle in our current configuration.