### PR TITLE
Add feed tracking events and some clean up

### DIFF
--- a/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -15,6 +15,7 @@ import { getTimeSince } from 'utils/time';
 import { CollectionCreatedFeedEventFragment$key } from '__generated__/CollectionCreatedFeedEventFragment.graphql';
 import FeedEventTokenPreviews, { TokenToPreview } from '../FeedEventTokenPreviews';
 import { StyledClickHandler, StyledEvent, StyledEventHeader, StyledTime } from './EventStyles';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
 
 type Props = {
   eventRef: CollectionCreatedFeedEventFragment$key;
@@ -49,12 +50,14 @@ export default function CollectionCreatedFeedEvent({ eventRef }: Props) {
   }, [event.collection.tokens]) as TokenToPreview[];
 
   const collectionPagePath = `/${event.owner.username}/${event.collection.dbid}`;
+  const track = useTrack();
   const handleEventClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       event.preventDefault();
+      track('Feed: Clicked collection created event');
       void push(collectionPagePath);
     },
-    [collectionPagePath, push]
+    [collectionPagePath, push, track]
   );
 
   const showSeeAllButton = event.collection.tokens.length > 4;

--- a/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
@@ -13,6 +13,7 @@ import { CollectorsNoteAddedToTokenFeedEventFragment$key } from '__generated__/C
 import { StyledClickHandler, StyledEvent, StyledEventHeader, StyledTime } from './EventStyles';
 import EventMedia from './EventMedia';
 import unescape from 'utils/unescape';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
 
 type Props = {
   eventRef: CollectorsNoteAddedToTokenFeedEventFragment$key;
@@ -52,10 +53,13 @@ export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef }: Props)
   const { showModal } = useModalActions();
 
   const size = isMobile ? (windowSize.width - 2 * MARGIN - MIDDLE_GAP) / 2 : IMAGE_SPACE_SIZE;
+  const track = useTrack();
 
   const handleEventClick = useCallback(
     (e) => {
       e.preventDefault();
+      track('Feed: Clicked collectors note added to token event');
+
       showModal({
         content: (
           <StyledNftDetailViewPopover>
@@ -69,7 +73,7 @@ export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef }: Props)
         isFullPage: true,
       });
     },
-    [event, showModal]
+    [event.owner.username, event.token, showModal, track]
   );
 
   return (

--- a/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -55,7 +55,7 @@ export default function TokensAddedToCollectionFeedEvent({ eventRef }: Props) {
   const handleEventClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       event.preventDefault();
-      track('Feed: Tokens added to collection event click');
+      track('Feed: Clicked Tokens added to collection event');
       void push(collectionPagePath);
     },
     [collectionPagePath, push, track]

--- a/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -16,6 +16,7 @@ import { TokensAddedToCollectionFeedEventFragment$key } from '__generated__/Toke
 import FeedEventTokenPreviews, { TokenToPreview } from '../FeedEventTokenPreviews';
 import { StyledClickHandler, StyledEvent, StyledEventHeader, StyledTime } from './EventStyles';
 import unescape from 'utils/unescape';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
 
 type Props = {
   eventRef: TokensAddedToCollectionFeedEventFragment$key;
@@ -50,12 +51,14 @@ export default function TokensAddedToCollectionFeedEvent({ eventRef }: Props) {
   }, [event.newTokens]) as TokenToPreview[];
 
   const collectionPagePath = `/${event.owner.username}/${event.collection.dbid}`;
+  const track = useTrack();
   const handleEventClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       event.preventDefault();
+      track('Feed: Tokens added to collection event click');
       void push(collectionPagePath);
     },
-    [collectionPagePath, push]
+    [collectionPagePath, push, track]
   );
 
   const showSeeAllButton = event.newTokens.length > 4;

--- a/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -76,7 +76,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
   const handleSeeFollowedUserClick = useCallback(
     (e) => {
       e.preventDefault();
-      track('Feed: See single followed user event click');
+      track('Feed: Clicked see single followed user event');
       void push(`/${firstFolloweeUsername}`);
     },
     [firstFolloweeUsername, push, track]
@@ -111,7 +111,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
   const handleSeeMoreClick = useCallback(
     (e) => {
       e.preventDefault();
-      track('Feed: See more followed users event click');
+      track('Feed: Clicked See more followed users event');
       showModal({
         content: (
           <StyledFollowList fullscreen={isMobile}>

--- a/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -5,6 +5,7 @@ import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 import Spacer from 'components/core/Spacer/Spacer';
 import { BaseM, TitleXS } from 'components/core/Text/Text';
 import FollowListUsers from 'components/Follow/FollowListUsers';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { MODAL_PADDING_THICC_PX } from 'contexts/modal/constants';
 import { useModalActions } from 'contexts/modal/ModalContext';
 import { useIsMobileOrMobileLargeWindowWidth } from 'hooks/useWindowSize';
@@ -70,10 +71,16 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
 
   // cache first username in followed list, to be displayed when user followed only 1 collector
   const firstFolloweeUsername = event.followed[0]?.user?.username;
+  const track = useTrack();
 
-  const handleSeeFollowedUserClick = useCallback(() => {
-    void push(`/${firstFolloweeUsername}`);
-  }, [firstFolloweeUsername, push]);
+  const handleSeeFollowedUserClick = useCallback(
+    (e) => {
+      e.preventDefault();
+      track('Feed: See single followed user event click');
+      void push(`/${firstFolloweeUsername}`);
+    },
+    [firstFolloweeUsername, push, track]
+  );
 
   // a single Follow feed event can contain multiple follow actions taken by a user within a window of time.
   // We want to display "Followed you" and "Followed you back" actions as distinct events from "Followed x, y, z", so for now the front end will be responsible for splitting these events.
@@ -104,6 +111,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
   const handleSeeMoreClick = useCallback(
     (e) => {
       e.preventDefault();
+      track('Feed: See more followed users event click');
       showModal({
         content: (
           <StyledFollowList fullscreen={isMobile}>
@@ -115,7 +123,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
         headerVariant: 'thicc',
       });
     },
-    [flattenedGenericFollows, isMobile, showModal]
+    [flattenedGenericFollows, isMobile, showModal, track]
   );
 
   // The event displays different content depending on whether the user followed a single or multiple collectors

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -6,6 +6,7 @@ import Spacer from 'components/core/Spacer/Spacer';
 import transitions from 'components/core/transitions';
 import { FADE_TRANSITION_TIME_MS } from 'components/FadeTransitioner/FadeTransitioner';
 import NavbarGLink from 'components/NavbarGLink';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { useGlobalLayoutActions } from 'contexts/globalLayout/GlobalLayoutContext';
 import { useCallback, useEffect, useState } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
@@ -26,16 +27,19 @@ type ControlProps = {
 function FeedNavbarControl({ setFeedMode, initialFeedMode }: ControlProps) {
   // Internally mirror the feed mode state so that we can avoid adding it to the dep array, and avoid re-adding these controls to the navbar when the user switches from Following to Worldwide feed
   const [feedModeCopy, setFeedModeCopy] = useState<FeedMode>(initialFeedMode);
+  const track = useTrack();
 
   const handleFollowingModeClick = useCallback(() => {
+    track('Feed: Clicked toggle to Following feed');
     setFeedMode(FOLLOWING);
     setFeedModeCopy(FOLLOWING);
-  }, [setFeedMode]);
+  }, [setFeedMode, track]);
 
   const handleWorldwideModeClick = useCallback(() => {
+    track('Feed: Clicked toggle to Worldwide feed');
     setFeedMode(WORLDWIDE);
     setFeedModeCopy(WORLDWIDE);
-  }, [setFeedMode]);
+  }, [setFeedMode, track]);
 
   return (
     <StyledFeedNavbarControl>

--- a/src/components/Feed/FeedList.tsx
+++ b/src/components/Feed/FeedList.tsx
@@ -2,7 +2,6 @@ import colors from 'components/core/colors';
 import Loader from 'components/core/Loader/Loader';
 import { TitleM } from 'components/core/Text/Text';
 import transitions from 'components/core/transitions';
-import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { useCallback, useMemo, useState } from 'react';
 import {
   AutoSizer,
@@ -23,18 +22,10 @@ type Props = {
   loadNextPage: () => void;
   hasNext: boolean;
   queryRef: FeedEventQueryFragment$key;
-  isNextPageLoading: boolean;
   feedMode: FeedMode;
 };
 
-export default function FeedList({
-  feedData,
-  loadNextPage,
-  hasNext,
-  queryRef,
-  isNextPageLoading,
-  feedMode,
-}: Props) {
+export default function FeedList({ feedData, loadNextPage, hasNext, queryRef, feedMode }: Props) {
   const measurerCache = useMemo(() => {
     return new CellMeasurerCache({
       fixedWidth: true,

--- a/src/components/Feed/FeedList.tsx
+++ b/src/components/Feed/FeedList.tsx
@@ -1,7 +1,8 @@
 import colors from 'components/core/colors';
 import { TitleM } from 'components/core/Text/Text';
 import transitions from 'components/core/transitions';
-import { useMemo } from 'react';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
+import { useCallback, useMemo } from 'react';
 import {
   AutoSizer,
   CellMeasurer,
@@ -18,7 +19,7 @@ import FeedEvent from './FeedEvent';
 
 type Props = {
   feedData: any;
-  onLoadNext: () => void;
+  loadNextPage: () => void;
   hasNext: boolean;
   queryRef: FeedEventQueryFragment$key;
   isNextPageLoading: boolean;
@@ -27,7 +28,7 @@ type Props = {
 
 export default function FeedList({
   feedData,
-  onLoadNext,
+  loadNextPage,
   hasNext,
   queryRef,
   isNextPageLoading,
@@ -88,7 +89,13 @@ export default function FeedList({
   const rowCount = hasNext ? feedData.edges.length + 1 : feedData.edges.length;
   // Only load 1 page of items at a time.
   // Pass an empty callback to InfiniteLoader in case it asks us to load more than once.
-  const loadMoreRows = isNextPageLoading ? noop : onLoadNext;
+  const track = useTrack();
+  const handleLoadMoreClick = useCallback(() => {
+    if (!isNextPageLoading) {
+      track('Feed: Clicked Load More button');
+      loadNextPage();
+    }
+  }, [isNextPageLoading, loadNextPage, track]);
 
   return (
     <WindowScroller>
@@ -106,7 +113,7 @@ export default function FeedList({
                 scrollTop={scrollTop}
               />
               {hasNext && (
-                <StyledLoadMoreRow width={width} onClick={loadMoreRows}>
+                <StyledLoadMoreRow width={width} onClick={handleLoadMoreClick}>
                   <TitleM>More</TitleM>
                 </StyledLoadMoreRow>
               )}

--- a/src/components/Feed/GlobalFeed.tsx
+++ b/src/components/Feed/GlobalFeed.tsx
@@ -21,10 +21,7 @@ export default function GlobalFeed() {
     }
   );
 
-  const { data, hasPrevious, loadPrevious, isLoadingPrevious } = usePaginationFragment<
-    GlobalFeedQuery,
-    any
-  >(
+  const { data, hasPrevious, loadPrevious } = usePaginationFragment<GlobalFeedQuery, any>(
     graphql`
       fragment GlobalFeedFragment on Query @refetchable(queryName: "GlobalFeedPaginationQuery") {
         globalFeed(before: $before, last: $last) @connection(key: "GlobalFeed_globalFeed") {
@@ -49,11 +46,15 @@ export default function GlobalFeed() {
     `,
     query
   );
+
   const trackLoadMoreFeedEvents = useTrackLoadMoreFeedEvents();
 
   const loadNextPage = useCallback(() => {
-    trackLoadMoreFeedEvents('global');
-    loadPrevious(ITEMS_PER_PAGE);
+    return new Promise((resolve) => {
+      trackLoadMoreFeedEvents('global');
+      // Infinite scroll component wants load callback to return a promise
+      loadPrevious(ITEMS_PER_PAGE, { onComplete: () => resolve('loaded') });
+    });
   }, [loadPrevious, trackLoadMoreFeedEvents]);
 
   return (
@@ -63,7 +64,6 @@ export default function GlobalFeed() {
         feedData={data.globalFeed}
         loadNextPage={loadNextPage}
         hasNext={hasPrevious}
-        isNextPageLoading={isLoadingPrevious}
         feedMode={'WORLDWIDE'}
       />
     </StyledGlobalFeed>

--- a/src/components/Feed/GlobalFeed.tsx
+++ b/src/components/Feed/GlobalFeed.tsx
@@ -50,11 +50,8 @@ export default function GlobalFeed() {
     query
   );
 
-  const onLoadNext = useCallback(() => {
-    return new Promise((resolve) => {
-      // Infite scroll component wants load callback to return a promise
-      loadPrevious(10, { onComplete: () => resolve('loaded') });
-    });
+  const loadNextPage = useCallback(() => {
+    loadPrevious(ITEMS_PER_PAGE);
   }, [loadPrevious]);
 
   return (
@@ -62,7 +59,7 @@ export default function GlobalFeed() {
       <FeedList
         queryRef={query}
         feedData={data.globalFeed}
-        onLoadNext={onLoadNext}
+        loadNextPage={loadNextPage}
         hasNext={hasPrevious}
         isNextPageLoading={isLoadingPrevious}
         feedMode={WORLDWIDE}

--- a/src/components/Feed/ViewerFeed.tsx
+++ b/src/components/Feed/ViewerFeed.tsx
@@ -1,6 +1,7 @@
 import Button from 'components/core/Button/Button';
 import Spacer from 'components/core/Spacer/Spacer';
 import { BaseM, TitleDiatypeL } from 'components/core/Text/Text';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { useCallback } from 'react';
 import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 import styled from 'styled-components';
@@ -76,7 +77,12 @@ export default function ViewerFeed({ viewerUserId, setFeedMode }: Props) {
 
   const noViewerFeedEvents = !data.feedByUserId.edges.length;
 
-  const handleSeeWorldwideClick = useCallback(() => setFeedMode('WORLDWIDE'), [setFeedMode]);
+  const track = useTrack();
+
+  const handleSeeWorldwideClick = useCallback(() => {
+    track('Feed: Clicked worldwide button from inbox zero');
+    setFeedMode('WORLDWIDE');
+  }, [setFeedMode, track]);
 
   return (
     <StyledViewerFeed>

--- a/src/components/Feed/ViewerFeed.tsx
+++ b/src/components/Feed/ViewerFeed.tsx
@@ -65,11 +65,8 @@ export default function ViewerFeed({ viewerUserId, setFeedMode }: Props) {
     query
   );
 
-  const onLoadNext = useCallback(() => {
-    return new Promise((resolve) => {
-      // Infite scroll component wants load callback to return a promise
-      loadPrevious(10, { onComplete: () => resolve('loaded') });
-    });
+  const loadNextPage = useCallback(() => {
+    loadPrevious(ITEMS_PER_PAGE);
   }, [loadPrevious]);
 
   const noViewerFeedEvents = !data.feedByUserId.edges.length;
@@ -94,7 +91,7 @@ export default function ViewerFeed({ viewerUserId, setFeedMode }: Props) {
       ) : (
         <FeedList
           feedData={data.feedByUserId}
-          onLoadNext={onLoadNext}
+          loadNextPage={loadNextPage}
           hasNext={hasPrevious}
           queryRef={query}
           isNextPageLoading={isLoadingPrevious}

--- a/src/components/Feed/analytics.ts
+++ b/src/components/Feed/analytics.ts
@@ -7,7 +7,7 @@ export function useTrackLoadMoreFeedEvents() {
 
   return useCallback(
     (mode: 'global' | 'viewer') => {
-      track('Load More Feed Events', {
+      track('Feed: Clicked load more events', {
         pageNum: ++pageNum.current,
         mode,
       });

--- a/src/components/NavbarGLink.tsx
+++ b/src/components/NavbarGLink.tsx
@@ -1,3 +1,4 @@
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 import SecondaryGLogoIcon from 'src/icons/SecondaryGLogoIcon';
@@ -5,12 +6,14 @@ import styled from 'styled-components';
 
 export default function NavbarGLink() {
   const { push } = useRouter();
+  const track = useTrack();
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       event.preventDefault();
+      track('Feed: Clicked navbar entry point');
       void push('/home');
     },
-    [push]
+    [push, track]
   );
 
   return (

--- a/src/components/core/Button/Button.tsx
+++ b/src/components/core/Button/Button.tsx
@@ -32,7 +32,6 @@ function Button({
     () => (type === 'primary' ? StyledPrimaryButton : StyledSecondaryButton),
     [type]
   );
-
   return (
     <ButtonComponent
       // Renaming this prop `buttonStyle` since the `type` prop

--- a/src/components/core/Button/Button.tsx
+++ b/src/components/core/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import Loader from '../Loader/Loader';
 import { TitleXS } from '../Text/Text';
@@ -32,6 +32,7 @@ function Button({
     () => (type === 'primary' ? StyledPrimaryButton : StyledSecondaryButton),
     [type]
   );
+
   return (
     <ButtonComponent
       // Renaming this prop `buttonStyle` since the `type` prop

--- a/src/components/core/Button/Button.tsx
+++ b/src/components/core/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import styled from 'styled-components';
 import Loader from '../Loader/Loader';
 import { TitleXS } from '../Text/Text';

--- a/src/components/core/Button/SuppressedHrefWrapper.tsx
+++ b/src/components/core/Button/SuppressedHrefWrapper.tsx
@@ -1,0 +1,24 @@
+import { ReactNode, useCallback } from 'react';
+import styled from 'styled-components';
+
+type Props = {
+  children: ReactNode;
+  href: string;
+};
+
+// All links should be a tags but we on our app we sometimes use onClicks to navigate.
+// This component wraps an <a> tag around any component like a button that redirects onClick, so that we properly have hrefs for elements that trigger navigation.
+export default function SuppressedHrefWrapper({ children, href }: Props) {
+  const handleClick = useCallback((e) => {
+    e.preventDefault();
+  }, []);
+  return (
+    <StyledLink href={href} onClick={handleClick}>
+      {children}
+    </StyledLink>
+  );
+}
+
+const StyledLink = styled.a`
+  text-decoration: none;
+`;

--- a/src/scenes/LandingPage/LandingPage.tsx
+++ b/src/scenes/LandingPage/LandingPage.tsx
@@ -10,6 +10,7 @@ import { graphql, useLazyLoadQuery } from 'react-relay';
 import { FeatureFlag } from 'components/core/enums';
 import isFeatureEnabled from 'utils/graphql/isFeatureEnabled';
 import SuppressedHrefWrapper from 'components/core/Button/SuppressedHrefWrapper';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
 
 function LandingPage() {
   const query = useLazyLoadQuery<any>(
@@ -23,16 +24,18 @@ function LandingPage() {
 
   const { push } = useRouter();
 
+  const track = useTrack();
+
   const handleEnterGallery = useCallback(() => {
     // If the user is already authenticated, /auth will handle forwarding
-    // them directly to their profile
+    // them directly to the feed
     void push('/auth');
   }, [push]);
 
-  // TODO: change to href
   const handleExploreClick = useCallback(() => {
+    track('Landing page Explore button click');
     void push('/home');
-  }, [push]);
+  }, [push, track]);
 
   return (
     <StyledLandingPage>

--- a/src/scenes/LandingPage/LandingPage.tsx
+++ b/src/scenes/LandingPage/LandingPage.tsx
@@ -9,6 +9,7 @@ import NavLink from 'components/core/NavLink/NavLink';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { FeatureFlag } from 'components/core/enums';
 import isFeatureEnabled from 'utils/graphql/isFeatureEnabled';
+import SuppressedHrefWrapper from 'components/core/Button/SuppressedHrefWrapper';
 
 function LandingPage() {
   const query = useLazyLoadQuery<any>(
@@ -38,16 +39,20 @@ function LandingPage() {
       <GalleryIntro />
       <Spacer height={24} />
       <StyledButtonContainer>
-        <Button text="Sign In" onClick={handleEnterGallery} dataTestId="sign-in-button" />
+        <SuppressedHrefWrapper href="/auth">
+          <Button text="Sign In" onClick={handleEnterGallery} dataTestId="sign-in-button" />
+        </SuppressedHrefWrapper>
         {isFeatureEnabled(FeatureFlag.FEED, query) && (
           <>
             <Spacer width={12} />
-            <Button
-              text="Explore"
-              type="secondary"
-              onClick={handleExploreClick}
-              dataTestId="explore-button"
-            />
+            <SuppressedHrefWrapper href="/home">
+              <Button
+                text="Explore"
+                type="secondary"
+                onClick={handleExploreClick}
+                dataTestId="explore-button"
+              />
+            </SuppressedHrefWrapper>
           </>
         )}
       </StyledButtonContainer>


### PR DESCRIPTION
Added click events to 


- [x] Collectors note added to token event
- [x] Collection created
- [x] Tokens added to collection
- [x] User followed users
- [x] Clicking "G" logo in navbar to enter feed
- [x] Clicking "Explore" on landing page to enter feed
- [x] Clicking the "Following / Worldwide toggle in navbar

Also added a SuppressedHrefWrapper that allows us to wrap components like Buttons that navigate on click, so that we can properly have <a> tags with hrefs on elements that cause navigation