### PR TITLE
[GAL-519] Improve Admire Comment Jitter

### DIFF
--- a/src/components/Feed/FeedEvent.tsx
+++ b/src/components/Feed/FeedEvent.tsx
@@ -14,6 +14,7 @@ import { FeedEventWithErrorBoundaryFragment$key } from '../../../__generated__/F
 import { FeedEventWithErrorBoundaryQueryFragment$key } from '../../../__generated__/FeedEventWithErrorBoundaryQueryFragment.graphql';
 import { VStack } from 'components/core/Spacer/Stack';
 import isFeatureEnabled, { FeatureFlag } from 'utils/graphql/isFeatureEnabled';
+import { useCallback, useLayoutEffect, useRef } from 'react';
 
 type FeedEventProps = {
   eventRef: FeedEventFragment$key;
@@ -96,13 +97,15 @@ function FeedEvent({ eventRef, queryRef, feedMode }: FeedEventProps) {
 }
 
 type FeedEventWithBoundaryProps = {
+  index: number;
   feedMode: FeedMode;
-  onPotentialLayoutShift: () => void;
+  onPotentialLayoutShift: (index: number) => void;
   eventRef: FeedEventWithErrorBoundaryFragment$key;
   queryRef: FeedEventWithErrorBoundaryQueryFragment$key;
 };
 
 export default function FeedEventWithBoundary({
+  index,
   feedMode,
   eventRef,
   queryRef,
@@ -111,6 +114,12 @@ export default function FeedEventWithBoundary({
   const event = useFragment(
     graphql`
       fragment FeedEventWithErrorBoundaryFragment on FeedEvent {
+        eventData {
+          ... on UserFollowedUsersFeedEventData {
+            __typename
+          }
+        }
+
         ...FeedEventFragment
         ...FeedEventSocializeSectionFragment
       }
@@ -131,18 +140,26 @@ export default function FeedEventWithBoundary({
   );
 
   const isAdmireCommentEnabled = isFeatureEnabled(FeatureFlag.ADMIRE_COMMENT, query);
+  const eventSupportsAdmireComment =
+    event.eventData?.__typename !== 'UserFollowedUsersFeedEventData';
+
+  const shouldShowAdmireComment = isAdmireCommentEnabled && eventSupportsAdmireComment;
+
+  const handlePotentialLayoutShift = useCallback(() => {
+    onPotentialLayoutShift(index);
+  }, [index, onPotentialLayoutShift]);
 
   return (
     <FeedEventErrorBoundary>
       <VStack gap={16}>
         <FeedEvent eventRef={event} queryRef={query} feedMode={feedMode} />
 
-        {isAdmireCommentEnabled && (
+        {shouldShowAdmireComment && (
           <ErrorBoundary fallback={<></>}>
             <FeedEventSocializeSection
               eventRef={event}
               queryRef={query}
-              onPotentialLayoutShift={onPotentialLayoutShift}
+              onPotentialLayoutShift={handlePotentialLayoutShift}
             />
           </ErrorBoundary>
         )}

--- a/src/components/Feed/FeedEvent.tsx
+++ b/src/components/Feed/FeedEvent.tsx
@@ -14,7 +14,7 @@ import { FeedEventWithErrorBoundaryFragment$key } from '../../../__generated__/F
 import { FeedEventWithErrorBoundaryQueryFragment$key } from '../../../__generated__/FeedEventWithErrorBoundaryQueryFragment.graphql';
 import { VStack } from 'components/core/Spacer/Stack';
 import isFeatureEnabled, { FeatureFlag } from 'utils/graphql/isFeatureEnabled';
-import { useCallback, useLayoutEffect, useRef } from 'react';
+import { useCallback } from 'react';
 
 type FeedEventProps = {
   eventRef: FeedEventFragment$key;

--- a/src/components/Feed/FeedList.tsx
+++ b/src/components/Feed/FeedList.tsx
@@ -117,8 +117,10 @@ export default function FeedList({
                 // Whenever the height changes, we need to ask react-virtualized
                 // to re-evaluate the height of the item to keep the virtualization good.
                 onPotentialLayoutShift={() => {
-                  measurerCache.clear(index, 0);
-                  virtualizedListRef.current?.recomputeRowHeights();
+                  setTimeout(() => {
+                    measurerCache.clear(index, 0);
+                    virtualizedListRef.current?.recomputeRowHeights(index);
+                  }, 0);
                 }}
                 eventRef={content}
                 key={content.dbid}

--- a/src/components/Feed/FeedList.tsx
+++ b/src/components/Feed/FeedList.tsx
@@ -61,6 +61,7 @@ export default function FeedList({
 
   const measurerCache = useMemo(() => {
     return new CellMeasurerCache({
+      defaultHeight: 400,
       fixedWidth: true,
       minHeight: 0,
     });
@@ -136,7 +137,7 @@ export default function FeedList({
         </CellMeasurer>
       );
     },
-    [feedData, feedMode, isRowLoaded, measurerCache, query]
+    [feedData, feedMode, handlePotentialLayoutShift, isRowLoaded, measurerCache, query]
   );
 
   // If there are more items to be loaded then add extra rows
@@ -165,6 +166,7 @@ export default function FeedList({
                 rowCount={rowCount}
                 rowHeight={measurerCache.rowHeight}
                 scrollTop={scrollTop}
+                overscanRowCount={10}
                 // By default, react-virtualized's list has the css property `will-change` set to `transform`
                 // An element with `position: fixed` beneath an element with `will-change: transform` will
                 // be incredibly busted. You can read more about that [here](https://stackoverflow.com/questions/28157125/why-does-transform-break-position-fixed)

--- a/src/components/Feed/FeedList.tsx
+++ b/src/components/Feed/FeedList.tsx
@@ -117,10 +117,8 @@ export default function FeedList({
                 // Whenever the height changes, we need to ask react-virtualized
                 // to re-evaluate the height of the item to keep the virtualization good.
                 onPotentialLayoutShift={() => {
-                  setTimeout(() => {
-                    measurerCache.clear(index, 0);
-                    virtualizedListRef.current?.recomputeRowHeights(index);
-                  }, 0);
+                  measurerCache.clear(index, 0);
+                  virtualizedListRef.current?.recomputeRowHeights(index);
                 }}
                 eventRef={content}
                 key={content.dbid}

--- a/src/components/Feed/FeedList.tsx
+++ b/src/components/Feed/FeedList.tsx
@@ -74,6 +74,14 @@ export default function FeedList({
 
   const virtualizedListRef = useRef<List | null>(null);
 
+  const handlePotentialLayoutShift = useCallback(
+    (index: number) => {
+      measurerCache.clear(index, 0);
+      virtualizedListRef.current?.recomputeRowHeights(index);
+    },
+    [measurerCache]
+  );
+
   //Render a list item or a loading indicator.
   const rowRenderer = useCallback(
     ({
@@ -116,10 +124,8 @@ export default function FeedList({
                 //
                 // Whenever the height changes, we need to ask react-virtualized
                 // to re-evaluate the height of the item to keep the virtualization good.
-                onPotentialLayoutShift={() => {
-                  measurerCache.clear(index, 0);
-                  virtualizedListRef.current?.recomputeRowHeights(index);
-                }}
+                onPotentialLayoutShift={handlePotentialLayoutShift}
+                index={index}
                 eventRef={content}
                 key={content.dbid}
                 queryRef={query}

--- a/src/components/Feed/Socialize/AdmireButton.tsx
+++ b/src/components/Feed/Socialize/AdmireButton.tsx
@@ -134,15 +134,6 @@ export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: Adm
 
           store.delete(relayId);
         }
-
-        // Tell the virtualized list that some data has changed
-        // therefore this cell's height might change.
-        //
-        // Ideally, this lives in a useEffect inside of the
-        // changing data's component, but right now the virtualized
-        // list is remounting the component every update, causing
-        // an infinite useEffect to occur
-        onPotentialLayoutShift();
       }
     };
 
@@ -221,15 +212,6 @@ export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: Adm
         const pageInfo = store.get(interactionsConnection)?.getLinkedRecord('pageInfo');
 
         pageInfo?.setValue(((pageInfo?.getValue('total') as number) ?? 0) + 1, 'total');
-
-        // Tell the virtualized list that some data has changed
-        // therefore this cell's height might change.
-        //
-        // Ideally, this lives in a useEffect inside of the
-        // changing data's component, but right now the virtualized
-        // list is remounting the component every update, causing
-        // an infinite useEffect to occur
-        onPotentialLayoutShift();
       }
     };
 

--- a/src/components/Feed/Socialize/AdmireButton.tsx
+++ b/src/components/Feed/Socialize/AdmireButton.tsx
@@ -15,7 +15,6 @@ import { AdmireButtonRemoveMutation } from '../../../../__generated__/AdmireButt
 type AdmireButtonProps = {
   eventRef: AdmireButtonFragment$key;
   queryRef: AdmireButtonQueryFragment$key;
-  onPotentialLayoutShift: () => void;
 };
 
 export function AdmireButton({ eventRef, queryRef }: AdmireButtonProps) {

--- a/src/components/Feed/Socialize/AdmireButton.tsx
+++ b/src/components/Feed/Socialize/AdmireButton.tsx
@@ -18,7 +18,7 @@ type AdmireButtonProps = {
   onPotentialLayoutShift: () => void;
 };
 
-export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: AdmireButtonProps) {
+export function AdmireButton({ eventRef, queryRef }: AdmireButtonProps) {
   const event = useFragment(
     graphql`
       fragment AdmireButtonFragment on FeedEvent {
@@ -181,7 +181,6 @@ export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: Adm
     event.dbid,
     event.viewerAdmire?.dbid,
     interactionsConnection,
-    onPotentialLayoutShift,
     pushToast,
     removeAdmire,
     reportError,
@@ -276,7 +275,6 @@ export function AdmireButton({ eventRef, queryRef, onPotentialLayoutShift }: Adm
     event.id,
     interactionsConnection,
     notesModalConnection,
-    onPotentialLayoutShift,
     pushToast,
     query,
     reportError,

--- a/src/components/Feed/Socialize/CommentBox.tsx
+++ b/src/components/Feed/Socialize/CommentBox.tsx
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import colors from 'components/core/colors';
 import {
+  ClipboardEventHandler,
   FormEventHandler,
   KeyboardEventHandler,
   MouseEventHandler,
@@ -255,6 +256,17 @@ export function CommentBox({ active, onClose, eventRef, queryRef, onPotentialLay
     }
   }, []);
 
+  // This prevents someone from pasting a styled element into the textbox
+  const handlePaste = useCallback<ClipboardEventHandler<HTMLParagraphElement>>((event) => {
+    event.preventDefault();
+    const text = event.clipboardData.getData('text/plain');
+
+    setValue(text);
+    if (textareaRef.current) {
+      textareaRef.current.innerText = text;
+    }
+  }, []);
+
   return (
     <>
       {active && <ClickPreventingOverlay onClick={onClose} />}
@@ -262,7 +274,12 @@ export function CommentBox({ active, onClose, eventRef, queryRef, onPotentialLay
         <Wrapper onClick={handleClick}>
           <InputWrapper gap={12}>
             {/* Purposely not using a controlled input here to avoid cursor jitter */}
-            <Textarea onKeyDown={handleInputKeyDown} ref={textareaRef} onInput={handleInput} />
+            <Textarea
+              onPaste={handlePaste}
+              onKeyDown={handleInputKeyDown}
+              ref={textareaRef}
+              onInput={handleInput}
+            />
 
             <ControlsContainer gap={12} align="center">
               <BaseM color={colors.metal}>{MAX_TEXT_LENGTH - value.length}</BaseM>

--- a/src/components/Feed/Socialize/CommentBox.tsx
+++ b/src/components/Feed/Socialize/CommentBox.tsx
@@ -2,7 +2,6 @@ import styled, { css } from 'styled-components';
 import colors from 'components/core/colors';
 import {
   ClipboardEventHandler,
-  FormEventHandler,
   KeyboardEventHandler,
   MouseEventHandler,
   useCallback,
@@ -32,7 +31,7 @@ type Props = {
   onPotentialLayoutShift: () => void;
 };
 
-export function CommentBox({ active, onClose, eventRef, queryRef, onPotentialLayoutShift }: Props) {
+export function CommentBox({ active, onClose, eventRef, queryRef }: Props) {
   const query = useFragment(
     graphql`
       fragment CommentBoxQueryFragment on Query {
@@ -180,7 +179,6 @@ export function CommentBox({ active, onClose, eventRef, queryRef, onPotentialLay
     event.id,
     isSubmittingComment,
     onClose,
-    onPotentialLayoutShift,
     pushToast,
     query.viewer?.user?.id,
     query.viewer?.user?.username,

--- a/src/components/Feed/Socialize/CommentBox.tsx
+++ b/src/components/Feed/Socialize/CommentBox.tsx
@@ -28,7 +28,6 @@ type Props = {
   onClose: () => void;
   eventRef: CommentBoxFragment$key;
   queryRef: CommentBoxQueryFragment$key;
-  onPotentialLayoutShift: () => void;
 };
 
 export function CommentBox({ active, onClose, eventRef, queryRef }: Props) {

--- a/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -89,7 +89,11 @@ export function FeedEventSocializeSection({
       <SocializeSectionWrapper>
         <HStack justify="space-between" align="flex-end" gap={24}>
           <VStack shrink>
-            <Interactions eventRef={event} queryRef={query} />
+            <Interactions
+              onPotentialLayoutShift={onPotentialLayoutShift}
+              eventRef={event}
+              queryRef={query}
+            />
           </VStack>
 
           <HStack align="center">

--- a/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -98,18 +98,13 @@ export function FeedEventSocializeSection({
 
           <HStack align="center">
             <IconWrapper>
-              <AdmireButton
-                eventRef={event}
-                queryRef={query}
-                onPotentialLayoutShift={onPotentialLayoutShift}
-              />
+              <AdmireButton eventRef={event} queryRef={query} />
             </IconWrapper>
 
             <IconWrapper>
               <CommentIcon onClick={handleToggle} ref={commentIconRef} />
 
               <CommentBox
-                onPotentialLayoutShift={onPotentialLayoutShift}
                 onClose={handleClose}
                 eventRef={event}
                 queryRef={query}

--- a/src/components/Feed/Socialize/Interactions.tsx
+++ b/src/components/Feed/Socialize/Interactions.tsx
@@ -5,16 +5,17 @@ import { CommentLine } from 'components/Feed/Socialize/CommentLine';
 import { AdmireLine } from 'components/Feed/Socialize/AdmireLine';
 import { RemainingAdmireCount } from 'components/Feed/Socialize/RemainingAdmireCount';
 import { NoteModalOpenerText } from 'components/Feed/Socialize/NoteModalOpenerText';
-import { useMemo } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { InteractionsQueryFragment$key } from '../../../../__generated__/InteractionsQueryFragment.graphql';
 import { InteractionsFragment$key } from '../../../../__generated__/InteractionsFragment.graphql';
 
 type Props = {
+  onPotentialLayoutShift: () => void;
   eventRef: InteractionsFragment$key;
   queryRef: InteractionsQueryFragment$key;
 };
 
-export function Interactions({ eventRef, queryRef }: Props) {
+export function Interactions({ eventRef, queryRef, onPotentialLayoutShift }: Props) {
   const event = useFragment(
     graphql`
       fragment InteractionsFragment on FeedEvent {
@@ -95,6 +96,17 @@ export function Interactions({ eventRef, queryRef }: Props) {
   const totalComments = event.comments?.pageInfo.total ?? 0;
   const totalAdmires = event.admires?.pageInfo.total ?? 0;
   const totalInteractions = totalComments + totalAdmires;
+
+  const isFirstMount = useRef(true);
+  useLayoutEffect(() => {
+    if (!isFirstMount.current) {
+      onPotentialLayoutShift();
+    }
+
+    isFirstMount.current = false;
+
+    // These are all the things that might cause the layout to shift
+  }, [onPotentialLayoutShift, nonNullAdmires, nonNullComments, totalComments, totalAdmires]);
 
   /**
    * The below logic is a bit annoying to read so I'll try to explain it here

--- a/src/components/Feed/Socialize/Interactions.tsx
+++ b/src/components/Feed/Socialize/Interactions.tsx
@@ -5,7 +5,7 @@ import { CommentLine } from 'components/Feed/Socialize/CommentLine';
 import { AdmireLine } from 'components/Feed/Socialize/AdmireLine';
 import { RemainingAdmireCount } from 'components/Feed/Socialize/RemainingAdmireCount';
 import { NoteModalOpenerText } from 'components/Feed/Socialize/NoteModalOpenerText';
-import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { useLayoutEffect, useMemo, useRef } from 'react';
 import { InteractionsQueryFragment$key } from '../../../../__generated__/InteractionsQueryFragment.graphql';
 import { InteractionsFragment$key } from '../../../../__generated__/InteractionsFragment.graphql';
 


### PR DESCRIPTION
### Changes
- Height recomputations are now done in a `useLayoutEffect` so the user sees no jitter when the height of an event changes
- Fixed pasting of stylized text into the comment box (we were seeing some weird behavior before)


The layout shift you're seeing at the end of the video is from the server stripping a trailing newline (I'm 99% sure)

https://user-images.githubusercontent.com/6754223/196294988-505f15d2-3d4a-4cfb-841f-66b8300907c7.mov


### THE REMAINING ISSUE
There is one more incredibly shitty behavior I'm seeing when scrolling through the list (independent of admire / comment). There seems to be this issue where when you scroll fast enough you can get into this fucked state where scrolling up one pixel shifts you way far, and then scrolling down one pixel scrolls you way far. I'm not sure what the root cause is but it seems deeply rooted in react-virtualized and I'm hoping this is just fixed when we migrate to `react-window`