### PR TITLE
Interactions fixes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1027,6 +1027,7 @@ type AdmireFeedEventPayload {
 
 type RemoveAdmirePayload {
     viewer: Viewer
+    admireID: DBID
     feedEvent: FeedEvent @goField(forceResolver: true)
 }
 
@@ -1077,7 +1078,7 @@ type Mutation {
     followUser(userId: DBID!): FollowUserPayloadOrError @authRequired
     unfollowUser(userId: DBID!): UnfollowUserPayloadOrError @authRequired
     admireFeedEvent(feedEventId: DBID!): AdmireFeedEventPayloadOrError @authRequired
-    removeAdmire(admireId: DBID!): RemoveAdmirePayloadOrError @authRequired
+    removeAdmire(feedEventId: DBID!): RemoveAdmirePayloadOrError @authRequired
     commentOnFeedEvent(feedEventId: DBID!, replyToID: DBID, comment: String!): CommentOnFeedEventPayloadOrError @authRequired
     removeComment(commentId: DBID!): RemoveCommentPayloadOrError @authRequired
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -522,6 +522,10 @@ type FeedEvent implements Node {
     # If typeFilter is omitted, all interaction types will be queried.
     interactions(before: String, after: String, first: Int, last: Int, typeFilter:[InteractionType!]): FeedEventInteractionsConnection @goField(forceResolver: true)
 
+    viewerAdmire: Admire @goField(forceResolver: true)
+
+    # TODO: This is just here while we migrate the frontend over to viewerAdmire.
+    # Remove this in the near future.
     hasViewerAdmiredEvent: Boolean @goField(forceResolver: true)
 }
 
@@ -893,6 +897,18 @@ type ErrSyncFailed implements Error {
     message: String!
 }
 
+type ErrAdmireNotFound implements Error {
+    message: String!
+}
+
+type ErrAdmireAlreadyExists implements Error {
+    message: String!
+}
+
+type ErrCommentNotFound implements Error {
+    message: String!
+}
+
 input AuthMechanism {
     eoa: EoaAuth
     gnosisSafe: GnosisSafeAuth
@@ -1000,12 +1016,14 @@ union AdmireFeedEventPayloadOrError =
     | ErrAuthenticationFailed
     | ErrFeedEventNotFound
     | ErrInvalidInput
+    | ErrAdmireAlreadyExists
 
 union RemoveAdmirePayloadOrError =
     RemoveAdmirePayload
     | ErrAuthenticationFailed
     | ErrFeedEventNotFound
     | ErrInvalidInput
+    | ErrAdmireNotFound
 
 union CommentOnFeedEventPayloadOrError =
     CommentOnFeedEventPayload
@@ -1018,6 +1036,7 @@ union RemoveCommentPayloadOrError =
     | ErrAuthenticationFailed
     | ErrFeedEventNotFound
     | ErrInvalidInput
+    | ErrCommentNotFound
 
 type AdmireFeedEventPayload {
     viewer: Viewer
@@ -1078,7 +1097,7 @@ type Mutation {
     followUser(userId: DBID!): FollowUserPayloadOrError @authRequired
     unfollowUser(userId: DBID!): UnfollowUserPayloadOrError @authRequired
     admireFeedEvent(feedEventId: DBID!): AdmireFeedEventPayloadOrError @authRequired
-    removeAdmire(feedEventId: DBID!): RemoveAdmirePayloadOrError @authRequired
+    removeAdmire(admireId: DBID!): RemoveAdmirePayloadOrError @authRequired
     commentOnFeedEvent(feedEventId: DBID!, replyToID: DBID, comment: String!): CommentOnFeedEventPayloadOrError @authRequired
     removeComment(commentId: DBID!): RemoveCommentPayloadOrError @authRequired
 }

--- a/src/components/Feed/Socialize/AdmireButton.tsx
+++ b/src/components/Feed/Socialize/AdmireButton.tsx
@@ -1,5 +1,5 @@
 import { useFragment } from 'react-relay';
-import { ConnectionHandler, graphql } from 'relay-runtime';
+import { ConnectionHandler, graphql, SelectorStoreUpdater } from 'relay-runtime';
 import { AdmireButtonFragment$key } from '__generated__/AdmireButtonFragment.graphql';
 import { AuthModal } from 'hooks/useAuthModal';
 import { AdditionalContext, useReportError } from 'contexts/errorReporting/ErrorReportingContext';
@@ -10,6 +10,7 @@ import { useModalActions } from 'contexts/modal/ModalContext';
 import { usePromisifiedMutation } from 'hooks/usePromisifiedMutation';
 import { AdmireButtonMutation } from '../../../../__generated__/AdmireButtonMutation.graphql';
 import { AdmireIcon } from 'icons/SocializeIcons';
+import { AdmireButtonRemoveMutation } from '../../../../__generated__/AdmireButtonRemoveMutation.graphql';
 
 type AdmireButtonProps = {
   eventRef: AdmireButtonFragment$key;
@@ -66,6 +67,17 @@ export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: Adm
     }
   `);
 
+  const [removeAdmire] = usePromisifiedMutation<AdmireButtonRemoveMutation>(graphql`
+    mutation AdmireButtonRemoveMutation($eventId: DBID!) @raw_response_type {
+      removeAdmire(feedEventId: $eventId) {
+        ... on RemoveAdmirePayload {
+          __typename
+          admireID
+        }
+      }
+    }
+  `);
+
   const reportError = useReportError();
   const { pushToast } = useToastActions();
   const { showModal } = useModalActions();
@@ -78,6 +90,91 @@ export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: Adm
     event.id,
     'NotesModal_interactions'
   );
+
+  const handleRemoveAdmire = useCallback(async () => {
+    const errorMetadata: AdditionalContext['tags'] = {
+      eventId: event.dbid,
+    };
+
+    function pushErrorToast() {
+      pushToast({
+        autoClose: true,
+        message: `Something went wrong while unadmiring this post. We're actively looking into it.`,
+      });
+    }
+
+    const updater: SelectorStoreUpdater<AdmireButtonRemoveMutation['response']> = (
+      store,
+      response
+    ) => {
+      if (response?.removeAdmire?.__typename === 'RemoveAdmirePayload') {
+        const pageInfo = store.get(interactionsConnection)?.getLinkedRecord('pageInfo');
+
+        pageInfo?.setValue(((pageInfo?.getValue('total') as number) ?? 1) - 1, 'total');
+
+        store.get(event.id)?.setValue(false, 'hasViewerAdmiredEvent');
+      }
+    };
+
+    try {
+      const response = await removeAdmire({
+        updater: updater,
+        optimisticUpdater: updater,
+        optimisticResponse: {
+          removeAdmire: {
+            __typename: 'RemoveAdmirePayload',
+          },
+        },
+        variables: {
+          eventId: event.dbid,
+        },
+      });
+
+      if (response.removeAdmire?.__typename === 'RemoveAdmirePayload') {
+        // Tell the virtualized list that some data has changed
+        // therefore this cell's height might change.
+        //
+        // Ideally, this lives in a useEffect inside of the
+        // changing data's component, but right now the virtualized
+        // list is remounting the component every update, causing
+        // an infinite useEffect to occur
+        setTimeout(() => {
+          onPotentialLayoutShift();
+        }, 100);
+      } else {
+        pushErrorToast();
+
+        reportError(
+          `Could not unadmire feed event, typename was ${response.removeAdmire?.__typename}`,
+          {
+            tags: errorMetadata,
+          }
+        );
+      }
+    } catch (error) {
+      console.log(error);
+      pushErrorToast();
+
+      if (error instanceof Error) {
+        reportError(error);
+      } else {
+        reportError(`Could not remove admire on feed event for an unknown reason`, {
+          tags: errorMetadata,
+        });
+      }
+    }
+  }, [
+    admire,
+    event.dbid,
+    event.id,
+    interactionsConnection,
+    notesModalConnection,
+    onPotentialLayoutShift,
+    pushToast,
+    query,
+    reportError,
+    showModal,
+  ]);
 
   const handleAdmire = useCallback(async () => {
     if (query.viewer?.__typename !== 'Viewer') {
@@ -99,18 +196,21 @@ export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: Adm
       });
     }
 
+    const updater: SelectorStoreUpdater<AdmireButtonMutation['response']> = (store, response) => {
+      if (response?.admireFeedEvent?.__typename === 'AdmireFeedEventPayload') {
+        const pageInfo = store.get(interactionsConnection)?.getLinkedRecord('pageInfo');
+
+        pageInfo?.setValue(((pageInfo?.getValue('total') as number) ?? 0) + 1, 'total');
+
+        store.get(event.id)?.setValue(true, 'hasViewerAdmiredEvent');
+      }
+    };
+
     try {
       const optimisticAdmireId = Math.random().toString();
       const response = await admire({
-        updater: (store, response) => {
-          if (response.admireFeedEvent?.__typename === 'AdmireFeedEventPayload') {
-            const pageInfo = store.get(interactionsConnection)?.getLinkedRecord('pageInfo');
-
-            pageInfo?.setValue(((pageInfo?.getValue('total') as number) ?? 0) + 1, 'total');
-
-            store.get(event.id)?.setValue(true, 'hasViewerAdmiredEvent');
-          }
-        },
+        optimisticUpdater: updater,
+        updater: updater,
         optimisticResponse: {
           admireFeedEvent: {
             __typename: 'AdmireFeedEventPayload',
@@ -177,5 +277,10 @@ export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: Adm
     showModal,
   ]);
 
-  return <AdmireIcon onClick={handleAdmire} active={event.hasViewerAdmiredEvent ?? false} />;
+  return (
+    <AdmireIcon
+      onClick={event.hasViewerAdmiredEvent ? handleRemoveAdmire : handleAdmire}
+      active={event.hasViewerAdmiredEvent ?? false}
+    />
+  );
 }

--- a/src/components/Feed/Socialize/AdmireButton.tsx
+++ b/src/components/Feed/Socialize/AdmireButton.tsx
@@ -113,12 +113,16 @@ export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: Adm
         pageInfo?.setValue(((pageInfo?.getValue('total') as number) ?? 1) - 1, 'total');
 
         store.get(event.id)?.setValue(false, 'hasViewerAdmiredEvent');
+
+        if (response.removeAdmire.admireID) {
+          store.delete(`Admire:${response.removeAdmire.admireID}`);
+        }
       }
     };
 
     try {
       const response = await removeAdmire({
-        updater: updater,
+        updater,
         optimisticUpdater: updater,
         optimisticResponse: {
           removeAdmire: {
@@ -209,8 +213,8 @@ export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: Adm
     try {
       const optimisticAdmireId = Math.random().toString();
       const response = await admire({
+        updater,
         optimisticUpdater: updater,
-        updater: updater,
         optimisticResponse: {
           admireFeedEvent: {
             __typename: 'AdmireFeedEventPayload',

--- a/src/components/Feed/Socialize/Interactions.tsx
+++ b/src/components/Feed/Socialize/Interactions.tsx
@@ -18,7 +18,7 @@ export function Interactions({ eventRef, queryRef }: Props) {
   const event = useFragment(
     graphql`
       fragment InteractionsFragment on FeedEvent {
-        admires(last: 1) @connection(key: "Interactions_admires") {
+        admires(last: 2) @connection(key: "Interactions_admires") {
           pageInfo {
             total
           }

--- a/src/components/Feed/Socialize/Interactions.tsx
+++ b/src/components/Feed/Socialize/Interactions.tsx
@@ -18,7 +18,9 @@ export function Interactions({ eventRef, queryRef }: Props) {
   const event = useFragment(
     graphql`
       fragment InteractionsFragment on FeedEvent {
-        admires(last: 2) @connection(key: "Interactions_admires") {
+        # We only show 1 but in case the user deletes something
+        # we want to be sure that we can show another comment beneath
+        admires(last: 5) @connection(key: "Interactions_admires") {
           pageInfo {
             total
           }
@@ -31,7 +33,9 @@ export function Interactions({ eventRef, queryRef }: Props) {
           }
         }
 
-        comments(last: 2) @connection(key: "Interactions_comments") {
+        # We only show 2 but in case the user deletes something
+        # we want to be sure that we can show another comment beneath
+        comments(last: 5) @connection(key: "Interactions_comments") {
           pageInfo {
             total
           }
@@ -88,8 +92,9 @@ export function Interactions({ eventRef, queryRef }: Props) {
     return admires;
   }, [event.admires?.edges]);
 
-  const totalInteractions =
-    (event.admires?.pageInfo.total ?? 0) + (event.comments?.pageInfo.total ?? 0);
+  const totalComments = event.comments?.pageInfo.total ?? 0;
+  const totalAdmires = event.admires?.pageInfo.total ?? 0;
+  const totalInteractions = totalComments + totalAdmires;
 
   /**
    * The below logic is a bit annoying to read so I'll try to explain it here
@@ -104,35 +109,56 @@ export function Interactions({ eventRef, queryRef }: Props) {
    *      Show "Person admired this"
    *    If there's > 1 admire
    *      Show "X admired this" => Link to NotesModal
+   *
+   * Extra:
+   * There's a bit of extra logic you can see where we're checking the `PageInfo.total`
+   * as well as checking the actual length of the admires / comments array.
+   *
+   * This is because there is a possibility that the user will either delete a comment
+   * or delete an admire. Under this case, the total count of comments / admires might
+   * be some large number, but we only actually have 0, 1, or 2 in the list
+   *
+   * Imagine this:
+   * 1. We load the page, and we hypothetically fetch 5 comments posted by the logged in user
+   * 2. There's actually a total of 10 comments on the server, but we only fetched 5
+   * 3. The user then goes and deletes all 5 of those comments
+   *
+   * Now we're in a state where `totalComments` is 5, but we don't actually have any comments
+   * to show, so we'll have to fallback to some other UI here. In this case, we'll just show
+   * the total number of comments / admires that links to the NotesModal
    */
-  if (nonNullComments.length) {
+  if (totalComments > 0) {
     const lastTwoComments = nonNullComments.slice(0, 2);
 
-    // 2 comments and "+ x others" below
-    // Not hard coding 2 here since there might only be one comment from the slice
-    const remainingAdmiresAndComments = Math.max(totalInteractions - lastTwoComments.length, 0);
+    if (lastTwoComments.length > 0) {
+      // 2 comments and "+ x others" below
+      // Not hard coding 2 here since there might only be one comment from the slice
+      const remainingAdmiresAndComments = Math.max(totalInteractions - lastTwoComments.length, 0);
 
-    return (
-      <VStack gap={8}>
-        {nonNullComments?.slice(0, 2).map((comment) => {
-          return <CommentLine key={comment.dbid} commentRef={comment} />;
-        })}
-
-        <RemainingAdmireCount remainingCount={remainingAdmiresAndComments} eventRef={event} />
-      </VStack>
-    );
-  } else if (nonNullAdmires.length) {
-    if (nonNullAdmires.length === 1) {
-      const [admire] = nonNullAdmires;
-
-      return <AdmireLine admireRef={admire} queryRef={query} />;
-    } else {
       return (
-        <NoteModalOpenerText eventRef={event}>
-          {event.admires?.pageInfo.total} admired this
-        </NoteModalOpenerText>
+        <VStack gap={8}>
+          {lastTwoComments.map((comment) => {
+            return <CommentLine key={comment.dbid} commentRef={comment} />;
+          })}
+
+          <RemainingAdmireCount remainingCount={remainingAdmiresAndComments} eventRef={event} />
+        </VStack>
       );
     }
+
+    return <RemainingAdmireCount remainingCount={totalInteractions} eventRef={event} />;
+  }
+
+  if (totalAdmires > 0) {
+    if (totalAdmires === 1) {
+      const [admire] = nonNullAdmires;
+
+      if (admire) {
+        return <AdmireLine admireRef={admire} queryRef={query} />;
+      }
+    }
+
+    return <NoteModalOpenerText eventRef={event}>{totalAdmires} admired this</NoteModalOpenerText>;
   }
 
   return null;


### PR DESCRIPTION
Fixing an edge case with admires / comments. See this comment
```
   * There's a bit of extra logic you can see where we're checking the `PageInfo.total`
   * as well as checking the actual length of the admires / comments array.
   *
   * This is because there is a possibility that the user will either delete a comment
   * or delete an admire. Under this case, the total count of comments / admires might
   * be some large number, but we only actually have 0, 1, or 2 in the list
   *
   * Imagine this:
   * 1. We load the page, and we hypothetically fetch 5 comments posted by the logged in user
   * 2. There's actually a total of 10 comments on the server, but we only fetched 5
   * 3. The user then goes and deletes all 5 of those comments
   *
   * Now we're in a state where `totalComments` is 5, but we don't actually have any comments
   * to show, so we'll have to fallback to some other UI here. In this case, we'll just show
   * the total number of comments / admires that links to the NotesModal
 ```

Also cleaning up some of the logic around updates with admires

Also handling removing admires