### PR TITLE
[GAL-329] Fix broken OG Image link

### DIFF
--- a/src/components/opengraph/OpenGraphPreview.tsx
+++ b/src/components/opengraph/OpenGraphPreview.tsx
@@ -58,9 +58,8 @@ const StyledGalleryContainer = styled.div`
 
 const StyledImage = styled.img`
   max-width: 100%;
-  max-height: 190px;
   width: auto;
-  height: auto;
+  height: 190px;
   display: block;
   margin: 0 auto;
 `;

--- a/src/components/opengraph/SingleOpenGraphPreview.tsx
+++ b/src/components/opengraph/SingleOpenGraphPreview.tsx
@@ -70,9 +70,8 @@ const StyledGalleryContainer = styled.div<{ hasCollectorNote?: boolean }>`
 
 const StyledImage = styled.img`
   max-width: 100%;
-  max-height: 265px;
+  height: 265px;
   width: auto;
-  height: auto;
   display: block;
   margin: 0 0 0 auto;
 `;

--- a/src/components/opengraph/SingleOpenGraphPreview.tsx
+++ b/src/components/opengraph/SingleOpenGraphPreview.tsx
@@ -17,6 +17,7 @@ export const SingleOpenGraphPreview = ({
   imageUrls,
   collectorsNote,
 }: Props) => {
+  const firstLineDescription = description.split('\n')[0];
   return (
     <>
       <StyledContainer>
@@ -34,7 +35,7 @@ export const SingleOpenGraphPreview = ({
           <TitleL>{unescape(title)}</TitleL>
           {description && (
             <StyledDescription>
-              <Markdown text={unescape(description)} />
+              <Markdown text={unescape(firstLineDescription)} />
             </StyledDescription>
           )}
         </StyledTitleContainer>


### PR DESCRIPTION
**Changes**
1. Set initial height to image since some SVG dont have it
2. Trim the nft description on single nft preview link

**Before/After - NFT Description**

![CleanShot 2022-08-11 at 13 04 15](https://user-images.githubusercontent.com/4480258/184067810-4dfddc4b-f853-453e-b063-cf147cb5b0d7.png)
![CleanShot 2022-08-11 at 13 02 39](https://user-images.githubusercontent.com/4480258/184067676-76c18a6b-9312-4c74-80bf-8ecbf53daba8.png)

**Before/After - Single NFT (SVG)**

![CleanShot 2022-08-11 at 13 04 43](https://user-images.githubusercontent.com/4480258/184067844-a5bbe3c6-74af-47ee-a11b-a7e70f2dde15.png)
![CleanShot 2022-08-11 at 13 05 07](https://user-images.githubusercontent.com/4480258/184067870-d8fbd355-a0ed-49d7-9295-67d251bc2eb1.png)

**Before/After - Collection with NFT (SVG)**

![CleanShot 2022-08-11 at 13 05 32](https://user-images.githubusercontent.com/4480258/184067900-ef4acecf-d132-4feb-a8a5-767c1d28d206.png)
![CleanShot 2022-08-11 at 13 05 46](https://user-images.githubusercontent.com/4480258/184067918-63716d75-ca37-4123-8b5f-b48271a01b07.png)


