### PR TITLE
[GAL-323] Popover component when clicking on links from the feed

### DIFF
--- a/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -18,6 +18,7 @@ import breakpoints from 'components/core/breakpoints';
 import { UnstyledLink } from 'components/core/Link/UnstyledLink';
 import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
 import { CollectorsNoteAddedToCollectionFeedEventQueryFragment$key } from '__generated__/CollectorsNoteAddedToCollectionFeedEventQueryFragment.graphql';
+import Markdown from 'components/core/Markdown/Markdown';
 
 type Props = {
   eventRef: CollectorsNoteAddedToCollectionFeedEventFragment$key;
@@ -92,7 +93,9 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({ eventRef, que
           <StyledTime>{getTimeSince(event.eventTime)}</StyledTime>
         </StyledEventHeader>
         <Spacer height={8} />
-        <StyledQuote>{unescape(event.newCollectorsNote ?? '')}</StyledQuote>
+        <StyledQuote>
+          <Markdown text={unescape(event.newCollectorsNote ?? '')} inheritLinkStyling />
+        </StyledQuote>
         <Spacer height={16} />
         <FeedEventTokenPreviews tokensToPreview={tokensToPreview} />
         {showAdditionalPiecesIndicator && (

--- a/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
@@ -16,6 +16,7 @@ import unescape from 'utils/unescape';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import HoverCardOnUsername from 'components/HoverCard/HoverCardOnUsername';
 import { CollectorsNoteAddedToTokenFeedEventQueryFragment$key } from '__generated__/CollectorsNoteAddedToTokenFeedEventQueryFragment.graphql';
+import Markdown from 'components/core/Markdown/Markdown';
 
 type Props = {
   eventRef: CollectorsNoteAddedToTokenFeedEventFragment$key;
@@ -114,7 +115,9 @@ export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef, queryRef
           </StyledMediaWrapper>
           <Spacer width={MIDDLE_GAP} />
           <StyledNoteWrapper>
-            <StyledNote>{unescape(event.newCollectorsNote ?? '')}</StyledNote>
+            <StyledNote>
+              <Markdown text={unescape(event.newCollectorsNote ?? '')} inheritLinkStyling={true} />
+            </StyledNote>
           </StyledNoteWrapper>
         </StyledContent>
       </StyledEvent>

--- a/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
@@ -116,7 +116,7 @@ export default function CollectorsNoteAddedToTokenFeedEvent({ eventRef, queryRef
           <Spacer width={MIDDLE_GAP} />
           <StyledNoteWrapper>
             <StyledNote>
-              <Markdown text={unescape(event.newCollectorsNote ?? '')} inheritLinkStyling={true} />
+              <Markdown text={unescape(event.newCollectorsNote ?? '')} inheritLinkStyling />
             </StyledNote>
           </StyledNoteWrapper>
         </StyledContent>

--- a/src/components/core/InteractiveLink/InteractiveLink.tsx
+++ b/src/components/core/InteractiveLink/InteractiveLink.tsx
@@ -123,7 +123,7 @@ export function InteractiveLinkNeedsVerification({
       showModal({
         content: <NavigateConfirmation href={href} />,
         isFullPage: false,
-        headerText: 'Are you sure?',
+        headerText: 'Leaving gallery.so?',
       });
     },
     [showModal, track]

--- a/src/components/core/InteractiveLink/InteractiveLink.tsx
+++ b/src/components/core/InteractiveLink/InteractiveLink.tsx
@@ -16,6 +16,7 @@ type InteractiveLinkProps = {
   className?: string;
   disabled?: boolean;
   onClick?: (event?: React.MouseEvent<HTMLElement>) => void;
+  // allows the parent to override default link styles
   inheritLinkStyling?: boolean;
 };
 
@@ -36,6 +37,7 @@ export default function InteractiveLink({
 
       track('Link Click', {
         to: to || href,
+        needsVerification: false,
       });
 
       if (onClick) {
@@ -96,18 +98,23 @@ export default function InteractiveLink({
 }
 
 export function InteractiveLinkNeedsVerification({
-  inheritLinkStyling,
+  inheritLinkStyling = false,
   href,
   children,
 }: {
-  inheritLinkStyling: boolean;
+  inheritLinkStyling?: boolean;
   href: string;
   children: ReactNode;
 }) {
   const { showModal } = useModalActions();
+  const track = useTrack();
+
   const handleClick = useCallback(
     (href) => {
-      // track('What to track here?');
+      track('Link Click', {
+        to: href,
+        needsVerification: true,
+      });
 
       // FIXME: This conflicts with viewing the NFT preview page, because that is a modal.
       // So running `showModal` will close that preview modal, and then open the verify navigation modal.
@@ -117,7 +124,7 @@ export function InteractiveLinkNeedsVerification({
         headerText: `Are you sure you want to navigate to ${href}?`,
       });
     },
-    [showModal]
+    [showModal, track]
   );
   return (
     <InteractiveLink

--- a/src/components/core/InteractiveLink/InteractiveLink.tsx
+++ b/src/components/core/InteractiveLink/InteractiveLink.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useCallback } from 'react';
 import Link from 'next/link';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { BODY_FONT_FAMILY } from '../Text/Text';
 import colors from '../colors';
@@ -143,18 +143,12 @@ export const StyledAnchor = styled.a<{ disabled?: boolean; inheritStyles?: boole
   color: ${({ disabled }) => (disabled ? colors.porcelain : colors.shadow)};
   transition: color ${transitions.cubic};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  // font-family: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : BODY_FONT_FAMILY)};
+  // font-size: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : '14px')};
+  // line-height: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : '18px')};
 
   &:hover {
     text-decoration: none;
     color: ${colors.offBlack};
   }
-
-  ${({ inheritStyles }) =>
-    inheritStyles
-      ? ''
-      : css`
-          font-family: ${BODY_FONT_FAMILY};
-          font-size: 14px;
-          line-height: 18px;
-        `}
 `;

--- a/src/components/core/InteractiveLink/InteractiveLink.tsx
+++ b/src/components/core/InteractiveLink/InteractiveLink.tsx
@@ -29,7 +29,6 @@ export default function InteractiveLink({
   onClick,
   inheritLinkStyling = false,
 }: InteractiveLinkProps) {
-  console.log('inherit: ', to, inheritLinkStyling);
   const track = useTrack();
 
   const handleClick = useCallback(
@@ -154,17 +153,3 @@ export const StyledAnchor = styled.a<{ disabled?: boolean; inheritStyles?: boole
     color: ${colors.offBlack};
   }
 `;
-
-// export const StyledAnchor = styled.a<{ disabled?: boolean }>`
-//   color: ${({ disabled }) => (disabled ? colors.porcelain : colors.shadow)};
-//   text-decoration: underline;
-//   font-family: ${BODY_FONT_FAMILY};
-//   font-size: 14px;
-//   line-height: 18px;
-//   transition: color ${transitions.cubic};
-//   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-//   &:hover {
-//     text-decoration: none;
-//     color: ${colors.offBlack};
-//   }
-// `;

--- a/src/components/core/InteractiveLink/InteractiveLink.tsx
+++ b/src/components/core/InteractiveLink/InteractiveLink.tsx
@@ -29,6 +29,7 @@ export default function InteractiveLink({
   onClick,
   inheritLinkStyling = false,
 }: InteractiveLinkProps) {
+  console.log('inherit: ', to, inheritLinkStyling);
   const track = useTrack();
 
   const handleClick = useCallback(
@@ -141,16 +142,29 @@ export function InteractiveLinkNeedsVerification({
 }
 
 export const StyledAnchor = styled.a<{ disabled?: boolean; inheritStyles?: boolean }>`
-  text-decoration: underline;
   color: ${({ disabled }) => (disabled ? colors.porcelain : colors.shadow)};
-  transition: color ${transitions.cubic};
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  text-decoration: underline;
   font-family: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : BODY_FONT_FAMILY)};
   font-size: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : '14px')};
   line-height: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : '18px')};
-
+  transition: color ${transitions.cubic};
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   &:hover {
     text-decoration: none;
     color: ${colors.offBlack};
   }
 `;
+
+// export const StyledAnchor = styled.a<{ disabled?: boolean }>`
+//   color: ${({ disabled }) => (disabled ? colors.porcelain : colors.shadow)};
+//   text-decoration: underline;
+//   font-family: ${BODY_FONT_FAMILY};
+//   font-size: 14px;
+//   line-height: 18px;
+//   transition: color ${transitions.cubic};
+//   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+//   &:hover {
+//     text-decoration: none;
+//     color: ${colors.offBlack};
+//   }
+// `;

--- a/src/components/core/InteractiveLink/InteractiveLink.tsx
+++ b/src/components/core/InteractiveLink/InteractiveLink.tsx
@@ -110,7 +110,9 @@ export function InteractiveLinkNeedsVerification({
   const track = useTrack();
 
   const handleClick = useCallback(
-    (href) => {
+    (e, href) => {
+      e.preventDefault();
+
       track('Link Click', {
         to: href,
         needsVerification: true,
@@ -129,8 +131,8 @@ export function InteractiveLinkNeedsVerification({
   return (
     <InteractiveLink
       inheritLinkStyling={inheritLinkStyling}
-      onClick={() => {
-        handleClick(href);
+      onClick={(e) => {
+        handleClick(e, href);
       }}
     >
       {children}

--- a/src/components/core/InteractiveLink/InteractiveLink.tsx
+++ b/src/components/core/InteractiveLink/InteractiveLink.tsx
@@ -145,9 +145,9 @@ export const StyledAnchor = styled.a<{ disabled?: boolean; inheritStyles?: boole
   color: ${({ disabled }) => (disabled ? colors.porcelain : colors.shadow)};
   transition: color ${transitions.cubic};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  // font-family: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : BODY_FONT_FAMILY)};
-  // font-size: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : '14px')};
-  // line-height: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : '18px')};
+  font-family: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : BODY_FONT_FAMILY)};
+  font-size: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : '14px')};
+  line-height: ${({ inheritStyles }) => (inheritStyles ? 'inherit' : '18px')};
 
   &:hover {
     text-decoration: none;

--- a/src/components/core/InteractiveLink/InteractiveLink.tsx
+++ b/src/components/core/InteractiveLink/InteractiveLink.tsx
@@ -123,7 +123,7 @@ export function InteractiveLinkNeedsVerification({
       showModal({
         content: <NavigateConfirmation href={href} />,
         isFullPage: false,
-        headerText: `Are you sure you want to navigate to ${href}?`,
+        headerText: 'Are you sure?',
       });
     },
     [showModal, track]

--- a/src/components/core/InteractiveLink/NavigateConfirmation.tsx
+++ b/src/components/core/InteractiveLink/NavigateConfirmation.tsx
@@ -1,0 +1,46 @@
+import { useModalActions } from 'contexts/modal/ModalContext';
+import styled from 'styled-components';
+import { Button } from 'components/core/Button/Button';
+import colors from 'components/core/colors';
+import Spacer from 'components/core/Spacer/Spacer';
+
+export default function VerifyNavigationPopover({ href }: { href: string }) {
+  const { hideModal } = useModalActions();
+
+  return (
+    <StyledConfirmation>
+      <Spacer height={16} />
+      <ButtonContainer>
+        <StyledCancelButton onClick={hideModal}>Cancel</StyledCancelButton>
+        <StyledButton
+          onClick={() => {
+            window.open(href);
+            hideModal();
+          }}
+        >
+          Navigate
+        </StyledButton>
+      </ButtonContainer>
+    </StyledConfirmation>
+  );
+}
+
+const StyledConfirmation = styled.div`
+  width: 400px;
+`;
+
+const StyledButton = styled(Button)`
+  width: 80px;
+`;
+
+const StyledCancelButton = styled(Button).attrs({ variant: 'secondary' })`
+  border: none;
+  width: 80px;
+  margin-right: 8px;
+  color: ${colors.metal};
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;

--- a/src/components/core/InteractiveLink/NavigateConfirmation.tsx
+++ b/src/components/core/InteractiveLink/NavigateConfirmation.tsx
@@ -12,14 +12,14 @@ export default function VerifyNavigationPopover({ href }: { href: string }) {
       <Spacer height={16} />
       <ButtonContainer>
         <StyledCancelButton onClick={hideModal}>Cancel</StyledCancelButton>
-        <StyledButton
+        <Button
           onClick={() => {
             window.open(href);
             hideModal();
           }}
         >
           Navigate
-        </StyledButton>
+        </Button>
       </ButtonContainer>
     </StyledConfirmation>
   );
@@ -27,10 +27,6 @@ export default function VerifyNavigationPopover({ href }: { href: string }) {
 
 const StyledConfirmation = styled.div`
   width: 400px;
-`;
-
-const StyledButton = styled(Button)`
-  width: 80px;
 `;
 
 const StyledCancelButton = styled(Button).attrs({ variant: 'secondary' })`

--- a/src/components/core/InteractiveLink/NavigateConfirmation.tsx
+++ b/src/components/core/InteractiveLink/NavigateConfirmation.tsx
@@ -3,12 +3,18 @@ import styled from 'styled-components';
 import { Button } from 'components/core/Button/Button';
 import colors from 'components/core/colors';
 import Spacer from 'components/core/Spacer/Spacer';
+import { BaseM } from '../Text/Text';
 
 export default function VerifyNavigationPopover({ href }: { href: string }) {
   const { hideModal } = useModalActions();
 
   return (
     <StyledConfirmation>
+      <TextContainer>
+        <StyledBaseM>
+          Confirm that you are navigating to: <b>{href}</b>
+        </StyledBaseM>
+      </TextContainer>
       <Spacer height={16} />
       <ButtonContainer>
         <StyledCancelButton onClick={hideModal}>Cancel</StyledCancelButton>
@@ -27,6 +33,14 @@ export default function VerifyNavigationPopover({ href }: { href: string }) {
 
 const StyledConfirmation = styled.div`
   width: 400px;
+`;
+
+const TextContainer = styled.div`
+  display: block;
+`;
+
+const StyledBaseM = styled(BaseM)`
+  word-break: break-all;
 `;
 
 const StyledCancelButton = styled(Button).attrs({ variant: 'secondary' })`

--- a/src/components/core/Markdown/Markdown.tsx
+++ b/src/components/core/Markdown/Markdown.tsx
@@ -1,4 +1,3 @@
-// import { useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import styled from 'styled-components';
 import InteractiveLink, {

--- a/src/components/core/Markdown/Markdown.tsx
+++ b/src/components/core/Markdown/Markdown.tsx
@@ -69,7 +69,6 @@ function BaseMarkdown({
         h3: ({ children }) => <StyledBodyHeading>{children}</StyledBodyHeading>,
         ul: ({ children }) => <StyledUl>{children}</StyledUl>,
         p: ({ children }) => <StyledP>{children}</StyledP>,
-        // strong: ({ children }) => <StyledStrong>{children}</StyledStrong>, // DELETE ME
       }}
       allowedElements={allowedElements}
       unwrapDisallowed
@@ -96,9 +95,3 @@ const StyledP = styled.p`
     padding-bottom: 0px;
   }
 `;
-
-// DELETE ME
-// const StyledStrong = styled.strong`
-//   font-style: inherit !important;
-//   font-weight: 400 !important;
-// `;

--- a/src/components/core/Markdown/Markdown.tsx
+++ b/src/components/core/Markdown/Markdown.tsx
@@ -1,10 +1,14 @@
+// import { useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import styled from 'styled-components';
-import InteractiveLink from '../InteractiveLink/InteractiveLink';
+import InteractiveLink, {
+  InteractiveLinkNeedsVerification,
+} from '../InteractiveLink/InteractiveLink';
 import { BaseXL } from '../Text/Text';
 
 type PublicProps = {
   text: string;
+  inheritLinkStyling?: boolean;
   CustomInternalLinkComponent?: React.FunctionComponent<{ href: string }>;
 };
 
@@ -27,7 +31,12 @@ type BaseProps = {
   allowedElements: string[];
 } & PublicProps;
 
-function BaseMarkdown({ text, CustomInternalLinkComponent, allowedElements }: BaseProps) {
+function BaseMarkdown({
+  text,
+  CustomInternalLinkComponent,
+  allowedElements,
+  inheritLinkStyling = false,
+}: BaseProps) {
   return (
     <ReactMarkdown
       components={{
@@ -40,9 +49,17 @@ function BaseMarkdown({ text, CustomInternalLinkComponent, allowedElements }: Ba
               );
             }
             if (isInternalLink) {
-              return <InteractiveLink to={href}>{children}</InteractiveLink>;
+              return (
+                <InteractiveLink inheritLinkStyling={inheritLinkStyling} to={href}>
+                  {children}
+                </InteractiveLink>
+              );
             }
-            return <InteractiveLink href={href}>{children}</InteractiveLink>;
+            return (
+              <InteractiveLinkNeedsVerification inheritLinkStyling={inheritLinkStyling} href={href}>
+                {children}
+              </InteractiveLinkNeedsVerification>
+            );
           }
           // if href is blank, we must render the empty string this way;
           // simply rendering `children` causes the markdown library to crash
@@ -52,6 +69,7 @@ function BaseMarkdown({ text, CustomInternalLinkComponent, allowedElements }: Ba
         h3: ({ children }) => <StyledBodyHeading>{children}</StyledBodyHeading>,
         ul: ({ children }) => <StyledUl>{children}</StyledUl>,
         p: ({ children }) => <StyledP>{children}</StyledP>,
+        // strong: ({ children }) => <StyledStrong>{children}</StyledStrong>, // DELETE ME
       }}
       allowedElements={allowedElements}
       unwrapDisallowed
@@ -78,3 +96,9 @@ const StyledP = styled.p`
     padding-bottom: 0px;
   }
 `;
+
+// DELETE ME
+// const StyledStrong = styled.strong`
+//   font-style: inherit !important;
+//   font-weight: 400 !important;
+// `;


### PR DESCRIPTION
This PR creates two changes to support popover components to verify navigation when a user clicks on an external link

### 1. Markdown is now supported in feed

The content passed into our `StyledNote` is now passed into our `Markdown` component ([see change](
https://github.com/gallery-so/gallery/pull/923/files#diff-cd0356a1bacbd0b4c7256769d68afa4638e61c1836aa9e9d0a30d9ac50b192a8R118-R120)]. Associated with this change is a new prop called `inheritLinkStyling`, which essentially tells the `Markdown` component to skip its usual styling of links, and instead inherit styles of the parent text. In our case, we wanted to do this so that the links rendered in Markdown would inherit the same size, font family, etc. as the note (which was an H3 title).

By passing this prop into the `InteractiveLink` components, we are able to bypass the traditional link styling provided in `InteractiveLink` and maintain important styles like font size and family.

In action, markdown looks like this in feed:

![image](https://user-images.githubusercontent.com/13339581/182512126-fe6577bb-02a3-4dd3-8efe-33232172e61c.png)

Bolded text will unitalicize. This is thanks to [this style](https://github.com/gallery-so/gallery/blob/main/src/components/core/Text/Text.tsx#L45-L58). (We can undo this if you want)

![image](https://user-images.githubusercontent.com/13339581/182512182-33e4bd22-6a13-4b41-b7b3-d6cdbd41ad93.png)

We are able to adjust any appearance (e.g. remove the underline) of the rendered links thanks to `inheritLinkStyling`. (We might want to rename that prop if we do make more significant changes)

Here is how all markdown-rendered content looks: 

![image](https://user-images.githubusercontent.com/13339581/182512745-8c10a65f-8712-477a-8313-5c4362070885.png)

Let me know if we want to change any default appearances. Might loop in Jess for this?

### 2. Clicking on an external link will open a modal to confirm navigation intent

https://user-images.githubusercontent.com/13339581/182513456-6879f653-ec39-4b7b-92ab-3c9c52414592.mov

Behind the scenes, we pass any external link to a new component called [`InteractiveLinkNeedsVerification`](https://github.com/gallery-so/gallery/compare/connor/link-popover?expand=1#diff-77cb0c31415e5e596238569d18218d01333b8193fa2c695dfa2ffcef4016c3f9R98-R132) which essentially just passes shows a new modal—[`NavigateConfirmation`](https://github.com/gallery-so/gallery/pull/923/files#diff-702dc5388a1a3df93cef4bed5c1ec6407ad5f2fef3632dde3630cdce74e9007a)—to show `onClick`.

#### Known bug

Clicking on an external link when looking at an NFT preview from feed will close the feed before opening the modal, I assume because the preview itself is considered a fullscreen modal. [Noted here.](https://github.com/gallery-so/gallery/pull/923/files#diff-77cb0c31415e5e596238569d18218d01333b8193fa2c695dfa2ffcef4016c3f9R112-R121)

https://user-images.githubusercontent.com/13339581/182514030-59807ea4-421b-4a2b-8c56-a14c5676c07f.mov
