### PR TITLE
dont log exception if because user is not early access

### DIFF
--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingDefault.tsx
@@ -21,6 +21,7 @@ import { useModalActions } from 'contexts/modal/ModalContext';
 import ManageWalletsModal from 'scenes/Modals/ManageWalletsModal';
 import { signMessageWithEOA } from '../walletUtils';
 import {
+  isNotEarlyAccessError,
   useTrackAddWalletAttempt,
   useTrackAddWalletError,
   useTrackAddWalletSuccess,
@@ -139,7 +140,9 @@ function AddWalletPendingDefault({
         setIsConnecting(false);
         trackAddWalletError(userFriendlyWalletName, error);
         if (isWeb3Error(error)) {
-          captureException(error.message);
+          if (!isNotEarlyAccessError(error.message)) {
+            captureException(error.message);
+          }
           setDetectedError(error);
         }
 

--- a/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AddWalletPending/AddWalletPendingGnosisSafe.tsx
@@ -28,6 +28,7 @@ import {
   useTrackAddWalletAttempt,
   useTrackAddWalletSuccess,
   useTrackAddWalletError,
+  isNotEarlyAccessError,
 } from 'contexts/analytics/authUtil';
 import { captureException } from '@sentry/nextjs';
 import { graphql, useFragment } from 'react-relay';
@@ -101,7 +102,9 @@ function AddWalletPendingGnosisSafe({
     (error: unknown) => {
       trackAddWalletError('Gnosis Safe', error);
       if (isWeb3Error(error)) {
-        captureException(error.message);
+        if (!isNotEarlyAccessError(error.message)) {
+          captureException(error.message);
+        }
         setDetectedError(error);
       }
 

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingDefault.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingDefault.tsx
@@ -10,6 +10,7 @@ import { INITIAL, PROMPT_SIGNATURE, PendingState } from 'types/Wallet';
 import Spacer from 'components/core/Spacer/Spacer';
 import { signMessageWithEOA } from '../walletUtils';
 import {
+  isNotEarlyAccessError,
   useTrackCreateUserSuccess,
   useTrackSignInAttempt,
   useTrackSignInError,
@@ -98,7 +99,10 @@ function AuthenticateWalletPendingDefault({
           trackSignInError(userFriendlyWalletName, error);
 
           if (isWeb3Error(error)) {
-            captureException(error.message);
+            // dont log error if because user is not early access
+            if (!isNotEarlyAccessError(error.message)) {
+              captureException(error.message);
+            }
             setDetectedError(error);
           }
 

--- a/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
+++ b/src/components/WalletSelector/AuthenticateWalletPending/AuthenticateWalletPendingGnosisSafe.tsx
@@ -18,6 +18,7 @@ import {
   useTrackSignInSuccess,
   useTrackSignInError,
   useTrackCreateUserSuccess,
+  isNotEarlyAccessError,
 } from 'contexts/analytics/authUtil';
 import { captureException } from '@sentry/nextjs';
 import useCreateNonce from '../mutations/useCreateNonce';
@@ -73,7 +74,9 @@ function AuthenticateWalletPendingGnosisSafe({
     (error: unknown) => {
       trackSignInError('Gnosis Safe', error);
       if (isWeb3Error(error)) {
-        captureException(error.message);
+        if (!isNotEarlyAccessError(error.message)) {
+          captureException(error.message);
+        }
         setDetectedError(error);
       }
 

--- a/src/components/WalletSelector/WalletSelector.tsx
+++ b/src/components/WalletSelector/WalletSelector.tsx
@@ -17,6 +17,7 @@ import Markdown from 'components/core/Markdown/Markdown';
 import { getUserFriendlyWalletName } from 'utils/wallet';
 import { graphql, useFragment } from 'react-relay';
 import { WalletSelectorFragment$key } from '__generated__/WalletSelectorFragment.graphql';
+import { isNotEarlyAccessError } from 'contexts/analytics/authUtil';
 
 const walletConnectorMap: Record<string, AbstractConnector> = {
   Metamask: injected,
@@ -118,7 +119,7 @@ function WalletSelector({ connectionMode = AUTH, queryRef }: Props) {
     if (detectedError) {
       // Handle error from server
       if (detectedError.code === 'GALLERY_SERVER_ERROR') {
-        if (detectedError.message.toLowerCase().includes('required tokens not owned')) {
+        if (isNotEarlyAccessError(detectedError.message)) {
           return {
             heading: 'Authorization Error',
             body: "We weren't able to locate a Membership Card in your wallet. Gallery is in closed beta and requires one for access. You can buy one on the [secondary market](https://opensea.io/collection/gallerygeneralmembershipcards) or visit our [FAQ](https://gallery-so.notion.site/Gallery-FAQ-b5ee57c1d7f74c6695e42c84cb6964ba) for more info.",

--- a/src/contexts/analytics/authUtil.ts
+++ b/src/contexts/analytics/authUtil.ts
@@ -105,3 +105,7 @@ function getAuthErrorMessage(error: unknown) {
 
   return 'Unknown';
 }
+
+export function isNotEarlyAccessError(errorMessage: string) {
+  return errorMessage.toLowerCase().includes('required tokens not owned');
+}


### PR DESCRIPTION
### Context
Sentry alerts keep getting fired because an error gets logged when a user tries to sign in and they don't have a membership nft.
This isn't an app error, so we don't need to log it in Sentry. we still track the event in analytics, so we don't lose this information.

### Changes
Added a util function `isNotEarlyAccessError` to check the error type using the error message, and updated the add wallet + sign in flows to not log the exception if this is true.