### PR TITLE
[GAL-358] Fix filtering bug with NFT Sidebar Search

### DIFF
--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/Sidebar.tsx
@@ -215,7 +215,7 @@ const SidebarTokens = ({ nftFragmentsKeyedByID, tokens }: SidebarTokensProps) =>
           <List
             style={{ outline: 'none' }}
             rowRenderer={rowRenderer}
-            rowCount={Math.ceil(displayedTokens.length / COLUMN_COUNT)}
+            rowCount={rows.length}
             rowHeight={rowHeight}
             width={width}
             height={height}


### PR DESCRIPTION
**Changes**

Used the generated rows instead of calculation by amount of tokens to set virtualize rows.

**Demo**

I have **3 Moonclones NFT** in my account

**Before**
![CleanShot 2022-08-30 at 17 05 28](https://user-images.githubusercontent.com/4480258/187396893-73965585-1edd-4f30-9919-aa2018506a1a.png)

**After**
![CleanShot 2022-08-30 at 17 05 40](https://user-images.githubusercontent.com/4480258/187396920-3dffb53a-13f4-40b0-9ea4-07efb8154b2f.png)
