### PR TITLE
[GAL-534] Fix footer overflow on small devices

### DIFF
--- a/src/contexts/globalLayout/GlobalFooter/GlobalFooter.tsx
+++ b/src/contexts/globalLayout/GlobalFooter/GlobalFooter.tsx
@@ -30,7 +30,7 @@ function GlobalFooter() {
           </Link>
           <BaseS>BETA</BaseS>
         </HStack>
-        <HStack gap={8}>
+        <HStack gap={8} wrap="wrap">
           <StyledFooterLink href={GALLERY_FAQ}>FAQ</StyledFooterLink>
           <StyledFooterLink href={GALLERY_TWITTER}>Twitter</StyledFooterLink>
           <StyledFooterLink href={GALLERY_DISCORD}>Discord</StyledFooterLink>


### PR DESCRIPTION
This overflow bug on happens on small devices (width < 294px).


**Before**

![CleanShot 2022-10-15 at 13 37 00](https://user-images.githubusercontent.com/4480258/195970809-be316c5d-6174-4799-b6f3-f9ac0e0a8208.png)

**After**

![CleanShot 2022-10-15 at 13 38 03](https://user-images.githubusercontent.com/4480258/195970834-9421a75b-8fdd-45d2-b744-73f37a83e6e3.png)
