### PR TITLE
dont show confirmation modal on save

### DIFF
--- a/pages/gallery/[galleryId]/collection/[collectionId]/edit.tsx
+++ b/pages/gallery/[galleryId]/collection/[collectionId]/edit.tsx
@@ -86,10 +86,13 @@ function LazyLoadedCollectionEditor({ galleryId, collectionId }: Props) {
       }
     }
   }, [
+    back,
+    canGoBack,
     collectionId,
     collectionMetadata.tokenSettings,
-    handlePrevious,
+    editGalleryUrl,
     pushToast,
+    replace,
     stagedCollectionState,
     updateCollection,
   ]);

--- a/pages/gallery/[galleryId]/collection/[collectionId]/edit.tsx
+++ b/pages/gallery/[galleryId]/collection/[collectionId]/edit.tsx
@@ -70,7 +70,11 @@ function LazyLoadedCollectionEditor({ galleryId, collectionId }: Props) {
         tokenSettings: collectionMetadata.tokenSettings,
       });
 
-      handlePrevious();
+      if (canGoBack) {
+        back();
+      } else {
+        replace(editGalleryUrl);
+      }
     } catch (error: unknown) {
       if (error instanceof Error) {
         pushToast({


### PR DESCRIPTION
Currently, when you click "save" in the editor, there is no confirmation that the change was saved and instead a confirmation modal appears saying "Would you like to stop editing?" 
This is confusing (user reported this was difficult to understand) and I believe the original behavior was to return to where the user came from.
This PR changes the editor so that upon saving it redirects the user instead of showing the "Would you like to stop editing?"  popover.

<img width="663" alt="Screen Shot 2022-10-13 at 22 46 39" src="https://user-images.githubusercontent.com/80802871/195614443-1164ed86-4dbc-4326-aa62-cf6b3d75d596.png">
