### PR TITLE
Fix bug where QR Code does not render "G" icon

### DIFF
--- a/src/contexts/globalLayout/GlobalBanner/GlobalBanner.tsx
+++ b/src/contexts/globalLayout/GlobalBanner/GlobalBanner.tsx
@@ -5,6 +5,7 @@ import { BaseM, TitleS } from 'components/core/Text/Text';
 import usePersistedState from 'hooks/usePersistedState';
 import { useCallback } from 'react';
 import { graphql, useFragment } from 'react-relay';
+import { DecoratedCloseIcon } from 'src/icons/CloseIcon';
 import styled from 'styled-components';
 import { GlobalBannerFragment$key } from '__generated__/GlobalBannerFragment.graphql';
 import { GLOBAL_NAVBAR_HEIGHT } from '../GlobalNavbar/GlobalNavbar';
@@ -58,7 +59,7 @@ export default function Banner({
         </BaseM>
         <StyledAction>
           {actionComponent}
-          <StyledClose onClick={hideBanner}>&#x2715;</StyledClose>
+          <StyledClose onClick={hideBanner} />
         </StyledAction>
       </StyledBanner>
     </StyledContainer>
@@ -99,14 +100,17 @@ const StyledBanner = styled.div`
   }
 `;
 
-const StyledClose = styled.span`
-  cursor: pointer;
-  color: #141414;
+const StyledClose = styled(DecoratedCloseIcon)`
+  padding: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  position: absolute;
+  right: 0;
 
   @media (max-width: ${contentSize.desktop}px) {
-    position: absolute;
-    top: 8px;
-    right: 8px;
+    top: 0;
   }
 `;
 

--- a/src/icons/CloseIcon.tsx
+++ b/src/icons/CloseIcon.tsx
@@ -10,12 +10,12 @@ export default function CloseIcon({ isActive }: Props) {
   return (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
-        d="M12.6666 3.33334L3.33331 12.6667"
+        d="M12.6667 3.33333L3.33333 12.6667"
         stroke={isActive ? colors.offBlack : colors.shadow}
         stroke-miterlimit="10"
       />
       <path
-        d="M3.33331 3.33334L12.6666 12.6667"
+        d="M3.33333 3.33333L12.6667 12.6667"
         stroke={isActive ? colors.offBlack : colors.shadow}
         stroke-miterlimit="10"
       />

--- a/src/scenes/MaintenancePage/MaintenancePage.tsx
+++ b/src/scenes/MaintenancePage/MaintenancePage.tsx
@@ -16,8 +16,9 @@ function MaintenancePage() {
       <StyledLogo src="/icons/logo-large.svg" />
       <Spacer height={8} />
       <StyledBaseM>
-        Gallery is currently undergoing planned maintenance until Monday, 6/20 11:59am EST, and is
-        not usable at this time. Keep up to date on our socials.
+        Gallery is currently undergoing planned maintenance until{' '}
+        <strong>Monday June 20th, 11:59am EST</strong> and is not usable at this time. Keep up to
+        date on our socials.
       </StyledBaseM>
       <Spacer height={24} />
       <StyledLinkContainer>

--- a/src/scenes/UserGalleryPage/QRCode.tsx
+++ b/src/scenes/UserGalleryPage/QRCode.tsx
@@ -25,17 +25,11 @@ export default function QRCode({ username }: { username: string }) {
         data: `https://gallery.so/${username}`,
         margin: 0,
         qrOptions: { typeNumber: '0', mode: 'Byte', errorCorrectionLevel: 'Q' },
-        imageOptions: {
-          hideBackgroundDots: true,
-          imageSize: 0.4,
-          margin: 0,
-          crossOrigin: 'anonymous',
-        },
+        imageOptions: { hideBackgroundDots: true, imageSize: 0.4, margin: 0 },
         dotsOptions: { type: 'square', color: '#000000', gradient: null },
         backgroundOptions: { color: '#ffffff', gradient: null },
         image:
           'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJcAAACWCAYAAADTwxrcAAAACXBIWXMAABCcAAAQnAEmzTo0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAVNSURBVHgB7d3dUSNHFIbhA4hrY0D3IgJrI7CIwOsIFkdgNgIgAnsjgI0AE8EOGeAIVr6GC90Dwt8RzZYWj3qEdmZx9XmfKpVAM0hU6avunp7+MQMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQtjXDQluyubk50I/Dh4eHLX8pHZro9/H6+vr4+vr6ylCLcD3jger1er/rx1F6NJnoUa2trV0oaGd1J2xvbx8qiLNg3t3dnU0mk7EFQLiS3d3dkZ6ObLlA1Uql2cl8yJTVgcL6ee60/Zubm8oCWLfgvKRSsP7Qj58sEyyVTGM9VenhVeGk5pyBAna6s7Pzud/vH/hrCtsvFlTokku5Gm5sbJx7KBacUulxoqrsSlXZpO7v1SYbTqfTo8x7PBem5AobLpUu7xSIswWHKwXqvfK0dGPdSyqVWl4CbjWcSrVYslyw9PoHffn7LwmW83aWAvnG212GmXDhUrDeZkosb4wf2or8KvD+/n7fatpjEYUKl1+5KVinCw5XKrGO7RulboZfDbHCpca7XxHWtolUpf1mLfE2larHjxZcmHCpuyF3RXfSdsemqsdjCy5EuLw6VElyUHfMG+Dea24tS2GtLLAQ4VJ1eJzry+rwdsyJBVZ8uFIj/t2i46q+OguAd75a4CvH4sOlHvRR5vBVlzeRU69+2FETxYfLb80sOqYS7dI6pjbd3xZU0eHykQ65e3764v+y7lUWVNHhUnje5o6nNlGn1KYLWy32rGAqtX7OHK4d6dCB2WDCp1/0P4Vp4BcbLh+npadh5pR/7DtIAd63gIqtFnu93rDhFMa+d6zkNtcodzCNLEWHig2XGvPDhuNjQ6eKDZdKph8Mr6rkajFbcqkbYmzoVMnhahrLjo4VGa7UDZEVZWLqayq1n6vVUivNwj63DvgI2FKDXnQPfYs8rCPDi4SfcY3uUHItwast1Yx76VevIr9Uu2kK/0A/+n3M0bJvaY8zuauS235FzriuWfzjP/TF/tj2jWv/XJ9h1DS1X5+9F+GCoshqcckvrvWuCv9cBatpitpFlCvVkttcrzK0xecsNty3rCyIkm//ZMOlanNgHZlOpwuHT/tqhBZEseHSF5wdu/6CJY9apf8rzGDBkqvFce5gWuMUHSo2XKp+soMBFa6fDJ0qNly3t7fZcKlabBqpim9UbLjS4m259s3A0KnSp5blJr1u9ft9Sq8OFR0utbuyk14VvpF1g5UFrfBwqd3l4cp90Z0s4x1pbmJO0eHye4cNVeNwmYGFWE3xQ25UivyZOewjHA4MnSg+XGnN9ypzStgdLroWZbBgboG3Udr3pzX0/j8KEa60uvKHzClH1i5KQws0zNlXV87MsvbS69Ba0LQmWCRhwuVXjg0D+Y7a6FT1XcsMM6EmaKTG/fsFh7em0+m5D1W2Fc2vde+lZPSNDsLN/lHAvGuitoHvwfAx8Ks08H2zKj0dz73XR90hqCywkFPL0h4/XoLVbsipp08Ky+kypZh3wurcs/nNqrzU8s9Y4g5B0aJv5rnMbJ1Kj0sF5urpto6fryp0qGcfEzaaP9mD5TuXPU3CUCn4fAfaMPsthp63mAKw5xtxZnZ7HflDx768oADZ/O9zr38VLKf3vVD1OLKAmHFtjxtxKhRv0tXkKstZzia5+ns8nzamcH2P5cj/l0JXi4t4dek7b6gk8s7Qp4V7v+p19+ljCk6lUunS21a5Cba+gajOm/29zi16ljUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC34F9wnFUw4gXCoAAAAAElFTkSuQmCC',
-        // 'https://gallery.so/icons/logo-large.svg',
         dotsOptionsHelper: {
           colorType: { single: true, gradient: false },
           gradient: {

--- a/src/scenes/UserGalleryPage/QRCode.tsx
+++ b/src/scenes/UserGalleryPage/QRCode.tsx
@@ -25,12 +25,7 @@ export default function QRCode({ username }: { username: string }) {
         data: `https://gallery.so/${username}`,
         margin: 0,
         qrOptions: { typeNumber: '0', mode: 'Byte', errorCorrectionLevel: 'Q' },
-        imageOptions: {
-          hideBackgroundDots: true,
-          imageSize: 0.4,
-          margin: 0,
-          crossOrigin: 'anonymous',
-        },
+        imageOptions: { hideBackgroundDots: true, imageSize: 0.4, margin: 0 },
         dotsOptions: { type: 'square', color: '#000000', gradient: null },
         backgroundOptions: { color: '#ffffff', gradient: null },
         image:
@@ -92,7 +87,7 @@ export default function QRCode({ username }: { username: string }) {
     // Need a brief timeout so that the modal renders before rendering QR code. Otherwise the ref will not exist and renderQRCode cannot append the ref
     setTimeout(() => {
       renderQRCode();
-    }, 200);
+    }, 1000);
 
     showModal({
       content: (

--- a/src/scenes/UserGalleryPage/QRCode.tsx
+++ b/src/scenes/UserGalleryPage/QRCode.tsx
@@ -1,6 +1,6 @@
 import colors from 'components/core/colors';
 import styled from 'styled-components';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Spacer from 'components/core/Spacer/Spacer';
 import QRIcon from 'src/icons/QRIcon';
 import { useModalActions } from 'contexts/modal/ModalContext';
@@ -25,11 +25,17 @@ export default function QRCode({ username }: { username: string }) {
         data: `https://gallery.so/${username}`,
         margin: 0,
         qrOptions: { typeNumber: '0', mode: 'Byte', errorCorrectionLevel: 'Q' },
-        imageOptions: { hideBackgroundDots: true, imageSize: 0.4, margin: 0 },
+        imageOptions: {
+          hideBackgroundDots: true,
+          imageSize: 0.4,
+          margin: 0,
+          crossOrigin: 'anonymous',
+        },
         dotsOptions: { type: 'square', color: '#000000', gradient: null },
         backgroundOptions: { color: '#ffffff', gradient: null },
         image:
           'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJcAAACWCAYAAADTwxrcAAAACXBIWXMAABCcAAAQnAEmzTo0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAVNSURBVHgB7d3dUSNHFIbhA4hrY0D3IgJrI7CIwOsIFkdgNgIgAnsjgI0AE8EOGeAIVr6GC90Dwt8RzZYWj3qEdmZx9XmfKpVAM0hU6avunp7+MQMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQtjXDQluyubk50I/Dh4eHLX8pHZro9/H6+vr4+vr6ylCLcD3jger1er/rx1F6NJnoUa2trV0oaGd1J2xvbx8qiLNg3t3dnU0mk7EFQLiS3d3dkZ6ObLlA1Uql2cl8yJTVgcL6ee60/Zubm8oCWLfgvKRSsP7Qj58sEyyVTGM9VenhVeGk5pyBAna6s7Pzud/vH/hrCtsvFlTokku5Gm5sbJx7KBacUulxoqrsSlXZpO7v1SYbTqfTo8x7PBem5AobLpUu7xSIswWHKwXqvfK0dGPdSyqVWl4CbjWcSrVYslyw9PoHffn7LwmW83aWAvnG212GmXDhUrDeZkosb4wf2or8KvD+/n7fatpjEYUKl1+5KVinCw5XKrGO7RulboZfDbHCpca7XxHWtolUpf1mLfE2larHjxZcmHCpuyF3RXfSdsemqsdjCy5EuLw6VElyUHfMG+Dea24tS2GtLLAQ4VJ1eJzry+rwdsyJBVZ8uFIj/t2i46q+OguAd75a4CvH4sOlHvRR5vBVlzeRU69+2FETxYfLb80sOqYS7dI6pjbd3xZU0eHykQ65e3764v+y7lUWVNHhUnje5o6nNlGn1KYLWy32rGAqtX7OHK4d6dCB2WDCp1/0P4Vp4BcbLh+npadh5pR/7DtIAd63gIqtFnu93rDhFMa+d6zkNtcodzCNLEWHig2XGvPDhuNjQ6eKDZdKph8Mr6rkajFbcqkbYmzoVMnhahrLjo4VGa7UDZEVZWLqayq1n6vVUivNwj63DvgI2FKDXnQPfYs8rCPDi4SfcY3uUHItwast1Yx76VevIr9Uu2kK/0A/+n3M0bJvaY8zuauS235FzriuWfzjP/TF/tj2jWv/XJ9h1DS1X5+9F+GCoshqcckvrvWuCv9cBatpitpFlCvVkttcrzK0xecsNty3rCyIkm//ZMOlanNgHZlOpwuHT/tqhBZEseHSF5wdu/6CJY9apf8rzGDBkqvFce5gWuMUHSo2XKp+soMBFa6fDJ0qNly3t7fZcKlabBqpim9UbLjS4m259s3A0KnSp5blJr1u9ft9Sq8OFR0utbuyk14VvpF1g5UFrfBwqd3l4cp90Z0s4x1pbmJO0eHye4cNVeNwmYGFWE3xQ25UivyZOewjHA4MnSg+XGnN9ypzStgdLroWZbBgboG3Udr3pzX0/j8KEa60uvKHzClH1i5KQws0zNlXV87MsvbS69Ba0LQmWCRhwuVXjg0D+Y7a6FT1XcsMM6EmaKTG/fsFh7em0+m5D1W2Fc2vde+lZPSNDsLN/lHAvGuitoHvwfAx8Ks08H2zKj0dz73XR90hqCywkFPL0h4/XoLVbsipp08Ky+kypZh3wurcs/nNqrzU8s9Y4g5B0aJv5rnMbJ1Kj0sF5urpto6fryp0qGcfEzaaP9mD5TuXPU3CUCn4fAfaMPsthp63mAKw5xtxZnZ7HflDx768oADZ/O9zr38VLKf3vVD1OLKAmHFtjxtxKhRv0tXkKstZzia5+ns8nzamcH2P5cj/l0JXi4t4dek7b6gk8s7Qp4V7v+p19+ljCk6lUunS21a5Cba+gajOm/29zi16ljUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC34F9wnFUw4gXCoAAAAAElFTkSuQmCC',
+        // 'https://gallery.so/icons/logo-large.svg',
         dotsOptionsHelper: {
           colorType: { single: true, gradient: false },
           gradient: {
@@ -81,18 +87,28 @@ export default function QRCode({ username }: { username: string }) {
   const { showModal } = useModalActions();
   const track = useTrack();
 
+  const [dummyQR, setDummyQR] = useState(false);
+  useEffect(() => {
+    setDummyQR(true);
+
+    setTimeout(() => {
+      renderQRCode();
+      setDummyQR(false);
+    }, 100);
+  }, [showModal, username, renderQRCode]);
+
   const handleClick = useCallback(() => {
     track('Profile QR Code Click', { username });
 
     // Need a brief timeout so that the modal renders before rendering QR code. Otherwise the ref will not exist and renderQRCode cannot append the ref
     setTimeout(() => {
       renderQRCode();
-    }, 1000);
+    }, 100);
 
     showModal({
       content: (
         <StyledFullScreenQR>
-          <StyledQRWrapper ref={ref} />
+          <StyledQRWrapper hidden={false} ref={ref} />
           <Spacer height={24} />
           <TitleM>
             <strong>{username}</strong>
@@ -106,6 +122,7 @@ export default function QRCode({ username }: { username: string }) {
 
   return (
     <StyledButton onClick={handleClick} title="Open QR code">
+      {dummyQR && <StyledQRWrapper hidden={true} ref={ref} />}
       <QRIcon />
     </StyledButton>
   );
@@ -141,12 +158,13 @@ const StyledBaseM = styled(BaseM)`
 `;
 
 // In order to render the QR code at a higher quality, we render it at 10x its initial size, and then scale it down with the following CSS
-const StyledQRWrapper = styled.div`
+const StyledQRWrapper = styled.div<{ hidden: boolean }>`
   height: 159px;
   width: 159px;
   transform: scale(0.25);
   display: flex;
   justify-content: center;
   place-items: center;
+  display: ${({ hidden }) => (hidden ? 'none' : 'flex')};
 }
 `;

--- a/src/scenes/UserGalleryPage/QRCode.tsx
+++ b/src/scenes/UserGalleryPage/QRCode.tsx
@@ -87,6 +87,8 @@ export default function QRCode({ username }: { username: string }) {
   const { showModal } = useModalActions();
   const track = useTrack();
 
+  // The Gallery logo does not appear the first time that the QR code loads. It does appear every time afterward.
+  // Here, we instantiate the StyledQRWrapper briefly on page load (but it is visually hidden), so that the first time the user clicks the icon is actually render #2.
   const [dummyQR, setDummyQR] = useState(false);
   useEffect(() => {
     setDummyQR(true);

--- a/src/scenes/UserGalleryPage/QRCode.tsx
+++ b/src/scenes/UserGalleryPage/QRCode.tsx
@@ -25,7 +25,12 @@ export default function QRCode({ username }: { username: string }) {
         data: `https://gallery.so/${username}`,
         margin: 0,
         qrOptions: { typeNumber: '0', mode: 'Byte', errorCorrectionLevel: 'Q' },
-        imageOptions: { hideBackgroundDots: true, imageSize: 0.4, margin: 0 },
+        imageOptions: {
+          hideBackgroundDots: true,
+          imageSize: 0.4,
+          margin: 0,
+          crossOrigin: 'anonymous',
+        },
         dotsOptions: { type: 'square', color: '#000000', gradient: null },
         backgroundOptions: { color: '#ffffff', gradient: null },
         image:

--- a/src/scenes/UserGalleryPage/QRCode.tsx
+++ b/src/scenes/UserGalleryPage/QRCode.tsx
@@ -92,7 +92,7 @@ export default function QRCode({ username }: { username: string }) {
     // Need a brief timeout so that the modal renders before rendering QR code. Otherwise the ref will not exist and renderQRCode cannot append the ref
     setTimeout(() => {
       renderQRCode();
-    }, 100);
+    }, 200);
 
     showModal({
       content: (


### PR DESCRIPTION
This fixes the issue where, on first open, the QR code would not display the Gallery logo in the center. 

After (too much) research, I found that the issue was **not** related to a setTimeout/race condition. Instead its related to the fact that, on click, a QR code is rendered and then appended to a ref, but that ref does not exist until the modal is present. So there is this sort of dependency cycle where one element (the QR code or the modal) has to exist in order for the other to render properly.

No matter the details, we know that this bug only occurred on **the first click**. If a user clicked X and then clicked the QR code again, everything would render properly.

So my solution here is to:
1. On page load, instantiate the existing `StyledQRWrapper` which contains the ref, for a brief period of time (this is done by setting `dummyQR` to true
2. Pass the prop `hidden` to this element so that it never visually appears 
3. Run `renderQRCode` so that the element is QR ref appended to `StyledQRWrapper` once (but the user never sees this)
4. After a brief period (100ms), remove the `StyledQRWrapper` from the DOM by setting `dummyQR` to false. That way, there will only be one `StyledQRWrapper` at a time (and one ref) when the user does click the QR Code Icon.

This guarantees the render will have occurred once (but never perceptually to the user), which means the "bad render" without a logo has already occurred once the user clicks the QR code icon for the first time.

Before:

https://user-images.githubusercontent.com/13339581/174685214-c4b5b147-75d0-4793-85fa-1f5d6ad8616c.mov

After:

https://user-images.githubusercontent.com/13339581/174685209-fc176fc6-fb0d-4ec8-b678-54e7930b1e9c.mov
