### PR TITLE
[GAL-322] Open images in new tab from NFT Detail Page

### DIFF
--- a/src/components/LoadingAsset/ImageWithLoading.tsx
+++ b/src/components/LoadingAsset/ImageWithLoading.tsx
@@ -14,7 +14,7 @@ type Props = {
   src: string;
   alt: string;
   heightType?: ContentHeightType;
-  inDetailPage: boolean;
+  inDetailPage?: boolean;
 };
 
 export default function ImageWithLoading({

--- a/src/components/LoadingAsset/ImageWithLoading.tsx
+++ b/src/components/LoadingAsset/ImageWithLoading.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import styled from 'styled-components';
 import isFirefox from 'utils/isFirefox';
 import isSvg from 'utils/isSvg';
+import noop from 'utils/noop';
 
 type ContentHeightType =
   | 'maxHeightMinScreen' // fill up to 80vh of screen or 100% of container
@@ -14,7 +15,7 @@ type Props = {
   src: string;
   alt: string;
   heightType?: ContentHeightType;
-  inDetailPage?: boolean;
+  onClick?: () => void;
 };
 
 export default function ImageWithLoading({
@@ -22,7 +23,7 @@ export default function ImageWithLoading({
   heightType,
   src,
   alt,
-  inDetailPage = false,
+  onClick = noop,
 }: Props) {
   const setContentIsLoaded = useSetContentIsLoaded();
 
@@ -53,9 +54,7 @@ export default function ImageWithLoading({
       alt={alt}
       loading="lazy"
       onLoad={setContentIsLoaded}
-      onClick={() => {
-        if (inDetailPage) window.open(src);
-      }}
+      onClick={onClick}
     />
   );
 }

--- a/src/components/LoadingAsset/ImageWithLoading.tsx
+++ b/src/components/LoadingAsset/ImageWithLoading.tsx
@@ -14,9 +14,10 @@ type Props = {
   src: string;
   alt: string;
   heightType?: ContentHeightType;
+  inDetailPage: boolean;
 };
 
-export default function ImageWithLoading({ className, heightType, src, alt }: Props) {
+export default function ImageWithLoading({ className, heightType, src, alt, inDetailPage }: Props) {
   const setContentIsLoaded = useSetContentIsLoaded();
 
   const maxHeight = useMemo(() => {
@@ -46,6 +47,9 @@ export default function ImageWithLoading({ className, heightType, src, alt }: Pr
       alt={alt}
       loading="lazy"
       onLoad={setContentIsLoaded}
+      onClick={() => {
+        if (inDetailPage) window.open(src);
+      }}
     />
   );
 }
@@ -60,4 +64,5 @@ export const StyledImageWithLoading = styled.img<StyledImageWithLoadingProps>`
   max-height: ${({ maxHeight }) => maxHeight};
   width: ${({ renderFullWidth }) => (renderFullWidth ? '100%' : 'auto')};
   max-width: 100%;
+  cursor: pointer;
 `;

--- a/src/components/LoadingAsset/ImageWithLoading.tsx
+++ b/src/components/LoadingAsset/ImageWithLoading.tsx
@@ -17,7 +17,13 @@ type Props = {
   inDetailPage: boolean;
 };
 
-export default function ImageWithLoading({ className, heightType, src, alt, inDetailPage }: Props) {
+export default function ImageWithLoading({
+  className,
+  heightType,
+  src,
+  alt,
+  inDetailPage = false,
+}: Props) {
   const setContentIsLoaded = useSetContentIsLoaded();
 
   const maxHeight = useMemo(() => {

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -19,14 +19,9 @@ import { StyledImageWithLoading } from 'components/LoadingAsset/ImageWithLoading
 type NftDetailAssetComponentProps = {
   tokenRef: NftDetailAssetComponentFragment$key;
   maxHeight: number;
-  inDetailPage: boolean;
 };
 
-function NftDetailAssetComponent({
-  tokenRef,
-  maxHeight,
-  inDetailPage,
-}: NftDetailAssetComponentProps) {
+function NftDetailAssetComponent({ tokenRef, maxHeight }: NftDetailAssetComponentProps) {
   const token = useFragment(
     graphql`
       fragment NftDetailAssetComponentFragment on CollectionToken {
@@ -39,6 +34,7 @@ function NftDetailAssetComponent({
             }
             ... on ImageMedia {
               __typename
+              contentRenderURL
             }
             ... on HtmlMedia {
               __typename
@@ -72,7 +68,13 @@ function NftDetailAssetComponent({
       return <NftDetailAudio tokenRef={token.token} />;
     case 'ImageMedia':
       return (
-        <NftDetailImage tokenRef={token.token} maxHeight={maxHeight} inDetailPage={inDetailPage} />
+        <NftDetailImage
+          tokenRef={token.token}
+          maxHeight={maxHeight}
+          // @ts-expect-error: we know contentRenderURL is present within the media field
+          // if token type is `ImageMedia`
+          onClick={() => window.open(token.token.media.contentRenderURL)}
+        />
       );
     case 'GltfMedia':
       return <NftDetailModel mediaRef={token.token.media} />;
@@ -150,7 +152,7 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
       hasExtraPaddingForNote={hasExtraPaddingForNote}
       backgroundColorOverride={backgroundColorOverride}
     >
-      <NftDetailAssetComponent tokenRef={token} maxHeight={maxHeight} inDetailPage={true} />
+      <NftDetailAssetComponent tokenRef={token} maxHeight={maxHeight} />
     </StyledAssetContainer>
   );
 }

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -19,9 +19,14 @@ import { StyledImageWithLoading } from 'components/LoadingAsset/ImageWithLoading
 type NftDetailAssetComponentProps = {
   tokenRef: NftDetailAssetComponentFragment$key;
   maxHeight: number;
+  inDetailPage: boolean;
 };
 
-function NftDetailAssetComponent({ tokenRef, maxHeight }: NftDetailAssetComponentProps) {
+function NftDetailAssetComponent({
+  tokenRef,
+  maxHeight,
+  inDetailPage,
+}: NftDetailAssetComponentProps) {
   const token = useFragment(
     graphql`
       fragment NftDetailAssetComponentFragment on CollectionToken {
@@ -66,7 +71,9 @@ function NftDetailAssetComponent({ tokenRef, maxHeight }: NftDetailAssetComponen
     case 'AudioMedia':
       return <NftDetailAudio tokenRef={token.token} />;
     case 'ImageMedia':
-      return <NftDetailImage tokenRef={token.token} maxHeight={maxHeight} />;
+      return (
+        <NftDetailImage tokenRef={token.token} maxHeight={maxHeight} inDetailPage={inDetailPage} />
+      );
     case 'GltfMedia':
       return <NftDetailModel mediaRef={token.token.media} />;
     default:
@@ -143,7 +150,7 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
       hasExtraPaddingForNote={hasExtraPaddingForNote}
       backgroundColorOverride={backgroundColorOverride}
     >
-      <NftDetailAssetComponent tokenRef={token} maxHeight={maxHeight} />
+      <NftDetailAssetComponent tokenRef={token} maxHeight={maxHeight} inDetailPage={true} />
     </StyledAssetContainer>
   );
 }

--- a/src/scenes/NftDetailPage/NftDetailImage.tsx
+++ b/src/scenes/NftDetailPage/NftDetailImage.tsx
@@ -12,9 +12,10 @@ import { useSetContentIsLoaded } from 'contexts/shimmer/ShimmerContext';
 type Props = {
   tokenRef: NftDetailImageFragment$key;
   maxHeight: number;
+  inDetailPage: boolean;
 };
 
-function NftDetailImage({ tokenRef }: Props) {
+function NftDetailImage({ tokenRef, inDetailPage }: Props) {
   const token = useFragment(
     graphql`
       fragment NftDetailImageFragment on Token {
@@ -64,6 +65,7 @@ function NftDetailImage({ tokenRef }: Props) {
       src={url}
       alt={token.name ?? ''}
       heightType={breakpoint === size.desktop ? 'maxHeightMinScreen' : undefined}
+      inDetailPage={inDetailPage}
     />
   );
 }

--- a/src/scenes/NftDetailPage/NftDetailImage.tsx
+++ b/src/scenes/NftDetailPage/NftDetailImage.tsx
@@ -8,14 +8,15 @@ import { NftDetailImageFragment$key } from '__generated__/NftDetailImageFragment
 import { useMemo } from 'react';
 import { StyledVideo } from './NftDetailVideo';
 import { useSetContentIsLoaded } from 'contexts/shimmer/ShimmerContext';
+import noop from 'utils/noop';
 
 type Props = {
   tokenRef: NftDetailImageFragment$key;
   maxHeight: number;
-  inDetailPage: boolean;
+  onClick?: () => void;
 };
 
-function NftDetailImage({ tokenRef, inDetailPage }: Props) {
+function NftDetailImage({ tokenRef, onClick = noop }: Props) {
   const token = useFragment(
     graphql`
       fragment NftDetailImageFragment on Token {
@@ -65,7 +66,7 @@ function NftDetailImage({ tokenRef, inDetailPage }: Props) {
       src={url}
       alt={token.name ?? ''}
       heightType={breakpoint === size.desktop ? 'maxHeightMinScreen' : undefined}
-      inDetailPage={inDetailPage}
+      onClick={onClick}
     />
   );
 }


### PR DESCRIPTION
This opens images in a new tab when clicked from an NFT detail page. 
* Audio: Does not open in new tab, because I think these are usually two separate components (one for audio, one for video)
* Video: Clicking pauses/plays videos
* **GIFs: Open in new tab**
* **SVGs: Open in new tab**
* **Images: Open in new tab**