### PR TITLE
Ensure final row of NFTs are displayed in sidebar

### DIFF
--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
@@ -153,15 +153,19 @@ const SidebarTokens = ({ nftFragmentsKeyedByID, tokens }: SidebarTokensProps) =>
 
     let row: TokenOrWhitespace[] = ['whitespace'];
 
-    displayedTokens.forEach((token) => {
+    displayedTokens.forEach((token, index) => {
       row.push(token);
 
       // if the row is full, push it to the rows array
       if (row.length % COLUMN_COUNT === 0) {
         rows.push(row);
         row = [];
+        // make sure the final row gets pushed in even if it isn't full
+      } else if (row.length && index === displayedTokens.length - 1) {
+        rows.push(row);
       }
     });
+
     return rows;
   }, [displayedTokens]);
 


### PR DESCRIPTION
Only full rows were being pushed into the set of rows to display, and the last row was being ignored if it wasn't full.

**Before** – only 2 zorbs appearing in sidebar
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/12162433/182461299-6b5cfb38-73f9-4402-a8d1-3c1e1b531e3f.png">


**After** – all zorbs listed
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/12162433/182461228-a30ef21e-326d-413b-a997-96fa67c899af.png">
