### PR TITLE
Remove padding in between paragraph blocks for collection description

### DIFF
--- a/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -256,15 +256,19 @@ const StyledCollectorsNote = styled(BaseM)<{ showMore: boolean }>`
           -webkit-line-clamp: unset;
         `
       : css`
-          // We only care about line clamping on mobile
-          @media only screen and ${breakpoints.tablet} {
-            -webkit-line-clamp: unset;
-          }
-
           -webkit-line-clamp: 2;
 
           p {
             padding-bottom: 0 !important;
+          }
+
+          // We only care about line clamping on mobile
+          @media only screen and ${breakpoints.tablet} {
+            -webkit-line-clamp: unset;
+
+            p:not(:last-child) {
+              padding-bottom: 12px !important;
+            }
           }
         `}
 `;


### PR DESCRIPTION
**Reported Bug**
![image](https://user-images.githubusercontent.com/12162433/199828695-6fde96e2-8894-418f-a12f-a101b5b4ac91.png)

**Before**
- no padding in between paragraphs
- weird expanding behavior on-click

https://user-images.githubusercontent.com/12162433/199828898-02f0a0ba-a8de-4326-b38c-46c2d2d9d4d5.mov



**After**
- ensure padding
- no padding change on click
![image](https://user-images.githubusercontent.com/12162433/199828604-a02c9418-f0b5-440e-88a4-37b7f3ff1ef6.png)
