### PR TITLE
Paste URL onto text to create link

### DIFF
--- a/src/components/core/TextArea/TextArea.tsx
+++ b/src/components/core/TextArea/TextArea.tsx
@@ -36,9 +36,10 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         if (event.key === 'v' && event.metaKey) {
           // Wrap in a try/catch because navigator.clipboard.readText() is not supported in Firefox. If it fails, pasting behavior will be default
           try {
-            // FIXME: Handle Typescript error from forwardRef
-            if (ref.current) {
-              const textArea = ref.current;
+            // @ts-expect-error: Handle Typescript error from forwardRef
+            if (ref?.current) {
+              // @ts-expect-error: Handle Typescript error from forwardRef
+              const textArea = ref?.current;
               const [selectionStart, selectionEnd] = [
                 textArea.selectionStart,
                 textArea.selectionEnd,


### PR DESCRIPTION
This PR creates the magic "paste-to-link" functionality seen on Notion, etc.

https://user-images.githubusercontent.com/13339581/190868703-53a47f5b-1c38-411a-8acc-6a1b6ab44076.mov

https://user-images.githubusercontent.com/13339581/190869107-442536e0-24bf-46e5-b5f7-fe026fda0a8a.mov



It only triggers the "paste-to-link" when the user's clipboard text begins with `http`. Otherwise, the paste behavior will be default (overwriting the selected text)

https://user-images.githubusercontent.com/13339581/190868800-ba8d2513-77c4-4d9f-b127-5e6a0e547e7b.mov

---

We wrap the pasting functionality in a `try/catch` block which means if it errors out for any reason, it will default to normal pasting behavior.

[`navigator.clipboard.readText()` is not supported in Firefox](https://stackoverflow.com/questions/67440036/navigator-clipboard-readtext-is-not-working-in-firefox), and so this functionality will not work there. Because this will fail in the `try` block, Firefox will simply default to normal pasting behavior.