### PR TITLE
Fix video poster bug

### DIFF
--- a/src/components/NftPreview/NftPreviewAsset.tsx
+++ b/src/components/NftPreview/NftPreviewAsset.tsx
@@ -6,6 +6,7 @@ import { NftPreviewAssetFragment$key } from '__generated__/NftPreviewAssetFragme
 import VideoWithLoading from 'components/LoadingAsset/VideoWithLoading';
 import { ContentIsLoadedEvent } from 'contexts/shimmer/ShimmerContext';
 import { CouldNotRenderNftError } from 'errors/CouldNotRenderNftError';
+import isVideoUrl from 'utils/isVideoUrl';
 
 type Props = {
   tokenRef: NftPreviewAssetFragment$key;
@@ -75,7 +76,7 @@ function NftPreviewAsset({ tokenRef, size, onLoad }: Props) {
   // TODO: this is a hack to handle videos that are returned by OS as images.
   // i.e., assets that do not have animation_urls, and whose image_urls all contain
   // links to videos. we should be able to remove this hack once we're off of OS.
-  if (src.endsWith('.mp4') || src.endsWith('.webm')) {
+  if (isVideoUrl(src)) {
     return <VideoWithLoading onLoad={onLoad} src={src} />;
   }
 

--- a/src/scenes/NftDetailPage/NftDetailImage.tsx
+++ b/src/scenes/NftDetailPage/NftDetailImage.tsx
@@ -10,6 +10,7 @@ import { StyledVideo } from './NftDetailVideo';
 import noop from 'utils/noop';
 import { CouldNotRenderNftError } from 'errors/CouldNotRenderNftError';
 import { useThrowOnMediaFailure } from 'hooks/useNftRetry';
+import isVideoUrl from 'utils/isVideoUrl';
 
 type Props = {
   tokenRef: NftDetailImageFragment$key;
@@ -56,7 +57,7 @@ function NftDetailImage({ tokenRef, onClick = noop, onLoad }: Props) {
   // TODO: this is a hack to handle videos that are returned by OS as images.
   // i.e., assets that do not have animation_urls, and whose image_urls all contain
   // links to videos. we should be able to remove this hack once we're off of OS.
-  if (url.endsWith('.mp4') || url.endsWith('.webm')) {
+  if (isVideoUrl(url)) {
     return (
       <StyledVideo
         onLoadedData={onLoad}

--- a/src/scenes/NftDetailPage/NftDetailVideo.tsx
+++ b/src/scenes/NftDetailPage/NftDetailVideo.tsx
@@ -4,6 +4,8 @@ import { graphql } from 'relay-runtime';
 import { NftDetailVideoFragment$key } from '__generated__/NftDetailVideoFragment.graphql';
 import { ContentIsLoadedEvent } from 'contexts/shimmer/ShimmerContext';
 import { useThrowOnMediaFailure } from 'hooks/useNftRetry';
+import { useMemo } from 'react';
+import isVideoUrl from 'utils/isVideoUrl';
 
 type Props = {
   mediaRef: NftDetailVideoFragment$key;
@@ -29,6 +31,18 @@ function NftDetailVideo({ mediaRef, hideControls = false, onLoad }: Props) {
 
   const { handleError } = useThrowOnMediaFailure('NftDetailVideo');
 
+  const poster = useMemo(() => {
+    if (!token?.previewURLs?.large) {
+      return undefined;
+    }
+
+    if (isVideoUrl(token.previewURLs.large)) {
+      return undefined;
+    }
+
+    return token.previewURLs.large;
+  }, [token?.previewURLs?.large]);
+
   return (
     <StyledVideo
       src={`${token.contentRenderURLs.large}#t=0.001`}
@@ -48,7 +62,7 @@ function NftDetailVideo({ mediaRef, hideControls = false, onLoad }: Props) {
        * a static poster in its place.
        */
       onError={handleError}
-      poster={token?.previewURLs?.large ?? ''}
+      poster={poster}
     />
   );
 }

--- a/src/utils/isVideoUrl.ts
+++ b/src/utils/isVideoUrl.ts
@@ -1,0 +1,3 @@
+export default function isVideoUrl(src: string) {
+  return src.includes('.mp4') || src.includes('.webm');
+}


### PR DESCRIPTION
Rendering a video URL as a `poster` causes the video component to throw an error; the poster must be an image.

Follow-up: ensure `previewURLs` that are sent from the server are always images