### PR TITLE
Add close warning on create page

### DIFF
--- a/pages/gallery/[galleryId]/collection/[collectionId]/edit.tsx
+++ b/pages/gallery/[galleryId]/collection/[collectionId]/edit.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import CollectionEditorProvider, {
   useCollectionMetadataState,
   useStagedCollectionState,
@@ -17,6 +17,7 @@ import FullPageStep from 'components/Onboarding/FullPageStep';
 import { VStack } from 'components/core/Spacer/Stack';
 import { useModalActions } from 'contexts/modal/ModalContext';
 import GenericActionModal from 'scenes/Modals/GenericActionModal';
+import useConfirmationMessageBeforeClose from '../useConfirmationMessageBeforeClose';
 
 type Props = {
   galleryId: string;
@@ -99,23 +100,7 @@ function LazyLoadedCollectionEditor({ galleryId, collectionId }: Props) {
 
   const [isCollectionValid, setIsCollectionValid] = useState(false);
 
-  useEffect(() => {
-    const message =
-      'Are you sure you want to quit editing the collection? You will lose all of your changes.';
-    const savedOnBeforeUnload = window.onbeforeunload;
-
-    window.onbeforeunload = (e) => {
-      // Doing both `returnValue` and `return` here as a recommendation from this StackOverflow post
-      // https://stackoverflow.com/questions/10311341/confirmation-before-closing-of-tab-browser
-      e.returnValue = message;
-
-      return message;
-    };
-
-    return () => {
-      window.onbeforeunload = savedOnBeforeUnload;
-    };
-  }, []);
+  useConfirmationMessageBeforeClose();
 
   return (
     <VStack>

--- a/pages/gallery/[galleryId]/collection/create.tsx
+++ b/pages/gallery/[galleryId]/collection/create.tsx
@@ -16,6 +16,7 @@ import { useCanGoBack } from 'contexts/navigation/GalleryNavigationProvider';
 import { createCollectionQuery } from '../../../../__generated__/createCollectionQuery.graphql';
 import { VStack } from 'components/core/Spacer/Stack';
 import FullPageStep from 'components/Onboarding/FullPageStep';
+import useConfirmationMessageBeforeClose from './useConfirmationMessageBeforeClose';
 
 type Props = {
   galleryId: string;
@@ -35,6 +36,8 @@ function LazyLoadedCollectionEditor({ galleryId }: Props) {
   const { showModal } = useModalActions();
   const stagedCollectionState = useStagedCollectionState();
   const collectionMetadata = useCollectionMetadataState();
+
+  useConfirmationMessageBeforeClose();
 
   const { push, back, replace } = useRouter();
 

--- a/pages/gallery/[galleryId]/collection/useConfirmationMessageBeforeClose.ts
+++ b/pages/gallery/[galleryId]/collection/useConfirmationMessageBeforeClose.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+export default function useConfirmationMessageBeforeClose() {
+  useEffect(() => {
+    const message =
+      'Are you sure you want to quit editing the collection? You have unsaved changes.';
+    const savedOnBeforeUnload = window.onbeforeunload;
+
+    window.onbeforeunload = (e) => {
+      // Doing both `returnValue` and `return` here as a recommendation from this StackOverflow post
+      // https://stackoverflow.com/questions/10311341/confirmation-before-closing-of-tab-browser
+      e.returnValue = message;
+
+      return message;
+    };
+
+    return () => {
+      window.onbeforeunload = savedOnBeforeUnload;
+    };
+  }, []);
+}


### PR DESCRIPTION
previous the warning only existed on `/edit`

extension of #1062 