### PR TITLE
GAL-450 Update error message during create user to account for invalid username OR bio

### DIFF
--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarChainSelector.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarChainSelector.tsx
@@ -72,7 +72,7 @@ export function SidebarChainSelector({ selected, onChange, queryRef }: SidebarCh
 
   const selectedChain = chains.find((chain) => chain.name === selected);
 
-  const isPOAPEnabled = isFeatureEnabled(FeatureFlag.POAP, query);
+  const isPOAPEnabled = true;
   const [tezosEnabled] = usePersistedState<boolean>(TEZOS_EARLY_ACCESS_LOCAL_STORAGE_KEY, false);
 
   const handleChainClick = useCallback(
@@ -140,7 +140,7 @@ export function SidebarChainSelector({ selected, onChange, queryRef }: SidebarCh
           if (chain.name === 'Ethereum') {
             locked = false;
           } else if (chain.name === 'POAP') {
-            locked = isPOAPEnabled;
+            locked = !isPOAPEnabled;
           } else if (chain.name === 'Tezos') {
             locked = !tezosEnabled;
           }

--- a/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarChainSelector.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Sidebar/SidebarChainSelector.tsx
@@ -72,7 +72,7 @@ export function SidebarChainSelector({ selected, onChange, queryRef }: SidebarCh
 
   const selectedChain = chains.find((chain) => chain.name === selected);
 
-  const isPOAPEnabled = true;
+  const isPOAPEnabled = isFeatureEnabled(FeatureFlag.POAP, query);
   const [tezosEnabled] = usePersistedState<boolean>(TEZOS_EARLY_ACCESS_LOCAL_STORAGE_KEY, false);
 
   const handleChainClick = useCallback(
@@ -140,7 +140,7 @@ export function SidebarChainSelector({ selected, onChange, queryRef }: SidebarCh
           if (chain.name === 'Ethereum') {
             locked = false;
           } else if (chain.name === 'POAP') {
-            locked = !isPOAPEnabled;
+            locked = isPOAPEnabled;
           } else if (chain.name === 'Tezos') {
             locked = !tezosEnabled;
           }

--- a/src/hooks/api/users/useCreateUser.ts
+++ b/src/hooks/api/users/useCreateUser.ts
@@ -88,7 +88,7 @@ export default function useCreateUser() {
         throw new Error('The username is taken');
       }
       if (response.createUser?.__typename === 'ErrInvalidInput') {
-        throw new Error('Username is invalid');
+        throw new Error('Username or bio is invalid');
       }
 
       return response;


### PR DESCRIPTION
During onboarding (create user), if you enter an invalid bio, the UI displays the error message "Username is invalid". 
This confused a user who thought their username was bad and couldn't proceed through onboarding, even though it was the bio that caused the error.

In the edit username/bio ui, (for existing users), the message we display is "Username or bio is invalid", so this PR updates the error message when creating a user to match.


Error message for invalid bio when creating a user (confusing)
<img width="704" alt="Screen Shot 2022-09-22 at 11 10 44" src="https://user-images.githubusercontent.com/80802871/191643340-e38347c1-b036-4399-bbe4-b14645bed72d.png">


Error message for invalid bio when editing an existing user (less confusing)
<img width="534" alt="Screen Shot 2022-09-22 at 11 09 47" src="https://user-images.githubusercontent.com/80802871/191643360-66de8dbe-fad5-4282-8d5c-d7bf20f46c19.png">
