### PR TITLE
[GAL-466] Block "Next" step until username is valid

### DIFF
--- a/src/components/Profile/useUserInfoForm.ts
+++ b/src/components/Profile/useUserInfoForm.ts
@@ -66,6 +66,9 @@ export default function useUserInfoForm({
 
   const usernameFieldIsDirty = useRef(false);
 
+  // This cannot be derived from a "null" `usernameError`
+  // since the value starts off as empty when the form is empty
+  const [isUsernameValid, setIsUsernameValid] = useState(false);
   const [usernameError, setUsernameError] = useState('');
 
   // Generic error that doesn't belong to username / bio
@@ -130,6 +133,8 @@ export default function useUserInfoForm({
 
   const handleUsernameChange = useCallback((username: string) => {
     setUsername(username);
+
+    setIsUsernameValid(false);
     usernameFieldIsDirty.current = true;
   }, []);
 
@@ -150,15 +155,19 @@ export default function useUserInfoForm({
       ]);
 
       if (clientSideUsernameError) {
-        setUsernameError(clientSideUsernameError || '');
+        setUsernameError(clientSideUsernameError);
 
         return;
+      } else {
+        setUsernameError('');
       }
 
       isUsernameAvailableFetcher(debouncedUsername)
         .then((isUsernameAvailable) => {
           if (!isUsernameAvailable) {
             setUsernameError('Username is taken');
+          } else {
+            setIsUsernameValid(true);
           }
         })
         .catch((error) => {
@@ -178,18 +187,25 @@ export default function useUserInfoForm({
     [debouncedUsername, isUsernameAvailableFetcher, reportError]
   );
 
-  const values = useMemo(
+  return useMemo(
     () => ({
       bio,
       username,
       generalError,
       usernameError,
+      isUsernameValid,
       onBioChange: setBio,
       onEditUser: handleCreateOrEditUser,
       onUsernameChange: handleUsernameChange,
     }),
-    [bio, generalError, handleCreateOrEditUser, handleUsernameChange, username, usernameError]
+    [
+      bio,
+      generalError,
+      handleCreateOrEditUser,
+      handleUsernameChange,
+      isUsernameValid,
+      username,
+      usernameError,
+    ]
   );
-
-  return values;
 }

--- a/src/components/Profile/useUserInfoForm.ts
+++ b/src/components/Profile/useUserInfoForm.ts
@@ -18,6 +18,7 @@ import useDebounce from 'hooks/useDebounce';
 import useAuthPayloadQuery from 'hooks/api/users/useAuthPayloadQuery';
 import { useTrackCreateUserSuccess } from 'contexts/analytics/authUtil';
 import { useUserInfoFormIsUsernameAvailableQuery } from '../../../__generated__/useUserInfoFormIsUsernameAvailableQuery.graphql';
+import { useReportError } from 'contexts/errorReporting/ErrorReportingContext';
 
 type Props = {
   onSuccess: (username: string) => void;
@@ -60,22 +61,28 @@ export default function useUserInfoForm({
   existingBio,
   userId,
 }: Props) {
+  const [bio, setBio] = useState(existingBio ?? '');
   const [username, setUsername] = useState(existingUsername ?? '');
-  const [usernameError, setUsernameError] = useState('');
+
   const usernameFieldIsDirty = useRef(false);
 
-  const [bio, setBio] = useState(existingBio ?? '');
+  const [usernameError, setUsernameError] = useState('');
 
   // Generic error that doesn't belong to username / bio
   const [generalError, setGeneralError] = useState('');
+
   const updateUser = useUpdateUser();
   const createUser = useCreateUser();
+  const reportError = useReportError();
   const authPayloadQuery = useAuthPayloadQuery();
+  const isUsernameAvailableFetcher = useIsUsernameAvailableFetcher();
   const trackCreateUserSuccess = useTrackCreateUserSuccess(
     authPayloadQuery?.userFriendlyWalletName
   );
 
-  const handleCreateOrEditUser = useCallback(async () => {
+  const debouncedUsername = useDebounce(username, 500);
+
+  const handleCreateOrEditUser = useCallback(async (): Promise<{ success: boolean }> => {
     setGeneralError('');
 
     if (usernameError) {
@@ -94,15 +101,19 @@ export default function useUserInfoForm({
         if (!authPayloadQuery) {
           throw new Error('Auth signature for creating user not found');
         }
+
         await createUser(authPayloadQuery, username, bio);
         trackCreateUserSuccess();
       }
+
       onSuccess(username);
+
       return { success: true };
     } catch (error: unknown) {
       if (error instanceof Error) {
         setGeneralError(formatError(error));
       }
+
       return { success: false };
     }
   }, [
@@ -122,47 +133,60 @@ export default function useUserInfoForm({
     usernameFieldIsDirty.current = true;
   }, []);
 
-  const isUsernameAvailableFetcher = useIsUsernameAvailableFetcher();
-
-  const debouncedUsername = useDebounce(username, 500);
-
-  // validate username
-  useEffect(() => {
-    async function validateUsername() {
+  useEffect(
+    function validateUsername() {
       setGeneralError('');
 
-      if (debouncedUsername.length >= 2) {
-        const clientSideUsernameError = validate(debouncedUsername, [
-          required,
-          minLength(2),
-          maxLength(20),
-          alphanumericUnderscores,
-          noConsecutivePeriodsOrUnderscores,
-        ]);
+      if (debouncedUsername.length < 2) {
+        return;
+      }
 
+      const clientSideUsernameError = validate(debouncedUsername, [
+        required,
+        minLength(2),
+        maxLength(20),
+        alphanumericUnderscores,
+        noConsecutivePeriodsOrUnderscores,
+      ]);
+
+      if (clientSideUsernameError) {
         setUsernameError(clientSideUsernameError || '');
 
-        if (usernameFieldIsDirty.current && !clientSideUsernameError) {
-          const isUsernameAvailable = await isUsernameAvailableFetcher(debouncedUsername);
+        return;
+      }
+
+      isUsernameAvailableFetcher(debouncedUsername)
+        .then((isUsernameAvailable) => {
           if (!isUsernameAvailable) {
             setUsernameError('Username is taken');
           }
-        }
-      }
-    }
+        })
+        .catch((error) => {
+          if (error instanceof Error) {
+            reportError(error);
+          } else {
+            reportError('Failure while validating username', {
+              tags: { username: debouncedUsername },
+            });
+          }
 
-    validateUsername();
-  }, [debouncedUsername, isUsernameAvailableFetcher]);
+          setGeneralError(
+            "Something went wrong while validating your username. We're looking into it."
+          );
+        });
+    },
+    [debouncedUsername, isUsernameAvailableFetcher, reportError]
+  );
 
   const values = useMemo(
     () => ({
-      username,
-      onUsernameChange: handleUsernameChange,
-      usernameError,
       bio,
-      onBioChange: setBio,
+      username,
       generalError,
+      usernameError,
+      onBioChange: setBio,
       onEditUser: handleCreateOrEditUser,
+      onUsernameChange: handleUsernameChange,
     }),
     [bio, generalError, handleCreateOrEditUser, handleUsernameChange, username, usernameError]
   );

--- a/src/flows/OnboardingFlow/steps/AddUserInfo.tsx
+++ b/src/flows/OnboardingFlow/steps/AddUserInfo.tsx
@@ -25,29 +25,27 @@ function useWizardConfig({ onNext }: ConfigProps) {
 }
 
 function AddUserInfo({ next }: WizardContext) {
-  const { username, onUsernameChange, usernameError, bio, onBioChange, generalError, onEditUser } =
-    useUserInfoForm({
-      onSuccess: next,
-      userId: undefined,
-      existingUsername: '',
-      existingBio: '',
-    });
+  const {
+    bio,
+    username,
+    onEditUser,
+    onBioChange,
+    generalError,
+    usernameError,
+    isUsernameValid,
+    onUsernameChange,
+  } = useUserInfoForm({
+    existingBio: '',
+    onSuccess: next,
+    userId: undefined,
+    existingUsername: '',
+  });
 
   const { setNextEnabled } = useWizardValidationActions();
 
   useEffect(() => {
-    let isFormValid = true;
-
-    if (username.length < 2) {
-      isFormValid = false;
-    }
-
-    if (usernameError) {
-      isFormValid = false;
-    }
-
-    setNextEnabled(isFormValid);
-  }, [setNextEnabled, username, usernameError]);
+    setNextEnabled(isUsernameValid);
+  }, [isUsernameValid, setNextEnabled]);
 
   const track = useTrack();
 

--- a/src/flows/OnboardingFlow/steps/AddUserInfo.tsx
+++ b/src/flows/OnboardingFlow/steps/AddUserInfo.tsx
@@ -27,20 +27,26 @@ function useWizardConfig({ onNext }: ConfigProps) {
 function AddUserInfo({ next }: WizardContext) {
   const { username, onUsernameChange, usernameError, bio, onBioChange, generalError, onEditUser } =
     useUserInfoForm({
-    onSuccess: next,
-    userId: undefined,
-    existingUsername: '',
-    existingBio: '',
-  });
+      onSuccess: next,
+      userId: undefined,
+      existingUsername: '',
+      existingBio: '',
+    });
 
   const { setNextEnabled } = useWizardValidationActions();
 
   useEffect(() => {
+    let isFormValid = true;
+
     if (username.length < 2) {
-      setNextEnabled(false);
-      return;
+      isFormValid = false;
     }
-    setNextEnabled(!usernameError);
+
+    if (usernameError) {
+      isFormValid = false;
+    }
+
+    setNextEnabled(isFormValid);
   }, [setNextEnabled, username, usernameError]);
 
   const track = useTrack();


### PR DESCRIPTION
I cleaned up some of the logic in `useUserInfoForm` while I was at it.

The new flow is we track this new state `isUsernameValid` which starts as `false`. 
- Every time the username is changed, we reset it to `false`.
- Only when the validation passes do we finally set it to `true`.

All of this logic feels very imperative. Bringing the bottom bar (the thing with the "next" button) into the step component itself should help make this logic simpler. In the future, the "Next" button itself can `useLazyLoadQuery` with the validation state. The fallback state for that component would be a disabled version of the button. 

For now, this is fine.