### PR TITLE
[GAL-269] Fix collector notes overlap on Audio NFT

### DIFF
--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -55,3 +55,7 @@ export function useIsMobileOrMobileLargeWindowWidth() {
   const breakpoint = useBreakpoint();
   return breakpoint === size.mobileLarge || breakpoint === size.mobile;
 }
+
+export function useIsDesktopWindowWidth() {
+  return useBreakpoint() === size.desktop;
+}

--- a/src/scenes/NftDetailPage/NftDetailAudio.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAudio.tsx
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import ImageWithLoading from 'components/LoadingAsset/ImageWithLoading';
 import { graphql, useFragment } from 'react-relay';
 import { NftDetailAudioFragment$key } from '__generated__/NftDetailAudioFragment.graphql';
+import Spacer from 'components/core/Spacer/Spacer';
+import { useIsDesktopWindowWidth } from 'hooks/useWindowSize';
 
 type Props = {
   tokenRef: NftDetailAudioFragment$key;
@@ -30,6 +32,8 @@ function NftDetailAudio({ tokenRef }: Props) {
     throw new Error('Using an NftDetailAudio component without an audio media type');
   }
 
+  const isDesktop = useIsDesktopWindowWidth();
+
   return (
     <StyledAudioContainer>
       <ImageWithLoading src={token.media?.previewURLs.large} alt={token.name ?? ''} />
@@ -40,6 +44,7 @@ function NftDetailAudio({ tokenRef }: Props) {
         preload="none"
         src={token.media.contentRenderURL}
       />
+      {isDesktop && <Spacer height={40} />}
     </StyledAudioContainer>
   );
 }


### PR DESCRIPTION
## Finding

Find out that the bug only happens on audio NFT that have `<audio>` tag and used the`desktop` breakpoints. It didn't happen on tablet and mobile view

## Solution

Add spacing if its desktop view and only applicable to audio NFT components

## Screenshot

**Before**

![image](https://user-images.githubusercontent.com/4480258/179432696-60770150-e7dc-47c2-be9b-3ec6f16abd73.png)


**After**

![CleanShot 2022-07-18 at 09 10 56](https://user-images.githubusercontent.com/4480258/179432778-a67d8f10-f59f-4f86-b18e-3a6900282bb4.png)

