### PR TITLE
Asset sizing improvements

### DIFF
--- a/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
+++ b/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
@@ -68,7 +68,6 @@ function FeedEventNftPreviewWrapper({ tokenRef, maxWidth, maxHeight }: Props) {
       onClick={(e) => e.stopPropagation()}
     >
       <NftPreview
-        variant="feed"
         tokenRef={token}
         previewSize={maxWidth}
         onClick={handleClick}

--- a/src/components/LoadingAsset/ImageWithLoading.tsx
+++ b/src/components/LoadingAsset/ImageWithLoading.tsx
@@ -15,7 +15,6 @@ type Props = {
   src: string;
   alt: string;
   heightType?: ContentHeightType;
-  fullWidth?: boolean;
   onClick?: () => void;
 };
 
@@ -24,7 +23,6 @@ export default function ImageWithLoading({
   src,
   alt,
   heightType,
-  fullWidth,
   onClick = noop,
 }: Props) {
   const setContentIsLoaded = useSetContentIsLoaded();
@@ -45,7 +43,7 @@ export default function ImageWithLoading({
     return '100%';
   }, [heightType]);
 
-  const renderFullWidth = fullWidth || (isSvg(src) && !isFirefox());
+  const renderFullWidth = isSvg(src) && !isFirefox();
 
   return (
     <StyledImageWithLoading

--- a/src/components/NftPreview/GalleryNftPreviewWrapper.tsx
+++ b/src/components/NftPreview/GalleryNftPreviewWrapper.tsx
@@ -1,6 +1,5 @@
-import ShimmerProvider, { useContentState } from 'contexts/shimmer/ShimmerContext';
+import ShimmerProvider from 'contexts/shimmer/ShimmerContext';
 import { useIsMobileWindowWidth } from 'hooks/useWindowSize';
-import { useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import { GalleryNftPreviewWrapperFragment$key } from '__generated__/GalleryNftPreviewWrapperFragment.graphql';
 import NftPreview from './NftPreview';
@@ -55,34 +54,7 @@ function GalleryNftPreviewWrapper({ tokenRef, columns }: Props) {
   const isMobile = useIsMobileWindowWidth();
   const previewSize = isMobile ? MOBILE_NFT_WIDTH : LAYOUT_DIMENSIONS[columns];
 
-  const { aspectRatioType } = useContentState();
-
-  const nftPreviewMaxWidth = useMemo(() => {
-    if (columns > 1) return '100%';
-
-    // this could be a 1-liner but wanted to make it explicit
-    if (columns === 1) {
-      if (isMobile) {
-        return '100%';
-      }
-      if (aspectRatioType === 'wide') {
-        return '100%';
-      }
-      if (aspectRatioType === 'square' || aspectRatioType === 'tall') {
-        return '60%';
-      }
-    }
-  }, [columns, aspectRatioType, isMobile]);
-
-  return (
-    <NftPreview
-      variant="gallery"
-      tokenRef={collectionTokenRef}
-      nftPreviewMaxWidth={nftPreviewMaxWidth}
-      previewSize={previewSize}
-      columns={columns}
-    />
-  );
+  return <NftPreview tokenRef={collectionTokenRef} previewSize={previewSize} columns={columns} />;
 }
 
 export default NftPreviewWithShimmer;

--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -180,7 +180,8 @@ const StyledA = styled.a`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
+  width: inherit;
+  height: inherit;
   text-decoration: none;
 `;
 
@@ -219,6 +220,7 @@ const StyledNftPreview = styled.div<{
   max-height: 80vh;
   max-width: ${({ aspectRatio }) => `calc(80vh * ${aspectRatio})`};
   width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
+  height: inherit;
 
   ${({ backgroundColorOverride }) =>
     backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};

--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -15,11 +15,10 @@ import getVideoOrImageUrlForNftPreview from 'utils/graphql/getVideoOrImageUrlFor
 import isFirefox from 'utils/isFirefox';
 import isSvg from 'utils/isSvg';
 import LinkToNftDetailView from 'scenes/NftDetailPage/LinkToNftDetailView';
+import { useContentState } from 'contexts/shimmer/ShimmerContext';
 
 type Props = {
-  variant: 'gallery' | 'feed';
   tokenRef: NftPreviewFragment$key;
-  nftPreviewMaxWidth?: string;
   previewSize: number;
   ownerUsername?: string;
   onClick?: () => void;
@@ -29,9 +28,7 @@ type Props = {
 };
 
 function NftPreview({
-  variant,
   tokenRef,
-  nftPreviewMaxWidth,
   previewSize,
   onClick,
   hideLabelOnMobile = false,
@@ -116,7 +113,6 @@ function NftPreview({
           tokenRef={token}
           // we'll request images at double the size of the element so that it looks sharp on retina
           size={previewSize * 2}
-          fullWidth={variant === 'gallery'}
         />
       );
     }
@@ -131,10 +127,9 @@ function NftPreview({
         tokenRef={token}
         // we'll request images at double the size of the element so that it looks sharp on retina
         size={previewSize * 2}
-        fullWidth={variant === 'gallery'}
       />
     );
-  }, [disableLiverender, shouldLiverender, token, isIFrameLiveDisplay, previewSize, variant]);
+  }, [disableLiverender, shouldLiverender, token, isIFrameLiveDisplay, previewSize]);
 
   const result = getVideoOrImageUrlForNftPreview(token);
   const isFirefoxSvg = isSvg(result?.urls?.large) && isFirefox();
@@ -147,6 +142,8 @@ function NftPreview({
     // the asset is an iframe in single column mode
     (columns === 1 && isIFrameLiveDisplay);
 
+  const { aspectRatio } = useContentState();
+
   return (
     <LinkToNftDetailView
       username={username ?? ''}
@@ -158,7 +155,7 @@ function NftPreview({
           This will inherit the `as` URL from the parent component. */}
       <StyledA onClick={handleClick}>
         <StyledNftPreview
-          maxWidth={nftPreviewMaxWidth}
+          aspectRatio={aspectRatio}
           backgroundColorOverride={backgroundColorOverride}
           fullWidth={fullWidth}
         >
@@ -208,10 +205,9 @@ const StyledNftFooter = styled.div`
 `;
 
 const StyledNftPreview = styled.div<{
-  maxWidth?: string;
-  width?: string;
   backgroundColorOverride: string;
   fullWidth: boolean;
+  aspectRatio: number | null;
 }>`
   cursor: pointer;
 
@@ -221,12 +217,11 @@ const StyledNftPreview = styled.div<{
   position: relative;
   overflow: hidden;
   max-height: 80vh;
+  max-width: ${({ aspectRatio }) => `calc(80vh * ${aspectRatio})`};
+  width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
 
   ${({ backgroundColorOverride }) =>
     backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
-
-  max-width: ${({ maxWidth }) => maxWidth};
-  width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
 
   &:hover ${StyledNftLabel} {
     transform: translateY(0px);

--- a/src/components/NftPreview/NftPreviewAsset.tsx
+++ b/src/components/NftPreview/NftPreviewAsset.tsx
@@ -32,10 +32,9 @@ function UnrenderedPreviewAsset({ id, assetType }: UnrenderedPreviewAssetProps) 
 type Props = {
   tokenRef: NftPreviewAssetFragment$key;
   size: number;
-  fullWidth: boolean;
 };
 
-function NftPreviewAsset({ tokenRef, size, fullWidth }: Props) {
+function NftPreviewAsset({ tokenRef, size }: Props) {
   const token = useFragment(
     graphql`
       fragment NftPreviewAssetFragment on Token {
@@ -106,14 +105,7 @@ function NftPreviewAsset({ tokenRef, size, fullWidth }: Props) {
       return <VideoWithLoading src={src} />;
     }
 
-    return (
-      <ImageWithLoading
-        src={src}
-        heightType="maxHeightScreen"
-        alt={token.name ?? ''}
-        fullWidth={fullWidth}
-      />
-    );
+    return <ImageWithLoading src={src} heightType="maxHeightScreen" alt={token.name ?? ''} />;
   }
 
   // TODO: instead of rendering this, just throw to an error boundary and have that report to sentry

--- a/src/components/opengraph/OpenGraphPreview.tsx
+++ b/src/components/opengraph/OpenGraphPreview.tsx
@@ -59,7 +59,7 @@ const StyledGalleryContainer = styled.div`
 const StyledImage = styled.img`
   max-width: 100%;
   max-height: 190px;
-  width: auto;
+  width: 100%;
   height: auto;
   display: block;
   margin: 0 auto;

--- a/src/contexts/shimmer/ShimmerContext.tsx
+++ b/src/contexts/shimmer/ShimmerContext.tsx
@@ -108,6 +108,7 @@ const ShimmerProvider = memo(({ children }: Props) => {
 const Container = styled.div<{ overflowHidden: boolean }>`
   position: relative;
   width: 100%;
+  height: 100%;
 
   display: flex;
   justify-content: center;
@@ -126,7 +127,7 @@ const StyledShimmerComponent = styled.div<VisibleProps>`
 `;
 
 const StyledChildren = styled.div<VisibleProps>`
-  height: 100%;
+  height: inherit;
   width: inherit;
   display: flex;
   justify-content: center;

--- a/src/contexts/shimmer/ShimmerContext.tsx
+++ b/src/contexts/shimmer/ShimmerContext.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 import styled from 'styled-components';
 
-type AspectRatio = 'wide' | 'square' | 'tall';
+type AspectRatio = 'wide' | 'square' | 'tall' | 'unknown';
 
 type ShimmerState = {
   aspectRatio: null | number;
@@ -62,17 +62,22 @@ const ShimmerProvider = memo(({ children }: Props) => {
     () => ({
       setContentIsLoaded: (event?: SyntheticEvent) => {
         if (event) {
-          // @ts-expect-error: issues with TS image onload event
-          const aspectRatio = event.target.width / event.target.height;
+          // @ts-expect-error: the element that fires the event on load may be different (e.g. image vs. video vs. iframe).
+          // `naturalWidth` and `naturalHeight` are available on images and represent their original dimensions, whereas
+          // `width` and `height` are the literal dimensions that are rendered on the page.
+          const aspectRatio = event.target?.naturalWidth / event.target?.naturalHeight;
           if (aspectRatio === 1) {
             setAspectRatioType('square');
           } else if (aspectRatio > 1) {
             setAspectRatioType('wide');
           } else if (aspectRatio < 1) {
             setAspectRatioType('tall');
+          } else {
+            setAspectRatioType('unknown');
           }
 
-          setAspectRatio(aspectRatio);
+          // if an aspect ratio is indeterminate, we give it a square viewport
+          setAspectRatio(aspectRatio || 1);
         }
 
         setIsLoaded(true);
@@ -112,12 +117,12 @@ type VisibleProps = { visible: boolean };
 const StyledShimmerComponent = styled.div<VisibleProps>`
   position: absolute;
   display: ${({ visible }) => (visible ? 'block' : 'none')};
-  width: 100%;
+  width: inherit;
 `;
 
 const StyledChildren = styled.div<VisibleProps>`
   height: 100%;
-  width: 100%;
+  width: inherit;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,11 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import { size } from 'components/core/breakpoints';
+import useDebounce from './useDebounce';
 
 export default function useWindowSize() {
   const [windowSize, setWindowSize] = useState({
     width: window.innerWidth,
     height: window.innerHeight,
   });
+
+  const debouncedWindowSize = useDebounce(windowSize, 50);
 
   useEffect(() => {
     function handleResize() {
@@ -22,7 +25,7 @@ export default function useWindowSize() {
     };
   }, []);
 
-  return windowSize;
+  return debouncedWindowSize;
 }
 
 export function useBreakpoint(): size {

--- a/src/scenes/NftDetailPage/NftDetailAnimation.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAnimation.tsx
@@ -58,14 +58,16 @@ function NftDetailAnimation({ mediaRef }: Props) {
 }
 
 const StyledNftDetailAnimation = styled.div`
-  width: 100%;
-  height: 100%;
+  width: inherit;
+  height: inherit;
 `;
 
 const StyledIframe = styled.iframe`
-  width: 100%;
-  height: 100%;
+  width: inherit;
+  height: inherit;
   border: none;
+
+  aspect-ratio: 1;
 `;
 
 export default NftDetailAnimation;

--- a/src/scenes/NftDetailPage/NftDetailAnimation.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAnimation.tsx
@@ -59,13 +59,13 @@ function NftDetailAnimation({ mediaRef }: Props) {
 
 const StyledNftDetailAnimation = styled.div`
   width: 100%;
+  height: 100%;
 `;
 
 const StyledIframe = styled.iframe`
   width: 100%;
   height: 100%;
   border: none;
-  aspect-ratio: 1;
 `;
 
 export default NftDetailAnimation;

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -13,7 +13,6 @@ import NftDetailModel from './NftDetailModel';
 import { useMemo } from 'react';
 import { getBackgroundColorOverrideForContract } from 'utils/token';
 import { GLOBAL_FOOTER_HEIGHT } from 'contexts/globalLayout/GlobalFooter/GlobalFooter';
-import { GLOBAL_NAVBAR_HEIGHT } from 'contexts/globalLayout/GlobalNavbar/GlobalNavbar';
 import { StyledImageWithLoading } from 'components/LoadingAsset/ImageWithLoading';
 
 type NftDetailAssetComponentProps = {
@@ -86,15 +85,6 @@ type Props = {
   hasExtraPaddingForNote: boolean;
 };
 
-// number that determines a reasonable max height for the displayed NFT
-let heightWithoutNavAndFooterGutters: number;
-
-if (typeof window !== 'undefined') {
-  // NOTE: don't need to handle MOBILE footer height here, since this logic only applies to desktop + tablet
-  heightWithoutNavAndFooterGutters =
-    window.screen.availHeight - 2 * (GLOBAL_NAVBAR_HEIGHT + GLOBAL_FOOTER_HEIGHT);
-}
-
 function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
   const token = useFragment(
     graphql`
@@ -125,15 +115,6 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
     [contractAddress]
   );
 
-  const maxWidth = Math.min(
-    heightWithoutNavAndFooterGutters,
-    // TODO: this number should be determined by the dimensions of the media itself. once the media is fetched,
-    // we should grab its dimensions and set it on the shimmer context. this will allow us to display very large
-    // NFTs on very large screens
-    600
-  );
-  const maxHeight = heightWithoutNavAndFooterGutters;
-
   const { aspectRatioType } = useContentState();
   const breakpoint = useBreakpoint();
 
@@ -146,8 +127,6 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
   return (
     <StyledAssetContainer
       footerHeight={GLOBAL_FOOTER_HEIGHT}
-      maxWidth={maxWidth}
-      maxHeight={maxHeight}
       shouldEnforceSquareAspectRatio={shouldEnforceSquareAspectRatio}
       hasExtraPaddingForNote={hasExtraPaddingForNote}
       backgroundColorOverride={backgroundColorOverride}
@@ -159,8 +138,6 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
 
 type AssetContainerProps = {
   footerHeight: number;
-  maxWidth: number;
-  maxHeight: number;
   shouldEnforceSquareAspectRatio: boolean;
   hasExtraPaddingForNote: boolean;
   backgroundColorOverride: string;
@@ -181,17 +158,11 @@ const StyledAssetContainer = styled.div<AssetContainerProps>`
     backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 
   @media only screen and ${breakpoints.tablet} {
-    width: 100%;
-
-    ${({ hasExtraPaddingForNote, footerHeight }) =>
-      hasExtraPaddingForNote ? `max-height: calc(85vh - 46px - ${footerHeight}px)` : ''};
+    width: 600px;
+    min-height: 600px;
+    height: 100%;
   }
-
-  @media only screen and ${breakpoints.desktop} {
-    width: ${({ maxWidth }) => maxWidth}px;
-    height: ${({ maxHeight }) => maxHeight}px;
-  }
-
+  
   // enforce auto width on NFT detail page as to not stretch to shimmer container
   ${StyledImageWithLoading} {
     width: auto;

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -18,10 +18,9 @@ import { StyledImageWithLoading } from 'components/LoadingAsset/ImageWithLoading
 
 type NftDetailAssetComponentProps = {
   tokenRef: NftDetailAssetComponentFragment$key;
-  maxHeight: number;
 };
 
-function NftDetailAssetComponent({ tokenRef, maxHeight }: NftDetailAssetComponentProps) {
+function NftDetailAssetComponent({ tokenRef }: NftDetailAssetComponentProps) {
   const token = useFragment(
     graphql`
       fragment NftDetailAssetComponentFragment on CollectionToken {
@@ -70,7 +69,6 @@ function NftDetailAssetComponent({ tokenRef, maxHeight }: NftDetailAssetComponen
       return (
         <NftDetailImage
           tokenRef={token.token}
-          maxHeight={maxHeight}
           // @ts-expect-error: we know contentRenderURL is present within the media field
           // if token type is `ImageMedia`
           onClick={() => window.open(token.token.media.contentRenderURL)}
@@ -127,13 +125,14 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
     [contractAddress]
   );
 
-  const maxHeight = Math.min(
+  const maxWidth = Math.min(
     heightWithoutNavAndFooterGutters,
     // TODO: this number should be determined by the dimensions of the media itself. once the media is fetched,
     // we should grab its dimensions and set it on the shimmer context. this will allow us to display very large
     // NFTs on very large screens
     600
   );
+  const maxHeight = heightWithoutNavAndFooterGutters;
 
   const { aspectRatioType } = useContentState();
   const breakpoint = useBreakpoint();
@@ -147,18 +146,20 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
   return (
     <StyledAssetContainer
       footerHeight={GLOBAL_FOOTER_HEIGHT}
+      maxWidth={maxWidth}
       maxHeight={maxHeight}
       shouldEnforceSquareAspectRatio={shouldEnforceSquareAspectRatio}
       hasExtraPaddingForNote={hasExtraPaddingForNote}
       backgroundColorOverride={backgroundColorOverride}
     >
-      <NftDetailAssetComponent tokenRef={token} maxHeight={maxHeight} />
+      <NftDetailAssetComponent tokenRef={token} />
     </StyledAssetContainer>
   );
 }
 
 type AssetContainerProps = {
   footerHeight: number;
+  maxWidth: number;
   maxHeight: number;
   shouldEnforceSquareAspectRatio: boolean;
   hasExtraPaddingForNote: boolean;
@@ -187,7 +188,7 @@ const StyledAssetContainer = styled.div<AssetContainerProps>`
   }
 
   @media only screen and ${breakpoints.desktop} {
-    width: ${({ maxHeight }) => maxHeight}px;
+    width: ${({ maxWidth }) => maxWidth}px;
     height: ${({ maxHeight }) => maxHeight}px;
   }
 

--- a/src/scenes/NftDetailPage/NftDetailImage.tsx
+++ b/src/scenes/NftDetailPage/NftDetailImage.tsx
@@ -12,7 +12,6 @@ import noop from 'utils/noop';
 
 type Props = {
   tokenRef: NftDetailImageFragment$key;
-  maxHeight: number;
   onClick?: () => void;
 };
 

--- a/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -123,6 +123,7 @@ const StyledContentContainer = styled.div`
 const StyledAssetAndNoteContainer = styled.div`
   position: relative;
   width: 100%;
+  height: 100%;
 `;
 
 // We position the arrows using position absolute (so they reach the page bounds)


### PR DESCRIPTION
Cleans up a lot of complex asset handling logic that was leading to regressions.

**This PR may lead to further regressions, but I believe the simplifications and improvements are a step in the right direction.** A perfect solution would require a deeper cleanup.

### Before / After

Fix stretched out images

![fix stretched out images](https://user-images.githubusercontent.com/12162433/184196648-5028d1a3-1fec-412e-a434-07da3f385296.png)

![fix stretched out images 2](https://user-images.githubusercontent.com/12162433/184196655-360ea93c-d4b7-4172-b88f-eca4bc48c464.png)

![fix stretched out images 3](https://user-images.githubusercontent.com/12162433/184196670-76daa44d-d799-4641-b771-7c680ca3884a.png)

^ Tall images look better aligned when window is tall

![tall images look better aligned when window is tall](https://user-images.githubusercontent.com/12162433/184196732-f445a224-0386-48cf-945e-4d67bfc4dcda.png)

Fix cutoff on tall iframes

![nft detail - fix cutoff on iframes](https://user-images.githubusercontent.com/12162433/184196787-47977eca-4794-43d6-a2ed-f14cf168dff1.png)

![main gallery - fix cutoff on iframes](https://user-images.githubusercontent.com/12162433/184196807-6b665d72-6699-44b0-beeb-9b45284bcb95.png)

Fix stretched iframes

![fix stretched iframes](https://user-images.githubusercontent.com/12162433/184196846-7be73f38-6cfc-4f4b-a2ef-fae4dfd7e1f7.png)

Ensure no regression when live-rendering squiggles

![ensure no regression when live-rendering squiggles](https://user-images.githubusercontent.com/12162433/184196510-53de6d82-112c-4e80-b8a3-8ec4a9e29e3d.png)

Ensure no regression when live-rendering videos

![ensure no regression when live-rendering videos](https://user-images.githubusercontent.com/12162433/184196586-bac13ba8-ef56-4122-80e9-fbe9bc13dd0c.png)

Fix opengraph issue

![image](https://user-images.githubusercontent.com/12162433/184198712-f1ac276a-c689-4531-be13-e250fa986067.png)


### Known issue: tall live display iframe on gallery

This is because it's difficult to determine an iframe's inner contents / dimensions. Without enforcing an aspect ratio, the iframe images would appear very small – only with a height of ~150px. This would also cause a regression in square/wide iframes, so for now we're enforcing an aspect ratio of 1.

![known issue - tall live display iframe on gallery](https://user-images.githubusercontent.com/12162433/184196945-c9367084-92bf-400a-b62f-d7c0ce47eeff.png)

