### PR TITLE
Fix non-clickable settings on collection row

### DIFF
--- a/src/flows/shared/steps/OrganizeGallery/SortableCollectionRow.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/SortableCollectionRow.tsx
@@ -42,12 +42,13 @@ function SortableCollectionRow({ collectionRef }: Props) {
       active={isDragging}
       // @ts-expect-error force overload
       style={style}
-      {...attributes}
-      {...listeners}
     >
       <>
+        {/* ensures that the entire collection row is draggable, while the Settings remains clickable (and doesn't activate drag) */}
+        <div {...listeners} {...attributes}>
+          <CollectionRow collectionRef={collection} />
+        </div>
         <CollectionRowSettings collectionRef={collection} />
-        <CollectionRow collectionRef={collection} />
       </>
     </StyledSortableCollectionRow>
   );


### PR DESCRIPTION
Ensures the `CollectionRowSettings` are clickable

![image](https://user-images.githubusercontent.com/12162433/178205808-fcf3aca8-1bef-4044-91a5-cb66ea2cf871.png)
