### PR TITLE
[GAL-324] Enable multi-modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "styled-components": "^5.2.3",
     "swr": "^1.1.1",
     "utf-8-validate": "^5.0.7",
+    "uuid": "^8.3.2",
     "wagmi": "^0.6.1",
     "web3": "^1.6.1"
   },
@@ -80,6 +81,7 @@
     "@types/react-virtualized": "^9.21.21",
     "@types/relay-runtime": "^13.0.0",
     "@types/styled-components": "5.1.9",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",
     "babel-jest": "^27.3.1",

--- a/src/contexts/modal/AnimatedModal.tsx
+++ b/src/contexts/modal/AnimatedModal.tsx
@@ -1,21 +1,28 @@
-import { ReactElement, useCallback, useEffect, useMemo } from 'react';
+import { ReactElement, useEffect, useMemo } from 'react';
 import styled, { css, keyframes } from 'styled-components';
 import colors from 'components/core/colors';
 import transitions, {
+  ANIMATED_COMPONENT_TRANSITION_MS,
   ANIMATED_COMPONENT_TRANSLATION_PIXELS_LARGE,
 } from 'components/core/transitions';
 import breakpoints from 'components/core/breakpoints';
 import { DecoratedCloseIcon } from 'src/icons/CloseIcon';
-import useKeyDown from 'hooks/useKeyDown';
 import { ModalPaddingVariant, MODAL_PADDING_PX } from './constants';
 import { TitleS } from 'components/core/Text/Text';
+import { useIsMobileOrMobileLargeWindowWidth } from 'hooks/useWindowSize';
 
 type Props = {
-  isActive: boolean;
+  /**
+   * `hideModal` and `dismountModal` are used separately.
+   * hideModal begins the process for removing the modal, and
+   * dismount actually removes it by the end of the animation.
+   */
   hideModal: () => void;
+  dismountModal: (id: string) => void;
+
+  isActive: boolean;
   content: ReactElement;
   isFullPage: boolean;
-  isMobile: boolean;
   isPaddingDisabled: boolean;
   headerText: string;
   headerVariant: ModalPaddingVariant;
@@ -24,31 +31,20 @@ type Props = {
 function AnimatedModal({
   isActive,
   hideModal,
+  dismountModal,
   content,
   isFullPage,
-  isMobile,
   isPaddingDisabled,
   headerText,
   headerVariant,
 }: Props) {
-  // hide modal if user clicks Back
   useEffect(() => {
-    function handlePopState() {
-      hideModal();
+    if (!isActive) {
+      setTimeout(dismountModal, ANIMATED_COMPONENT_TRANSITION_MS);
     }
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, [hideModal]);
+  }, [isActive, dismountModal]);
 
-  // this is wrapped in a setTimeout so that any event that triggers showModal
-  // via escape does not cause jitter. e.g. CollectionEditor.tsx opens the modal
-  // via escape, so trying to close here would jitter an open/close rapidly
-  const delayedHideModal = useCallback(() => {
-    setTimeout(hideModal, 150);
-  }, [hideModal]);
-
-  // hide modal if user clicks Escape
-  useKeyDown('Escape', delayedHideModal);
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
 
   const padding = useMemo(() => {
     if (isFullPage || isPaddingDisabled) {
@@ -108,6 +104,7 @@ const _ToggleFade = styled.div<{ isActive: boolean }>`
     css`
       ${isActive ? fadeIn : fadeOut} ${transitions.cubic}
     `};
+  animation-fill-mode: forwards;
 `;
 
 const translateUp = keyframes`
@@ -125,6 +122,7 @@ const _ToggleTranslate = styled.div<{ isActive: boolean }>`
     css`
       ${isActive ? translateUp : translateDown} ${transitions.cubic}
     `};
+  animation-fill-mode: forwards;
 `;
 
 const Overlay = styled.div`

--- a/src/contexts/modal/AnimatedModal.tsx
+++ b/src/contexts/modal/AnimatedModal.tsx
@@ -18,7 +18,7 @@ type Props = {
    * dismount actually removes it by the end of the animation.
    */
   hideModal: () => void;
-  dismountModal: (id: string) => void;
+  dismountModal: () => void;
 
   isActive: boolean;
   content: ReactElement;

--- a/src/contexts/modal/ModalContext.tsx
+++ b/src/contexts/modal/ModalContext.tsx
@@ -164,9 +164,9 @@ function ModalProvider({ children }: Props) {
 
   const clearAllModals = useCallback(() => setModals([]), []);
 
-  // ----------------------------- SIDE EFFECTS -----------------------------
-
-  // close modal on route change
+  /**
+   * EFFECT: Close modal on route change
+   */
   const route = useStabilizedRouteTransitionKey();
   useEffect(() => {
     if (isModalOpenRef.current) {
@@ -175,12 +175,16 @@ function ModalProvider({ children }: Props) {
     }
   }, [route, hideModal]);
 
-  // prevent main body from being scrollable while any modals are open
+  /**
+   * EFFECT: Prevent main body from being scrollable while any modals are open
+   */
   useEffect(() => {
     document.body.style.overflow = modals.length ? 'hidden' : 'unset';
   }, [modals.length]);
 
-  // hide all modals if user clicks Back
+  /**
+   * EFFECT: Hide all modals if user clicks Back
+   */
   useEffect(() => {
     function handlePopState() {
       clearAllModals();
@@ -189,15 +193,17 @@ function ModalProvider({ children }: Props) {
     return () => window.removeEventListener('popstate', handlePopState);
   }, [clearAllModals]);
 
-  // pop one modal if user hits Escape key
-  // TODO: below logic may be fixed via stopPropagation
-  // this is wrapped in a setTimeout so that any event that triggers showModal
-  // via escape does not cause jitter. e.g. CollectionEditor.tsx opens the modal
-  // via escape, so trying to close here would jitter an open/close rapidly
+  /**
+   * EFFECT: Pop one modal if user hits Escape key
+   *
+   * TODO: below logic may be fixed via stopPropagation
+   * this is wrapped in a setTimeout so that any event that triggers showModal
+   * via escape does not cause jitter. e.g. CollectionEditor.tsx opens the modal
+   * via escape, so trying to close here would jitter an open/close rapidly
+   */
   const delayedHideModal = useCallback(() => {
     setTimeout(hideModal, 150);
   }, [hideModal]);
-  // hide modal if user clicks Escape
   useKeyDown('Escape', delayedHideModal);
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5233,6 +5233,11 @@
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
   integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/ws@^8.0.0":
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"


### PR DESCRIPTION
## Overview

Enable modal stacking by storing an array of modals in state rather than building the context around a singleton. Ended up having the nice effect of cleaning up a bunch of anti-pattern-y stuff where we were setting and un-setting config variables as the modal came and went.

**Tests**
- [x] Ensure existing usages of showModal / hideModal are unaffected
- [x] Ensure `Escape` and other hotkeys still work
- [x] Ensure hitting "Back" keeps modal open
- [x] Ensure `isModalOpenRef` prop is maintained

**Before**

https://user-images.githubusercontent.com/12162433/184471307-47da74fe-1978-4f2c-af58-c212f6145105.mov

**After**

https://user-images.githubusercontent.com/12162433/184471310-0356ebf7-9cca-4702-992e-2470a25e0076.mov

**Before**

https://user-images.githubusercontent.com/12162433/184471313-993e4a61-b21d-4d70-91fa-bb5da85642c2.mov

**After**

https://user-images.githubusercontent.com/12162433/184471356-cac6a8fb-1060-4800-8671-5c0551a5c4a6.mov
