### PR TITLE
Fix styling of collector's note title

### DIFF
--- a/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRow.tsx
@@ -8,13 +8,13 @@ import {
   getBackgroundColorOverrideForContract,
   graphqlGetResizedNftImageUrlWithFallback,
 } from 'utils/token';
-import Settings from 'public/icons/ellipses.svg';
 import { graphql, useFragment } from 'react-relay';
 import { CollectionRowFragment$key } from '__generated__/CollectionRowFragment.graphql';
 import { removeNullValues } from 'utils/removeNullValues';
 import { CollectionRowCompactNftsFragment$key } from '__generated__/CollectionRowCompactNftsFragment.graphql';
 import getVideoOrImageUrlForNftPreview from 'utils/graphql/getVideoOrImageUrlForNftPreview';
 import Markdown from 'components/core/Markdown/Markdown';
+import { useIsMobileOrMobileLargeWindowWidth } from 'hooks/useWindowSize';
 
 type Props = {
   collectionRef: CollectionRowFragment$key;
@@ -51,6 +51,8 @@ function CollectionRow({ collectionRef, className }: Props) {
     `,
     collectionRef
   );
+
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
 
   const { name, collectorsNote, hidden } = collection;
   const tokens = useMemo(() => removeNullValues(collection.tokens), [collection]);
@@ -90,7 +92,6 @@ function CollectionRow({ collectionRef, className }: Props) {
             <Markdown text={truncatedCollectorsNote} />
           </StyledBaseM>
         </TextContainer>
-        <Settings />
       </Header>
       <Spacer height={12} />
       <Body>
@@ -121,7 +122,7 @@ function CollectionRow({ collectionRef, className }: Props) {
             </BigNftContainer>
           );
         })}
-        {remainingNfts.length > 0 ? (
+        {remainingNfts.length > 0 && !isMobile ? (
           <CompactNfts nftRefs={remainingNfts.map((it) => it.token)} />
         ) : null}
       </Body>
@@ -160,6 +161,8 @@ const StyledBaseM = styled(BaseM)`
 const TextContainer = styled.div`
   display: flex;
   flex-direction: column;
+
+  max-width: calc(100% - 75px);
 `;
 
 const StyledHiddenLabel = styled(BaseM)`

--- a/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/CollectionRowSettings.tsx
@@ -13,6 +13,7 @@ import DeleteCollectionConfirmation from './DeleteCollectionConfirmation';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { graphql, useFragment } from 'react-relay';
 import { CollectionRowSettingsFragment$key } from '__generated__/CollectionRowSettingsFragment.graphql';
+import Settings from 'public/icons/ellipses.svg';
 
 type Props = {
   collectionRef: CollectionRowSettingsFragment$key;
@@ -83,6 +84,7 @@ function CollectionRowSettings({ collectionRef, wizard: { push } }: Props & Wiza
 
   return (
     <StyledCollectionRowSettings>
+      <StyledSettings />
       <StyledTextButton onClick={handleEditCollectionClick} text="Edit" />
       <Dropdown>
         <TextButton onClick={handleEditNameClick} text="Edit name & bio" />
@@ -115,6 +117,11 @@ const StyledTextButton = styled(TextButton)`
   border-radius: 1px;
   padding: 8px;
   font-weight: 500;
+`;
+
+const StyledSettings = styled(Settings)`
+  position: absolute;
+  right: 0;
 `;
 
 export default withWizard(CollectionRowSettings);

--- a/src/flows/shared/steps/OrganizeGallery/OrganizeGallery.tsx
+++ b/src/flows/shared/steps/OrganizeGallery/OrganizeGallery.tsx
@@ -160,7 +160,7 @@ function OrganizeGallery({
     () => gallery.collections.length === 0,
     [gallery.collections.length]
   );
-  
+
   return (
     <StyledOrganizeGallery>
       <Spacer height={GLOBAL_NAVBAR_HEIGHT} />
@@ -198,7 +198,9 @@ const StyledOrganizeGallery = styled.div`
 `;
 
 const Content = styled.div`
-  width: 777px;
+  width: 100%;
+  padding: 0 16px;
+  max-width: 777px;
 `;
 
 export default OrganizeGallery;

--- a/src/scenes/CollectionGalleryPage/CollectionGallery.tsx
+++ b/src/scenes/CollectionGalleryPage/CollectionGallery.tsx
@@ -54,7 +54,7 @@ function CollectionGallery({ queryRef }: Props) {
         <NftGalleryWrapper>
           <NftGallery collectionRef={collection} mobileLayout={mobileLayout} />
         </NftGalleryWrapper>
-        <Spacer height={64} />
+        <Spacer height={isMobile ? 16 : 64} />
       </StyledCollectionGallery>
     );
   } else if (collection?.__typename === 'ErrCollectionNotFound') {

--- a/src/scenes/NftDetailPage/NftDetailNote.tsx
+++ b/src/scenes/NftDetailPage/NftDetailNote.tsx
@@ -1,4 +1,4 @@
-import { BaseM } from 'components/core/Text/Text';
+import { BaseM, TitleXS } from 'components/core/Text/Text';
 import Spacer from 'components/core/Spacer/Spacer';
 import TextButton from 'components/core/Button/TextButton';
 import { useCallback, useState, useMemo, useRef } from 'react';
@@ -177,7 +177,7 @@ type NoteViewerProps = {
 function NoteViewer({ nftCollectorsNote }: NoteViewerProps) {
   return (
     <>
-      <BaseM>Collector&rsquo;s Note</BaseM>
+      <TitleXS>Collector&rsquo;s Note</TitleXS>
       <Spacer height={8} />
       <StyledCollectorsNote footerHeight={GLOBAL_FOOTER_HEIGHT}>
         <Markdown text={nftCollectorsNote} />


### PR DESCRIPTION
The collector's note title is now aligned with the styling of other "NFT Detail Text" (`Owner`, `Creator`, etc). It applies the styles from `TitleXS`

Before

<img width="399" alt="image" src="https://user-images.githubusercontent.com/13339581/181864456-9110fa34-ff40-41e0-a55e-59ee05c92197.png">

After

<img width="320" alt="image" src="https://user-images.githubusercontent.com/13339581/181864507-457e2daf-4eba-4f79-a45b-2f55444dd606.png">