### PR TITLE
[GAL-544] Fix TV's gallery 

### DIFF
--- a/src/scenes/NftDetailPage/NftDetailVideo.tsx
+++ b/src/scenes/NftDetailPage/NftDetailVideo.tsx
@@ -36,8 +36,10 @@ function NftDetailVideo({ mediaRef, hideControls = false, onLoad }: Props) {
 
   const handleVideoLoadError = useCallback(
     (e: SyntheticEvent<HTMLVideoElement, Event>) => {
-      setErrored(true);
-      handleError(e);
+      if (e.currentTarget.error) {
+        setErrored(true);
+        handleError(e);
+      }
     },
     [handleError]
   );


### PR DESCRIPTION
It seems like the browser is reporting an error on the video without there actually being an error on the element.

- Tested that actual errors still trigger the failure state
- Tested that TV's gallery works now