### PR TITLE
[GAL-533] Recompute virtualized row heights on window resize

### DIFF
--- a/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -19,6 +19,7 @@ import {
   WindowScroller,
 } from 'react-virtualized';
 import breakpoints from 'components/core/breakpoints';
+import useWindowSize from 'hooks/useWindowSize';
 
 type Props = {
   galleryRef: UserGalleryCollectionsFragment$key;
@@ -75,12 +76,13 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
     })
   );
   const listRef = useRef<List>(null);
+  const windowSize = useWindowSize();
 
   // If the mobileLayout is changed, we need to recalculate the cache height.
   useEffect(() => {
     cache.current.clearAll();
     listRef.current?.recomputeRowHeights();
-  }, [mobileLayout]);
+  }, [mobileLayout, windowSize]);
 
   const collectionsToDisplay = useMemo(
     () =>


### PR DESCRIPTION
Recompute the virtualize height on user gallery if the browser size changed (Device rotate, resize browser, etc)

**Before**

https://user-images.githubusercontent.com/4480258/195970213-86fbf049-b150-43ba-8409-b8b22466b6a9.mp4


**After**

https://user-images.githubusercontent.com/4480258/195970226-5b1bdc65-219a-4f4c-b9dd-498b7642d074.mp4
