### PR TITLE
give failure fallback min width

### DIFF
--- a/src/components/NftFailureFallback/NftFailureFallback.tsx
+++ b/src/components/NftFailureFallback/NftFailureFallback.tsx
@@ -112,6 +112,8 @@ const AspectRatioWrapper = styled.div`
   height: 0;
   padding-bottom: 100%;
   position: relative;
+
+  min-width: 150px;
 `;
 
 // No support for aspect-ratio trick


### PR DESCRIPTION
In a grid, if the failed NFT is the only item, it has no basis for a width since there are no other NFTs to fill the space and give the other stuff a reference. 

The fix is to give the fallback a `min-width` in the case that there are no other NFTs.

<img width="1240" alt="image" src="https://user-images.githubusercontent.com/6754223/189221789-b30ee511-82e4-4327-979b-6921d52beee7.png">
