### PR TITLE
[GAL-549] Fix profile jank on iOS

### DIFF
--- a/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -76,13 +76,13 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
     })
   );
   const listRef = useRef<List>(null);
-  const windowSize = useWindowSize();
+  const { width } = useWindowSize();
 
   // If the mobileLayout is changed, we need to recalculate the cache height.
   useEffect(() => {
     cache.current.clearAll();
     listRef.current?.recomputeRowHeights();
-  }, [mobileLayout, windowSize]);
+  }, [mobileLayout, width]);
 
   const collectionsToDisplay = useMemo(
     () =>


### PR DESCRIPTION
**FInding**
Seems like the issue happens because the virtualize recompute the height when the window size changed (in this case the height changed)

Solution: We only monitor the `width` of the window, if its changed we will recomputed the height. To cover if the user rotate their phone or resize browser. 


**Demo**

**Before**

https://user-images.githubusercontent.com/4480258/196842375-7f2eb78f-fdf7-4ee8-9f9a-4763a9fc302f.mp4

**After**

https://user-images.githubusercontent.com/4480258/196842430-b479193e-9508-45ad-bdf6-81fa323dd760.mp4

