### PR TITLE
[GAL-385] Add Activity View (User Feed) to User Gallery page

### DIFF
--- a/pages/[username]/activity.tsx
+++ b/pages/[username]/activity.tsx
@@ -6,6 +6,8 @@ import { useLazyLoadQuery } from 'react-relay';
 import { activityQuery } from '__generated__/activityQuery.graphql';
 import GalleryRoute from 'scenes/_Router/GalleryRoute';
 import UserActivityPage from 'scenes/UserActivityPage/UserActivityPage';
+import { ITEMS_PER_PAGE } from 'components/Feed/constants';
+import { NOTES_PER_PAGE } from 'components/Feed/Socialize/NotesModal/NotesModal';
 
 type UserActivityProps = MetaTagProps & {
   username: string;
@@ -14,11 +16,21 @@ type UserActivityProps = MetaTagProps & {
 export default function UserFeed({ username }: UserActivityProps) {
   const query = useLazyLoadQuery<activityQuery>(
     graphql`
-      query activityQuery($username: String!) {
+      query activityQuery(
+        $username: String!
+        $interactionsFirst: Int!
+        $interactionsAfter: String
+        $viewerLast: Int!
+        $viewerBefore: String
+      ) {
         ...UserActivityPageFragment
       }
     `,
-    { username }
+    {
+      username: username,
+      interactionsFirst: NOTES_PER_PAGE,
+      viewerLast: ITEMS_PER_PAGE,
+    }
   );
 
   return <GalleryRoute element={<UserActivityPage username={username} queryRef={query} />} />;

--- a/pages/[username]/activity.tsx
+++ b/pages/[username]/activity.tsx
@@ -1,0 +1,49 @@
+import { GetServerSideProps } from 'next';
+import { MetaTagProps } from 'pages/_app';
+import { openGraphMetaTags } from 'utils/openGraphMetaTags';
+import { graphql } from 'relay-runtime';
+import { useLazyLoadQuery } from 'react-relay';
+import { activityQuery } from '__generated__/activityQuery.graphql';
+import GalleryRoute from 'scenes/_Router/GalleryRoute';
+import UserActivityPage from 'scenes/UserActivityPage/UserActivityPage';
+
+type UserActivityProps = MetaTagProps & {
+  username: string;
+};
+
+export default function UserFeed({ username }: UserActivityProps) {
+  const query = useLazyLoadQuery<activityQuery>(
+    graphql`
+      query activityQuery($username: String!) {
+        ...UserActivityPageFragment
+      }
+    `,
+    { username }
+  );
+
+  return <GalleryRoute element={<UserActivityPage username={username} queryRef={query} />} />;
+}
+
+export const getServerSideProps: GetServerSideProps<UserActivityProps> = async ({ params }) => {
+  const username = params?.username ? (params.username as string) : undefined;
+
+  if (!username)
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/',
+      },
+    };
+
+  return {
+    props: {
+      username,
+      metaTags: username
+        ? openGraphMetaTags({
+            title: `${username} | Gallery`,
+            previewPath: `/opengraph/user/${username}`,
+          })
+        : null,
+    },
+  };
+};

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -18,7 +18,7 @@ import ViewerFeed from './ViewerFeed';
 import { FeedViewerFragment$key } from '__generated__/FeedViewerFragment.graphql';
 import { HStack, VStack } from 'components/core/Spacer/Stack';
 
-export type FeedMode = 'FOLLOWING' | 'WORLDWIDE';
+export type FeedMode = 'FOLLOWING' | 'WORLDWIDE' | 'USER';
 
 type ControlProps = {
   setFeedMode: (mode: FeedMode) => void;

--- a/src/scenes/UserActivityPage/UserActivity.tsx
+++ b/src/scenes/UserActivityPage/UserActivity.tsx
@@ -1,0 +1,82 @@
+import useKeyDown from 'hooks/useKeyDown';
+import NotFound from 'scenes/NotFound/NotFound';
+import { useRouter } from 'next/router';
+import { useCallback } from 'react';
+import { useFragment } from 'react-relay';
+import { graphql } from 'relay-runtime';
+import useDisplayFullPageNftDetailModal from 'scenes/NftDetailPage/useDisplayFullPageNftDetailModal';
+import { useModalState } from 'contexts/modal/ModalContext';
+import { UserActivityLayout } from './UserActivityLayout';
+import { UserActivityFragment$key } from '__generated__/UserActivityFragment.graphql';
+
+type Props = {
+  queryRef: UserActivityFragment$key;
+};
+
+function UserActivity({ queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment UserActivityFragment on Query {
+        viewer {
+          ... on Viewer {
+            user {
+              dbid
+            }
+            viewerGalleries {
+              gallery {
+                dbid
+              }
+            }
+          }
+        }
+
+        user: userByUsername(username: $username) @required(action: THROW) {
+          ... on GalleryUser {
+            __typename
+
+            ...UserActivityLayoutFragment
+          }
+          ... on ErrUserNotFound {
+            __typename
+            message
+          }
+        }
+
+        ...UserActivityLayoutQueryFragment
+      }
+    `,
+    queryRef
+  );
+
+  const { user } = query;
+  const { push } = useRouter();
+
+  const galleryId = query.viewer?.viewerGalleries?.[0]?.gallery?.dbid;
+
+  const loggedInUserId = query.viewer?.user?.dbid;
+  const isLoggedIn = Boolean(loggedInUserId);
+
+  const { isModalOpenRef } = useModalState();
+
+  const navigateToEdit = useCallback(() => {
+    if (!isLoggedIn) return;
+    if (isModalOpenRef.current) return;
+    void push(`/gallery/${galleryId}/edit`);
+  }, [isLoggedIn, isModalOpenRef, push, galleryId]);
+
+  useKeyDown('e', navigateToEdit);
+
+  useDisplayFullPageNftDetailModal();
+
+  if (user.__typename === 'ErrUserNotFound') {
+    return <NotFound />;
+  }
+
+  if (user.__typename !== 'GalleryUser') {
+    throw new Error(`Expected user to be type GalleryUser. Received: ${user.__typename}`);
+  }
+
+  return <UserActivityLayout userRef={user} queryRef={query} />;
+}
+
+export default UserActivity;

--- a/src/scenes/UserActivityPage/UserActivityFeed.tsx
+++ b/src/scenes/UserActivityPage/UserActivityFeed.tsx
@@ -1,5 +1,82 @@
-function UserActivityFeed() {
-  return <div>UserActivityFeed</div>;
+import { useTrackLoadMoreFeedEvents } from 'components/Feed/analytics';
+import { ITEMS_PER_PAGE } from 'components/Feed/constants';
+import FeedList from 'components/Feed/FeedList';
+import { useCallback, useMemo } from 'react';
+import { graphql, useFragment, usePaginationFragment } from 'react-relay';
+import { UserActivityFeedFragment$key } from '__generated__/UserActivityFeedFragment.graphql';
+import { UserActivityFeedQueryFragment$key } from '__generated__/UserActivityFeedQueryFragment.graphql';
+import { UserFeedByUserIdPaginationQuery } from '__generated__/UserFeedByUserIdPaginationQuery.graphql';
+
+type Props = {
+  userRef: UserActivityFeedFragment$key;
+  queryRef: UserActivityFeedQueryFragment$key;
+};
+
+function UserActivityFeed({ userRef, queryRef }: Props) {
+  const { data: user, loadPrevious, hasPrevious } = usePaginationFragment<
+    UserFeedByUserIdPaginationQuery,
+    UserActivityFeedFragment$key
+  >(
+    graphql`
+      fragment UserActivityFeedFragment on GalleryUser
+        @refetchable(queryName: "UserFeedByUserIdPaginationQuery") {
+        feed(before: $viewerBefore, last: $viewerLast)
+          @connection(key: "UserActivityFeedFragment_feed") {
+          edges {
+            node {
+              ... on FeedEvent {
+                __typename
+
+                ...FeedListEventDataFragment
+              }
+            }
+          }
+        }
+      }
+    `,
+    userRef
+  );
+
+  const query = useFragment(
+    graphql`
+      fragment UserActivityFeedQueryFragment on Query {
+        ...FeedListFragment
+      }
+    `,
+    queryRef
+  );
+
+  const trackLoadMoreFeedEvents = useTrackLoadMoreFeedEvents();
+
+  const loadNextPage = useCallback(() => {
+    return new Promise((resolve) => {
+      trackLoadMoreFeedEvents('viewer');
+      // Infinite scroll component wants load callback to return a promise
+      loadPrevious(ITEMS_PER_PAGE, { onComplete: () => resolve('loaded') });
+    });
+  }, [loadPrevious, trackLoadMoreFeedEvents]);
+
+  const feedData = useMemo(() => {
+    const events = [];
+
+    for (const edge of user.feed?.edges ?? []) {
+      if (edge?.node?.__typename === 'FeedEvent' && edge.node) {
+        events.push(edge.node);
+      }
+    }
+
+    return events;
+  }, [user.feed?.edges]);
+
+  return (
+    <FeedList
+      feedEventRefs={feedData}
+      loadNextPage={loadNextPage}
+      hasNext={hasPrevious}
+      queryRef={query}
+      feedMode={'FOLLOWING'}
+    />
+  );
 }
 
 export default UserActivityFeed;

--- a/src/scenes/UserActivityPage/UserActivityFeed.tsx
+++ b/src/scenes/UserActivityPage/UserActivityFeed.tsx
@@ -74,7 +74,7 @@ function UserActivityFeed({ userRef, queryRef }: Props) {
       loadNextPage={loadNextPage}
       hasNext={hasPrevious}
       queryRef={query}
-      feedMode={'FOLLOWING'}
+      feedMode={'USER'}
     />
   );
 }

--- a/src/scenes/UserActivityPage/UserActivityFeed.tsx
+++ b/src/scenes/UserActivityPage/UserActivityFeed.tsx
@@ -1,0 +1,5 @@
+function UserActivityFeed() {
+  return <div>UserActivityFeed</div>;
+}
+
+export default UserActivityFeed;

--- a/src/scenes/UserActivityPage/UserActivityLayout.tsx
+++ b/src/scenes/UserActivityPage/UserActivityLayout.tsx
@@ -88,6 +88,7 @@ export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
 const StyledUserActivityLayout = styled(VStack)`
   margin: 0 -16px;
   padding-top: 24px;
+  width: 100vw;
 
   @media only screen and ${breakpoints.desktop} {
     width: ${FEED_MAX_WIDTH}px;

--- a/src/scenes/UserActivityPage/UserActivityLayout.tsx
+++ b/src/scenes/UserActivityPage/UserActivityLayout.tsx
@@ -8,10 +8,10 @@ import { useGlobalLayoutActions } from 'contexts/globalLayout/GlobalLayoutContex
 import { useEffect } from 'react';
 import NavActionFollow from 'components/Follow/NavActionFollow';
 import { VStack } from 'components/core/Spacer/Stack';
-import breakpoints from 'components/core/breakpoints';
 import UserActivityFeed from './UserActivityFeed';
 import { UserActivityLayoutQueryFragment$key } from '__generated__/UserActivityLayoutQueryFragment.graphql';
 import { UserActivityLayoutFragment$key } from '__generated__/UserActivityLayoutFragment.graphql';
+import { StyledUserGalleryLayout } from 'scenes/UserGalleryPage/UserGalleryLayout';
 
 type Props = {
   userRef: UserActivityLayoutFragment$key;
@@ -82,16 +82,6 @@ export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
     </StyledUserGalleryLayout>
   );
 };
-
-const StyledUserGalleryLayout = styled(VStack)`
-  width: 100%;
-  max-width: 1200px;
-  padding: 48px 0 32px;
-
-  @media only screen and ${breakpoints.tablet} {
-    padding: 80px 0 32px;
-  }
-`;
 
 const StyledUserActivityLayout = styled(VStack)`
   margin: 0 -16px;

--- a/src/scenes/UserActivityPage/UserActivityLayout.tsx
+++ b/src/scenes/UserActivityPage/UserActivityLayout.tsx
@@ -84,9 +84,9 @@ export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
         mobileLayout={mobileLayout}
         setMobileLayout={setMobileLayout}
       />
-      <VStack gap={32}>
+      <StyledUserActivityLayout gap={32}>
         <UserActivityFeed userRef={user} queryRef={query} />
-      </VStack>
+      </StyledUserActivityLayout>
     </StyledUserGalleryLayout>
   );
 };
@@ -99,4 +99,9 @@ const StyledUserGalleryLayout = styled(VStack)`
   @media only screen and ${breakpoints.tablet} {
     padding: 80px 0 32px;
   }
+`;
+
+const StyledUserActivityLayout = styled(VStack)`
+  margin: 0 -16px;
+  padding-top: 24px;
 `;

--- a/src/scenes/UserActivityPage/UserActivityLayout.tsx
+++ b/src/scenes/UserActivityPage/UserActivityLayout.tsx
@@ -21,9 +21,11 @@ type Props = {
 export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
   const query = useFragment(
     graphql`
-      fragment UserActivityLayoutQueryFragment on Query {
+      fragment UserActivityLayoutQueryFragment on Query
+        @refetchable(queryName: "UserGalleryFeedRefreshQuery") {
         ...NavActionFollowQueryFragment
         ...UserGalleryHeaderQueryFragment
+        ...UserActivityFeedQueryFragment
       }
     `,
     queryRef
@@ -44,6 +46,8 @@ export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
         ...NavActionFollowUserFragment
 
         ...UserGalleryHeaderFragment
+
+        ...UserActivityFeedFragment
       }
     `,
     userRef
@@ -80,8 +84,8 @@ export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
         mobileLayout={mobileLayout}
         setMobileLayout={setMobileLayout}
       />
-      <VStack gap={32} align="center" justify="center" grow>
-        <UserActivityFeed />
+      <VStack gap={32}>
+        <UserActivityFeed userRef={user} queryRef={query} />
       </VStack>
     </StyledUserGalleryLayout>
   );

--- a/src/scenes/UserActivityPage/UserActivityLayout.tsx
+++ b/src/scenes/UserActivityPage/UserActivityLayout.tsx
@@ -35,13 +35,6 @@ export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
     graphql`
       fragment UserActivityLayoutFragment on GalleryUser {
         username
-        galleries {
-          collections {
-            __typename
-          }
-
-          ...UserGalleryCollectionsFragment
-        }
 
         ...NavActionFollowUserFragment
 
@@ -54,7 +47,6 @@ export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
   );
 
   const isMobile = useIsMobileWindowWidth();
-  const showMobileLayoutToggle = Boolean(isMobile && user.galleries?.[0]?.collections?.length);
   const { mobileLayout, setMobileLayout } = useMobileLayout();
 
   const { setCustomNavLeftContent } = useGlobalLayoutActions();
@@ -79,7 +71,7 @@ export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
       <UserGalleryHeader
         userRef={user}
         queryRef={query}
-        showMobileLayoutToggle={showMobileLayoutToggle}
+        showMobileLayoutToggle={false}
         isMobile={isMobile}
         mobileLayout={mobileLayout}
         setMobileLayout={setMobileLayout}

--- a/src/scenes/UserActivityPage/UserActivityLayout.tsx
+++ b/src/scenes/UserActivityPage/UserActivityLayout.tsx
@@ -12,6 +12,8 @@ import UserActivityFeed from './UserActivityFeed';
 import { UserActivityLayoutQueryFragment$key } from '__generated__/UserActivityLayoutQueryFragment.graphql';
 import { UserActivityLayoutFragment$key } from '__generated__/UserActivityLayoutFragment.graphql';
 import { StyledUserGalleryLayout } from 'scenes/UserGalleryPage/UserGalleryLayout';
+import { FEED_MAX_WIDTH } from 'components/Feed/dimensions';
+import breakpoints from 'components/core/breakpoints';
 
 type Props = {
   userRef: UserActivityLayoutFragment$key;
@@ -67,7 +69,7 @@ export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
   }, [query, setCustomNavLeftContent, user]);
 
   return (
-    <StyledUserGalleryLayout>
+    <StyledUserGalleryLayout align="center">
       <UserGalleryHeader
         userRef={user}
         queryRef={query}
@@ -86,4 +88,8 @@ export const UserActivityLayout = ({ userRef, queryRef }: Props) => {
 const StyledUserActivityLayout = styled(VStack)`
   margin: 0 -16px;
   padding-top: 24px;
+
+  @media only screen and ${breakpoints.desktop} {
+    width: ${FEED_MAX_WIDTH}px;
+  }
 `;

--- a/src/scenes/UserActivityPage/UserActivityPage.tsx
+++ b/src/scenes/UserActivityPage/UserActivityPage.tsx
@@ -1,0 +1,63 @@
+import breakpoints, { pageGutter } from 'components/core/breakpoints';
+import styled from 'styled-components';
+
+import Head from 'next/head';
+import { useEffect } from 'react';
+import { useTrack } from 'contexts/analytics/AnalyticsContext';
+import { useFragment } from 'react-relay';
+import { graphql } from 'relay-runtime';
+import { GLOBAL_NAVBAR_HEIGHT } from 'contexts/globalLayout/GlobalNavbar/GlobalNavbar';
+import UserActivity from './UserActivity';
+import { UserActivityPageFragment$key } from '__generated__/UserActivityPageFragment.graphql';
+
+type UserActivityPageProps = {
+  queryRef: UserActivityPageFragment$key;
+  username: string;
+};
+
+function UserActivityPage({ queryRef, username }: UserActivityPageProps) {
+  const query = useFragment(
+    graphql`
+      fragment UserActivityPageFragment on Query {
+        ...UserActivityFragment
+      }
+    `,
+    queryRef
+  );
+
+  const headTitle = `${username} | Gallery`;
+
+  const track = useTrack();
+
+  useEffect(() => {
+    track('Page View: User Gallery', { username });
+  }, [username, track]);
+
+  return (
+    <>
+      <Head>
+        <title>{headTitle}</title>
+      </Head>
+      <StyledUserGalleryPage>
+        <UserActivity queryRef={query} />
+      </StyledUserGalleryPage>
+    </>
+  );
+}
+
+const StyledUserGalleryPage = styled.div`
+  display: flex;
+  justify-content: center;
+  padding-top: ${GLOBAL_NAVBAR_HEIGHT}px;
+  min-height: 100vh;
+
+  display: flex;
+  justify-content: center;
+  margin: 0 ${pageGutter.mobile}px 24px;
+
+  @media only screen and ${breakpoints.tablet} {
+    margin: 0 ${pageGutter.tablet}px;
+  }
+`;
+
+export default UserActivityPage;

--- a/src/scenes/UserActivityPage/UserActivityPage.tsx
+++ b/src/scenes/UserActivityPage/UserActivityPage.tsx
@@ -1,14 +1,11 @@
-import breakpoints, { pageGutter } from 'components/core/breakpoints';
-import styled from 'styled-components';
-
 import Head from 'next/head';
 import { useEffect } from 'react';
 import { useTrack } from 'contexts/analytics/AnalyticsContext';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
-import { GLOBAL_NAVBAR_HEIGHT } from 'contexts/globalLayout/GlobalNavbar/GlobalNavbar';
 import UserActivity from './UserActivity';
 import { UserActivityPageFragment$key } from '__generated__/UserActivityPageFragment.graphql';
+import { StyledUserGalleryPage } from 'scenes/UserGalleryPage/UserGalleryPage';
 
 type UserActivityPageProps = {
   queryRef: UserActivityPageFragment$key;
@@ -44,20 +41,5 @@ function UserActivityPage({ queryRef, username }: UserActivityPageProps) {
     </>
   );
 }
-
-const StyledUserGalleryPage = styled.div`
-  display: flex;
-  justify-content: center;
-  padding-top: ${GLOBAL_NAVBAR_HEIGHT}px;
-  min-height: 100vh;
-
-  display: flex;
-  justify-content: center;
-  margin: 0 ${pageGutter.mobile}px 24px;
-
-  @media only screen and ${breakpoints.tablet} {
-    margin: 0 ${pageGutter.tablet}px;
-  }
-`;
 
 export default UserActivityPage;

--- a/src/scenes/UserGalleryPage/UserGalleryLayout.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryLayout.tsx
@@ -97,7 +97,7 @@ export const UserGalleryLayout = ({ userRef, queryRef }: Props) => {
   );
 };
 
-const StyledUserGalleryLayout = styled(VStack)`
+export const StyledUserGalleryLayout = styled(VStack)`
   width: 100%;
   max-width: 1200px;
   padding: 48px 0 32px;

--- a/src/scenes/UserGalleryPage/UserGalleryPage.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryPage.tsx
@@ -45,7 +45,7 @@ function UserGalleryPage({ queryRef, username }: UserGalleryPageProps) {
   );
 }
 
-const StyledUserGalleryPage = styled.div`
+export const StyledUserGalleryPage = styled.div`
   display: flex;
   justify-content: center;
   padding-top: ${GLOBAL_NAVBAR_HEIGHT}px;


### PR DESCRIPTION
**Changes**
- Added user activity feed
- Access it directly through https://gallery.so/username/activity

**Demo**

**Mobile**

https://user-images.githubusercontent.com/4480258/196184395-23dc714a-9b7a-4a6e-bceb-d69b074c44bc.mp4

**Desktop**

https://user-images.githubusercontent.com/4480258/196184753-5c307752-2a8a-4e99-af8c-92b49a87e26f.mp4


