### PR TITLE
Fix for missing query fields when going from sign in -> open add wallet modal

### DIFF
--- a/src/components/WalletSelector/mutations/useLoginOrCreateUser.ts
+++ b/src/components/WalletSelector/mutations/useLoginOrCreateUser.ts
@@ -19,6 +19,18 @@ export default function useLoginOrCreateUser() {
 
           ... on LoginPayload {
             userId @required(action: THROW)
+            viewer {
+              ... on Viewer {
+                user {
+                  wallets @required(action: THROW) {
+                    dbid @required(action: THROW)
+                    chainAddress @required(action: THROW) {
+                      address @required(action: THROW)
+                    }
+                  }
+                }
+              }
+            }
           }
           ... on ErrUserNotFound {
             message


### PR DESCRIPTION
This fixes a bug we were seeing when testing for the Merge

bug:
Opening the Add Wallet modal immediately after signing in triggered a graphql error, because wallets was not populated on the user.

Fix
The fix in this PR is to request the viewer user and list of wallets in the log in query. This populates the viewer user with the wallet data upon logging in and makes it immediately available when the Add Wallet modal is opened.


