### PR TITLE
[GAL-445] fix issue getting owned supply which prevented price from showing

### DIFF
--- a/src/hooks/useMintContractWithQuantity.tsx
+++ b/src/hooks/useMintContractWithQuantity.tsx
@@ -57,7 +57,12 @@ export default function useMintContractWithQuantity({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async (contract: any) => {
       if (contract && address) {
-        return web3.utils.hexToNumber(await contract.balanceOfType(tokenId, address));
+        try {
+          const balance = await contract.balanceOfType(tokenId, address);
+          return web3.utils.hexToNumber(balance);
+        } catch {
+          return 0;
+        }
       }
     },
     [address, tokenId]


### PR DESCRIPTION
The item price didn't appear on the item page on the merch store, preventing users from minting.
It was caused by an error thrown while calculating the owned supply that prevented the page from fetching the price.

Before 

![Screen Shot 2022-09-20 at 18 38 03](https://user-images.githubusercontent.com/80802871/191235068-9465cb4c-14ef-4df3-9aed-8a031a32f972.png)


After
![Screen Shot 2022-09-20 at 19 29 17](https://user-images.githubusercontent.com/80802871/191235078-346d1537-0616-4edd-84e7-3f79972c71b0.png)
