### PR TITLE
change collection page top spacing for mobile

### DIFF
--- a/src/scenes/CollectionGalleryPage/CollectionGallery.tsx
+++ b/src/scenes/CollectionGalleryPage/CollectionGallery.tsx
@@ -7,6 +7,7 @@ import NftGallery from 'components/NftGallery/NftGallery';
 import useMobileLayout from 'hooks/useMobileLayout';
 import { graphql, useFragment } from 'react-relay';
 import { CollectionGalleryFragment$key } from '__generated__/CollectionGalleryFragment.graphql';
+import { useIsMobileWindowWidth } from 'hooks/useWindowSize';
 
 type Props = {
   queryRef: CollectionGalleryFragment$key;
@@ -38,11 +39,12 @@ function CollectionGallery({ queryRef }: Props) {
   );
 
   const { collection } = query;
+  const isMobile = useIsMobileWindowWidth();
 
   if (collection?.__typename === 'Collection') {
     return (
       <StyledCollectionGallery>
-        <Spacer height={80} />
+        <Spacer height={isMobile ? 48 : 80} />
         <CollectionGalleryHeader
           queryRef={query}
           collectionRef={collection}

--- a/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
+++ b/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
@@ -204,7 +204,7 @@ function CollectionGalleryHeader({
         </>
       )}
 
-      <Spacer height={80} />
+      <Spacer height={isMobile ? 48 : 80} />
     </StyledCollectionGalleryHeaderWrapper>
   );
 }


### PR DESCRIPTION
Change the spacing above and below the header on the collection page for mobile, reported by jess
this makes the spacing  consistent with the main gallery page


collection
![Screen Shot 2022-06-25 at 10 38 53](https://user-images.githubusercontent.com/80802871/175753450-180157f7-24b8-4157-b9de-b9e8ab166441.png)



gallery
![Screen Shot 2022-06-25 at 10 38 49](https://user-images.githubusercontent.com/80802871/175753452-66d3eb0d-24dd-4d7d-b7ef-b3227a590bc6.png)


