### PR TITLE
[GAL-135] filter hidden collections from gallery link preview image

### DIFF
--- a/pages/opengraph/user/[username].tsx
+++ b/pages/opengraph/user/[username].tsx
@@ -23,6 +23,7 @@ export default function OpenGraphUserPage() {
             bio
             galleries {
               collections {
+                hidden
                 nfts {
                   nft {
                     ...getVideoOrImageUrlForNftPreviewFragment
@@ -45,7 +46,8 @@ export default function OpenGraphUserPage() {
 
   const imageUrls = removeNullValues(
     user.galleries?.[0]?.collections
-      ?.flatMap((collection) => collection?.nfts)
+      ?.filter((collection) => !collection?.hidden)
+      .flatMap((collection) => collection?.nfts)
       .map((galleryNft) => {
         return galleryNft?.nft ? getVideoOrImageUrlForNftPreview(galleryNft.nft) : null;
       })


### PR DESCRIPTION
Fixes bug where hidden collections are included in the gallery link preview image