### PR TITLE
[GAL-442] Rows rendering incorrectly on Safari 16

### DIFF
--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -131,8 +131,8 @@ function NftPreview({
 
   const { handleNftLoaded, handleNftError, retryKey, refreshMetadata, refreshingMetadata } =
     useNftRetry({
-    tokenId: token.dbid,
-  });
+      tokenId: token.dbid,
+    });
 
   const PreviewAsset = useMemo(() => {
     if (disableLiverender) {

--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -131,8 +131,8 @@ function NftPreview({
 
   const { handleNftLoaded, handleNftError, retryKey, refreshMetadata, refreshingMetadata } =
     useNftRetry({
-      tokenId: token.dbid,
-    });
+    tokenId: token.dbid,
+  });
 
   const PreviewAsset = useMemo(() => {
     if (disableLiverender) {
@@ -268,14 +268,7 @@ const StyledNftPreview = styled.div<{
   max-height: 80vh;
   max-width: ${({ aspectRatio }) => `calc(80vh * ${aspectRatio})`};
   width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
-  height: inherit;
-
-  // Only apply to safari. Somehow the height is not being set properly on safari.
-  @media not all and (min-resolution: 0.001dpcm) {
-    @supports (-webkit-appearance: none) {
-      height: initial;
-    }
-  }
+  height: initial;
 
   ${({ backgroundColorOverride }) =>
     backgroundColorOverride && `background-color: ${backgroundColorOverride};`}


### PR DESCRIPTION
Seems like the Safari 16 deprecated the `-webkit-appearance`

Can't find the documentation that mentioned its deprecated but this tweet helps - https://twitter.com/bigel/status/1570953610611294208 😬

**Before**
https://user-images.githubusercontent.com/4480258/190954844-ca06bb58-f317-424e-a3bb-3363718cca6d.MP4



**After**
https://user-images.githubusercontent.com/4480258/190954860-a0c60272-4b5e-467c-9b5c-6c47be5f2f16.MP4



