### PR TITLE
Fix modal width

### DIFF
--- a/src/components/core/InteractiveLink/NavigateConfirmation.tsx
+++ b/src/components/core/InteractiveLink/NavigateConfirmation.tsx
@@ -4,19 +4,16 @@ import { Button } from 'components/core/Button/Button';
 import colors from 'components/core/colors';
 import Spacer from 'components/core/Spacer/Spacer';
 import { BaseM } from '../Text/Text';
-import { useIsMobileOrMobileLargeWindowWidth } from 'hooks/useWindowSize';
+import { MODAL_PADDING_PX } from 'contexts/modal/constants';
 
 export default function VerifyNavigationPopover({ href }: { href: string }) {
   const { hideModal } = useModalActions();
 
-  const isMobile = useIsMobileOrMobileLargeWindowWidth();
-
   return (
-    <StyledConfirmation isMobile={isMobile}>
+    <StyledConfirmation>
       <TextContainer>
         <StyledBaseM>
-          Confirm that you are navigating to: Confirm that you are navigating to: Confirm that you
-          are navigating to: Confirm that you are navigating to: <b>{href}</b>
+          Confirm that you are navigating to: <b>{href}</b>
         </StyledBaseM>
       </TextContainer>
       <Spacer height={16} />
@@ -36,8 +33,8 @@ export default function VerifyNavigationPopover({ href }: { href: string }) {
 }
 
 // TODO: maybe the width should be set when triggering the modal, as opposed to this component
-const StyledConfirmation = styled.div<{ isMobile: boolean }>`
-  width: ${({ isMobile }) => (isMobile ? 'unset' : '400px')};
+const StyledConfirmation = styled.div`
+  width: min(calc(100vw - ${MODAL_PADDING_PX * 4}px), 400px);
 `;
 
 const TextContainer = styled.div`

--- a/src/components/core/InteractiveLink/NavigateConfirmation.tsx
+++ b/src/components/core/InteractiveLink/NavigateConfirmation.tsx
@@ -4,15 +4,19 @@ import { Button } from 'components/core/Button/Button';
 import colors from 'components/core/colors';
 import Spacer from 'components/core/Spacer/Spacer';
 import { BaseM } from '../Text/Text';
+import { useIsMobileOrMobileLargeWindowWidth } from 'hooks/useWindowSize';
 
 export default function VerifyNavigationPopover({ href }: { href: string }) {
   const { hideModal } = useModalActions();
 
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
+
   return (
-    <StyledConfirmation>
+    <StyledConfirmation isMobile={isMobile}>
       <TextContainer>
         <StyledBaseM>
-          Confirm that you are navigating to: <b>{href}</b>
+          Confirm that you are navigating to: Confirm that you are navigating to: Confirm that you
+          are navigating to: Confirm that you are navigating to: <b>{href}</b>
         </StyledBaseM>
       </TextContainer>
       <Spacer height={16} />
@@ -31,8 +35,9 @@ export default function VerifyNavigationPopover({ href }: { href: string }) {
   );
 }
 
-const StyledConfirmation = styled.div`
-  width: 400px;
+// TODO: maybe the width should be set when triggering the modal, as opposed to this component
+const StyledConfirmation = styled.div<{ isMobile: boolean }>`
+  width: ${({ isMobile }) => (isMobile ? 'unset' : '400px')};
 `;
 
 const TextContainer = styled.div`

--- a/src/contexts/modal/AnimatedModal.tsx
+++ b/src/contexts/modal/AnimatedModal.tsx
@@ -63,6 +63,17 @@ function AnimatedModal({
     return `calc(100vw - ${MODAL_PADDING_PX}px)`;
   }, [isFullPage, isMobile]);
 
+  // TODO: could consolidate maxWidth and width styles
+  const width = useMemo(() => {
+    if (isFullPage) {
+      return '100vw';
+    }
+    if (isMobile) {
+      return `calc(100vw - ${MODAL_PADDING_PX * 2}px)`;
+    }
+    return 'unset';
+  }, [isFullPage, isMobile]);
+
   return (
     <_ToggleFade isActive={isActive}>
       <Overlay onClick={hideModal} />
@@ -72,6 +83,7 @@ function AnimatedModal({
             isFullPage={isFullPage}
             isPaddingDisabled={isPaddingDisabled}
             maxWidth={maxWidth}
+            width={width}
             padding={padding}
           >
             <StyledHeader>
@@ -171,6 +183,7 @@ const StyledContent = styled.div<{
   isFullPage: boolean;
   isPaddingDisabled: boolean;
   maxWidth: string;
+  width: string;
   padding: string;
 }>`
   position: relative;
@@ -183,18 +196,11 @@ const StyledContent = styled.div<{
 
   // no border on full page
   border: ${({ isFullPage }) => `${isFullPage ? 0 : 1}px solid ${colors.shadow}`};
-  // no padding on full page
   max-height: ${({ isFullPage }) => `calc(100vh - ${isFullPage ? 0 : MODAL_PADDING_PX * 2}px)`};
+  min-height: ${({ isFullPage }) => (isFullPage ? '-webkit-fill-available' : 'unset')};
   padding: ${({ padding }) => padding};
   max-width: ${({ maxWidth }) => maxWidth};
-  // take up entire page on full page
-  ${({ isFullPage }) =>
-    isFullPage
-      ? `
-    width: 100vw;
-    min-height: -webkit-fill-available;
-  `
-      : ''};
+  width: ${({ width }) => width};
 `;
 
 const StyledDecoratedCloseIcon = styled(DecoratedCloseIcon)`


### PR DESCRIPTION
The navigation confirmation modal had a hard-coded width of 400px, making it appear cropped for screen widths <400px.

In a future PR, the width should be dictated when opening the modal, such as:
```js
showModal({
  width: '400px',
  ...
})
```
and the ModalContext should use that to set the width in non-mobile scenarios. This will avoid us having to set custom logic on the inner content.

| Before | After |
| ----- | ----- |
|  ![image](https://user-images.githubusercontent.com/12162433/187277711-2a12565b-6780-473b-bb58-9aaccbf81426.png) | ![image](https://user-images.githubusercontent.com/12162433/187277841-43c2a425-f839-481d-a519-0272b298d877.png) |
