### PR TITLE
[GAL-514] Interactive FxHash NFT detail page appears frozen

### DIFF
--- a/src/scenes/NftDetailPage/NftDetailAnimation.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAnimation.tsx
@@ -50,7 +50,7 @@ function NftDetailAnimation({ mediaRef, onLoad }: Props) {
         onLoad={onLoad}
         // Lets the resource run scripts (but not create popup windows): https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
         // More specifically, this prevents the rendered iframe from displaying Alerts
-        sandbox="allow-scripts"
+        sandbox="allow-scripts allow-same-origin"
       />
     </StyledNftDetailAnimation>
   );


### PR DESCRIPTION

**Finding**
Seems like this iframe failed to fetch an [image](https://gallery.infura-ipfs.io/ipfs/QmUme7vRedQ1poJBmQrqEQUM1sCjcUAzd8NajP2VbpAHUf/Bayer8x8.png) assets that required to render the design. 

[Example NFT](https://gallery.so/qaulv/2FLxx0S2M3NIgIKy1FE7MwmPZHy/2FLyBAGeprYirFgubtluKGsMOxJ)

[IPFS Asset](https://gallery.infura-ipfs.io/ipfs/QmUme7vRedQ1poJBmQrqEQUM1sCjcUAzd8NajP2VbpAHUf/)

Error log from the nft itself:
`Failed to execute 'texImage2D' on 'WebGLRenderingContext': The image element contains cross-origin data, and may not be loaded.`

**Before**

![CleanShot 2022-10-15 at 17 19 12](https://user-images.githubusercontent.com/4480258/195979016-dbbb194f-17d8-475e-891e-59af9288e11e.png)


https://user-images.githubusercontent.com/4480258/195979042-f4cb4b8f-e778-4d78-94aa-7c9a5c69cab8.mp4


**References**
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox
- https://stackoverflow.com/questions/31184505/sandboxing-iframe-and-allow-same-origin

