### PR TITLE
Fix OG image cutoff

### DIFF
--- a/src/components/opengraph/OpenGraphPreview.tsx
+++ b/src/components/opengraph/OpenGraphPreview.tsx
@@ -13,8 +13,9 @@ type Props = {
   imageUrls: string[];
 };
 
-export const OpenGraphPreview = ({ title, description, imageUrls }: Props) => (
-  <>
+export const OpenGraphPreview = ({ title, description, imageUrls }: Props) => {
+  const firstLineDescription = description.split('\n')[0];
+  return (
     <StyledContainer>
       <StyledGalleryContainer>
         <OpenBracket />
@@ -27,13 +28,13 @@ export const OpenGraphPreview = ({ title, description, imageUrls }: Props) => (
         <TitleL>{unescape(title)}</TitleL>
         {description && (
           <StyledDescription>
-            <Markdown text={unescape(description)} />
+            <Markdown text={unescape(firstLineDescription)} />
           </StyledDescription>
         )}
       </StyledTitleContainer>
     </StyledContainer>
-  </>
-);
+  );
+};
 
 const StyledContainer = styled.div`
   width: 100%;

--- a/src/constants/opengraph.ts
+++ b/src/constants/opengraph.ts
@@ -1,2 +1,3 @@
-export const WIDTH_OPENGRAPH_IMAGE = 1012;
-export const HEIGHT_OPENGRAPH_IMAGE = 506;
+// these values are also configured in https://github.com/gallery-so/opengraph/blob/main/src/pages/api/opengraph/image.ts
+export const WIDTH_OPENGRAPH_IMAGE = 1200;
+export const HEIGHT_OPENGRAPH_IMAGE = 628;


### PR DESCRIPTION
- [x] Update twitter OG image preview dimensions to new guidelines
- [x] Fix cutoff descriptions

Reported bug 1:
<img width="724" alt="image" src="https://user-images.githubusercontent.com/12162433/180668900-e25fbf56-eab3-47fb-9757-678ce8022f37.png">

Reported bug 2:
<img width="637" alt="image" src="https://user-images.githubusercontent.com/12162433/180668911-cb560db8-fd2a-4b54-87f9-e3521bd2e0aa.png">
