### PR TITLE
[GAL-471] Fix gallery width

### DIFF
--- a/src/scenes/CollectionGalleryPage/CollectionGallery.tsx
+++ b/src/scenes/CollectionGalleryPage/CollectionGallery.tsx
@@ -77,17 +77,15 @@ function CollectionGallery({ queryRef }: Props) {
   if (collection?.__typename === 'Collection') {
     return (
       <StyledCollectionGallery isMobile={isMobile} align="center">
-        <VStack gap={isMobile ? 48 : 80}>
+        <NftGalleryWrapper gap={isMobile ? 48 : 80}>
           <CollectionGalleryHeader
             queryRef={query}
             collectionRef={collection}
             mobileLayout={mobileLayout}
             setMobileLayout={setMobileLayout}
           />
-          <NftGalleryWrapper>
-            <NftGallery collectionRef={collection} mobileLayout={mobileLayout} />
-          </NftGalleryWrapper>
-        </VStack>
+          <NftGallery collectionRef={collection} mobileLayout={mobileLayout} />
+        </NftGalleryWrapper>
       </StyledCollectionGallery>
     );
   } else if (collection?.__typename === 'ErrCollectionNotFound') {
@@ -104,7 +102,7 @@ const StyledCollectionGallery = styled(VStack)<{ isMobile: boolean }>`
   padding: ${({ isMobile }) => (isMobile ? '48px 0 16px 0' : '80px 0 64px 0')};
 `;
 
-const NftGalleryWrapper = styled.div`
+const NftGalleryWrapper = styled(VStack)`
   width: 100%;
 `;
 


### PR DESCRIPTION
## Problem

Seems like this issue happens only on **Single Collection page** and there is only **one NFT inside** the collection. 

## Demo gallery width comparing side by side Main gallery <-> Collection page

**Before**

https://user-images.githubusercontent.com/4480258/192917240-cf66d05d-8d57-47ea-81c0-a65afc04d9e9.mp4


**After**

https://user-images.githubusercontent.com/4480258/192917122-8a4f1506-293a-406a-877e-e8f9c1866c03.mp4


## Mobile view if there is one NFT / none

**Before**

![CleanShot 2022-09-29 at 09 25 48](https://user-images.githubusercontent.com/4480258/192917628-e649cea8-bc5d-44c0-b7fe-808c51eb6f47.png)


**After**

![CleanShot 2022-09-29 at 09 26 15](https://user-images.githubusercontent.com/4480258/192917692-8a1d3437-25a7-44de-8d57-96560ba77a52.png)
