### PR TITLE
Fix collector's note title styling

### DIFF
--- a/src/scenes/NftDetailPage/NftDetailNote.tsx
+++ b/src/scenes/NftDetailPage/NftDetailNote.tsx
@@ -1,4 +1,4 @@
-import { BaseM } from 'components/core/Text/Text';
+import { BaseM, TitleXS } from 'components/core/Text/Text';
 import Spacer from 'components/core/Spacer/Spacer';
 import TextButton from 'components/core/Button/TextButton';
 import { useCallback, useState, useMemo, useRef } from 'react';
@@ -177,7 +177,7 @@ type NoteViewerProps = {
 function NoteViewer({ nftCollectorsNote }: NoteViewerProps) {
   return (
     <>
-      <BaseM>Collector&rsquo;s Note</BaseM>
+      <TitleXS>Collector&rsquo;s Note</TitleXS>
       <Spacer height={8} />
       <StyledCollectorsNote footerHeight={GLOBAL_FOOTER_HEIGHT}>
         <Markdown text={nftCollectorsNote} />


### PR DESCRIPTION
The collector's note title is now aligned with the styling of other "NFT Detail Text" (`Owner`, `Creator`, etc). It applies the styles from `TitleXS`

Before

<img width="399" alt="image" src="https://user-images.githubusercontent.com/13339581/181864456-9110fa34-ff40-41e0-a55e-59ee05c92197.png">

After

<img width="320" alt="image" src="https://user-images.githubusercontent.com/13339581/181864507-457e2daf-4eba-4f79-a45b-2f55444dd606.png">