### PR TITLE
Backspace bugfix on editor

### DIFF
--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
@@ -205,6 +205,7 @@ const SidebarTokens = ({ nftFragmentsKeyedByID, tokens }: SidebarTokensProps) =>
       <AutoSizer>
         {({ width, height }) => (
           <List
+            style={{ outline: 'none' }}
             rowRenderer={rowRenderer}
             rowCount={Math.ceil(displayedTokens.length / COLUMN_COUNT)}
             rowHeight={rowHeight}

--- a/src/hooks/useKeyDown.tsx
+++ b/src/hooks/useKeyDown.tsx
@@ -6,8 +6,11 @@ export default function useKeyDown(targetKey: string, callbackFn: () => void) {
 
   // If pressed key is our target key then set to true
   const pressHandler = useCallback(
-    ({ key }: KeyboardEvent) => {
-      setKeyPressed(key === targetKey);
+    (event) => {
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+      setKeyPressed(event.key === targetKey);
     },
     [targetKey]
   );


### PR DESCRIPTION
**Problem:** Pressing backspace in the searchbar of the editor ended up remaining sections from the main editing area.

**Solution:** Ignore keypress events if they're coming from inputs