### PR TITLE
Use ABC Diatype for rainbowkit font

### DIFF
--- a/src/contexts/auth/EthereumProviders.tsx
+++ b/src/contexts/auth/EthereumProviders.tsx
@@ -45,9 +45,9 @@ const myCustomTheme = merge(lightTheme(), {
     //   selectedOptionBorder: '...',
     //   standby: '...',
   },
-  // fonts: {
-  //   body: '...',
-  // },
+  fonts: {
+    body: 'ABC Diatype',
+  },
   radii: {
     actionButton: '0',
     connectButton: '0',


### PR DESCRIPTION
**Before**

<img width="776" alt="Screen Shot 2022-09-07 at 11 51 14 PM" src="https://user-images.githubusercontent.com/12162433/189030407-10f60713-8c99-4f20-96d7-0662421c3815.png">

**After**

<img width="784" alt="Screen Shot 2022-09-07 at 11 51 06 PM" src="https://user-images.githubusercontent.com/12162433/189030400-ff240908-adec-416a-8226-533ba630ecb7.png">
