### PR TITLE
[GAL-373] [GAL-361] Update empty state UI

### DIFF
--- a/src/components/WalletSelector/multichain/WalletOnboardingMessage.tsx
+++ b/src/components/WalletSelector/multichain/WalletOnboardingMessage.tsx
@@ -1,0 +1,20 @@
+import { BaseM, BaseXL } from 'components/core/Text/Text';
+import styled from 'styled-components';
+
+type Props = {
+  title: string;
+  description: string;
+};
+
+export default function WalletOnboardingMessage({ title, description }: Props) {
+  return (
+    <div>
+      <StyledTitle>{title}</StyledTitle>
+      <BaseM>{description}</BaseM>
+    </div>
+  );
+}
+
+const StyledTitle = styled(BaseXL)`
+  font-weight: 700;
+`;

--- a/src/components/WalletSelector/multichain/tezos/TezosAddWallet.tsx
+++ b/src/components/WalletSelector/multichain/tezos/TezosAddWallet.tsx
@@ -30,6 +30,7 @@ import { normalizeError } from '../normalizeError';
 import { WalletError } from '../WalletError';
 import { generatePayload, getNonceNumber } from './tezosUtils';
 import { useBeaconState } from 'contexts/beacon/BeaconContext';
+import WalletOnboardingMessage from '../WalletOnboardingMessage';
 
 type Props = {
   queryRef: TezosAddWalletFragment$key;
@@ -231,21 +232,19 @@ export const TezosAddWallet = ({ queryRef, reset }: Props) => {
 
   if (pendingState === PROMPT_SIGNATURE) {
     return (
-      <div>
-        <TitleS>Connect with Tezos</TitleS>
-        <Spacer height={8} />
-        <BaseM>Sign the message with your wallet.</BaseM>
-      </div>
+      <WalletOnboardingMessage
+        title="Connect with Tezos wallet"
+        description="Sign the message with your wallet."
+      />
     );
   }
 
   // Default view for when pendingState === INITIAL
   return (
-    <div>
-      <TitleS>Connect with Tezos</TitleS>
-      <Spacer height={8} />
-      <BaseM>Approve your wallet to connect to Gallery.</BaseM>
-    </div>
+    <WalletOnboardingMessage
+      title="Connect with Tezos wallet"
+      description="Approve your wallet to connect to Gallery."
+    />
   );
 };
 

--- a/src/components/WalletSelector/multichain/tezos/TezosAddWallet.tsx
+++ b/src/components/WalletSelector/multichain/tezos/TezosAddWallet.tsx
@@ -47,9 +47,7 @@ export const TezosAddWallet = ({ queryRef, reset }: Props) => {
   const [wallet, setWallet] = useState<string>();
   const { requestPermissions, requestSignature } = useBeaconActions();
 
-  const messageHeaderText = useMemo(() => {
-    return `Connect with ${wallet} wallet`;
-  }, [wallet]);
+  const messageHeaderText = `Connect with ${wallet || 'Tezos'} wallet`;
 
   const query = useFragment(
     graphql`

--- a/src/components/WalletSelector/multichain/tezos/TezosAddWallet.tsx
+++ b/src/components/WalletSelector/multichain/tezos/TezosAddWallet.tsx
@@ -47,7 +47,9 @@ export const TezosAddWallet = ({ queryRef, reset }: Props) => {
   const [wallet, setWallet] = useState<string>();
   const { requestPermissions, requestSignature } = useBeaconActions();
 
-  const messageHeaderText = `Connect with ${wallet} wallet`;
+  const messageHeaderText = useMemo(() => {
+    return `Connect with ${wallet} wallet`;
+  }, [wallet]);
 
   const query = useFragment(
     graphql`

--- a/src/components/WalletSelector/multichain/tezos/TezosAuthenticateWallet.tsx
+++ b/src/components/WalletSelector/multichain/tezos/TezosAuthenticateWallet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuthActions } from 'contexts/auth/AuthContext';
 import { INITIAL, PROMPT_SIGNATURE, PendingState } from 'types/Wallet';
 import {
@@ -26,7 +26,9 @@ export const TezosAuthenticateWallet = ({ reset }: Props) => {
   const [address, setAddress] = useState<string>();
   const [wallet, setWallet] = useState<string>();
 
-  const messageHeaderText = `Connect with ${wallet} wallet`;
+  const messageHeaderText = useMemo(() => {
+    return `Connect with ${wallet} wallet`;
+  }, [wallet]);
 
   const { requestPermissions, requestSignature } = useBeaconActions();
 

--- a/src/components/WalletSelector/multichain/tezos/TezosAuthenticateWallet.tsx
+++ b/src/components/WalletSelector/multichain/tezos/TezosAuthenticateWallet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAuthActions } from 'contexts/auth/AuthContext';
 import { INITIAL, PROMPT_SIGNATURE, PendingState } from 'types/Wallet';
 import {

--- a/src/components/WalletSelector/multichain/tezos/TezosAuthenticateWallet.tsx
+++ b/src/components/WalletSelector/multichain/tezos/TezosAuthenticateWallet.tsx
@@ -26,9 +26,7 @@ export const TezosAuthenticateWallet = ({ reset }: Props) => {
   const [address, setAddress] = useState<string>();
   const [wallet, setWallet] = useState<string>();
 
-  const messageHeaderText = useMemo(() => {
-    return `Connect with ${wallet} wallet`;
-  }, [wallet]);
+  const messageHeaderText = `Connect with ${wallet || 'Tezos'} wallet`;
 
   const { requestPermissions, requestSignature } = useBeaconActions();
 

--- a/src/components/WalletSelector/multichain/tezos/TezosAuthenticateWallet.tsx
+++ b/src/components/WalletSelector/multichain/tezos/TezosAuthenticateWallet.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
-import { BaseM, TitleS } from 'components/core/Text/Text';
 import { useAuthActions } from 'contexts/auth/AuthContext';
 import { INITIAL, PROMPT_SIGNATURE, PendingState } from 'types/Wallet';
-import Spacer from 'components/core/Spacer/Spacer';
 import {
   isEarlyAccessError,
   useTrackSignInAttempt,
@@ -16,6 +14,7 @@ import { WalletError } from '../WalletError';
 import { normalizeError } from '../normalizeError';
 import { generatePayload, getNonceNumber } from './tezosUtils';
 import { useBeaconState } from 'contexts/beacon/BeaconContext';
+import WalletOnboardingMessage from '../WalletOnboardingMessage';
 
 type Props = {
   reset: () => void;
@@ -127,19 +126,18 @@ export const TezosAuthenticateWallet = ({ reset }: Props) => {
 
   if (pendingState === PROMPT_SIGNATURE) {
     return (
-      <div>
-        <TitleS>Connect with Tezos</TitleS>
-        <Spacer height={8} />
-        <BaseM>Sign the message with your wallet.</BaseM>
-      </div>
+      <WalletOnboardingMessage
+        title="Connect with Tezos wallet"
+        description="Sign the message with your wallet."
+      />
     );
   }
 
+  // Default view for when pendingState === INITIAL
   return (
-    <div>
-      <TitleS>Connect with Tezos</TitleS>
-      <Spacer height={8} />
-      <BaseM>Approve your wallet to connect to Gallery.</BaseM>
-    </div>
+    <WalletOnboardingMessage
+      title="Connect with Tezos wallet"
+      description="Approve your wallet to connect to Gallery."
+    />
   );
 };

--- a/src/components/WalletSelector/multichain/tezos/TezosAuthenticateWallet.tsx
+++ b/src/components/WalletSelector/multichain/tezos/TezosAuthenticateWallet.tsx
@@ -13,7 +13,7 @@ import useLoginOrRedirectToOnboarding from 'components/WalletSelector/mutations/
 import { WalletError } from '../WalletError';
 import { normalizeError } from '../normalizeError';
 import { generatePayload, getNonceNumber } from './tezosUtils';
-import { useBeaconState } from 'contexts/beacon/BeaconContext';
+import { useBeaconActions } from 'contexts/beacon/BeaconContext';
 import WalletOnboardingMessage from '../WalletOnboardingMessage';
 
 type Props = {
@@ -24,8 +24,11 @@ export const TezosAuthenticateWallet = ({ reset }: Props) => {
   const [pendingState, setPendingState] = useState<PendingState>(INITIAL);
   const [error, setError] = useState<Error>();
   const [address, setAddress] = useState<string>();
+  const [wallet, setWallet] = useState<string>();
 
-  const beaconClient = useBeaconState();
+  const messageHeaderText = `Connect with ${wallet} wallet`;
+
+  const { requestPermissions, requestSignature } = useBeaconActions();
 
   const { handleLogin } = useAuthActions();
 
@@ -54,7 +57,7 @@ export const TezosAuthenticateWallet = ({ reset }: Props) => {
 
       const payload = generatePayload(nonce, address);
 
-      const { signature } = await beaconClient.requestSignPayload(payload);
+      const signature = await requestSignature(payload);
 
       const nonceNumber = getNonceNumber(nonce);
 
@@ -80,22 +83,23 @@ export const TezosAuthenticateWallet = ({ reset }: Props) => {
       }
     },
     [
-      trackSignInAttempt,
-      beaconClient,
       createNonce,
-      loginOrRedirectToOnboarding,
-      trackSignInSuccess,
       handleLogin,
+      loginOrRedirectToOnboarding,
+      requestSignature,
+      trackSignInAttempt,
+      trackSignInSuccess,
     ]
   );
 
   useEffect(() => {
     async function authenticate() {
       try {
-        const { publicKey, address } = await beaconClient.requestPermissions();
+        const { publicKey, address, wallet } = await requestPermissions();
 
         if (!address || !publicKey) return;
         setAddress(address);
+        setWallet(wallet);
         await attemptAuthentication(address, publicKey);
       } catch (error) {
         trackSignInError('Tezos', error);
@@ -109,7 +113,7 @@ export const TezosAuthenticateWallet = ({ reset }: Props) => {
     }
 
     void authenticate();
-  }, [attemptAuthentication, beaconClient, trackSignInError]);
+  }, [attemptAuthentication, requestPermissions, trackSignInError]);
 
   if (error) {
     return (
@@ -127,7 +131,7 @@ export const TezosAuthenticateWallet = ({ reset }: Props) => {
   if (pendingState === PROMPT_SIGNATURE) {
     return (
       <WalletOnboardingMessage
-        title="Connect with Tezos wallet"
+        title={messageHeaderText}
         description="Sign the message with your wallet."
       />
     );
@@ -136,7 +140,7 @@ export const TezosAuthenticateWallet = ({ reset }: Props) => {
   // Default view for when pendingState === INITIAL
   return (
     <WalletOnboardingMessage
-      title="Connect with Tezos wallet"
+      title={messageHeaderText}
       description="Approve your wallet to connect to Gallery."
     />
   );

--- a/src/flows/shared/steps/OrganizeCollection/Directions.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Directions.tsx
@@ -2,15 +2,13 @@ import { memo } from 'react';
 import styled from 'styled-components';
 
 import { BaseXL, BaseM } from 'components/core/Text/Text';
-import Spacer from 'components/core/Spacer/Spacer';
 import { FOOTER_HEIGHT } from 'flows/shared/components/WizardFooter/WizardFooter';
 
 function Directions() {
   return (
     <DirectionsContainer>
       <StyledDirections>
-        <BaseXL>Add NFTs to your collection</BaseXL>
-        <Spacer height={8} />
+        <StyledDirectionsTitle>Add NFTs to your collection</StyledDirectionsTitle>
         <BaseM>Select NFTs to include in your collection. Drag and drop to rearrange.</BaseM>
       </StyledDirections>
     </DirectionsContainer>
@@ -30,6 +28,10 @@ const StyledDirections = styled.div`
   text-align: center;
 
   width: 269px;
+`;
+
+const StyledDirectionsTitle = styled(BaseXL)`
+  font-weight: 700;
 `;
 
 export default memo(Directions);


### PR DESCRIPTION
**Changes**
- Update the empty state design for tezos auth flow & collection editor
- The message title will based on pre-selected wallet on beacon


**Screenshot**

**Auth for Tezos**

![CleanShot 2022-09-05 at 17 39 55](https://user-images.githubusercontent.com/4480258/188419171-3aac9b68-afa6-43e3-85c1-bd1e70536b18.png)

**Kukai**

<img width="1476" alt="CleanShot 2022-09-07 at 14 25 33@2x" src="https://user-images.githubusercontent.com/4480258/188804277-76049f4c-1f5a-4b4a-9045-ac9a62cb1000.png">


**Temple**

![CleanShot 2022-09-07 at 13 10 18](https://user-images.githubusercontent.com/4480258/188793541-da5c135c-4ddf-4a4d-9593-9d036dfd50de.png)



**Collection Editor**

![CleanShot 2022-09-05 at 17 36 11](https://user-images.githubusercontent.com/4480258/188418414-b1c53e6b-d449-4a28-b862-c25a8509d41b.png)


**Pending**

- [x] Finalized with jess if we should show specific wallet (kukai/temple/etc) on auth screen

**Notes**

- Not sure why the cypress can't run. Will do a follow up PR to tackle the issue

