### PR TITLE
[GAL-127] Render links in community page description

### DIFF
--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import TextButton from 'components/core/Button/TextButton';
 import breakpoints from 'components/core/breakpoints';
 import TokenHolderList from 'components/TokenHolderList/TokenHolderList';
+import { VALID_URL } from 'utils/regex';
 
 type Props = {
   communityRef: CommunityPageViewFragment$key;
@@ -57,6 +58,18 @@ export default function CommunityPageView({ communityRef }: Props) {
     }
   }, [descriptionRef]);
 
+  function formatUrl(str: string) {
+    let matchesUrls = str.match(VALID_URL);
+    let formattedText = str;
+    matchesUrls?.map((url: string) => {
+      formattedText = formattedText.replace(url, `[${url}](${url})`);
+    });
+
+    return formattedText;
+  }
+
+  const formattedDescription = formatUrl(description || '');
+
   return (
     <MemberListPageProvider>
       <Spacer height={80} />
@@ -66,7 +79,7 @@ export default function CommunityPageView({ communityRef }: Props) {
           <StyledDescriptionWrapper>
             <Spacer height={4} />
             <StyledBaseM showExpandedDescription={showExpandedDescription} ref={descriptionRef}>
-              <Markdown text={description} />
+              <Markdown text={formattedDescription} />
             </StyledBaseM>
             <Spacer height={8} />
             {isLineClampEnabled && (

--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import TextButton from 'components/core/Button/TextButton';
 import breakpoints from 'components/core/breakpoints';
 import TokenHolderList from 'components/TokenHolderList/TokenHolderList';
-import { VALID_URL } from 'utils/regex';
+import formatUrl from 'utils/formatUrl';
 
 type Props = {
   communityRef: CommunityPageViewFragment$key;
@@ -57,16 +57,6 @@ export default function CommunityPageView({ communityRef }: Props) {
       );
     }
   }, [descriptionRef]);
-
-  function formatUrl(str: string) {
-    let matchesUrls = str.match(VALID_URL);
-    let formattedText = str;
-    matchesUrls?.map((url: string) => {
-      formattedText = formattedText.replace(url, `[${url}](${url})`);
-    });
-
-    return formattedText;
-  }
 
   const formattedDescription = formatUrl(description || '');
 

--- a/src/utils/formatUrl.ts
+++ b/src/utils/formatUrl.ts
@@ -1,0 +1,11 @@
+import { VALID_URL } from './regex';
+
+export default function formatUrl(str: string): string {
+  let matchesUrls = str.match(VALID_URL);
+  let formattedText = str;
+  matchesUrls?.map((url: string) => {
+    formattedText = formattedText.replace(url, `[${url}](${url})`);
+  });
+
+  return formattedText;
+}

--- a/src/utils/regex.test.tsx
+++ b/src/utils/regex.test.tsx
@@ -1,4 +1,4 @@
-import { ALPHANUMERIC_UNDERSCORES } from './regex';
+import { ALPHANUMERIC_UNDERSCORES, VALID_URL } from './regex';
 
 function testRegex(pattern: RegExp, values: string[], expectedValue: boolean) {
   for (const value of values) {
@@ -13,5 +13,22 @@ describe('regex', () => {
 
     testRegex(ALPHANUMERIC_UNDERSCORES, validUsernames, true);
     testRegex(ALPHANUMERIC_UNDERSCORES, invalidUsernames, false);
+  });
+
+  test('VALID_URL', () => {
+    const validUrls = [
+      'https://collection.xyz/',
+      'https://www.collection.xyz',
+      'https://www.collection.xyz/gallery?q=main',
+      'https://collection.xyz/',
+      'https://collection.xyz',
+      'https://collection.xyz/gallery?q=main',
+      'https://webbtelescope.org/news/first-images',
+    ];
+
+    const invalidUrls = ['', 'http://invalid', 'https://invalid'];
+
+    testRegex(VALID_URL, validUrls, true);
+    testRegex(VALID_URL, invalidUrls, false);
   });
 });

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -4,3 +4,5 @@ export const NO_CONSECUTIVE_PERIODS_OR_UNDERSCORES = /^(?=[\w.]*$)(?!.*[_.]{2})[
 
 // ends with =s256, =s128, etc.
 export const GOOGLE_CONTENT_IMG_URL = /=s\d{3}$/;
+
+export const VALID_URL = /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9(@:%_\+.~#?&\/=]*)/;


### PR DESCRIPTION
If there is any url in the community description, it will automatically render it as anchor text

Before

![CleanShot 2022-08-17 at 13 23 15](https://user-images.githubusercontent.com/4480258/185041100-ad5d9f49-9a79-4536-b061-9b73299ac460.png)

![Uploading CleanShot 2022-08-17 at 13.38.46.png…]()


After

https://user-images.githubusercontent.com/4480258/185041081-c03011e3-9eee-405d-a904-05725a0f06af.mp4

![CleanShot 2022-08-17 at 13 38 22](https://user-images.githubusercontent.com/4480258/185042845-4316420a-3ecc-47cb-8de4-6a5d36ea7c01.png)



