### PR TITLE
[GAL-205] Broken footer on mobile

### DIFF
--- a/src/contexts/globalLayout/GlobalFooter/GlobalFooter.tsx
+++ b/src/contexts/globalLayout/GlobalFooter/GlobalFooter.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import breakpoints, { pageGutter } from 'components/core/breakpoints';
 import { BaseS } from 'components/core/Text/Text';
 import Spacer from 'components/core/Spacer/Spacer';
@@ -11,17 +11,15 @@ import {
   GALLERY_TWITTER,
   GALLERY_BLOG,
 } from 'constants/urls';
-import { useIsMobileWindowWidth } from 'hooks/useWindowSize';
+import { useIsMobileOrMobileLargeWindowWidth } from 'hooks/useWindowSize';
 import Link from 'next/link';
 import NavLink from 'components/core/NavLink/NavLink';
 
-type GlobalFooterProps = { isFixed?: boolean };
-
-function GlobalFooter({ isFixed = false }: GlobalFooterProps) {
-  const isMobile = useIsMobileWindowWidth();
+function GlobalFooter() {
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
 
   return (
-    <StyledGlobalFooter isFixed={isFixed} isMobile={isMobile}>
+    <StyledGlobalFooter isMobile={isMobile}>
       {isMobile && <StyledHr />}
       <MainContent>
         <LogoWrapper>
@@ -62,7 +60,6 @@ function GlobalFooter({ isFixed = false }: GlobalFooterProps) {
 }
 
 type StyledFooterProps = {
-  isFixed: boolean;
   isMobile: boolean;
 };
 
@@ -79,26 +76,6 @@ const StyledGlobalFooter = styled.div<StyledFooterProps>`
   padding: 0 ${pageGutter.mobile}px 24px;
 
   background-color: ${colors.white};
-
-  // TODO: all of this can go away with new layout + NFT Detail Modal update
-  @media only screen and ${breakpoints.tablet} {
-    padding: 0 ${pageGutter.tablet}px 24px;
-
-    ${({ isFixed }) =>
-      isFixed &&
-      css`
-        position: fixed;
-        bottom: 0;
-        width: 100%;
-
-        background: ${colors.white};
-        background: linear-gradient(
-          to bottom,
-          rgba(255, 255, 255, 0) 0%,
-          rgba(255, 255, 255, 1) 50%
-        );
-      `}
-  }
 
   @media only screen and ${breakpoints.desktop} {
     padding: 0 32px 24px;


### PR DESCRIPTION
1.The broken footer only happens on large mobile devices ( > 420px )
2. Removed the `isFixed` props since we didn't used it

**Demo**

Before
![CleanShot 2022-08-17 at 09 24 44](https://user-images.githubusercontent.com/4480258/185014150-92fd17dc-a5ff-4145-be95-d220055de703.png)

After
![CleanShot 2022-08-17 at 09 25 39](https://user-images.githubusercontent.com/4480258/185014253-05e596fd-786c-4c07-a962-b1d1a41f5976.png)

