### PR TITLE
[GAL-457] NFT Preview Hover Text is misaligned on safari

### DIFF
--- a/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -210,7 +210,7 @@ const StyledSecondaryButton = styled(Button).attrs({ variant: 'secondary' })`
   width: 100%;
   @media only screen and ${breakpoints.tablet} {
     width: fit-content;
-    align-self: end;
+    align-self: flex-end;
   }
 `;
 

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -33,7 +33,7 @@ function NftPreviewLabel({ className, tokenRef }: Props) {
 
   return (
     <StyledNftPreviewLabel className={className}>
-      <HStack gap={4} justify={'end'} align="center">
+      <HStack gap={4} justify={'flex-end'} align="center">
         {token.chain === 'POAP' && <POAPLogo />}
         <VStack shrink>
           {token.chain === 'POAP' ? (
@@ -106,7 +106,7 @@ export const StyledNftPreviewLabel = styled.div`
 
   display: flex;
   flex-direction: column;
-  justify-content: end;
+  justify-content: flex-end;
 
   bottom: 0;
   width: 100%;


### PR DESCRIPTION
**Finding**
The bug only happens on Safari < 15.5 because of the flex CSS  `end`  value 

**Changes**
- Replace the `end` into `flex-end` for most wide browser support on all components

**Reference**
- https://caniuse.com/mdn-css_properties_align-items_flex_context_start_end
- https://github.com/chakra-ui/chakra-ui/issues/5562
- https://stackoverflow.com/questions/70339367/flexbox-align-items-and-justify-content-end-not-working-in-safari-macos

**Before**

<img width="1094" alt="CleanShot 2022-09-22 at 16 18 55@2x" src="https://user-images.githubusercontent.com/4480258/191783962-ebe310f4-43bc-4ec5-8971-72df74b9cb9c.png">


**After**

<img width="1078" alt="CleanShot 2022-09-22 at 16 16 23@2x" src="https://user-images.githubusercontent.com/4480258/191784053-b917c2f3-c4f5-412b-999f-e36ac46b58a5.png">


