### PR TITLE
Add fallback fonts

### DIFF
--- a/src/components/core/BigInput/BigInput.tsx
+++ b/src/components/core/BigInput/BigInput.tsx
@@ -47,7 +47,7 @@ const StyledBigInput = styled.input`
   padding: 12px;
   border: 0;
   font-size: 32px;
-  font-family: 'GT Alpina, serif';
+  font-family: GT Alpina, serif;
   line-height: 36px;
   letter-spacing: -0.03em;
   background: ${colors.faint};

--- a/src/components/core/BigInput/BigInput.tsx
+++ b/src/components/core/BigInput/BigInput.tsx
@@ -47,7 +47,7 @@ const StyledBigInput = styled.input`
   padding: 12px;
   border: 0;
   font-size: 32px;
-  font-family: 'GT Alpina';
+  font-family: 'GT Alpina, serif';
   line-height: 36px;
   letter-spacing: -0.03em;
   background: ${colors.faint};

--- a/src/components/core/Text/Text.tsx
+++ b/src/components/core/Text/Text.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 import colors from '../colors';
 
-const TITLE_FONT_FAMILY = 'GT Alpina, serif';
-export const BODY_FONT_FAMILY = 'ABC Diatype, Helvetica, Arial, sans-serif';
+const TITLE_FONT_FAMILY = "'GT Alpina', serif";
+export const BODY_FONT_FAMILY = "'ABC Diatype', Helvetica, Arial, sans-serif";
 
 type TextProps = {
   color?: colors;

--- a/src/components/core/Text/Text.tsx
+++ b/src/components/core/Text/Text.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 import colors from '../colors';
 
-const TITLE_FONT_FAMILY = 'GT Alpina';
-export const BODY_FONT_FAMILY = 'ABC Diatype';
+const TITLE_FONT_FAMILY = 'GT Alpina, serif';
+export const BODY_FONT_FAMILY = 'ABC Diatype, Helvetica, Arial, sans-serif';
 
 type TextProps = {
   color?: colors;

--- a/src/components/core/TextArea/TextArea.tsx
+++ b/src/components/core/TextArea/TextArea.tsx
@@ -61,7 +61,7 @@ const StyledTextArea = styled.textarea<TextAreaProps>`
   width: 100%;
   height: 100%;
   padding: 12px;
-  font-family: ABC Diatype, Helvetica, Arial, sans-serif;
+  font-family: 'ABC Diatype', Helvetica, Arial, sans-serif;
   border: none;
   border-bottom: 36px solid transparent;
   resize: none;

--- a/src/components/core/TextArea/TextArea.tsx
+++ b/src/components/core/TextArea/TextArea.tsx
@@ -61,7 +61,7 @@ const StyledTextArea = styled.textarea<TextAreaProps>`
   width: 100%;
   height: 100%;
   padding: 12px;
-  font-family: ABC Diatype;
+  font-family: ABC Diatype, Helvetica, Arial, sans-serif;
   border: none;
   border-bottom: 36px solid transparent;
   resize: none;

--- a/src/index.css
+++ b/src/index.css
@@ -90,7 +90,7 @@ html {
 body {
   margin: 0;
   font-family: 'Times New Roman', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'ABC Diatype', sans-serif;
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #fefefe;

--- a/src/scenes/BasicTextPage/BasicTextPage.tsx
+++ b/src/scenes/BasicTextPage/BasicTextPage.tsx
@@ -33,7 +33,7 @@ const StyledPage = styled.div`
 // Apply a generalized version of Gallery's style to the body text
 const StyledContent = styled.div`
   max-width: 800px;
-  font-family: ABC Diatype, Helvetica, Arial, sans-serif;
+  font-family: 'ABC Diatype', Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 24px;
 

--- a/src/scenes/BasicTextPage/BasicTextPage.tsx
+++ b/src/scenes/BasicTextPage/BasicTextPage.tsx
@@ -33,7 +33,7 @@ const StyledPage = styled.div`
 // Apply a generalized version of Gallery's style to the body text
 const StyledContent = styled.div`
   max-width: 800px;
-  font-family: 'ABC Diatype';
+  font-family: ABC Diatype, Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 24px;
 


### PR DESCRIPTION
This explicitly renders `serif` as a fallback font for `GT Alpina`, and `Helvetica, Arial, sans-serif` as a fallback for `ABC Diatype`.

I can't actually replicate Jess' problems with the brief flash of incorrect fonts, but for posterity here is a comparison of each font with its fallback:

### Serif (`GT Alpina`, fallback)

<img width="361" alt="image" src="https://user-images.githubusercontent.com/13339581/181866158-9a0ed856-f299-4b4d-8c2c-8ad1f4664c73.png">
<img width="347" alt="image" src="https://user-images.githubusercontent.com/13339581/181866162-146f5271-0de7-40de-ad1c-3ce3c4c31b11.png">

### Sans (`ABC Diatype`, fallback)

<img width="245" alt="image" src="https://user-images.githubusercontent.com/13339581/181866167-d69ee161-882b-4234-ba29-cd8dc529b60b.png">
<img width="244" alt="image" src="https://user-images.githubusercontent.com/13339581/181866173-310e7446-511d-4adf-944d-841316b3f7dc.png">
