### PR TITLE
Fix NFT spacing on safari

### DIFF
--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -222,6 +222,13 @@ const StyledNftPreview = styled.div<{
   width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
   height: inherit;
 
+  // Only apply to safari. Somehow the height is not being set properly on safari.
+  @media not all and (min-resolution:.001dpcm) { 
+     @supports (-webkit-appearance:none) {
+        height: initial;  
+      }
+  }
+
   ${({ backgroundColorOverride }) =>
     backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 


### PR DESCRIPTION
**Finding**
* This bug can be replicable on Safari desktop and iOS devices
* Seems like on safari, the NFT preview use 100% height on the container altought we already inherit the sizing from the asset itself. 
* Only set the `initial` height on Safari browser.

**Before**

![CleanShot 2022-08-15 at 10 38 09](https://user-images.githubusercontent.com/4480258/184568388-1be6bcc4-b813-4fd0-a894-40f20e6e8388.png)
![CleanShot 2022-08-15 at 10 43 07](https://user-images.githubusercontent.com/4480258/184568597-6920de36-0600-4dff-93e9-a729e78fd22f.png)



**After**


https://user-images.githubusercontent.com/4480258/184568403-4a664bc8-7059-4e10-88d0-6d9d22b8541e.mp4


https://user-images.githubusercontent.com/4480258/184568726-82909674-e6ed-45be-a0e3-71a9b4707623.mp4



