### PR TITLE
Fix username taken regression

### DIFF
--- a/src/components/Profile/useUserInfoForm.ts
+++ b/src/components/Profile/useUserInfoForm.ts
@@ -142,6 +142,11 @@ export default function useUserInfoForm({
     function validateUsername() {
       setGeneralError('');
 
+      // it doesn't make sense to tell users their current username is taken!
+      if (existingUsername && debouncedUsername === existingUsername) {
+        return;
+      }
+
       if (debouncedUsername.length < 2) {
         return;
       }
@@ -184,7 +189,7 @@ export default function useUserInfoForm({
           );
         });
     },
-    [debouncedUsername, isUsernameAvailableFetcher, reportError]
+    [debouncedUsername, existingUsername, isUsernameAvailableFetcher, reportError]
   );
 
   return useMemo(


### PR DESCRIPTION
fixes a regression where the Edit modal broke for existing users, claiming that their own username was taken (and was thus unable to add bio, etc.)

![image](https://user-images.githubusercontent.com/12162433/194794836-257f60a8-f5c6-4a51-83f9-29a162e3c7a8.png)
