### PR TITLE
Fix poap community label

### DIFF
--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -12,9 +12,12 @@ import { HStack, VStack } from 'components/core/Spacer/Stack';
 type Props = {
   className?: string;
   tokenRef: NftPreviewLabelFragment$key;
+  // if true, the community link will appear clickable.
+  // if false, the label will appear flat.
+  interactive?: boolean;
 };
 
-function NftPreviewLabel({ className, tokenRef }: Props) {
+function NftPreviewLabel({ className, tokenRef, interactive = true }: Props) {
   const token = useFragment(
     graphql`
       fragment NftPreviewLabelFragment on Token {
@@ -27,26 +30,24 @@ function NftPreviewLabel({ className, tokenRef }: Props) {
     tokenRef
   );
 
-  // Since POAPs' collection names are the same as the
-  // token name, we don't want to show duplicate information
-  const showCollectionName = token.name && token.chain !== 'POAP';
+  const showCollectionName = Boolean(token.name);
 
   return (
     <StyledNftPreviewLabel className={className}>
       <HStack gap={4} justify={'flex-end'} align="center">
         {token.chain === 'POAP' && <POAPLogo />}
         <VStack shrink>
-          {token.chain === 'POAP' ? (
-            <POAPTitle lines={1} color={colors.white}>
-              {token.name}
-            </POAPTitle>
-          ) : (
-            <StyledBaseM color={colors.white} lines={1}>
-              {token.name}
-            </StyledBaseM>
-          )}
+          {
+            // Since POAPs' collection names are the same as the
+            // token name, we don't want to show duplicate information
+            token.chain === 'POAP' ? null : (
+              <StyledBaseM color={colors.white} lines={1}>
+                {token.name}
+              </StyledBaseM>
+            )
+          }
 
-          {showCollectionName && <CollectionName tokenRef={token} />}
+          {showCollectionName && <CollectionName tokenRef={token} interactive={interactive} />}
         </VStack>
       </HStack>
     </StyledNftPreviewLabel>
@@ -55,9 +56,10 @@ function NftPreviewLabel({ className, tokenRef }: Props) {
 
 type CollectionNameProps = {
   tokenRef: NftPreviewLabelCollectionNameFragment$key;
+  interactive?: boolean;
 };
 
-function CollectionName({ tokenRef }: CollectionNameProps) {
+function CollectionName({ tokenRef, interactive }: CollectionNameProps) {
   const token = useFragment(
     graphql`
       fragment NftPreviewLabelCollectionNameFragment on Token {
@@ -82,7 +84,21 @@ function CollectionName({ tokenRef }: CollectionNameProps) {
     return null;
   }
 
-  return communityUrl ? (
+  const shouldDisplayLinkToCommunityPage = communityUrl && interactive;
+
+  if (token.chain === 'POAP') {
+    return shouldDisplayLinkToCommunityPage ? (
+      <POAPTitle lines={2}>
+        <StyledInteractiveLink to={communityUrl}>{collectionName}</StyledInteractiveLink>
+      </POAPTitle>
+    ) : (
+      <POAPTitle color={colors.white} lines={2}>
+        {collectionName}
+      </POAPTitle>
+    );
+  }
+
+  return shouldDisplayLinkToCommunityPage ? (
     <StyledBaseM lines={2}>
       <StyledInteractiveLink to={communityUrl}>{collectionName}</StyledInteractiveLink>
     </StyledBaseM>

--- a/src/flows/shared/steps/OrganizeCollection/Editor/StagedNftImage.tsx
+++ b/src/flows/shared/steps/OrganizeCollection/Editor/StagedNftImage.tsx
@@ -110,7 +110,7 @@ function StagedNftImageImage({
 
   return (
     <StyledGridImage srcUrl={url} ref={setNodeRef} size={size} {...props}>
-      {hideLabel ? null : <StyledNftPreviewLabel tokenRef={token} />}
+      {hideLabel ? null : <StyledNftPreviewLabel tokenRef={token} interactive={false} />}
     </StyledGridImage>
   );
 }
@@ -145,7 +145,7 @@ function StagedNftImageVideo({
   return (
     <VideoContainer ref={setNodeRef} size={size} {...props}>
       <StyledGridVideo onLoad={onLoad} src={url} />
-      {hideLabel ? null : <StyledNftPreviewLabel tokenRef={token} />}
+      {hideLabel ? null : <StyledNftPreviewLabel tokenRef={token} interactive={false} />}
     </VideoContainer>
   );
 }


### PR DESCRIPTION
**Ensure POAP community link is clickable from NFT label on gallery**

| Before | After |
| ----- | ----- |
| ![image](https://user-images.githubusercontent.com/12162433/192440207-17926afd-4a07-4c23-a7ff-54bfcf5f3450.png) | ![image](https://user-images.githubusercontent.com/12162433/192440794-a424cf19-ac6e-44a0-89a0-a23f28e3fb99.png) |

**Disable non-POAP community links from being clickable on editor**

| Before | After |
| ----- | ----- |
| ![image](https://user-images.githubusercontent.com/12162433/192440423-f2f8e7d9-78fb-45de-81e6-0251c94e53df.png) | ![image](https://user-images.githubusercontent.com/12162433/192440691-cb605c14-a9cb-4b80-90dd-552278b70c8c.png) |

Tested against regressions:
- Make sure community link for standard NFTs continue to appear clickable on gallery

![image](https://user-images.githubusercontent.com/12162433/192440610-6db04608-ce11-44c0-9719-21d0743f9c65.png)

- Make sure POAP community titles with long names still get truncated

![image](https://user-images.githubusercontent.com/12162433/192440838-00d8d187-721e-4bfb-b5ca-937978d7549f.png)

- Make sure POAP community titles continue to appear un-clickable in editor

![image](https://user-images.githubusercontent.com/12162433/192440902-6790402b-ffc0-4b8c-8b87-aedb02861374.png)
