### PR TITLE
Remove extra spacing from add wallet modal

### DIFF
--- a/src/scenes/Modals/ManageWalletsModal.tsx
+++ b/src/scenes/Modals/ManageWalletsModal.tsx
@@ -23,7 +23,6 @@ function ManageWalletsModal({ newAddress, queryRef }: Props) {
   return (
     <StyledManageWalletsModal>
       <ManageWallets queryRef={query} newAddress={newAddress} />
-      <Spacer height={24}></Spacer>
     </StyledManageWalletsModal>
   );
 }

--- a/src/scenes/Modals/ManageWalletsModal.tsx
+++ b/src/scenes/Modals/ManageWalletsModal.tsx
@@ -1,5 +1,4 @@
 import breakpoints from 'components/core/breakpoints';
-import Spacer from 'components/core/Spacer/Spacer';
 import ManageWallets from 'components/ManageWallets/ManageWallets';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';


### PR DESCRIPTION
this pr removes extra spacing at the bottom of the add wallet modal

before
<img width="581" alt="Screen Shot 2022-06-17 at 0 35 29" src="https://user-images.githubusercontent.com/80802871/174128521-fb5bf1c3-9679-494f-894a-d0bed3bd57b9.png">


after
<img width="634" alt="Screen Shot 2022-06-17 at 0 37 14" src="https://user-images.githubusercontent.com/80802871/174128565-2765277f-52c1-4e2b-a03f-d093ad3e6199.png">

