### PR TITLE
[GAL-541] prompt before closing collection editor

### DIFF
--- a/pages/gallery/[galleryId]/collection/[collectionId]/edit.tsx
+++ b/pages/gallery/[galleryId]/collection/[collectionId]/edit.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import CollectionEditorProvider, {
   useCollectionMetadataState,
   useStagedCollectionState,
@@ -98,6 +98,24 @@ function LazyLoadedCollectionEditor({ galleryId, collectionId }: Props) {
   ]);
 
   const [isCollectionValid, setIsCollectionValid] = useState(false);
+
+  useEffect(() => {
+    const message =
+      'Are you sure you want to quit editing the collection? You will lose all of your changes.';
+    const savedOnBeforeUnload = window.onbeforeunload;
+
+    window.onbeforeunload = (e) => {
+      // Doing both `returnValue` and `return` here as a recommendation from this StackOverflow post
+      // https://stackoverflow.com/questions/10311341/confirmation-before-closing-of-tab-browser
+      e.returnValue = message;
+
+      return message;
+    };
+
+    return () => {
+      window.onbeforeunload = savedOnBeforeUnload;
+    };
+  }, []);
 
   return (
     <VStack>


### PR DESCRIPTION
Simple little prompt to ensure users don't accidentally close the tab while editing their collections.