### PR TITLE
Virtualize main gallery

### DIFF
--- a/src/hooks/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+
+export default function useResizeObserver(ref: React.RefObject<HTMLElement>) {
+  const [dimensions, setDimensions] = useState({
+    width: 0,
+    height: 0,
+  });
+
+  useEffect(() => {
+    const observeTarget = ref.current;
+
+    if (!observeTarget) {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      setDimensions({ width, height });
+    });
+    observer.observe(observeTarget);
+
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return dimensions;
+}

--- a/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -28,10 +28,17 @@ type Props = {
   queryRef: UserGalleryCollectionQueryFragment$key;
   collectionRef: UserGalleryCollectionFragment$key;
   mobileLayout: DisplayLayout;
+  cacheHeight: number;
   onLoad: () => void;
 };
 
-function UserGalleryCollection({ queryRef, collectionRef, mobileLayout, onLoad }: Props) {
+function UserGalleryCollection({
+  queryRef,
+  collectionRef,
+  mobileLayout,
+  onLoad,
+  cacheHeight,
+}: Props) {
   const query = useFragment(
     graphql`
       fragment UserGalleryCollectionQueryFragment on Query {
@@ -83,8 +90,11 @@ function UserGalleryCollection({ queryRef, collectionRef, mobileLayout, onLoad }
   const { height: collectionElHeight } = useResizeObserver(componentRef);
 
   useEffect(() => {
-    onLoad();
-  }, [collectionElHeight, onLoad]);
+    // If the latest height is greater than the cache height, then we know that the collection has been expanded.
+    if (collectionElHeight > cacheHeight) {
+      onLoad();
+    }
+  }, [collectionElHeight, onLoad, cacheHeight]);
 
   const handleShareClick = useCallback(() => {
     track('Share Collection', { path: collectionUrl });

--- a/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -22,6 +22,7 @@ import CollectionCreateOrEditForm from 'flows/shared/steps/OrganizeCollection/Co
 import noop from 'utils/noop';
 import { useModalActions } from 'contexts/modal/ModalContext';
 import { UnstyledLink } from 'components/core/Link/UnstyledLink';
+import useResizeObserver from 'hooks/useResizeObserver';
 
 type Props = {
   queryRef: UserGalleryCollectionQueryFragment$key;
@@ -78,15 +79,12 @@ function UserGalleryCollection({ queryRef, collectionRef, mobileLayout, onLoad }
   const track = useTrack();
 
   // Get height of this component
-  const ref = useRef<HTMLDivElement>(null);
-  const elementHeight = useRef<number>(0);
+  const componentRef = useRef<HTMLDivElement>(null);
+  const { height: collectionElHeight } = useResizeObserver(componentRef);
 
   useEffect(() => {
-    if (elementHeight.current > 0) {
-      onLoad();
-    }
-    elementHeight.current = ref.current?.clientHeight ?? 0;
-  }, [ref.current?.clientHeight, onLoad]);
+    onLoad();
+  }, [collectionElHeight, onLoad]);
 
   const handleShareClick = useCallback(() => {
     track('Share Collection', { path: collectionUrl });
@@ -109,13 +107,11 @@ function UserGalleryCollection({ queryRef, collectionRef, mobileLayout, onLoad }
   }, [collection.collectorsNote, collection.dbid, collection.name, galleryId, showModal]);
 
   return (
-    <StyledCollectionWrapper ref={ref}>
+    <StyledCollectionWrapper ref={componentRef}>
       <StyledCollectionHeader>
         <StyledCollectionTitleWrapper>
           <UnstyledLink href={collectionUrl}>
-            <StyledCollectorsTitle>
-              {unescapedCollectionName} {elementHeight.current}
-            </StyledCollectorsTitle>
+            <StyledCollectorsTitle>{unescapedCollectionName}</StyledCollectorsTitle>
           </UnstyledLink>
           <StyledOptionsContainer>
             <StyledCopyToClipboard textToCopy={`${baseUrl}${collectionUrl}`}>

--- a/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -129,30 +129,37 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
   return (
     <StyledUserGalleryCollections>
       <Spacer height={isMobile ? 48 : 80} />
-      <div>
-        <WindowScroller>
-          {({ height, registerChild, scrollTop, onChildScroll }) => (
-            <AutoSizer disableHeight>
-              {({ width }) => (
-                <div ref={registerChild}>
-                  <List
-                    ref={listRef}
-                    autoHeight
-                    width={width}
-                    height={height}
-                    onScroll={onChildScroll}
-                    rowHeight={cache.current.rowHeight}
-                    rowCount={numCollectionsToDisplay}
-                    scrollTop={scrollTop}
-                    deferredMeasurementCache={cache.current}
-                    rowRenderer={rowRenderer}
-                  />
-                </div>
-              )}
-            </AutoSizer>
-          )}
-        </WindowScroller>
-      </div>
+      <WindowScroller>
+        {({ height, registerChild, scrollTop, onChildScroll }) => (
+          <AutoSizer disableHeight>
+            {({ width }) => (
+              <div ref={registerChild}>
+                <List
+                  ref={listRef}
+                  autoHeight
+                  width={width}
+                  height={height}
+                  onScroll={onChildScroll}
+                  rowHeight={cache.current.rowHeight}
+                  rowCount={numCollectionsToDisplay}
+                  scrollTop={scrollTop}
+                  deferredMeasurementCache={cache.current}
+                  rowRenderer={rowRenderer}
+                  overscanIndicesGetter={({
+                    cellCount,
+                    overscanCellsCount,
+                    startIndex,
+                    stopIndex,
+                  }) => ({
+                    overscanStartIndex: Math.max(0, startIndex - overscanCellsCount),
+                    overscanStopIndex: Math.min(cellCount - 1, stopIndex + overscanCellsCount),
+                  })}
+                />
+              </div>
+            )}
+          </AutoSizer>
+        )}
+      </WindowScroller>
     </StyledUserGalleryCollections>
   );
 }

--- a/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -17,6 +17,7 @@ import {
   CellMeasurer,
   CellMeasurerCache,
   List,
+  ListRowProps,
   WindowScroller,
 } from 'react-virtualized';
 
@@ -99,6 +100,34 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
 
   console.log('numCollectionsToDisplay', numCollectionsToDisplay);
 
+  const rowRenderer = ({ index, key, parent, style }: ListRowProps) => {
+    const collection = collectionsToDisplay[index];
+    return (
+      <CellMeasurer
+        cache={cache.current}
+        columnIndex={0}
+        rowIndex={index}
+        key={key}
+        parent={parent}
+      >
+        {({ registerChild, measure }) => {
+          return (
+            // @ts-ignore
+            <div ref={registerChild} key={key} style={style}>
+              <UserGalleryCollection
+                queryRef={query}
+                collectionRef={collection}
+                mobileLayout={mobileLayout}
+                onLoad={measure}
+              />
+              <Spacer height={48} />
+            </div>
+          );
+        }}
+      </CellMeasurer>
+    );
+  };
+
   return (
     <StyledUserGalleryCollections>
       <Spacer height={isMobile ? 48 : 80} />
@@ -118,34 +147,7 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
                     rowCount={numCollectionsToDisplay}
                     scrollTop={scrollTop} // Somehow adding this render all row
                     deferredMeasurementCache={cache.current}
-                    rowRenderer={({ index, key, style, parent }) => {
-                      const collection = collectionsToDisplay[index];
-                      return (
-                        <CellMeasurer
-                          cache={cache.current}
-                          columnIndex={0}
-                          rowIndex={index}
-                          key={key}
-                          parent={parent}
-                        >
-                          {({ registerChild, measure }) => {
-                            return (
-                              // @ts-ignore
-                              <div ref={registerChild} key={key} style={style}>
-                                <p>Index : {index}</p>
-                                <UserGalleryCollection
-                                  queryRef={query}
-                                  collectionRef={collection}
-                                  mobileLayout={mobileLayout}
-                                  onLoad={measure}
-                                />
-                                <Spacer height={48} />
-                              </div>
-                            );
-                          }}
-                        </CellMeasurer>
-                      );
-                    }}
+                    rowRenderer={rowRenderer}
                   />
                 </div>
               )}

--- a/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import Spacer from 'components/core/Spacer/Spacer';
 
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import EmptyGallery from './EmptyGallery';
 import UserGalleryCollection from './UserGalleryCollection';
 import { DisplayLayout } from 'components/core/enums';
@@ -99,18 +99,11 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
 
   console.log('numCollectionsToDisplay', numCollectionsToDisplay);
 
-  const containerRef = useRef<HTMLDivElement>(null);
-  const windowScrollerRef = useRef<WindowScroller>(null);
   return (
     <StyledUserGalleryCollections>
       <Spacer height={isMobile ? 48 : 80} />
-      <div ref={containerRef}>
-        <WindowScroller
-          ref={windowScrollerRef}
-          onScroll={() => {
-            console.log('scrolled');
-          }}
-        >
+      <div>
+        <WindowScroller>
           {({ height, registerChild, scrollTop, onChildScroll }) => (
             <AutoSizer disableHeight>
               {({ width }) => (
@@ -120,7 +113,6 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
                     autoHeight
                     width={width}
                     height={height}
-                    // height={18000} // There is something wrong with the height of the list
                     onScroll={onChildScroll}
                     rowHeight={cache.current.rowHeight}
                     rowCount={numCollectionsToDisplay}
@@ -167,12 +159,6 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
 
 const StyledUserGalleryCollections = styled.div`
   width: 100%;
-`;
-
-const StyledUserGalleryCollectionWrapper = styled.div`
-  background-color: 'red';
-  /* width: 100%;
-  display: contents; */
 `;
 
 export default UserGalleryCollections;

--- a/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -98,8 +98,6 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
     return <EmptyGallery message={emptyGalleryMessage} />;
   }
 
-  console.log('numCollectionsToDisplay', numCollectionsToDisplay);
-
   const rowRenderer = ({ index, key, parent, style }: ListRowProps) => {
     const collection = collectionsToDisplay[index];
     return (
@@ -145,7 +143,7 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
                     onScroll={onChildScroll}
                     rowHeight={cache.current.rowHeight}
                     rowCount={numCollectionsToDisplay}
-                    scrollTop={scrollTop} // Somehow adding this render all row
+                    scrollTop={scrollTop}
                     deferredMeasurementCache={cache.current}
                     rowRenderer={rowRenderer}
                   />

--- a/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import Spacer from 'components/core/Spacer/Spacer';
 
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import EmptyGallery from './EmptyGallery';
 import UserGalleryCollection from './UserGalleryCollection';
 import { DisplayLayout } from 'components/core/enums';
@@ -12,6 +12,13 @@ import { useLoggedInUserId } from 'hooks/useLoggedInUserId';
 import { UserGalleryCollectionsQueryFragment$key } from '__generated__/UserGalleryCollectionsQueryFragment.graphql';
 import { removeNullValues } from 'utils/removeNullValues';
 import { useIsMobileWindowWidth } from 'hooks/useWindowSize';
+import {
+  AutoSizer,
+  CellMeasurer,
+  CellMeasurerCache,
+  List,
+  WindowScroller,
+} from 'react-virtualized';
 
 type Props = {
   galleryRef: UserGalleryCollectionsFragment$key;
@@ -60,6 +67,15 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
   const nonNullCollections = removeNullValues(collections);
   const isMobile = useIsMobileWindowWidth();
 
+  const cache = useRef(
+    new CellMeasurerCache({
+      fixedWidth: true,
+      minHeight: 100,
+    })
+  );
+
+  const listRef = useRef<List>(null);
+
   const collectionsToDisplay = useMemo(
     () =>
       nonNullCollections.filter((collection) => {
@@ -73,40 +89,6 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
 
   const numCollectionsToDisplay = collectionsToDisplay.length;
 
-  /**
-   * Poor man's virtualization.
-   *
-   * The server doesn't have pagination and sends all of a user's collections.
-   * Rather than displaying them all, render them 10 at a time.
-   */
-  const PAGE_SIZE = 10;
-  const [numRenderedCollections, setNumRenderedCollections] = useState(
-    Math.min(numCollectionsToDisplay, PAGE_SIZE)
-  );
-
-  const numRenderedCollectionsRef = useRef(numRenderedCollections);
-
-  useEffect(() => {
-    function handleScrollPosition() {
-      const pixelsFromBottomOfPage =
-        document.body.offsetHeight - window.pageYOffset - window.innerHeight;
-      if (
-        pixelsFromBottomOfPage < 1200 &&
-        numRenderedCollectionsRef.current < numCollectionsToDisplay
-      ) {
-        numRenderedCollectionsRef.current = Math.min(
-          numCollectionsToDisplay,
-          numRenderedCollectionsRef.current + PAGE_SIZE
-        );
-        setNumRenderedCollections((prev) => Math.min(numCollectionsToDisplay, prev + PAGE_SIZE));
-      }
-    }
-
-    window.addEventListener('scroll', handleScrollPosition);
-
-    return () => window.removeEventListener('scroll', handleScrollPosition);
-  }, [numCollectionsToDisplay]);
-
   if (numCollectionsToDisplay === 0) {
     const emptyGalleryMessage = isAuthenticatedUsersPage
       ? 'Your gallery is empty. Display your NFTs by creating a collection.'
@@ -115,25 +97,82 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
     return <EmptyGallery message={emptyGalleryMessage} />;
   }
 
+  console.log('numCollectionsToDisplay', numCollectionsToDisplay);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const windowScrollerRef = useRef<WindowScroller>(null);
   return (
     <StyledUserGalleryCollections>
       <Spacer height={isMobile ? 48 : 80} />
-      {collectionsToDisplay.slice(0, numRenderedCollections).map((collection) => (
-        <Fragment key={collection.id}>
-          <UserGalleryCollection
-            queryRef={query}
-            collectionRef={collection}
-            mobileLayout={mobileLayout}
-          />
-          <Spacer height={48} />
-        </Fragment>
-      ))}
+      <div ref={containerRef}>
+        <WindowScroller
+          ref={windowScrollerRef}
+          onScroll={() => {
+            console.log('scrolled');
+          }}
+        >
+          {({ height, registerChild, scrollTop, onChildScroll }) => (
+            <AutoSizer disableHeight>
+              {({ width }) => (
+                <div ref={registerChild}>
+                  <List
+                    ref={listRef}
+                    autoHeight
+                    width={width}
+                    height={height}
+                    // height={18000} // There is something wrong with the height of the list
+                    onScroll={onChildScroll}
+                    rowHeight={cache.current.rowHeight}
+                    rowCount={numCollectionsToDisplay}
+                    scrollTop={scrollTop} // Somehow adding this render all row
+                    deferredMeasurementCache={cache.current}
+                    rowRenderer={({ index, key, style, parent }) => {
+                      const collection = collectionsToDisplay[index];
+                      return (
+                        <CellMeasurer
+                          cache={cache.current}
+                          columnIndex={0}
+                          rowIndex={index}
+                          key={key}
+                          parent={parent}
+                        >
+                          {({ registerChild, measure }) => {
+                            return (
+                              // @ts-ignore
+                              <div ref={registerChild} key={key} style={style}>
+                                <p>Index : {index}</p>
+                                <UserGalleryCollection
+                                  queryRef={query}
+                                  collectionRef={collection}
+                                  mobileLayout={mobileLayout}
+                                  onLoad={measure}
+                                />
+                                <Spacer height={48} />
+                              </div>
+                            );
+                          }}
+                        </CellMeasurer>
+                      );
+                    }}
+                  />
+                </div>
+              )}
+            </AutoSizer>
+          )}
+        </WindowScroller>
+      </div>
     </StyledUserGalleryCollections>
   );
 }
 
 const StyledUserGalleryCollections = styled.div`
   width: 100%;
+`;
+
+const StyledUserGalleryCollectionWrapper = styled.div`
+  background-color: 'red';
+  /* width: 100%;
+  display: contents; */
 `;
 
 export default UserGalleryCollections;

--- a/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import Spacer from 'components/core/Spacer/Spacer';
 
-import { useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import EmptyGallery from './EmptyGallery';
 import UserGalleryCollection from './UserGalleryCollection';
 import { DisplayLayout } from 'components/core/enums';
@@ -88,6 +88,38 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
     [nonNullCollections]
   );
 
+  const rowRenderer = useCallback(
+    ({ index, key, parent, style }: ListRowProps) => {
+      const collection = collectionsToDisplay[index];
+      return (
+        <CellMeasurer
+          cache={cache.current}
+          columnIndex={0}
+          rowIndex={index}
+          key={key}
+          parent={parent}
+        >
+          {({ registerChild, measure }) => {
+            return (
+              // @ts-ignore
+              <div ref={registerChild} key={key} style={style}>
+                <UserGalleryCollection
+                  queryRef={query}
+                  collectionRef={collection}
+                  mobileLayout={mobileLayout}
+                  cacheHeight={cache.current.getHeight(index, 0)}
+                  onLoad={measure}
+                />
+                <Spacer height={48} />
+              </div>
+            );
+          }}
+        </CellMeasurer>
+      );
+    },
+    [collectionsToDisplay, mobileLayout, query]
+  );
+
   const numCollectionsToDisplay = collectionsToDisplay.length;
 
   if (numCollectionsToDisplay === 0) {
@@ -97,35 +129,6 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
 
     return <EmptyGallery message={emptyGalleryMessage} />;
   }
-
-  const rowRenderer = ({ index, key, parent, style }: ListRowProps) => {
-    const collection = collectionsToDisplay[index];
-    return (
-      <CellMeasurer
-        cache={cache.current}
-        columnIndex={0}
-        rowIndex={index}
-        key={key}
-        parent={parent}
-      >
-        {({ registerChild, measure }) => {
-          return (
-            // @ts-ignore
-            <div ref={registerChild} key={key} style={style}>
-              <UserGalleryCollection
-                queryRef={query}
-                collectionRef={collection}
-                mobileLayout={mobileLayout}
-                cacheHeight={cache.current.getHeight(index, 0)}
-                onLoad={measure}
-              />
-              <Spacer height={48} />
-            </div>
-          );
-        }}
-      </CellMeasurer>
-    );
-  };
 
   return (
     <StyledUserGalleryCollections>

--- a/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -116,6 +116,7 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
                 queryRef={query}
                 collectionRef={collection}
                 mobileLayout={mobileLayout}
+                cacheHeight={cache.current.getHeight(index, 0)}
                 onLoad={measure}
               />
               <Spacer height={48} />


### PR DESCRIPTION
**Changes**

1. Added react virtualized to the main gallery page
2. Removed the slicing collection array + scroll event
3. Added new hooks to monitor element size - [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)


**How it works**

We consider one collection as one row in the virtualized list

![CleanShot 2022-08-04 at 16 29 32](https://user-images.githubusercontent.com/4480258/182801561-88ee0d80-6401-4040-bea4-976b415de89a.png)



**Notes on how the height calculation works**

1. Seems like the way react virtualized work is its calculate the sizing before rendering it in the DOM. In this case it only get the height of the `collection name` and `collection description`. 

![CleanShot 2022-08-04 at 16 33 39](https://user-images.githubusercontent.com/4480258/182802133-77f9d0d0-338e-4162-993c-e36c1a13c728.png)


2. To get the exact sizing of the collection, we may need to wait for the NFT to load (especially for live render). 
3. I've added a callback function in the `UserGalleryCollection` components,  it will trigger whenever the height of the row was changed.
4. If changes, we asked the react virtualize to update the row height in their cache - [Reference](https://github.com/bvaughn/react-virtualized/blob/master/docs/CellMeasurer.md#using-cellmeasurer-with-images)


**Demo**
https://user-images.githubusercontent.com/4480258/182798811-1fa9717f-9ba7-4193-be0b-3a76205df219.mp4
