### PR TITLE
Move connected address to top of screen

### DIFF
--- a/src/scenes/MerchStorePage/MerchMintButton.tsx
+++ b/src/scenes/MerchStorePage/MerchMintButton.tsx
@@ -69,12 +69,6 @@ export default function MintButton({ onMintSuccess, quantity, tokenId }: Props) 
       </StyledButton>
       {(transactionHash || address || error) && !isMobile && <Spacer height={16} />}
 
-      {address && !transactionHash && (
-        <>
-          <StyledBaseMWithWrap>Connected address: {address}</StyledBaseMWithWrap>
-        </>
-      )}
-
       {transactionHash && (
         <>
           <BaseM>
@@ -112,9 +106,4 @@ const StyledButton = styled(Button)`
     width: 176px;
     flex: 1;
   }
-`;
-
-const StyledBaseMWithWrap = styled(BaseM)`
-  word-break: break-all;
-  width: 100%;
 `;

--- a/src/scenes/MerchStorePage/SingleItemPage.tsx
+++ b/src/scenes/MerchStorePage/SingleItemPage.tsx
@@ -18,6 +18,8 @@ import { useMintMerchContract } from 'hooks/useContract';
 import useMintContractWithQuantity from 'hooks/useMintContractWithQuantity';
 import { useIsMobileOrMobileLargeWindowWidth } from 'hooks/useWindowSize';
 import { ethers } from 'ethers';
+import { useAccount } from 'wagmi';
+import { truncateAddress } from 'utils/wallet';
 
 export default function ItemPage({
   label,
@@ -33,6 +35,8 @@ export default function ItemPage({
   tokenId: number;
 }) {
   const contract = useMintMerchContract();
+  const { address: rawAddress } = useAccount();
+  const address = truncateAddress(rawAddress?.toLowerCase() ?? '');
 
   const { publicSupply, usedPublicSupply, tokenPrice, userOwnedSupply } =
     useMintContractWithQuantity({
@@ -43,37 +47,40 @@ export default function ItemPage({
   const isMobile = useIsMobileOrMobileLargeWindowWidth();
 
   return (
-    <StyledPage pushItemsDown={isMobile && userOwnedSupply > 0}>
-      <StyledWrapper>
-        <StyledImageContainer>
-          <FlippingImage src={image} />
-        </StyledImageContainer>
-        <StyledContent>
-          <TitleM>
-            {title} {label}
-          </TitleM>
-          <BaseM>{description}</BaseM>
-          {!isMobile && <Spacer height={8} />}
-          <StyledPriceQuantityAndPurchaseContainer>
-            <StyledPriceAndQuantity>
-              <StyledPrice>{ethers.utils.formatEther(tokenPrice)} Ξ each</StyledPrice>
-              <BaseM>
-                {typeof publicSupply == 'number' && typeof usedPublicSupply == 'number'
-                  ? `${publicSupply - usedPublicSupply} / ${publicSupply} left`
-                  : ''}
-              </BaseM>
-            </StyledPriceAndQuantity>
-            {!isMobile && <Spacer height={16} />}
-            <PurchaseBox
-              label={label}
-              tokenId={tokenId}
-              // We don't want to disable the button if the user is not logged in. So we don't simply check equality between these two variables, which will be undefined if the user is not logged in.
-              disabled={publicSupply - usedPublicSupply == 0}
-            />
-          </StyledPriceQuantityAndPurchaseContainer>
-        </StyledContent>
-      </StyledWrapper>
-    </StyledPage>
+    <>
+      {rawAddress && <StyledConnectedAddress>{address}</StyledConnectedAddress>}
+      <StyledPage pushItemsDown={isMobile && userOwnedSupply > 0}>
+        <StyledWrapper>
+          <StyledImageContainer>
+            <FlippingImage src={image} />
+          </StyledImageContainer>
+          <StyledContent>
+            <TitleM>
+              {title} {label}
+            </TitleM>
+            <BaseM>{description}</BaseM>
+            {!isMobile && <Spacer height={8} />}
+            <StyledPriceQuantityAndPurchaseContainer>
+              <StyledPriceAndQuantity>
+                <StyledPrice>{ethers.utils.formatEther(tokenPrice)} Ξ each</StyledPrice>
+                <BaseM>
+                  {typeof publicSupply == 'number' && typeof usedPublicSupply == 'number'
+                    ? `${publicSupply - usedPublicSupply} / ${publicSupply} left`
+                    : ''}
+                </BaseM>
+              </StyledPriceAndQuantity>
+              {!isMobile && <Spacer height={16} />}
+              <PurchaseBox
+                label={label}
+                tokenId={tokenId}
+                // We don't want to disable the button if the user is not logged in. So we don't simply check equality between these two variables, which will be undefined if the user is not logged in.
+                disabled={publicSupply - usedPublicSupply == 0}
+              />
+            </StyledPriceQuantityAndPurchaseContainer>
+          </StyledContent>
+        </StyledWrapper>
+      </StyledPage>
+    </>
   );
 }
 
@@ -138,6 +145,13 @@ const StyledContent = styled.div`
     margin: 0;
     padding: 0;
   }
+`;
+
+const StyledConnectedAddress = styled(BaseM)`
+  position: absolute;
+  padding: 14px 52px 0px 0px;
+  text-align: right;
+  width: 100%;
 `;
 
 const StyledPriceAndQuantity = styled.div`


### PR DESCRIPTION
- [x] away from where it’s currently displayed under mint button
- [x] non-interactive, flat black text. truncated
- [x] confirmed no regression on desktop and mobile, doesn't affect layout or responsiveness
- [x] nothing display if wallet not connected

wallet connected (desktop)
<img width="1512" alt="Screen Shot 2022-08-18 at 21 46 20" src="https://user-images.githubusercontent.com/80802871/185398195-0520b8dc-ff21-4cdd-8afa-94ada0d220f1.png">


wallet connected (mobile)
<img width="240" alt="Screen Shot 2022-08-18 at 21 46 28" src="https://user-images.githubusercontent.com/80802871/185398210-3df8d674-1509-40fd-9a4b-cb97da6f76fb.png">



 no wallet connected
<img width="1512" alt="Screen Shot 2022-08-18 at 21 45 01" src="https://user-images.githubusercontent.com/80802871/185398032-3dace23f-4aab-4b5e-96ee-aad1051cb053.png">

 