### PR TITLE
Apply full width on images displayed in main gallery

### DIFF
--- a/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
+++ b/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
@@ -68,6 +68,7 @@ function FeedEventNftPreviewWrapper({ tokenRef, maxWidth, maxHeight }: Props) {
       onClick={(e) => e.stopPropagation()}
     >
       <NftPreview
+        variant="feed"
         tokenRef={token}
         previewSize={maxWidth}
         onClick={handleClick}

--- a/src/components/LoadingAsset/ImageWithLoading.tsx
+++ b/src/components/LoadingAsset/ImageWithLoading.tsx
@@ -15,14 +15,16 @@ type Props = {
   src: string;
   alt: string;
   heightType?: ContentHeightType;
+  fullWidth?: boolean;
   onClick?: () => void;
 };
 
 export default function ImageWithLoading({
   className,
-  heightType,
   src,
   alt,
+  heightType,
+  fullWidth,
   onClick = noop,
 }: Props) {
   const setContentIsLoaded = useSetContentIsLoaded();
@@ -43,7 +45,7 @@ export default function ImageWithLoading({
     return '100%';
   }, [heightType]);
 
-  const renderFullWidth = isSvg(src) && !isFirefox();
+  const renderFullWidth = fullWidth || (isSvg(src) && !isFirefox());
 
   return (
     <StyledImageWithLoading

--- a/src/components/NftPreview/GalleryNftPreviewWrapper.tsx
+++ b/src/components/NftPreview/GalleryNftPreviewWrapper.tsx
@@ -76,6 +76,7 @@ function GalleryNftPreviewWrapper({ tokenRef, columns }: Props) {
 
   return (
     <NftPreview
+      variant="gallery"
       tokenRef={collectionTokenRef}
       nftPreviewMaxWidth={nftPreviewMaxWidth}
       previewSize={previewSize}

--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -17,6 +17,7 @@ import isSvg from 'utils/isSvg';
 import LinkToNftDetailView from 'scenes/NftDetailPage/LinkToNftDetailView';
 
 type Props = {
+  variant: 'gallery' | 'feed';
   tokenRef: NftPreviewFragment$key;
   nftPreviewMaxWidth?: string;
   previewSize: number;
@@ -28,6 +29,7 @@ type Props = {
 };
 
 function NftPreview({
+  variant,
   tokenRef,
   nftPreviewMaxWidth,
   previewSize,
@@ -114,6 +116,7 @@ function NftPreview({
           tokenRef={token}
           // we'll request images at double the size of the element so that it looks sharp on retina
           size={previewSize * 2}
+          fullWidth={variant === 'gallery'}
         />
       );
     }
@@ -128,9 +131,10 @@ function NftPreview({
         tokenRef={token}
         // we'll request images at double the size of the element so that it looks sharp on retina
         size={previewSize * 2}
+        fullWidth={variant === 'gallery'}
       />
     );
-  }, [disableLiverender, shouldLiverender, token, isIFrameLiveDisplay, previewSize]);
+  }, [disableLiverender, shouldLiverender, token, isIFrameLiveDisplay, previewSize, variant]);
 
   const result = getVideoOrImageUrlForNftPreview(token);
   const isFirefoxSvg = isSvg(result?.urls?.large) && isFirefox();

--- a/src/components/NftPreview/NftPreviewAsset.tsx
+++ b/src/components/NftPreview/NftPreviewAsset.tsx
@@ -32,9 +32,10 @@ function UnrenderedPreviewAsset({ id, assetType }: UnrenderedPreviewAssetProps) 
 type Props = {
   tokenRef: NftPreviewAssetFragment$key;
   size: number;
+  fullWidth: boolean;
 };
 
-function NftPreviewAsset({ tokenRef, size }: Props) {
+function NftPreviewAsset({ tokenRef, size, fullWidth }: Props) {
   const token = useFragment(
     graphql`
       fragment NftPreviewAssetFragment on Token {
@@ -105,7 +106,14 @@ function NftPreviewAsset({ tokenRef, size }: Props) {
       return <VideoWithLoading src={src} />;
     }
 
-    return <ImageWithLoading src={src} heightType="maxHeightScreen" alt={token.name ?? ''} />;
+    return (
+      <ImageWithLoading
+        src={src}
+        heightType="maxHeightScreen"
+        alt={token.name ?? ''}
+        fullWidth={fullWidth}
+      />
+    );
   }
 
   // TODO: instead of rendering this, just throw to an error boundary and have that report to sentry


### PR DESCRIPTION
Enforce full width on images displayed in main gallery.

- [x] Ensure no regressions on other galleries, feed

| Before | After |
| ----- | ----- |
|  ![image](https://user-images.githubusercontent.com/12162433/183775504-a68e675a-d5a6-4f53-96e5-8b5b1b1a9e3a.png) | ![image](https://user-images.githubusercontent.com/12162433/183775566-cd6a7cb7-94c8-4d07-83c6-f57fc8c35a41.png) |
