### PR TITLE
[GAL-303] Feed: user preview card on hover

### DIFF
--- a/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -14,6 +14,7 @@ import FeedEventTokenPreviews, { TokenToPreview } from '../FeedEventTokenPreview
 import { StyledEvent, StyledEventHeader, StyledTime } from './EventStyles';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { UnstyledLink } from 'components/core/Link/UnstyledLink';
+import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
 
 type Props = {
   eventRef: CollectionCreatedFeedEventFragment$key;
@@ -27,7 +28,7 @@ export default function CollectionCreatedFeedEvent({ eventRef }: Props) {
       fragment CollectionCreatedFeedEventFragment on CollectionCreatedFeedEventData {
         eventTime
         owner {
-          username
+          ...HoverCardOnUsernameFragment
         }
         collection @required(action: THROW) {
           dbid
@@ -69,7 +70,7 @@ export default function CollectionCreatedFeedEvent({ eventRef }: Props) {
     >
       <StyledEvent>
         <StyledEventHeader>
-          <InteractiveLink to={`/${event.owner.username}`}>{event.owner.username}</InteractiveLink>{' '}
+          <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
           <BaseM>
             added {tokens.length} {pluralize(tokens.length, 'piece')} to their new collection
             {collectionName && `, `}

--- a/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -82,11 +82,7 @@ export default function CollectionCreatedFeedEvent({ eventRef, queryRef }: Props
     >
       <StyledEvent>
         <StyledEventHeader>
-          <HoverCardOnUsername
-            username={event?.owner.username || ''}
-            userRef={event.owner}
-            queryRef={query}
-          />{' '}
+          <HoverCardOnUsername userRef={event.owner} queryRef={query} />{' '}
           <BaseM>
             added {tokens.length} {pluralize(tokens.length, 'piece')} to their new collection
             {collectionName && `, `}

--- a/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -10,6 +10,7 @@ import { removeNullValues } from 'utils/removeNullValues';
 import { pluralize } from 'utils/string';
 import { getTimeSince } from 'utils/time';
 import { CollectionCreatedFeedEventFragment$key } from '__generated__/CollectionCreatedFeedEventFragment.graphql';
+import { CollectionCreatedFeedEventQueryFragment$key } from '__generated__/CollectionCreatedFeedEventQueryFragment.graphql';
 import FeedEventTokenPreviews, { TokenToPreview } from '../FeedEventTokenPreviews';
 import { StyledEvent, StyledEventHeader, StyledTime } from './EventStyles';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
@@ -18,11 +19,12 @@ import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
 
 type Props = {
   eventRef: CollectionCreatedFeedEventFragment$key;
+  queryRef: CollectionCreatedFeedEventQueryFragment$key;
 };
 
 const MAX_PIECES_DISPLAYED = 4;
 
-export default function CollectionCreatedFeedEvent({ eventRef }: Props) {
+export default function CollectionCreatedFeedEvent({ eventRef, queryRef }: Props) {
   const event = useFragment(
     graphql`
       fragment CollectionCreatedFeedEventFragment on CollectionCreatedFeedEventData {
@@ -44,6 +46,15 @@ export default function CollectionCreatedFeedEvent({ eventRef }: Props) {
       }
     `,
     eventRef
+  );
+
+  const query = useFragment(
+    graphql`
+      fragment CollectionCreatedFeedEventQueryFragment on Query {
+        ...HoverCardOnUsernameFollowFragment
+      }
+    `,
+    queryRef
   );
 
   const tokens = event.newTokens;
@@ -71,7 +82,11 @@ export default function CollectionCreatedFeedEvent({ eventRef }: Props) {
     >
       <StyledEvent>
         <StyledEventHeader>
-          <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
+          <HoverCardOnUsername
+            username={event?.owner.username || ''}
+            userRef={event.owner}
+            queryRef={query}
+          />{' '}
           <BaseM>
             added {tokens.length} {pluralize(tokens.length, 'piece')} to their new collection
             {collectionName && `, `}

--- a/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -28,6 +28,7 @@ export default function CollectionCreatedFeedEvent({ eventRef }: Props) {
       fragment CollectionCreatedFeedEventFragment on CollectionCreatedFeedEventData {
         eventTime
         owner {
+          username
           ...HoverCardOnUsernameFragment
         }
         collection @required(action: THROW) {

--- a/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -16,6 +16,7 @@ import unescape from 'utils/unescape';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import breakpoints from 'components/core/breakpoints';
 import { UnstyledLink } from 'components/core/Link/UnstyledLink';
+import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
 
 type Props = {
   eventRef: CollectorsNoteAddedToCollectionFeedEventFragment$key;
@@ -30,6 +31,7 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({ eventRef }: P
         eventTime
         owner @required(action: THROW) {
           username
+          ...HoverCardOnUsernameFragment
         }
         collection @required(action: THROW) {
           dbid
@@ -71,9 +73,7 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({ eventRef }: P
       <StyledEvent>
         <StyledEventHeader>
           <BaseM>
-            <InteractiveLink to={`/${event.owner.username}`}>
-              {event.owner.username}
-            </InteractiveLink>{' '}
+            <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
             added a description to
             {collectionName ? ' ' : ' their collection'}
             <InteractiveLink to={collectionPagePath}>{collectionName}</InteractiveLink>

--- a/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -84,12 +84,7 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({ eventRef, que
       <StyledEvent>
         <StyledEventHeader>
           <BaseM>
-            <HoverCardOnUsername
-              username={event?.owner.username || ''}
-              userRef={event.owner}
-              queryRef={query}
-            />{' '}
-            added a description to
+            <HoverCardOnUsername userRef={event.owner} queryRef={query} /> added a description to
             {collectionName ? ' ' : ' their collection'}
             <InteractiveLink to={collectionPagePath}>{collectionName}</InteractiveLink>
           </BaseM>

--- a/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -17,14 +17,16 @@ import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import breakpoints from 'components/core/breakpoints';
 import { UnstyledLink } from 'components/core/Link/UnstyledLink';
 import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
+import { CollectorsNoteAddedToCollectionFeedEventQueryFragment$key } from '__generated__/CollectorsNoteAddedToCollectionFeedEventQueryFragment.graphql';
 
 type Props = {
   eventRef: CollectorsNoteAddedToCollectionFeedEventFragment$key;
+  queryRef: CollectorsNoteAddedToCollectionFeedEventQueryFragment$key;
 };
 
 const MAX_PIECES_DISPLAYED = 4;
 
-export default function CollectorsNoteAddedToCollectionFeedEvent({ eventRef }: Props) {
+export default function CollectorsNoteAddedToCollectionFeedEvent({ eventRef, queryRef }: Props) {
   const event = useFragment(
     graphql`
       fragment CollectorsNoteAddedToCollectionFeedEventFragment on CollectorsNoteAddedToCollectionFeedEventData {
@@ -47,6 +49,15 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({ eventRef }: P
       }
     `,
     eventRef
+  );
+
+  const query = useFragment(
+    graphql`
+      fragment CollectorsNoteAddedToCollectionFeedEventQueryFragment on Query {
+        ...HoverCardOnUsernameFollowFragment
+      }
+    `,
+    queryRef
   );
 
   const tokensToPreview = useMemo(() => {
@@ -73,7 +84,11 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({ eventRef }: P
       <StyledEvent>
         <StyledEventHeader>
           <BaseM>
-            <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
+            <HoverCardOnUsername
+              username={event?.owner.username || ''}
+              userRef={event.owner}
+              queryRef={query}
+            />{' '}
             added a description to
             {collectionName ? ' ' : ' their collection'}
             <InteractiveLink to={collectionPagePath}>{collectionName}</InteractiveLink>

--- a/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
@@ -95,12 +95,8 @@ export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef, queryRef
       <StyledEvent>
         <StyledEventHeader>
           <BaseM>
-            <HoverCardOnUsername
-              username={event?.owner.username || ''}
-              userRef={event.owner}
-              queryRef={query}
-            />{' '}
-            added a collector's note to{' '}
+            <HoverCardOnUsername userRef={event.owner} queryRef={query} /> added a collector's note
+            to{' '}
             <InteractiveLink
               to={`/${event.owner.username}/${event.token.collection?.dbid}/${event.token.token?.dbid}`}
               onClick={handleEventClick}

--- a/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
@@ -14,6 +14,7 @@ import { StyledClickHandler, StyledEvent, StyledEventHeader, StyledTime } from '
 import EventMedia from './EventMedia';
 import unescape from 'utils/unescape';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
+import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
 
 type Props = {
   eventRef: CollectorsNoteAddedToTokenFeedEventFragment$key;
@@ -31,6 +32,7 @@ export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef }: Props)
         eventTime
         owner @required(action: THROW) {
           username
+          ...HoverCardOnUsernameFragment
         }
         newCollectorsNote
         token @required(action: THROW) {
@@ -81,9 +83,7 @@ export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef }: Props)
       <StyledEvent>
         <StyledEventHeader>
           <BaseM>
-            <InteractiveLink to={`/${event.owner.username}`}>
-              {event.owner.username}
-            </InteractiveLink>{' '}
+            <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
             added a collector's note to{' '}
             <InteractiveLink
               to={`/${event.owner.username}/${event.token.collection?.dbid}/${event.token.token?.dbid}`}

--- a/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
@@ -15,9 +15,11 @@ import EventMedia from './EventMedia';
 import unescape from 'utils/unescape';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
+import { CollectorsNoteAddedToTokenFeedEventQueryFragment$key } from '__generated__/CollectorsNoteAddedToTokenFeedEventQueryFragment.graphql';
 
 type Props = {
   eventRef: CollectorsNoteAddedToTokenFeedEventFragment$key;
+  queryRef: CollectorsNoteAddedToTokenFeedEventQueryFragment$key;
 };
 
 const MARGIN = 16;
@@ -25,7 +27,7 @@ const MIDDLE_GAP = 24;
 // images will be rendered within a square of this size
 const IMAGE_SPACE_SIZE = 269;
 
-export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef }: Props) {
+export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef, queryRef }: Props) {
   const event = useFragment(
     graphql`
       fragment CollectorsNoteAddedToTokenFeedEventFragment on CollectorsNoteAddedToTokenFeedEventData {
@@ -50,6 +52,16 @@ export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef }: Props)
     `,
     eventRef
   );
+
+  const query = useFragment(
+    graphql`
+      fragment CollectorsNoteAddedToTokenFeedEventQueryFragment on Query {
+        ...HoverCardOnUsernameFollowFragment
+      }
+    `,
+    queryRef
+  );
+
   const isMobile = useIsMobileWindowWidth();
   const windowSize = useWindowSize();
   const { showModal } = useModalActions();
@@ -83,7 +95,11 @@ export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef }: Props)
       <StyledEvent>
         <StyledEventHeader>
           <BaseM>
-            <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
+            <HoverCardOnUsername
+              username={event?.owner.username || ''}
+              userRef={event.owner}
+              queryRef={query}
+            />{' '}
             added a collector's note to{' '}
             <InteractiveLink
               to={`/${event.owner.username}/${event.token.collection?.dbid}/${event.token.token?.dbid}`}

--- a/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -15,6 +15,7 @@ import { StyledEvent, StyledEventHeader, StyledTime } from './EventStyles';
 import unescape from 'utils/unescape';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { UnstyledLink } from 'components/core/Link/UnstyledLink';
+import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
 
 type Props = {
   eventRef: TokensAddedToCollectionFeedEventFragment$key;
@@ -29,6 +30,7 @@ export default function TokensAddedToCollectionFeedEvent({ eventRef }: Props) {
         eventTime
         owner @required(action: THROW) {
           username
+          ...HoverCardOnUsernameFragment
         }
         collection @required(action: THROW) {
           dbid
@@ -80,9 +82,7 @@ export default function TokensAddedToCollectionFeedEvent({ eventRef }: Props) {
       <StyledEvent>
         <StyledEventHeader>
           <BaseM>
-            <InteractiveLink to={`/${event.owner.username}`}>
-              {event.owner.username}
-            </InteractiveLink>{' '}
+            <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
             added {isPreFeed ? '' : `${tokens.length} ${pluralize(tokens.length, 'piece')}`} to
             {collectionName ? ' ' : ' their collection'}
             <InteractiveLink to={collectionPagePath}>{collectionName}</InteractiveLink>

--- a/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -93,12 +93,8 @@ export default function TokensAddedToCollectionFeedEvent({ eventRef, queryRef }:
       <StyledEvent>
         <StyledEventHeader>
           <BaseM>
-            <HoverCardOnUsername
-              username={event?.owner.username || ''}
-              userRef={event.owner}
-              queryRef={query}
-            />{' '}
-            added {isPreFeed ? '' : `${tokens.length} ${pluralize(tokens.length, 'piece')}`} to
+            <HoverCardOnUsername userRef={event.owner} queryRef={query} /> added{' '}
+            {isPreFeed ? '' : `${tokens.length} ${pluralize(tokens.length, 'piece')}`} to
             {collectionName ? ' ' : ' their collection'}
             <InteractiveLink to={collectionPagePath}>{collectionName}</InteractiveLink>
           </BaseM>

--- a/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -16,14 +16,16 @@ import unescape from 'utils/unescape';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { UnstyledLink } from 'components/core/Link/UnstyledLink';
 import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
+import { TokensAddedToCollectionFeedEventQueryFragment$key } from '__generated__/TokensAddedToCollectionFeedEventQueryFragment.graphql';
 
 type Props = {
   eventRef: TokensAddedToCollectionFeedEventFragment$key;
+  queryRef: TokensAddedToCollectionFeedEventQueryFragment$key;
 };
 
 const MAX_PIECES_DISPLAYED = 4;
 
-export default function TokensAddedToCollectionFeedEvent({ eventRef }: Props) {
+export default function TokensAddedToCollectionFeedEvent({ eventRef, queryRef }: Props) {
   const event = useFragment(
     graphql`
       fragment TokensAddedToCollectionFeedEventFragment on TokensAddedToCollectionFeedEventData {
@@ -54,6 +56,15 @@ export default function TokensAddedToCollectionFeedEvent({ eventRef }: Props) {
     eventRef
   );
 
+  const query = useFragment(
+    graphql`
+      fragment TokensAddedToCollectionFeedEventQueryFragment on Query {
+        ...HoverCardOnUsernameFollowFragment
+      }
+    `,
+    queryRef
+  );
+
   const { isPreFeed } = event;
 
   const tokens = isPreFeed ? event.collection.tokens : event.newTokens;
@@ -82,7 +93,11 @@ export default function TokensAddedToCollectionFeedEvent({ eventRef }: Props) {
       <StyledEvent>
         <StyledEventHeader>
           <BaseM>
-            <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
+            <HoverCardOnUsername
+              username={event?.owner.username || ''}
+              userRef={event.owner}
+              queryRef={query}
+            />{' '}
             added {isPreFeed ? '' : `${tokens.length} ${pluralize(tokens.length, 'piece')}`} to
             {collectionName ? ' ' : ' their collection'}
             <InteractiveLink to={collectionPagePath}>{collectionName}</InteractiveLink>

--- a/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -61,6 +61,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
             }
           }
         }
+        ...FollowButtonQueryFragment
         ...HoverCardOnUsernameFollowFragment
       }
     `,

--- a/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -42,6 +42,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
             username
             dbid
             bio
+            ...HoverCardOnUsernameFragment
           }
           followedBack
         }
@@ -73,6 +74,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
   const viewerUserId = query?.viewer?.user?.dbid;
 
   // cache first username in followed list, to be displayed when user followed only 1 collector
+  const firstFollowerUsernameRef = event.followed[0];
   const firstFolloweeUsername = event.followed[0]?.user?.username;
   const track = useTrack();
 
@@ -149,15 +151,10 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
           <StyledEventContent>
             <StyledEventHeader>
               <BaseM>
-                <HoverCardOnUsername
-                  username={event?.owner.username || ''}
-                  userRef={event.owner}
-                  queryRef={query}
-                />{' '}
-                followed{' '}
-                <InteractiveLink to={`/${firstFolloweeUsername}`}>
-                  {firstFolloweeUsername}
-                </InteractiveLink>
+                <HoverCardOnUsername userRef={event.owner} queryRef={query} /> followed{' '}
+                {firstFollowerUsernameRef && firstFollowerUsernameRef.user && (
+                  <HoverCardOnUsername userRef={firstFollowerUsernameRef.user} queryRef={query} />
+                )}
               </BaseM>
               <Spacer width={4} />
               <StyledTime>{getTimeSince(event.eventTime)}</StyledTime>
@@ -169,12 +166,8 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
           <StyledEventContent>
             <StyledEventHeader>
               <BaseM>
-                <HoverCardOnUsername
-                  username={event?.owner.username || ''}
-                  userRef={event.owner}
-                  queryRef={query}
-                />{' '}
-                followed {genericFollows.length} collectors.
+                <HoverCardOnUsername userRef={event.owner} queryRef={query} /> followed{' '}
+                {genericFollows.length} collectors.
               </BaseM>
               <Spacer width={4} />
               <StyledTime>{getTimeSince(event.eventTime)}</StyledTime>

--- a/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -5,6 +5,7 @@ import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 import Spacer from 'components/core/Spacer/Spacer';
 import { BaseM, TitleXS } from 'components/core/Text/Text';
 import FollowListUsers from 'components/Follow/FollowListUsers';
+import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { MODAL_PADDING_THICC_PX } from 'contexts/modal/constants';
 import { useModalActions } from 'contexts/modal/ModalContext';
@@ -33,6 +34,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
         eventTime
         owner @required(action: THROW) {
           username @required(action: THROW)
+          ...HoverCardOnUsernameFragment
           ...FollowButtonUserFragment
         }
         followed @required(action: THROW) {
@@ -146,9 +148,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
           <StyledEventContent>
             <StyledEventHeader>
               <BaseM>
-                <InteractiveLink to={`/${event.owner.username}`}>
-                  {event.owner.username}
-                </InteractiveLink>{' '}
+                <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
                 followed{' '}
                 <InteractiveLink to={`/${firstFolloweeUsername}`}>
                   {firstFolloweeUsername}
@@ -164,9 +164,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
           <StyledEventContent>
             <StyledEventHeader>
               <BaseM>
-                <InteractiveLink to={`/${event.owner.username}`}>
-                  {event.owner.username}
-                </InteractiveLink>{' '}
+                <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
                 followed {genericFollows.length} collectors.
               </BaseM>
               <Spacer width={4} />

--- a/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -1,7 +1,6 @@
 import breakpoints from 'components/core/breakpoints';
 import { Button } from 'components/core/Button/Button';
 import colors from 'components/core/colors';
-import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 import Spacer from 'components/core/Spacer/Spacer';
 import { BaseM, TitleXS } from 'components/core/Text/Text';
 import FollowListUsers from 'components/Follow/FollowListUsers';

--- a/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -61,7 +61,7 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
             }
           }
         }
-        ...FollowButtonQueryFragment
+        ...HoverCardOnUsernameFollowFragment
       }
     `,
     queryRef
@@ -148,7 +148,11 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
           <StyledEventContent>
             <StyledEventHeader>
               <BaseM>
-                <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
+                <HoverCardOnUsername
+                  username={event?.owner.username || ''}
+                  userRef={event.owner}
+                  queryRef={query}
+                />{' '}
                 followed{' '}
                 <InteractiveLink to={`/${firstFolloweeUsername}`}>
                   {firstFolloweeUsername}
@@ -164,7 +168,11 @@ export default function UserFollowedUsersFeedEvent({ eventRef, queryRef, feedMod
           <StyledEventContent>
             <StyledEventHeader>
               <BaseM>
-                <HoverCardOnUsername username={event?.owner.username || ''} userRef={event.owner} />{' '}
+                <HoverCardOnUsername
+                  username={event?.owner.username || ''}
+                  userRef={event.owner}
+                  queryRef={query}
+                />{' '}
                 followed {genericFollows.length} collectors.
               </BaseM>
               <Spacer width={4} />

--- a/src/components/Feed/FeedEvent.tsx
+++ b/src/components/Feed/FeedEvent.tsx
@@ -68,6 +68,10 @@ function FeedEvent({ eventRef, queryRef, feedMode }: Props) {
     graphql`
       fragment FeedEventQueryFragment on Query {
         ...UserFollowedUsersFeedEventQueryFragment
+        ...TokensAddedToCollectionFeedEventQueryFragment
+        ...CollectorsNoteAddedToCollectionFeedEventQueryFragment
+        ...CollectionCreatedFeedEventQueryFragment
+        ...CollectorsNoteAddedToTokenFeedEventQueryFragment
       }
     `,
     queryRef
@@ -78,17 +82,17 @@ function FeedEvent({ eventRef, queryRef, feedMode }: Props) {
       if (!event.collection) {
         return null;
       }
-      return <CollectionCreatedFeedEvent eventRef={event} />;
+      return <CollectionCreatedFeedEvent eventRef={event} queryRef={query} />;
     case 'CollectorsNoteAddedToTokenFeedEventData':
       if (!event.token) {
         return null;
       }
-      return <CollectorsNoteAddedToTokenFeedEvent eventRef={event} />;
+      return <CollectorsNoteAddedToTokenFeedEvent eventRef={event} queryRef={query} />;
     case 'TokensAddedToCollectionFeedEventData':
       if (!event.collection) {
         return null;
       }
-      return <TokensAddedToCollectionFeedEvent eventRef={event} />;
+      return <TokensAddedToCollectionFeedEvent eventRef={event} queryRef={query} />;
     case 'CollectorsNoteAddedToCollectionFeedEventData':
       if (!event.collection) {
         return null;
@@ -96,7 +100,7 @@ function FeedEvent({ eventRef, queryRef, feedMode }: Props) {
       if (!event.newCollectorsNote?.trim()) {
         return null;
       }
-      return <CollectorsNoteAddedToCollectionFeedEvent eventRef={event} />;
+      return <CollectorsNoteAddedToCollectionFeedEvent eventRef={event} queryRef={query} />;
     case 'UserFollowedUsersFeedEventData':
       if (!event.followed || !event.owner?.username) {
         return null;

--- a/src/components/Feed/FeedEvent.tsx
+++ b/src/components/Feed/FeedEvent.tsx
@@ -45,6 +45,7 @@ function FeedEvent({ eventRef, queryRef, feedMode }: Props) {
           followed {
             user {
               dbid
+              ...HoverCardOnUsernameFragment
             }
           }
         }

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import colors from 'components/core/colors';
 import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 import { BaseM, TitleM } from 'components/core/Text/Text';
@@ -13,6 +13,7 @@ import transitions, {
 } from 'components/core/transitions';
 import { HoverCardOnUsernameFollowFragment$key } from '__generated__/HoverCardOnUsernameFollowFragment.graphql';
 import { useLoggedInUserId } from 'hooks/useLoggedInUserId';
+import { useRouter } from 'next/router';
 
 type Props = {
   userRef: HoverCardOnUsernameFragment$key;
@@ -21,6 +22,8 @@ type Props = {
 
 export default function HoverCardOnUsername({ userRef, queryRef }: Props) {
   const [isHovering, setIsHovering] = useState(false);
+
+  const router = useRouter();
 
   const user = useFragment(
     graphql`
@@ -59,6 +62,14 @@ export default function HoverCardOnUsername({ userRef, queryRef }: Props) {
     setIsHovering(false);
   };
 
+  const handleClick = useCallback(
+    (e) => {
+      e.preventDefault();
+      router.push(`${user.username}`);
+    },
+    [user]
+  );
+
   const loggedInUserId = useLoggedInUserId(query);
   const isLoggedIn = !!loggedInUserId;
 
@@ -68,7 +79,7 @@ export default function HoverCardOnUsername({ userRef, queryRef }: Props) {
         <InteractiveLink to={`/${user.username}`}>{user.username}</InteractiveLink>
       </StyledLinkContainer>
       {isHovering && (
-        <StyledCardWrapper isHovering={isHovering}>
+        <StyledCardWrapper isHovering={isHovering} onClick={handleClick}>
           <StyledCardContainer>
             <StyledCardHeader>
               <StyledHoverCardTitleContainer>

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -69,23 +69,29 @@ export default function HoverCardOnUsername({ username, userRef, queryRef }: Pro
         <InteractiveLink to={`/${username}`}>{username}</InteractiveLink>
       </StyledLinkContainer>
 
-      <StyledCardContainer isHovering={isHovering}>
-        <StyledCardHeader>
-          <StyledHoverCardTitleContainer>
-            {isLoggedIn && <FollowButton userRef={user} queryRef={query} />}
-            <StyledCardUsername>{user.username}</StyledCardUsername>
-          </StyledHoverCardTitleContainer>
+      <StyledCardWrapper isHovering={isHovering}>
+        <StyledCardContainer>
+          <StyledCardHeader>
+            <StyledHoverCardTitleContainer>
+              {isLoggedIn && (
+                <StyledFollowButtonWrapper>
+                  <FollowButton userRef={user} queryRef={query} />
+                </StyledFollowButtonWrapper>
+              )}
+              <StyledCardUsername>{user.username}</StyledCardUsername>
+            </StyledHoverCardTitleContainer>
 
-          <BaseM>{totalCollections} collections</BaseM>
-        </StyledCardHeader>
-        {user.bio && (
-          <StyledCardDescription>
-            <BaseM>
-              <Markdown text={unescape(user.bio)}></Markdown>
-            </BaseM>
-          </StyledCardDescription>
-        )}
-      </StyledCardContainer>
+            <BaseM>{totalCollections} collections</BaseM>
+          </StyledCardHeader>
+          {user.bio && (
+            <StyledCardDescription>
+              <BaseM>
+                <Markdown text={unescape(user.bio)}></Markdown>
+              </BaseM>
+            </StyledCardDescription>
+          )}
+        </StyledCardContainer>
+      </StyledCardWrapper>
     </StyledContainer>
   );
 }
@@ -100,7 +106,7 @@ const translateDown = keyframes`
     to { transform: translateY(${ANIMATED_COMPONENT_TRANSLATION_PIXELS_LARGE}px) };
 `;
 
-const StyledContainer = styled.div`
+const StyledContainer = styled.span`
   position: relative;
   display: inline-block;
 `;
@@ -109,24 +115,25 @@ const StyledLinkContainer = styled.div`
   display: inline-block;
 `;
 
-const StyledCardContainer = styled.div<{ isHovering: boolean }>`
-  border: 1px solid ${colors.offBlack};
-  padding: 16px;
-  width: 375px;
-  display: grid;
-  gap: 8px;
-
+const StyledCardWrapper = styled.div<{ isHovering: boolean }>`
+  padding-top: 8px;
   position: absolute;
-  background-color: ${colors.white};
   z-index: ${({ isHovering }) => (isHovering ? '1' : '-1')};
-  /* top: calc(100% + 8px); */
-  top: calc(100%);
-
+  top: 100%;
   animation: ${({ isHovering }) =>
     css`
       ${isHovering ? translateUp : translateDown} ${transitions.cubic}
     `};
   opacity: ${({ isHovering }) => (isHovering ? 1 : 0)};
+`;
+
+const StyledCardContainer = styled.div`
+  border: 1px solid ${colors.offBlack};
+  padding: 16px;
+  width: 375px;
+  display: grid;
+  gap: 8px;
+  background-color: ${colors.white};
 `;
 
 const StyledCardHeader = styled.div`
@@ -138,6 +145,10 @@ const StyledCardHeader = styled.div`
 const StyledHoverCardTitleContainer = styled.div`
   display: flex;
   align-items: center;
+`;
+
+const StyledFollowButtonWrapper = styled.div`
+  margin-right: 8px;
 `;
 
 const StyledCardUsername = styled(TitleM)`

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -2,14 +2,16 @@ import { useCallback, useState } from 'react';
 import colors from 'components/core/colors';
 import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 import { BaseM, TitleM } from 'components/core/Text/Text';
-import IconButton from 'components/IconButton/IconButton';
-import styled from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 import { graphql, useFragment } from 'react-relay';
 import { HoverCardOnUsernameFragment$key } from '__generated__/HoverCardOnUsernameFragment.graphql';
 import router from 'next/router';
 import Markdown from 'components/core/Markdown/Markdown';
 import unescape from 'lodash/unescape';
 import FollowButton from 'components/Follow/FollowButton';
+import transitions, {
+  ANIMATED_COMPONENT_TRANSLATION_PIXELS_LARGE,
+} from 'components/core/transitions';
 
 type Props = {
   username: string;
@@ -62,28 +64,36 @@ export default function HoverCardOnUsername({ username, userRef }: Props) {
         <InteractiveLink to={`/${username}`}>{username}</InteractiveLink>
       </StyledLinkContainer>
 
-      {isHovering && (
-        <StyledCardContainer onClick={handleClick}>
-          <StyledCardHeader>
-            <StyledHoverCardTitleContainer>
-              {isLoggedIn && <FollowButton />}
-              <StyledCardUsername>{user.username}</StyledCardUsername>
-            </StyledHoverCardTitleContainer>
+      <StyledCardContainer onClick={handleClick} isHovering={isHovering}>
+        <StyledCardHeader>
+          <StyledHoverCardTitleContainer>
+            {isLoggedIn && <FollowButton />}
+            <StyledCardUsername>{user.username}</StyledCardUsername>
+          </StyledHoverCardTitleContainer>
 
-            <BaseM>{totalCollections} collections</BaseM>
-          </StyledCardHeader>
-          {user.bio && (
-            <StyledCardDescription>
-              <BaseM>
-                <Markdown text={unescape(user.bio)}></Markdown>
-              </BaseM>
-            </StyledCardDescription>
-          )}
-        </StyledCardContainer>
-      )}
+          <BaseM>{totalCollections} collections</BaseM>
+        </StyledCardHeader>
+        {user.bio && (
+          <StyledCardDescription>
+            <BaseM>
+              <Markdown text={unescape(user.bio)}></Markdown>
+            </BaseM>
+          </StyledCardDescription>
+        )}
+      </StyledCardContainer>
     </StyledContainer>
   );
 }
+
+const translateUp = keyframes`
+    from { transform: translateY(${ANIMATED_COMPONENT_TRANSLATION_PIXELS_LARGE}px) };
+    to { transform: translateY(0px) };
+`;
+
+const translateDown = keyframes`
+    from { transform: translateY(0px) };
+    to { transform: translateY(${ANIMATED_COMPONENT_TRANSLATION_PIXELS_LARGE}px) };
+`;
 
 const StyledContainer = styled.div`
   position: relative;
@@ -94,7 +104,7 @@ const StyledLinkContainer = styled.div`
   display: inline-block;
 `;
 
-const StyledCardContainer = styled.div`
+const StyledCardContainer = styled.div<{ isHovering: boolean }>`
   border: 1px solid ${colors.offBlack};
   padding: 16px;
   width: 375px;
@@ -103,9 +113,14 @@ const StyledCardContainer = styled.div`
 
   position: absolute;
   background-color: ${colors.white};
-  z-index: 1;
-  top: 100%;
-  /* top: calc(100% + 8px); */
+  z-index: ${({ isHovering }) => (isHovering ? '1' : '-1')};
+  top: calc(100% + 8px);
+
+  animation: ${({ isHovering }) =>
+    css`
+      ${isHovering ? translateUp : translateDown} ${transitions.cubic}
+    `};
+  opacity: ${({ isHovering }) => (isHovering ? 1 : 0)};
 `;
 
 const StyledCardHeader = styled.div`

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -12,13 +12,16 @@ import FollowButton from 'components/Follow/FollowButton';
 import transitions, {
   ANIMATED_COMPONENT_TRANSLATION_PIXELS_LARGE,
 } from 'components/core/transitions';
+import { HoverCardOnUsernameFollowFragment$key } from '__generated__/HoverCardOnUsernameFollowFragment.graphql';
+import { useLoggedInUserId } from 'hooks/useLoggedInUserId';
 
 type Props = {
   username: string;
   userRef: HoverCardOnUsernameFragment$key;
+  queryRef: HoverCardOnUsernameFollowFragment$key;
 };
 
-export default function HoverCardOnUsername({ username, userRef }: Props) {
+export default function HoverCardOnUsername({ username, userRef, queryRef }: Props) {
   const [isHovering, setIsHovering] = useState(false);
 
   const user = useFragment(
@@ -32,9 +35,20 @@ export default function HoverCardOnUsername({ username, userRef }: Props) {
             name
           }
         }
+        ...FollowButtonUserFragment
       }
     `,
     userRef
+  );
+
+  const query = useFragment(
+    graphql`
+      fragment HoverCardOnUsernameFollowFragment on Query {
+        ...FollowButtonQueryFragment
+        ...useLoggedInUserIdFragment
+      }
+    `,
+    queryRef
   );
 
   const totalCollections = user?.galleries[0]?.collections?.length || 0;
@@ -55,8 +69,8 @@ export default function HoverCardOnUsername({ username, userRef }: Props) {
     [username]
   );
 
-  // TODO: refactor this to use useLoggedInUserId
-  const isLoggedIn = false;
+  const loggedInUserId = useLoggedInUserId(query);
+  const isLoggedIn = !!loggedInUserId;
 
   return (
     <StyledContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
@@ -67,7 +81,7 @@ export default function HoverCardOnUsername({ username, userRef }: Props) {
       <StyledCardContainer onClick={handleClick} isHovering={isHovering}>
         <StyledCardHeader>
           <StyledHoverCardTitleContainer>
-            {isLoggedIn && <FollowButton />}
+            {isLoggedIn && <FollowButton userRef={user} queryRef={query} />}
             <StyledCardUsername>{user.username}</StyledCardUsername>
           </StyledHoverCardTitleContainer>
 
@@ -114,7 +128,8 @@ const StyledCardContainer = styled.div<{ isHovering: boolean }>`
   position: absolute;
   background-color: ${colors.white};
   z-index: ${({ isHovering }) => (isHovering ? '1' : '-1')};
-  top: calc(100% + 8px);
+  /* top: calc(100% + 8px); */
+  top: calc(100%);
 
   animation: ${({ isHovering }) =>
     css`

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import colors from 'components/core/colors';
+import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
+import { BaseM, TitleM } from 'components/core/Text/Text';
+import IconButton from 'components/IconButton/IconButton';
+import styled from 'styled-components';
+
+type Props = {
+  username: string;
+};
+
+export default function HoverCardOnUsername({ username }: Props) {
+  const [isHovering, setIsHovering] = useState(true);
+
+  const handleMouseEnter = () => {
+    setIsHovering(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsHovering(false);
+  };
+
+  return (
+    <StyledContainer>
+      <StyledLinkContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        <InteractiveLink to={`/${username}`}>{username} test</InteractiveLink>
+      </StyledLinkContainer>
+
+      {isHovering && (
+        <StyledCardContainer>
+          <StyledCardHeader>
+            <StyledHoverCardTitleContainer>
+              <IconButton />
+              <StyledCardUsername>ForgetfulElephantzxczxczxczxczx</StyledCardUsername>
+            </StyledHoverCardTitleContainer>
+
+            <BaseM>30 collections</BaseM>
+          </StyledCardHeader>
+
+          <StyledCardDescription>
+            <BaseM>
+              Kristian Levin aka noCreative is a 3D Artist working out of Copenhagen, Denmark. With
+              15+ years of experience across multiple disciplines in the creative industry, and
+              entered the NFT scene late 2020. Known for his striking, signature 3D cloth work,
+              Kristian has developed a notable presence within the NFT art community as an artist,
+              collector and curator.
+            </BaseM>
+          </StyledCardDescription>
+        </StyledCardContainer>
+      )}
+    </StyledContainer>
+  );
+}
+
+const StyledContainer = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+const StyledLinkContainer = styled.div`
+  display: inline-block;
+`;
+
+const StyledCardContainer = styled.div`
+  border: 1px solid ${colors.offBlack};
+  padding: 16px;
+  width: 375px;
+  display: grid;
+  gap: 8px;
+
+  position: absolute;
+  background-color: ${colors.white};
+  z-index: 1;
+  top: calc(100% + 8px);
+`;
+
+const StyledCardHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const StyledHoverCardTitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledCardUsername = styled(TitleM)`
+  font-style: normal;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 200px;
+`;
+
+const StyledCardDescription = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+`;

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -15,12 +15,11 @@ import { HoverCardOnUsernameFollowFragment$key } from '__generated__/HoverCardOn
 import { useLoggedInUserId } from 'hooks/useLoggedInUserId';
 
 type Props = {
-  username: string;
   userRef: HoverCardOnUsernameFragment$key;
   queryRef: HoverCardOnUsernameFollowFragment$key;
 };
 
-export default function HoverCardOnUsername({ username, userRef, queryRef }: Props) {
+export default function HoverCardOnUsername({ userRef, queryRef }: Props) {
   const [isHovering, setIsHovering] = useState(false);
 
   const user = useFragment(
@@ -66,7 +65,7 @@ export default function HoverCardOnUsername({ username, userRef, queryRef }: Pro
   return (
     <StyledContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       <StyledLinkContainer>
-        <InteractiveLink to={`/${username}`}>{username}</InteractiveLink>
+        <InteractiveLink to={`/${user.username}`}>{user.username}</InteractiveLink>
       </StyledLinkContainer>
 
       <StyledCardWrapper isHovering={isHovering}>

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -59,7 +59,7 @@ export default function HoverCardOnUsername({ username, userRef }: Props) {
   return (
     <StyledContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       <StyledLinkContainer>
-        <InteractiveLink to={`/${username}`}>{username} test</InteractiveLink>
+        <InteractiveLink to={`/${username}`}>{username}</InteractiveLink>
       </StyledLinkContainer>
 
       {isHovering && (

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -4,13 +4,34 @@ import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 import { BaseM, TitleM } from 'components/core/Text/Text';
 import IconButton from 'components/IconButton/IconButton';
 import styled from 'styled-components';
+import { graphql, useFragment } from 'react-relay';
+import { HoverCardOnUsernameFragment$key } from '__generated__/HoverCardOnUsernameFragment.graphql';
 
 type Props = {
   username: string;
+  userRef: HoverCardOnUsernameFragment$key;
 };
 
-export default function HoverCardOnUsername({ username }: Props) {
+export default function HoverCardOnUsername({ username, userRef }: Props) {
   const [isHovering, setIsHovering] = useState(true);
+
+  const user = useFragment(
+    graphql`
+      fragment HoverCardOnUsernameFragment on GalleryUser {
+        username
+        bio
+        galleries @required(action: THROW) {
+          collections {
+            dbid
+            name
+          }
+        }
+      }
+    `,
+    userRef
+  );
+
+  const totalCollections = user?.galleries[0]?.collections?.length || 0;
 
   const handleMouseEnter = () => {
     setIsHovering(true);
@@ -21,8 +42,8 @@ export default function HoverCardOnUsername({ username }: Props) {
   };
 
   return (
-    <StyledContainer>
-      <StyledLinkContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+    <StyledContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <StyledLinkContainer>
         <InteractiveLink to={`/${username}`}>{username} test</InteractiveLink>
       </StyledLinkContainer>
 
@@ -31,20 +52,14 @@ export default function HoverCardOnUsername({ username }: Props) {
           <StyledCardHeader>
             <StyledHoverCardTitleContainer>
               <IconButton />
-              <StyledCardUsername>ForgetfulElephantzxczxczxczxczx</StyledCardUsername>
+              <StyledCardUsername>{user.username}</StyledCardUsername>
             </StyledHoverCardTitleContainer>
 
-            <BaseM>30 collections</BaseM>
+            <BaseM>{totalCollections} collections</BaseM>
           </StyledCardHeader>
 
           <StyledCardDescription>
-            <BaseM>
-              Kristian Levin aka noCreative is a 3D Artist working out of Copenhagen, Denmark. With
-              15+ years of experience across multiple disciplines in the creative industry, and
-              entered the NFT scene late 2020. Known for his striking, signature 3D cloth work,
-              Kristian has developed a notable presence within the NFT art community as an artist,
-              collector and curator.
-            </BaseM>
+            <BaseM>{user.bio}</BaseM>
           </StyledCardDescription>
         </StyledCardContainer>
       )}
@@ -71,7 +86,7 @@ const StyledCardContainer = styled.div`
   position: absolute;
   background-color: ${colors.white};
   z-index: 1;
-  top: calc(100% + 8px);
+  /* top: calc(100% + 8px); */
 `;
 
 const StyledCardHeader = styled.div`

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -67,30 +67,31 @@ export default function HoverCardOnUsername({ userRef, queryRef }: Props) {
       <StyledLinkContainer>
         <InteractiveLink to={`/${user.username}`}>{user.username}</InteractiveLink>
       </StyledLinkContainer>
+      {isHovering && (
+        <StyledCardWrapper isHovering={isHovering}>
+          <StyledCardContainer>
+            <StyledCardHeader>
+              <StyledHoverCardTitleContainer>
+                {isLoggedIn && (
+                  <StyledFollowButtonWrapper>
+                    <FollowButton userRef={user} queryRef={query} />
+                  </StyledFollowButtonWrapper>
+                )}
+                <StyledCardUsername>{user.username}</StyledCardUsername>
+              </StyledHoverCardTitleContainer>
 
-      <StyledCardWrapper isHovering={isHovering}>
-        <StyledCardContainer>
-          <StyledCardHeader>
-            <StyledHoverCardTitleContainer>
-              {isLoggedIn && (
-                <StyledFollowButtonWrapper>
-                  <FollowButton userRef={user} queryRef={query} />
-                </StyledFollowButtonWrapper>
-              )}
-              <StyledCardUsername>{user.username}</StyledCardUsername>
-            </StyledHoverCardTitleContainer>
-
-            <BaseM>{totalCollections} collections</BaseM>
-          </StyledCardHeader>
-          {user.bio && (
-            <StyledCardDescription>
-              <BaseM>
-                <Markdown text={unescape(user.bio)}></Markdown>
-              </BaseM>
-            </StyledCardDescription>
-          )}
-        </StyledCardContainer>
-      </StyledCardWrapper>
+              <BaseM>{totalCollections} collections</BaseM>
+            </StyledCardHeader>
+            {user.bio && (
+              <StyledCardDescription>
+                <BaseM>
+                  <Markdown text={unescape(user.bio)}></Markdown>
+                </BaseM>
+              </StyledCardDescription>
+            )}
+          </StyledCardContainer>
+        </StyledCardWrapper>
+      )}
     </StyledContainer>
   );
 }

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import colors from 'components/core/colors';
 import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 import { BaseM, TitleM } from 'components/core/Text/Text';
@@ -6,6 +6,10 @@ import IconButton from 'components/IconButton/IconButton';
 import styled from 'styled-components';
 import { graphql, useFragment } from 'react-relay';
 import { HoverCardOnUsernameFragment$key } from '__generated__/HoverCardOnUsernameFragment.graphql';
+import router from 'next/router';
+import Markdown from 'components/core/Markdown/Markdown';
+import unescape from 'lodash/unescape';
+import FollowButton from 'components/Follow/FollowButton';
 
 type Props = {
   username: string;
@@ -13,7 +17,7 @@ type Props = {
 };
 
 export default function HoverCardOnUsername({ username, userRef }: Props) {
-  const [isHovering, setIsHovering] = useState(true);
+  const [isHovering, setIsHovering] = useState(false);
 
   const user = useFragment(
     graphql`
@@ -41,6 +45,17 @@ export default function HoverCardOnUsername({ username, userRef }: Props) {
     setIsHovering(false);
   };
 
+  const handleClick = useCallback(
+    (e) => {
+      e.preventDefault();
+      router.push(`/${username}`);
+    },
+    [username]
+  );
+
+  // TODO: refactor this to use useLoggedInUserId
+  const isLoggedIn = false;
+
   return (
     <StyledContainer onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       <StyledLinkContainer>
@@ -48,19 +63,22 @@ export default function HoverCardOnUsername({ username, userRef }: Props) {
       </StyledLinkContainer>
 
       {isHovering && (
-        <StyledCardContainer>
+        <StyledCardContainer onClick={handleClick}>
           <StyledCardHeader>
             <StyledHoverCardTitleContainer>
-              <IconButton />
+              {isLoggedIn && <FollowButton />}
               <StyledCardUsername>{user.username}</StyledCardUsername>
             </StyledHoverCardTitleContainer>
 
             <BaseM>{totalCollections} collections</BaseM>
           </StyledCardHeader>
-
-          <StyledCardDescription>
-            <BaseM>{user.bio}</BaseM>
-          </StyledCardDescription>
+          {user.bio && (
+            <StyledCardDescription>
+              <BaseM>
+                <Markdown text={unescape(user.bio)}></Markdown>
+              </BaseM>
+            </StyledCardDescription>
+          )}
         </StyledCardContainer>
       )}
     </StyledContainer>
@@ -86,6 +104,7 @@ const StyledCardContainer = styled.div`
   position: absolute;
   background-color: ${colors.white};
   z-index: 1;
+  top: 100%;
   /* top: calc(100% + 8px); */
 `;
 

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -65,11 +65,9 @@ export default function HoverCardOnUsername({ userRef, queryRef }: Props) {
   const handleClick = useCallback(
     (e) => {
       e.preventDefault();
-      // If the user click the follow button, ignore the click.
-      if (e.target.matches('circle')) return;
       router.push(`${user.username}`);
     },
-    [user]
+    [user, router]
   );
 
   const loggedInUserId = useLoggedInUserId(query);

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -65,6 +65,8 @@ export default function HoverCardOnUsername({ userRef, queryRef }: Props) {
   const handleClick = useCallback(
     (e) => {
       e.preventDefault();
+      // If the user click the follow button, ignore the click.
+      if (e.target.matches('circle')) return;
       router.push(`${user.username}`);
     },
     [user]

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import colors from 'components/core/colors';
 import InteractiveLink from 'components/core/InteractiveLink/InteractiveLink';
 import { BaseM, TitleM } from 'components/core/Text/Text';
 import styled, { css, keyframes } from 'styled-components';
 import { graphql, useFragment } from 'react-relay';
 import { HoverCardOnUsernameFragment$key } from '__generated__/HoverCardOnUsernameFragment.graphql';
-import router from 'next/router';
 import Markdown from 'components/core/Markdown/Markdown';
 import unescape from 'lodash/unescape';
 import FollowButton from 'components/Follow/FollowButton';
@@ -61,14 +60,6 @@ export default function HoverCardOnUsername({ username, userRef, queryRef }: Pro
     setIsHovering(false);
   };
 
-  const handleClick = useCallback(
-    (e) => {
-      e.preventDefault();
-      router.push(`/${username}`);
-    },
-    [username]
-  );
-
   const loggedInUserId = useLoggedInUserId(query);
   const isLoggedIn = !!loggedInUserId;
 
@@ -78,7 +69,7 @@ export default function HoverCardOnUsername({ username, userRef, queryRef }: Pro
         <InteractiveLink to={`/${username}`}>{username}</InteractiveLink>
       </StyledLinkContainer>
 
-      <StyledCardContainer onClick={handleClick} isHovering={isHovering}>
+      <StyledCardContainer isHovering={isHovering}>
         <StyledCardHeader>
           <StyledHoverCardTitleContainer>
             {isLoggedIn && <FollowButton userRef={user} queryRef={query} />}

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -62,6 +62,7 @@ export default function IconButton({
 
   const handleClick = useCallback(
     (e) => {
+      e.stopPropagation();
       e.preventDefault();
       setShowTooltip(false);
       setClickedAndStillHovering(true);

--- a/src/hooks/useLoggedInUserId.ts
+++ b/src/hooks/useLoggedInUserId.ts
@@ -18,5 +18,5 @@ export const useLoggedInUserId = (queryRef: useLoggedInUserIdFragment$key) => {
     queryRef
   );
 
-  return user.viewer?.user?.id;
+  return user?.viewer?.user?.id;
 };


### PR DESCRIPTION
## Changes
- Add `<HoverCardOnUsername/>` component
- Some query fragment passed into sub component for follow button 


## Not logged in user
https://user-images.githubusercontent.com/4480258/180928501-015f0980-ef37-4010-bf91-29590a6bd428.mp4

## Logged in user

https://user-images.githubusercontent.com/4480258/180928629-5a58a049-8d0e-4c69-b8ff-779b41a0a537.mp4


### Notes
In future, we can abstract into  `popover` component when we want to use it on other use-case likes collection hover, etc