### PR TITLE
Disable video looping on safari

### DIFF
--- a/src/components/LoadingAsset/ImageWithLoading.tsx
+++ b/src/components/LoadingAsset/ImageWithLoading.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import styled from 'styled-components';
-import isFirefox from 'utils/isFirefox';
 import isSvg from 'utils/isSvg';
 import noop from 'utils/noop';
 import { useThrowOnMediaFailure } from 'hooks/useNftRetry';
+import { isFirefox } from 'utils/browser';
 
 type ContentHeightType =
   | 'maxHeightMinScreen' // fill up to 80vh of screen or 100% of container

--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -12,7 +12,6 @@ import { NftPreviewFragment$key } from '__generated__/NftPreviewFragment.graphql
 import NftDetailVideo from 'scenes/NftDetailPage/NftDetailVideo';
 import NftDetailAnimation from 'scenes/NftDetailPage/NftDetailAnimation';
 import getVideoOrImageUrlForNftPreview from 'utils/graphql/getVideoOrImageUrlForNftPreview';
-import isFirefox from 'utils/isFirefox';
 import isSvg from 'utils/isSvg';
 import LinkToNftDetailView from 'scenes/NftDetailPage/LinkToNftDetailView';
 import { useContentState } from 'contexts/shimmer/ShimmerContext';
@@ -20,6 +19,7 @@ import { useNftRetry } from 'hooks/useNftRetry';
 import { NftFailureFallback } from 'components/NftFailureFallback/NftFailureFallback';
 import { NftPreviewTokenFragment$key } from '../../../__generated__/NftPreviewTokenFragment.graphql';
 import { NftFailureBoundary } from 'components/NftFailureFallback/NftFailureBoundary';
+import { isFirefox } from 'utils/browser';
 
 type Props = {
   tokenRef: NftPreviewFragment$key;

--- a/src/scenes/NftDetailPage/NftDetailVideo.tsx
+++ b/src/scenes/NftDetailPage/NftDetailVideo.tsx
@@ -6,6 +6,7 @@ import { ContentIsLoadedEvent } from 'contexts/shimmer/ShimmerContext';
 import { useThrowOnMediaFailure } from 'hooks/useNftRetry';
 import { useMemo } from 'react';
 import isVideoUrl from 'utils/isVideoUrl';
+import { isSafari } from 'utils/browser';
 
 type Props = {
   mediaRef: NftDetailVideoFragment$key;
@@ -48,9 +49,14 @@ function NftDetailVideo({ mediaRef, hideControls = false, onLoad }: Props) {
       src={`${token.contentRenderURLs.large}#t=0.001`}
       muted
       autoPlay
-      loop
       playsInline
       controls={!hideControls}
+      /**
+       * Disable video looping if browser is Safari. As of Sept 2022, there's a bug on Safari
+       * where data will continuously download each time the video loops, at worst case leading
+       * to several gigabytes being fetched (which is really bad on mobile devices)
+       */
+      loop={!isSafari()}
       onLoadedData={onLoad}
       /**
        * NOTE: As of July 2022, there's a bug on iOS where certain videos will fail to load.

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,0 +1,7 @@
+export function isSafari() {
+  return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+}
+
+export function isFirefox() {
+  return navigator.userAgent.toLowerCase().includes('firefox');
+}

--- a/src/utils/isFirefox.ts
+++ b/src/utils/isFirefox.ts
@@ -1,3 +1,0 @@
-export default function isFirefox() {
-  return navigator.userAgent.toLowerCase().includes('firefox');
-}


### PR DESCRIPTION
Disable video looping if browser is Safari. As of Sept 2022, there's a bug on Safari where data will continuously download each time the video loops, at worst case leading to several gigabytes being fetched (which is really bad on mobile devices)