### PR TITLE
[GAL-202] Remove vertical center on user gallery page

### DIFF
--- a/src/scenes/UserGalleryPage/UserGalleryPage.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryPage.tsx
@@ -48,7 +48,6 @@ function UserGalleryPage({ queryRef, username }: UserGalleryPageProps) {
 const StyledUserGalleryPage = styled.div`
   display: flex;
   justify-content: center;
-  align-items: center;
   padding-top: ${GLOBAL_NAVBAR_HEIGHT}px;
   min-height: 100vh;
 


### PR DESCRIPTION
Set vertical allignment to the top in the user gallery page

**Before**
<img width="1510" alt="CleanShot 2022-06-22 at 13 23 28@2x" src="https://user-images.githubusercontent.com/4480258/174950052-1b537bb4-9dde-448d-8240-3e0817b6cc05.png">

**After**
<img width="1512" alt="CleanShot 2022-06-22 at 13 23 09@2x" src="https://user-images.githubusercontent.com/4480258/174950058-cf782831-bf11-4f83-902d-74dff772256e.png">

Notes:
Seems like there is no regression since only one page that used this component `<UserGallerypage>`