### PR TITLE
[GAL-275] Polish pass on Collection Editor (desktop, moweb)

### DIFF
--- a/src/components/core/Button/TextButton.tsx
+++ b/src/components/core/Button/TextButton.tsx
@@ -39,7 +39,7 @@ export const StyledButtonText = styled(ActionText)<Pick<Props, 'disableTextTrans
   text-transform: ${({ disableTextTransform }) => (disableTextTransform ? 'none' : undefined)};
 `;
 
-const StyledButton = styled.button<Pick<Props, 'underlineOnHover' | 'disabled'>>`
+export const StyledButton = styled.button<Pick<Props, 'underlineOnHover' | 'disabled'>>`
   padding: 0;
   border-style: none;
   cursor: pointer;

--- a/src/components/core/Dropdown/Dropdown.tsx
+++ b/src/components/core/Dropdown/Dropdown.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 import styled from 'styled-components';
-import TextButton from '../Button/TextButton';
+import TextButton, { StyledButton, StyledButtonText } from 'components/core/Button/TextButton';
 import colors from '../colors';
 
 type Props = {
@@ -124,12 +124,12 @@ const StyledDropdownBox = styled.div<StyledDropdownProps>`
   width: max-content;
   background-color: ${colors.white};
 
-  button {
+  ${StyledButton} {
     height: 32px;
     padding: 8px;
   }
 
-  button p {
+  ${StyledButtonText} {
     font-weight: 500;
     color: ${colors.shadow};
   }

--- a/src/components/core/Dropdown/Dropdown.tsx
+++ b/src/components/core/Dropdown/Dropdown.tsx
@@ -117,10 +117,22 @@ const StyledDropdownBox = styled.div<StyledDropdownProps>`
 
   z-index: 1;
 
-  padding: 12px;
-  border: 1px solid ${colors.metal};
+  // min-width: 191px;
+
+  padding: 8px;
+  border: 1px solid ${colors.offBlack};
   width: max-content;
   background-color: ${colors.white};
+
+  button {
+    height: 32px;
+    padding: 8px;
+  }
+
+  button p {
+    font-weight: 500;
+    color: ${colors.shadow};
+  }
 `;
 
 export default Dropdown;

--- a/src/contexts/globalLayout/GlobalNavbar/LoggedInNav.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/LoggedInNav.tsx
@@ -87,7 +87,6 @@ function LoggedInNav({ queryRef }: Props) {
               text={routerQuery?.collectionId ? 'Edit Collection' : 'Edit Gallery'}
               onClick={handleEditDesignClick}
             />
-            <Spacer height={12} />
             <TextButton text="Name & Bio" onClick={handleEditNameClick} />
           </Dropdown>
         </NavElement>
@@ -100,9 +99,7 @@ function LoggedInNav({ queryRef }: Props) {
               text="My Gallery"
               onClick={username ? () => push(`/${username}`) : undefined}
             />
-            <Spacer height={12} />
             <TextButton text="Manage Accounts" onClick={handleManageWalletsClick} />
-            <Spacer height={12} />
             <TextButton text="Sign out" onClick={handleSignOutClick} />
           </Dropdown>
         </StyledDropdownWrapper>

--- a/src/flows/shared/steps/OrganizeCollection/Editor/EditorMenu.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/EditorMenu.tsx
@@ -22,11 +22,6 @@ function EditorMenu() {
 export const MENU_WIDTH = 250;
 
 const StyledTitleS = styled(TitleS)`
-  min-height: 52px;
-  width: 249px;
-  left: 0px;
-  top: 0px;
-  border-radius: 0px;
   padding: 16px 0;
 `;
 

--- a/src/flows/shared/steps/OrganizeCollection/Editor/EditorMenu.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/EditorMenu.tsx
@@ -4,20 +4,32 @@ import { TitleS } from 'components/core/Text/Text';
 import React from 'react';
 import styled from 'styled-components';
 import ColumnAdjuster from './ColumnAdjuster';
+// import LiveDisplayAdjuster from './LiveDisplayAdjuster';
 
 function EditorMenu() {
   return (
     <StyledEditorMenu>
-      <Spacer height={16} />
-      <TitleS>Collection settings</TitleS>
-      <Spacer height={28} />
-      <ColumnAdjuster />
-      <Spacer height={24} />
+      <StyledTitleS>Collection settings</StyledTitleS>
+      <StyledSidebarItem>
+        <ColumnAdjuster />
+      </StyledSidebarItem>
+      {/* <StyledSidebarItem>
+        <LiveDisplayAdjuster />
+      </StyledSidebarItem> */}
     </StyledEditorMenu>
   );
 }
 
 export const MENU_WIDTH = 250;
+
+const StyledTitleS = styled(TitleS)`
+  min-height: 52px;
+  width: 249px;
+  left: 0px;
+  top: 0px;
+  border-radius: 0px;
+  padding: 16px 0;
+`;
 
 const StyledEditorMenu = styled.div`
   display: flex;
@@ -25,6 +37,12 @@ const StyledEditorMenu = styled.div`
   padding: 0 16px;
   width: ${MENU_WIDTH}px;
   border-left: 1px solid ${colors.porcelain};
+`;
+
+const StyledSidebarItem = styled.div`
+  min-height: 52px;
+  padding: 16px 0;
+  justify: space-between;
 `;
 
 export default EditorMenu;

--- a/src/flows/shared/steps/OrganizeCollection/Editor/EditorMenu.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/EditorMenu.tsx
@@ -1,5 +1,4 @@
 import colors from 'components/core/colors';
-import Spacer from 'components/core/Spacer/Spacer';
 import { TitleS } from 'components/core/Text/Text';
 import React from 'react';
 import styled from 'styled-components';

--- a/src/flows/shared/steps/OrganizeCollection/Editor/LiveDisplayAdjuster.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/LiveDisplayAdjuster.tsx
@@ -1,0 +1,42 @@
+import colors from 'components/core/colors';
+import Spacer from 'components/core/Spacer/Spacer';
+import { BaseM, BaseS } from 'components/core/Text/Text';
+import VideoIcon from 'src/icons/Video';
+import styled from 'styled-components';
+
+function DisplayAdjuster() {
+  return (
+    <StyledDisplayAdjuster>
+      <StyledTopText>
+        <StyledIconAndTextContainer>
+          <VideoIcon />
+          <Spacer width={8} />
+          <BaseM>Live display</BaseM>
+        </StyledIconAndTextContainer>
+        <Spacer width={24} />
+        <input type="checkbox" />
+      </StyledTopText>
+      <StyledBaseS>Auto-play video and interactive formats. May impact load time.</StyledBaseS>
+    </StyledDisplayAdjuster>
+  );
+}
+
+const StyledDisplayAdjuster = styled.div``;
+
+const StyledTopText = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+`;
+
+const StyledIconAndTextContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledBaseS = styled(BaseS)`
+  color: ${colors.metal};
+`;
+
+export default DisplayAdjuster;

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/SearchBar.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/SearchBar.tsx
@@ -59,7 +59,7 @@ function SearchBar({ tokensRef, setSearchResults, setDebouncedSearchQuery }: Pro
 
   return (
     <StyledSearchBar>
-      <StyledSearchInput onChange={handleQueryChange} placeholder="Search" />
+      <StyledSearchInput onChange={handleQueryChange} placeholder="Search pieces" />
     </StyledSearchBar>
   );
 }

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
@@ -110,9 +110,9 @@ function Sidebar({ tokensRef, sidebarTokens }: Props) {
   return (
     <StyledSidebar>
       <Header>
-        <TitleS>Pieces</TitleS>
-        <TextButton
-          text={isRefreshingNfts ? 'Refreshing...' : 'Refresh Wallet'}
+        <TitleS>All pieces</TitleS>
+        <StyledRefreshButton
+          text={isRefreshingNfts ? 'Refreshing...' : 'Refresh wallet'}
           onClick={handleRefreshNfts}
           disabled={isRefreshingNfts}
         />
@@ -199,6 +199,7 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  min-height: 52px;
 `;
 
 const StyledSelectButtonWrapper = styled.div`
@@ -211,6 +212,16 @@ const Selection = styled.div`
   flex-wrap: wrap;
   width: 218px;
   grid-gap: 19px;
+`;
+
+// This has the styling from InteractiveLink but we cannot use InteractiveLink because it is a TextButton
+const StyledRefreshButton = styled(TextButton)`
+  & p {
+    font-size: 14px;
+    line-height: 18px;
+    text-transform: none;
+    text-decoration: underline;
+  }
 `;
 
 export default memo(Sidebar);

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
@@ -9,7 +9,6 @@ import {
   useCollectionEditorActions,
   SidebarTokensState,
 } from 'contexts/collectionEditor/CollectionEditorContext';
-import { EditModeToken } from '../types';
 import { convertObjectToArray } from '../convertObjectToArray';
 import SidebarNftIcon from './SidebarNftIcon';
 import SearchBar from './SearchBar';
@@ -40,7 +39,7 @@ function Sidebar({ tokensRef, sidebarTokens }: Props) {
 
   const tokens = removeNullValues(allTokens);
 
-  const { setTokensIsSelected, stageTokens, unstageAllItems } = useCollectionEditorActions();
+  const { stageTokens } = useCollectionEditorActions();
 
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<string[]>([]);
@@ -61,38 +60,6 @@ function Sidebar({ tokensRef, sidebarTokens }: Props) {
 
     return sidebarTokensAsArray;
   }, [debouncedSearchQuery, searchResults, sidebarTokens, sidebarTokensAsArray]);
-
-  const isAllNftsSelected = useMemo(
-    () => !tokensToDisplayInSidebar.some((token: EditModeToken) => !token.isSelected),
-    [tokensToDisplayInSidebar]
-  );
-
-  const handleSelectAllClick = useCallback(() => {
-    // Stage all tokens that are !isSelected
-    const tokensToStage = tokensToDisplayInSidebar.filter((token) => !token.isSelected);
-    if (tokensToStage.length === 0) {
-      return;
-    }
-
-    stageTokens(tokensToStage);
-    setTokensIsSelected(
-      tokensToStage.map((token) => token.id),
-      true
-    );
-  }, [tokensToDisplayInSidebar, stageTokens, setTokensIsSelected]);
-
-  const handleDeselectAllClick = useCallback(() => {
-    // deselect all tokens in sidebar
-    const tokenIdsToUnstage = tokensToDisplayInSidebar.map((token) => token.id);
-    if (tokenIdsToUnstage.length === 0) {
-      return;
-    }
-
-    setTokensIsSelected(tokenIdsToUnstage, false);
-
-    // Unstage all items from the DND
-    unstageAllItems();
-  }, [tokensToDisplayInSidebar, setTokensIsSelected, unstageAllItems]);
 
   const handleAddBlankBlockClick = useCallback(() => {
     const id = `blank-${generate12DigitId()}`;
@@ -123,20 +90,6 @@ function Sidebar({ tokensRef, sidebarTokens }: Props) {
         setSearchResults={setSearchResults}
         setDebouncedSearchQuery={setDebouncedSearchQuery}
       />
-      <Spacer height={24} />
-      <StyledSelectButtonWrapper>
-        {isAllNftsSelected ? (
-          <TextButton
-            text={`Deselect All (${tokensToDisplayInSidebar.length})`}
-            onClick={handleDeselectAllClick}
-          />
-        ) : (
-          <TextButton
-            text={`Select All (${tokensToDisplayInSidebar.length})`}
-            onClick={handleSelectAllClick}
-          />
-        )}
-      </StyledSelectButtonWrapper>
       <Spacer height={16} />
       <Selection>
         <StyledAddBlankBlock onClick={handleAddBlankBlockClick}>
@@ -200,11 +153,6 @@ const Header = styled.div`
   justify-content: space-between;
   align-items: baseline;
   min-height: 52px;
-`;
-
-const StyledSelectButtonWrapper = styled.div`
-  display: flex;
-  justify-content: flex-end;
 `;
 
 const Selection = styled.div`

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
@@ -152,7 +152,7 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  min-height: 52px;
+  min-height: calc(52px - 16px); /* Matches the padding of StyledSidebar */
 `;
 
 const Selection = styled.div`

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
@@ -84,7 +84,6 @@ function Sidebar({ tokensRef, sidebarTokens }: Props) {
           disabled={isRefreshingNfts}
         />
       </Header>
-      <Spacer height={16} />
       <SearchBar
         tokensRef={tokens}
         setSearchResults={setSearchResults}
@@ -152,7 +151,8 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  min-height: calc(52px - 16px); /* Matches the padding of StyledSidebar */
+  min-height: 52px;
+  padding-bottom: 16px;
 `;
 
 const Selection = styled.div`

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
@@ -66,7 +66,6 @@ function CollectionRow({ collectionRef, className }: Props) {
       <Header>
         <TextContainer>
           <TitleS>{unescapedCollectionName}</TitleS>
-          <Spacer height={4} />
           <StyledBaseM>
             {tokens.length} {tokens.length == 1 ? 'piece' : 'pieces'}
           </StyledBaseM>

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
@@ -363,6 +363,7 @@ const NftsWithMoreText = styled.div`
 const StyledBullet = styled(BaseM)`
   display: inline;
   margin: 0 3px;
+  font-weight: 100;
 `;
 
 const NumberPiecesText = styled(BaseM)`

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
@@ -14,6 +14,7 @@ import { CollectionRowFragment$key } from '__generated__/CollectionRowFragment.g
 import { removeNullValues } from 'utils/removeNullValues';
 import { CollectionRowCompactNftsFragment$key } from '__generated__/CollectionRowCompactNftsFragment.graphql';
 import getVideoOrImageUrlForNftPreview from 'utils/graphql/getVideoOrImageUrlForNftPreview';
+import Markdown from 'components/core/Markdown/Markdown';
 
 type Props = {
   collectionRef: CollectionRowFragment$key;
@@ -51,23 +52,42 @@ function CollectionRow({ collectionRef, className }: Props) {
     collectionRef
   );
 
-  const { name, hidden } = collection;
+  const { name, collectorsNote, hidden } = collection;
   const tokens = useMemo(() => removeNullValues(collection.tokens), [collection]);
 
   const unescapedCollectionName = useMemo(() => unescape(name ?? ''), [name]);
+  const unescapedCollectorsNote = useMemo(() => unescape(collectorsNote ?? ''), [collectorsNote]);
 
   const firstThreeNfts = useMemo(() => tokens.slice(0, 3), [tokens]);
   const remainingNfts = useMemo(() => tokens.slice(3), [tokens]);
 
   const isHidden = useMemo(() => Boolean(hidden), [hidden]);
 
+  const truncatedCollectorsNote = useMemo(() => {
+    const lines = unescapedCollectorsNote.split('\n');
+    const firstLine = lines[0];
+
+    // If it's multiline, always truncate to suggest there are more lines
+    if (lines.length > 1) {
+      return `${firstLine.slice(0, 97).trim()}...`;
+    }
+
+    // If it's single line, only truncate if it's longer than 100ch
+    return firstLine.length > 100 ? `${firstLine.slice(0, 97).trim()}...` : firstLine;
+  }, [unescapedCollectorsNote]);
+
   return (
     <StyledCollectionRow className={className} isHidden={isHidden}>
       <Header>
         <TextContainer>
-          <TitleS>{unescapedCollectionName}</TitleS>
+          <TitleS>
+            {unescapedCollectionName} <StyledBullet>&bull;</StyledBullet>{' '}
+            <NumberPiecesText>
+              {tokens.length} {tokens.length == 1 ? 'piece' : 'pieces'}
+            </NumberPiecesText>
+          </TitleS>
           <StyledBaseM>
-            {tokens.length} {tokens.length == 1 ? 'piece' : 'pieces'}
+            <Markdown text={truncatedCollectorsNote} />
           </StyledBaseM>
         </TextContainer>
         <Settings />
@@ -338,6 +358,16 @@ const NftsWithMoreText = styled.div`
   column-gap: 4px;
 
   white-space: nowrap;
+`;
+
+const StyledBullet = styled(BaseM)`
+  display: inline;
+  margin: 0 3px;
+`;
+
+const NumberPiecesText = styled(BaseM)`
+  display: inline;
+  font-weight: 400;
 `;
 
 export default CollectionRow;

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
@@ -1,14 +1,13 @@
 import { useMemo } from 'react';
 import styled from 'styled-components';
 import unescape from 'utils/unescape';
-import { BaseM } from 'components/core/Text/Text';
+import { BaseM, TitleS } from 'components/core/Text/Text';
 import Spacer from 'components/core/Spacer/Spacer';
 import colors from 'components/core/colors';
 import {
   getBackgroundColorOverrideForContract,
   graphqlGetResizedNftImageUrlWithFallback,
 } from 'utils/token';
-import Markdown from 'components/core/Markdown/Markdown';
 import Settings from 'public/icons/ellipses.svg';
 import { graphql, useFragment } from 'react-relay';
 import { CollectionRowFragment$key } from '__generated__/CollectionRowFragment.graphql';
@@ -52,38 +51,24 @@ function CollectionRow({ collectionRef, className }: Props) {
     collectionRef
   );
 
-  const { name, collectorsNote, hidden } = collection;
+  const { name, hidden } = collection;
   const tokens = useMemo(() => removeNullValues(collection.tokens), [collection]);
 
   const unescapedCollectionName = useMemo(() => unescape(name ?? ''), [name]);
-  const unescapedCollectorsNote = useMemo(() => unescape(collectorsNote ?? ''), [collectorsNote]);
 
   const firstThreeNfts = useMemo(() => tokens.slice(0, 3), [tokens]);
   const remainingNfts = useMemo(() => tokens.slice(3), [tokens]);
 
   const isHidden = useMemo(() => Boolean(hidden), [hidden]);
 
-  const truncatedCollectorsNote = useMemo(() => {
-    const lines = unescapedCollectorsNote.split('\n');
-    const firstLine = lines[0];
-
-    // If it's multiline, always truncate to suggest there are more lines
-    if (lines.length > 1) {
-      return `${firstLine.slice(0, 97).trim()}...`;
-    }
-
-    // If it's single line, only truncate if it's longer than 100ch
-    return firstLine.length > 100 ? `${firstLine.slice(0, 97).trim()}...` : firstLine;
-  }, [unescapedCollectorsNote]);
-
   return (
     <StyledCollectionRow className={className} isHidden={isHidden}>
       <Header>
         <TextContainer>
-          <BaseM>{unescapedCollectionName}</BaseM>
+          <TitleS>{unescapedCollectionName}</TitleS>
           <Spacer height={4} />
           <StyledBaseM>
-            <Markdown text={truncatedCollectorsNote} />
+            {tokens.length} {tokens.length == 1 ? 'piece' : 'pieces'}
           </StyledBaseM>
         </TextContainer>
         <Settings />
@@ -135,9 +120,9 @@ const StyledCollectionRow = styled.div<StyledCollectionRowProps>`
   flex-direction: column;
 
   width: 100%;
-  padding: 32px;
+  padding: 16px;
 
-  border: 1px solid ${colors.metal};
+  border: 1px solid ${colors.porcelain};
   background-color: ${colors.white};
 
   opacity: ${({ isHidden }) => (isHidden ? '0.4' : '1')};
@@ -196,7 +181,7 @@ const Body = styled.div`
   width: calc(100% + 24px);
   margin-left: -12px;
   ${BigNftContainer} {
-    margin: 12px;
+    margin: 0 12px;
   }
 `;
 
@@ -305,7 +290,7 @@ function CompactNfts({ nftRefs }: { nftRefs: CollectionRowCompactNftsFragment$ke
 const StyledCompactNfts = styled.div`
   width: ${BIG_NFT_SIZE_PX}px;
   height: ${BIG_NFT_SIZE_PX}px;
-  margin: 12px;
+  margin: 0 12px;
 
   display: flex;
   justify-content: center;

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
@@ -86,11 +86,12 @@ function CollectionRowSettings({ collectionRef, wizard: { push } }: Props & Wiza
     <StyledCollectionRowSettings>
       <StyledTextButton onClick={handleEditCollectionClick} text="Edit" />
       <Dropdown>
-        <TextButton onClick={handleEditNameClick} text="Edit name & bio" />
-        <Spacer height={12} />
-        <TextButton onClick={handleToggleHiddenClick} text={hidden ? 'Show' : 'Hide'} />
-        <Spacer height={12} />
-        <TextButton onClick={handleDeleteClick} text="Delete" />
+        <StyledDropdownTextButton onClick={handleEditNameClick} text="Edit name & bio" />
+        <StyledDropdownTextButton
+          onClick={handleToggleHiddenClick}
+          text={hidden ? 'Show' : 'Hide'}
+        />
+        <StyledDropdownTextButton onClick={handleDeleteClick} text="Delete" />
       </Dropdown>
     </StyledCollectionRowSettings>
   );
@@ -110,6 +111,15 @@ const StyledCollectionRowSettings = styled.div`
     width: 24px;
     height: 16px;
   }
+`;
+
+const StyledDropdownTextButton = styled(TextButton)`
+  width: 24px;
+  height: 16px;
+  gap: 10px;
+  width: 175px;
+  height: 32px;
+  padding: 4px 0 4px 8px; // FIXME: Adjust if dropdown is refactored
 `;
 
 const StyledTextButton = styled(TextButton)`

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
@@ -84,10 +84,9 @@ function CollectionRowSettings({ collectionRef, wizard: { push } }: Props & Wiza
 
   return (
     <StyledCollectionRowSettings>
+      <TextButton onClick={handleEditCollectionClick} text="Edit" />
       <Dropdown>
-        <TextButton onClick={handleEditCollectionClick} text="Edit collection" />
-        <Spacer height={12} />
-        <TextButton onClick={handleEditNameClick} text="Edit name & description" />
+        <TextButton onClick={handleEditNameClick} text="Edit name & bio" />
         <Spacer height={12} />
         <TextButton onClick={handleToggleHiddenClick} text={hidden ? 'Show' : 'Hide'} />
         <Spacer height={12} />
@@ -99,13 +98,16 @@ function CollectionRowSettings({ collectionRef, wizard: { push } }: Props & Wiza
 
 const StyledCollectionRowSettings = styled.div`
   position: absolute;
-  right: 24px;
-  top: 28px;
+  right: 16px;
+  top: 16px;
   z-index: 1;
+  display: flex;
+  place-items: center;
+  gap: 16px;
 
   ${StyledDropdownButton} {
-    width: 32px;
-    height: 24px;
+    width: 16px;
+    height: 16px;
   }
 `;
 

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import Dropdown, { StyledDropdownButton } from 'components/core/Dropdown/Dropdown';
 import TextButton from 'components/core/Button/TextButton';
 import { useModalActions } from 'contexts/modal/ModalContext';
-import Spacer from 'components/core/Spacer/Spacer';
 import { withWizard, WizardComponentProps } from 'react-albus';
 import { useCollectionWizardActions } from 'contexts/wizard/CollectionWizardContext';
 import useUpdateCollectionHidden from 'hooks/api/collections/useUpdateCollectionHidden';
@@ -86,12 +85,9 @@ function CollectionRowSettings({ collectionRef, wizard: { push } }: Props & Wiza
     <StyledCollectionRowSettings>
       <StyledTextButton onClick={handleEditCollectionClick} text="Edit" />
       <Dropdown>
-        <StyledDropdownTextButton onClick={handleEditNameClick} text="Edit name & bio" />
-        <StyledDropdownTextButton
-          onClick={handleToggleHiddenClick}
-          text={hidden ? 'Show' : 'Hide'}
-        />
-        <StyledDropdownTextButton onClick={handleDeleteClick} text="Delete" />
+        <TextButton onClick={handleEditNameClick} text="Edit name & bio" />
+        <TextButton onClick={handleToggleHiddenClick} text={hidden ? 'Show' : 'Hide'} />
+        <TextButton onClick={handleDeleteClick} text="Delete" />
       </Dropdown>
     </StyledCollectionRowSettings>
   );
@@ -108,18 +104,9 @@ const StyledCollectionRowSettings = styled.div`
   width: 75px;
 
   ${StyledDropdownButton} {
-    width: 24px;
+    width: 32px;
     height: 16px;
   }
-`;
-
-const StyledDropdownTextButton = styled(TextButton)`
-  width: 24px;
-  height: 16px;
-  gap: 10px;
-  width: 175px;
-  height: 32px;
-  padding: 4px 0 4px 8px; // FIXME: Adjust if dropdown is refactored
 `;
 
 const StyledTextButton = styled(TextButton)`

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
@@ -84,7 +84,7 @@ function CollectionRowSettings({ collectionRef, wizard: { push } }: Props & Wiza
 
   return (
     <StyledCollectionRowSettings>
-      <TextButton onClick={handleEditCollectionClick} text="Edit" />
+      <StyledTextButton onClick={handleEditCollectionClick} text="Edit" />
       <Dropdown>
         <TextButton onClick={handleEditNameClick} text="Edit name & bio" />
         <Spacer height={12} />
@@ -103,12 +103,21 @@ const StyledCollectionRowSettings = styled.div`
   z-index: 1;
   display: flex;
   place-items: center;
-  gap: 16px;
+  height: 20px;
+  width: 75px;
 
   ${StyledDropdownButton} {
-    width: 16px;
+    width: 24px;
     height: 16px;
   }
+`;
+
+const StyledTextButton = styled(TextButton)`
+  height: 32px;
+  width: 43px;
+  border-radius: 1px;
+  padding: 8px;
+  font-weight: 500;
 `;
 
 export default withWizard(CollectionRowSettings);

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowWrapper.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowWrapper.tsx
@@ -25,7 +25,7 @@ function CollectionRowWrapper({ collectionRef }: Props) {
     <StyledCollectionRowWrapper>
       <CollectionRowSettings collectionRef={collection} />
       <SortableCollectionRow collectionRef={collection} />
-      <Spacer height={32} />
+      <Spacer height={16} />
     </StyledCollectionRowWrapper>
   );
 }

--- a/src/flows/shared/steps/OrganizeGallery/Header.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/Header.tsx
@@ -28,7 +28,7 @@ function Header({ wizard: { push } }: WizardComponentProps) {
 const StyledHeader = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
 
   width: 100%;
 `;

--- a/src/flows/shared/steps/OrganizeGallery/Header.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/Header.tsx
@@ -13,9 +13,8 @@ function Header({ wizard: { push } }: WizardComponentProps) {
   return (
     <StyledHeader>
       <TitleContainer>
-        <TitleDiatypeL>Your Collections</TitleDiatypeL>
-        <Spacer height={4} />
-        <BaseM>Drag to reorder your collection</BaseM>
+        <TitleDiatypeL>Your collections</TitleDiatypeL>
+        <BaseM>Drag to re-order collections</BaseM>
       </TitleContainer>
       <OptionsContainer>
         <Spacer width={16} />

--- a/src/flows/shared/steps/OrganizeGallery/Header.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/Header.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import styled from 'styled-components';
-import { BaseM, BaseXL } from 'components/core/Text/Text';
+import { BaseM, TitleDiatypeL } from 'components/core/Text/Text';
 import Spacer from 'components/core/Spacer/Spacer';
 import { withWizard, WizardComponentProps } from 'react-albus';
-import TextButton from 'components/core/Button/TextButton';
+import Button from 'components/core/Button/Button';
 
 function Header({ wizard: { push } }: WizardComponentProps) {
   const handleAddCollection = useCallback(() => {
@@ -13,13 +13,13 @@ function Header({ wizard: { push } }: WizardComponentProps) {
   return (
     <StyledHeader>
       <TitleContainer>
-        <BaseXL>Organize your Gallery</BaseXL>
+        <TitleDiatypeL>Your Collections</TitleDiatypeL>
         <Spacer height={4} />
-        <BaseM>Drag and drop to reorder your collection</BaseM>
+        <BaseM>Drag to reorder your collection</BaseM>
       </TitleContainer>
       <OptionsContainer>
         <Spacer width={16} />
-        <TextButton text="+ Add Collection" onClick={handleAddCollection}></TextButton>
+        <Button text="Add" type="secondary" onClick={handleAddCollection} />
       </OptionsContainer>
     </StyledHeader>
   );

--- a/src/icons/Video.tsx
+++ b/src/icons/Video.tsx
@@ -1,0 +1,17 @@
+export default function Video() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M10.6668 10.3337V11.3337L9.66683 12.3337H2.3335L1.3335 11.3337V4.66699L2.3335 3.66699H4.00016"
+        stroke="#707070"
+        stroke-miterlimit="10"
+      />
+      <path
+        d="M6.6665 3.66699H9.6665L10.6665 4.66699V7.33366H11.3332L14.9998 4.66699V10.3337"
+        stroke="#707070"
+        stroke-miterlimit="10"
+      />
+      <path d="M2.3335 2.00024L13.6668 13.3336" stroke="#707070" stroke-miterlimit="10" />
+    </svg>
+  );
+}

--- a/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
+++ b/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
@@ -167,7 +167,6 @@ function CollectionGalleryHeader({
                   <TextButton onClick={handleEditNameClick} text="EDIT NAME & DESCRIPTION" />
                   {!shouldDisplayMobileLayoutToggle && (
                     <>
-                      <Spacer height={8} />
                       <NavElement>
                         <TextButton onClick={handleEditCollectionClick} text="Edit Collection" />
                       </NavElement>

--- a/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -135,13 +135,11 @@ function UserGalleryCollection({ queryRef, collectionRef, mobileLayout }: Props)
                       text="EDIT NAME & DESCRIPTION"
                       underlineOnHover
                     />
-                    <Spacer height={8} />
                     <TextButton
                       text="Edit Collection"
                       onClick={handleEditCollectionClick}
                       underlineOnHover
                     />
-                    <Spacer height={8} />
                   </>
                 )}
                 <TextButton


### PR DESCRIPTION
## Collection editor view

Figma/dev: (Note: we want to replace the collection description with the # of pieces? just confirming)

<img width="100%" src="https://user-images.githubusercontent.com/13339581/177050317-d63af8a4-d10c-4187-8b26-4d4dee0aa509.png"/>

![image](https://user-images.githubusercontent.com/13339581/177050738-ec69b750-0916-41e9-ab2d-7fbf6df01953.png)

#### Edit dropdown

Figma/dev: 

**Note: the Figma designs specify an approach to the dropdown that would require a sort of refactor across all dropdowns (change dropdown padding from `12px` -> `8px`, and increase the size of dropdown elements within)**. I think this should be scoped to a different PR, maybe? Or if this dropdown is meant to appear differently, we could style it independent of others

<img width="358" alt="image" src="https://user-images.githubusercontent.com/13339581/177051131-2c254a60-2cef-4b21-9830-2bf938149749.png">

<img width="326" alt="image" src="https://user-images.githubusercontent.com/13339581/177051360-e7a5ebc0-c31a-4f57-bba3-f1112279d9e5.png">

### Edit page 

**Note: I figured we wanted to keep the "select"/"deselect all" button here?**

Figma/dev:

<img width="886" alt="image" src="https://user-images.githubusercontent.com/13339581/177051999-af8693f0-479e-4917-938d-bd62020e6427.png">

![image](https://user-images.githubusercontent.com/13339581/177052454-81bbbf81-30a2-483c-b7de-5556af3247b1.png)


### Sidebar

Figma/dev:

**Note: Live display button currently does nothing, so it is commented out.** Unless this functionality is live? I didn't think so. 

<img width="349" alt="image" src="https://user-images.githubusercontent.com/13339581/177051796-b38ffed1-98bd-42bd-9a8c-61034c9ed2dd.png">

<img width="249" alt="image" src="https://user-images.githubusercontent.com/13339581/177052309-cfdf1a62-13fe-46ff-8f0e-07d8676215dc.png">
