### PR TITLE
Switch to 'mo' for months

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -46,7 +46,7 @@ export const getTimeSince = (time: string) => {
     return `${Math.floor(interval / DAY)}d`;
   }
   if (interval < YEAR) {
-    return `${Math.floor(interval / MONTH)}m`;
+    return `${Math.floor(interval / MONTH)}mo`;
   }
 
   return `${Math.floor(interval / YEAR)}y`;


### PR DESCRIPTION
`m` was pretty confusing as it referred to both `months` and `minutes`