### PR TITLE
[GAL-207] make followers list button visible for non logged in users always

### DIFF
--- a/src/components/Follow/FollowerListButton.tsx
+++ b/src/components/Follow/FollowerListButton.tsx
@@ -42,6 +42,5 @@ export default function FollowerListButton({ userRef, className }: Props) {
 }
 
 export const StyledFollowerListButton = styled.div`
-  opacity: 0;
   transition: opacity 0.2s ease-in-out;
 `;

--- a/src/components/Follow/NavActionFollow.tsx
+++ b/src/components/Follow/NavActionFollow.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { NavActionFollowQueryFragment$key } from '__generated__/NavActionFollowQueryFragment.graphql';
 import { NavActionFollowUserFragment$key } from '__generated__/NavActionFollowUserFragment.graphql';
 import FollowButton from './FollowButton';
-import FollowerCount, { StyledFollowerListButton } from './FollowerListButton';
+import FollowerListButton, { StyledFollowerListButton } from './FollowerListButton';
 
 type Props = {
   userRef: NavActionFollowUserFragment$key;
@@ -38,6 +38,7 @@ export default function NavActionFollow({ userRef, queryRef }: Props) {
   );
 
   const loggedInUserId = useLoggedInUserId(loggedInUserQuery);
+  const isLoggedIn = !!loggedInUserId;
 
   const followerIds = useMemo(
     () => user.followers.map((follower: { id: string } | null) => follower?.id),
@@ -50,17 +51,25 @@ export default function NavActionFollow({ userRef, queryRef }: Props) {
   );
 
   return (
-    <StyledNavActionFollow>
+    <StyledNavActionFollow isLoggedIn={isLoggedIn}>
       <FollowButton userRef={user} isFollowing={isFollowing} loggedInUserId={loggedInUserId} />
       <Spacer width={4} />
-      <FollowerCount userRef={user}></FollowerCount>
+      <FollowerListButton userRef={user}></FollowerListButton>
     </StyledNavActionFollow>
   );
 }
 
-const StyledNavActionFollow = styled.div`
+const StyledNavActionFollow = styled.div<{ isLoggedIn: boolean }>`
   display: flex;
   align-items: center;
+
+  ${({ isLoggedIn }) =>
+    isLoggedIn &&
+    `
+    ${StyledFollowerListButton} {
+      opacity: 0;
+    }
+  `}
 
   &:hover {
     ${StyledFollowerListButton} {


### PR DESCRIPTION
This PR makes the "Followers" button that displays the Followers List always visible for non-logged in users, to improve discoverability.

<img width="1410" alt="Screen Shot 2022-06-08 at 0 36 12" src="https://user-images.githubusercontent.com/80802871/172422126-53752f61-9269-45b4-a5aa-da58e0769878.png">
