### PR TITLE
[GAL-321] Fix follower/following popover on mobile width

### DIFF
--- a/src/components/Follow/FollowerListButton.tsx
+++ b/src/components/Follow/FollowerListButton.tsx
@@ -6,7 +6,7 @@ import FollowList from './FollowList';
 import { useModalActions } from 'contexts/modal/ModalContext';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { FollowerListButtonFragment$key } from '__generated__/FollowerListButtonFragment.graphql';
-import { useIsMobileWindowWidth } from 'hooks/useWindowSize';
+import { useIsMobileOrMobileLargeWindowWidth } from 'hooks/useWindowSize';
 
 type Props = {
   userRef: FollowerListButtonFragment$key;
@@ -25,7 +25,7 @@ export default function FollowerListButton({ userRef, className }: Props) {
 
   const { showModal } = useModalActions();
   const track = useTrack();
-  const isMobile = useIsMobileWindowWidth();
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
 
   const handleClick = useCallback(() => {
     track('View Follower List Click');


### PR DESCRIPTION
The following/follower popover had a lower width breakpoint (`useIsMobileWindowWidth`) than `FollowList` (`useIsMobileOrMobileLargeWindowWidth`). Practically, this meant that the `FollowList` applied a `width` and `height` of 100% on any screen between mobile -> tablet width, while `fullscreen` was not yet true for the modal.

This resulted in a modal that looked like this:

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/13339581/181936680-2f0df4ff-6837-4f60-8ea1-8c8c62beded3.png">

Fixed:

<img width="1093" alt="image" src="https://user-images.githubusercontent.com/13339581/181936703-a838dc9a-31af-4c1a-92db-d68d949fa7ab.png">
