### PR TITLE
[GAL-139] Debug Authenticator

### DIFF
--- a/src/components/Debugger/Debugger.tsx
+++ b/src/components/Debugger/Debugger.tsx
@@ -1,0 +1,154 @@
+import { Button } from 'components/core/Button/Button';
+import Input from 'components/core/Input/Input';
+import Spacer from 'components/core/Spacer/Spacer';
+import ErrorText from 'components/core/Text/ErrorText';
+import { TitleS } from 'components/core/Text/Text';
+import { DEBUG_USERNAME_KEY } from 'constants/storageKeys';
+import { useAuthActions } from 'contexts/auth/AuthContext';
+import useKeyDown from 'hooks/useKeyDown';
+import useMultiKeyDown from 'hooks/useMultiKeyDown';
+import usePersistedState from 'hooks/usePersistedState';
+import { useState, useCallback, useMemo } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import styled from 'styled-components';
+import { DebuggerQuery } from '__generated__/DebuggerQuery.graphql';
+import { useDebugAuthLogin } from './useDebugAuth';
+
+const Debugger = () => {
+  const query = useLazyLoadQuery<DebuggerQuery>(
+    graphql`
+      query DebuggerQuery {
+        viewer {
+          ... on Viewer {
+            user {
+              dbid
+              username
+              wallets {
+                dbid
+                chainAddress {
+                  chain
+                  address
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    {}
+  );
+
+  const loggedInUserInfo = useMemo(
+    () =>
+      JSON.stringify(
+        {
+          dbid: query.viewer?.user?.dbid ?? '',
+          username: query.viewer?.user?.username ?? '',
+          wallets: query.viewer?.user?.wallets ?? [],
+        },
+        undefined,
+        2
+      ),
+    [query]
+  );
+
+  const [username, setUsername] = usePersistedState(DEBUG_USERNAME_KEY, '');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isDebuggerVisible, setIsDebuggerVisible] = useState(false);
+
+  const handleCloseDebugger = useCallback(() => {
+    setIsDebuggerVisible(false);
+  }, []);
+
+  const handleToggleDebugger = useCallback(() => {
+    setIsDebuggerVisible((prev) => !prev);
+  }, []);
+
+  useKeyDown('Escape', handleCloseDebugger);
+  useMultiKeyDown(['Control', 'd'], handleToggleDebugger);
+
+  const login = useDebugAuthLogin();
+  const { handleLogin: handleRegisterLogin } = useAuthActions();
+
+  const handleLogin = useCallback(async () => {
+    try {
+      const userId = await login({ asUsername: username });
+      await handleRegisterLogin(userId, '');
+      setErrorMessage('');
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setErrorMessage(e.message);
+      }
+    }
+  }, [handleRegisterLogin, login, username]);
+
+  const handleUsernameChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setUsername(event.target.value);
+      setErrorMessage('');
+    },
+    [setUsername]
+  );
+
+  return isDebuggerVisible ? (
+    <StyledDebugger>
+      <TitleS>☢️ DEBUG MODE</TitleS>
+      <Spacer height={24} />
+      <LoginContainer>
+        <TitleS>Login As</TitleS>
+        <Spacer height={4} />
+        <LoginFormContainer>
+          <Input onChange={handleUsernameChange} placeholder="Username" defaultValue={username} />
+          <Spacer width={8} />
+          <StyledButton onClick={handleLogin} disabled={!username.length}>
+            Submit
+          </StyledButton>
+        </LoginFormContainer>
+        <Spacer height={4} />
+        <ErrorText message={errorMessage} />
+      </LoginContainer>
+      <Spacer height={16} />
+      <LoggedInUserContainer>
+        <TitleS>Detected User</TitleS>
+        <StyledPre>{loggedInUserInfo}</StyledPre>
+      </LoggedInUserContainer>
+    </StyledDebugger>
+  ) : null;
+};
+
+const StyledDebugger = styled.div`
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  padding: 24px;
+  width: 420px;
+
+  z-index: 2;
+  border: 1px solid black;
+  background: white;
+`;
+
+const LoginContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  input {
+    width: 100%;
+  }
+`;
+
+const LoginFormContainer = styled.div`
+  display: flex;
+`;
+
+const StyledButton = styled(Button)`
+  align-self: right;
+`;
+
+const LoggedInUserContainer = styled.div``;
+
+const StyledPre = styled.pre`
+  white-space: pre-wrap;
+`;
+
+export default Debugger;

--- a/src/components/Debugger/useDebugAuth.ts
+++ b/src/components/Debugger/useDebugAuth.ts
@@ -1,0 +1,69 @@
+import { usePromisifiedMutation } from 'hooks/usePromisifiedMutation';
+import { useCallback } from 'react';
+import { graphql } from 'relay-runtime';
+import {
+  DebugAuth,
+  useDebugAuthLoginMutation,
+} from '__generated__/useDebugAuthLoginMutation.graphql';
+
+export function useDebugAuthLogin() {
+  const [login] = usePromisifiedMutation<useDebugAuthLoginMutation>(
+    graphql`
+      mutation useDebugAuthLoginMutation($mechanism: AuthMechanism!) {
+        login(authMechanism: $mechanism) {
+          __typename
+
+          ... on LoginPayload {
+            userId @required(action: THROW)
+          }
+          ... on ErrUserNotFound {
+            message
+          }
+          ... on ErrAuthenticationFailed {
+            message
+          }
+          ... on ErrDoesNotOwnRequiredToken {
+            message
+          }
+        }
+      }
+    `
+  );
+
+  return useCallback(
+    async ({ asUsername, userId, chainAddresses }: DebugAuth) => {
+      const { login: result } = await login({
+        variables: {
+          mechanism: {
+            debug: {
+              asUsername,
+              userId,
+              chainAddresses,
+            },
+          },
+        },
+      });
+
+      if (!result) {
+        throw new Error('login failed to execute; check the network tab for more info.');
+      }
+
+      if (result.__typename === 'LoginPayload') {
+        return result.userId;
+      }
+
+      if (result && 'message' in result) {
+        throw new Error(result.message);
+      }
+
+      return '';
+    },
+    [login]
+  );
+}
+
+// TODO: implement
+export function useDebugAuthCreateUser() {}
+
+// TODO: implement
+export function useDebugAuthAddWallet() {}

--- a/src/components/Profile/UserInfoForm.tsx
+++ b/src/components/Profile/UserInfoForm.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import unescape from 'utils/unescape';
 
 import { TitleS } from 'components/core/Text/Text';
-import BigInput from 'components/core/BigInput/BigInput';
+import Input from 'components/core/Input/Input';
 import { TextAreaWithCharCount } from 'components/core/TextArea/TextArea';
 import Spacer from 'components/core/Spacer/Spacer';
 import { MODAL_PADDING_PX } from 'contexts/modal/constants';
@@ -75,12 +75,13 @@ function UserInfoForm({
     <StyledForm className={className} onSubmit={handleSubmit}>
       {mode === 'Add' ? <StyledTitleS>Add username and bio</StyledTitleS> : null}
       <Spacer height={16} />
-      <BigInput
+      <Input
         onChange={handleUsernameChange}
         placeholder="Username"
         defaultValue={username}
         errorMessage={usernameError}
         autoFocus={shouldAutofocusUsername}
+        variant="grande"
       />
       <Spacer height={16} />
       <StyledTextAreaWithCharCount

--- a/src/components/core/Input/Input.tsx
+++ b/src/components/core/Input/Input.tsx
@@ -11,14 +11,16 @@ type Props = {
   defaultValue?: string;
   autoFocus?: boolean;
   errorMessage?: string;
+  variant?: 'grande' | 'medium';
 };
 
-function BigInput({
+function Input({
   onChange = noop,
   placeholder,
   defaultValue,
   autoFocus = false,
   errorMessage,
+  variant = 'medium',
 }: Props) {
   return (
     <>
@@ -32,6 +34,7 @@ function BigInput({
         autoCorrect="off"
         autoCapitalize="off"
         spellCheck="false"
+        variant={variant}
       />
       {errorMessage && (
         <>
@@ -43,13 +46,13 @@ function BigInput({
   );
 }
 
-const StyledBigInput = styled.input`
-  padding: 12px;
-  border: 0;
-  font-size: 32px;
+const StyledBigInput = styled.input<{ variant: Props['variant'] }>`
   font-family: GT Alpina, serif;
-  line-height: 36px;
+  padding: ${({ variant }) => (variant === 'grande' ? 12 : 8)}px;
+  font-size: ${({ variant }) => (variant === 'grande' ? 32 : 16)}px;
+  line-height: ${({ variant }) => (variant === 'grande' ? 32 : 20)}px;
   letter-spacing: -0.03em;
+  border: 0;
   background: ${colors.faint};
   color: ${colors.offBlack};
 
@@ -58,4 +61,4 @@ const StyledBigInput = styled.input`
   }
 `;
 
-export default BigInput;
+export default Input;

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -4,3 +4,5 @@ export const USER_SIGNIN_ADDRESS_LOCAL_STORAGE_KEY = 'gallery_user_signin_addres
 export const FEED_ANNOUNCEMENT_STORAGE_KEY = 'gallery_feed_announcement_06_29_22';
 export const FEED_MODE_KEY = 'gallery_feed_mode';
 export const THREE_ARROWS_CAPITAL_BANNER_KEY = 'gallery_3ac_banner';
+
+export const DEBUG_USERNAME_KEY = 'debug_username';

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -10,11 +10,15 @@ import { GalleryNavigationProvider } from 'contexts/navigation/GalleryNavigation
 import { RelayProvider } from 'contexts/relay/RelayProvider';
 import { RecordMap } from 'relay-runtime/lib/store/RelayStoreTypes';
 import GlobalLayoutContextProvider from './globalLayout/GlobalLayoutContext';
+import Debugger from 'components/Debugger/Debugger';
+import isProduction from 'utils/isProduction';
 
 type Props = {
   children: React.ReactNode;
   relayCache?: RecordMap;
 };
+
+const isProd = isProduction();
 
 export default function AppProvider({ children, relayCache }: Props) {
   return (
@@ -28,7 +32,10 @@ export default function AppProvider({ children, relayCache }: Props) {
                   <SwrProvider>
                     <GalleryNavigationProvider>
                       <ModalProvider>
-                        <GlobalLayoutContextProvider>{children}</GlobalLayoutContextProvider>
+                        <GlobalLayoutContextProvider>
+                          {isProd ? null : <Debugger />}
+                          {children}
+                        </GlobalLayoutContextProvider>
                       </ModalProvider>
                     </GalleryNavigationProvider>
                   </SwrProvider>

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -72,6 +72,13 @@ const useImperativelyFetchUser = () => {
                 id
                 dbid
                 username
+                wallets {
+                  dbid
+                  chainAddress {
+                    chain
+                    address
+                  }
+                }
               }
             }
             ... on ErrNotAuthorized {

--- a/src/flows/shared/steps/OrganizeCollection/CollectionCreateOrEditForm.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/CollectionCreateOrEditForm.tsx
@@ -3,7 +3,7 @@ import { WizardContext } from 'react-albus';
 import styled from 'styled-components';
 import unescape from 'utils/unescape';
 
-import BigInput from 'components/core/BigInput/BigInput';
+import Input from 'components/core/Input/Input';
 import Spacer from 'components/core/Spacer/Spacer';
 import { Button } from 'components/core/Button/Button';
 import { TextAreaWithCharCount } from 'components/core/TextArea/TextArea';
@@ -154,11 +154,12 @@ function CollectionCreateOrEditForm({
   return (
     <StyledCollectionEditInfoForm>
       <Spacer height={16} />
-      <BigInput
+      <Input
         onChange={handleNameChange}
         defaultValue={unescapedCollectionName}
         placeholder="Collection name"
         autoFocus
+        variant="grande"
       />
       <Spacer height={16} />
       <StyledTextAreaWithCharCount

--- a/src/hooks/useMultiKeyDown.tsx
+++ b/src/hooks/useMultiKeyDown.tsx
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+
+const INITIAL_STATE = new Map();
+
+export default function useMultiKeyDown(targetKeys: string[], callbackFn: () => void) {
+  if (!targetKeys.length) {
+    throw new Error('target keys must be provided');
+  }
+
+  // State for keeping track of whether key is pressed
+  const [keyPressedMap, setKeyPressedMap] = useState<Map<string, boolean>>(INITIAL_STATE);
+
+  const areTargetKeysPressed = useMemo(() => {
+    return targetKeys.reduce((curr, key) => {
+      return Boolean(curr && keyPressedMap.get(key));
+    }, true);
+  }, [keyPressedMap, targetKeys]);
+
+  const handleToggleKeypress = useCallback(
+    (key, status) => {
+      setKeyPressedMap((prev) => {
+        const next = new Map(prev);
+        if (targetKeys.includes(key)) {
+          next.set(key, status);
+        }
+        return next;
+      });
+    },
+    [targetKeys]
+  );
+
+  const handleKeyUp = useCallback(
+    ({ key }: KeyboardEvent) => {
+      handleToggleKeypress(key, false);
+    },
+    [handleToggleKeypress]
+  );
+
+  const handleKeyDown = useCallback(
+    ({ key }: KeyboardEvent) => {
+      handleToggleKeypress(key, true);
+    },
+    [handleToggleKeypress]
+  );
+
+  // Add event listeners
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [handleKeyDown, handleKeyUp]);
+
+  // useEffect ensures that the callback function is called once, which is relevant when navigating
+  useEffect(() => {
+    if (areTargetKeysPressed) {
+      callbackFn();
+
+      // After executing, reset keyPressed to false so that the user can click the same key again on the same page
+      // Only currently relevant if user is on /edit -> escapes -> shows modal -> escapes -> clicks escape again
+      // This also prevents route-based navigation from duplicating
+      setKeyPressedMap(INITIAL_STATE);
+    }
+  }, [areTargetKeysPressed, callbackFn]);
+}


### PR DESCRIPTION
## Overview

Enables "log-in-as-user" for local development. Does not connect to production, and requires a specific version of the backend to be running.

- Toggle debugger with `Ctrl + D`. You can also hit `Escape` to close
- Input values will persist across sessions so that the debugger remains auto-filled

## Other changes
- [x] Key listener to support multiple keys being held down at once (e.g `Ctrl + D`)
- [x] Persist input value across sessions so that debugger remains auto-filled
- [x] Refactored `BigInput` to simply be `Input` that receives variants through props

## Next Up
- Enable further flexibility whenever `AuthMechanism!` is used, allowing us to control Account Creation + Adding Wallet flows.
- Multi-chain (implied by above)
- More informative error messages