### PR TITLE
Limit feed event token preview count

### DIFF
--- a/pages/[username]/activity.tsx
+++ b/pages/[username]/activity.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from 'next';
 import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import { ITEMS_PER_PAGE } from '~/components/Feed/constants';
+import { ITEMS_PER_PAGE, MAX_PIECES_DISPLAYED_PER_FEED_EVENT } from '~/components/Feed/constants';
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/NotesModal/NotesModal';
 import { GalleryNavbar } from '~/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavbar';
 import { activityQuery } from '~/generated/activityQuery.graphql';
@@ -24,6 +24,7 @@ export default function UserFeed({ username }: UserActivityProps) {
         $interactionsAfter: String
         $viewerLast: Int!
         $viewerBefore: String
+        $visibleTokensPerFeedEvent: Int!
       ) {
         ...UserActivityPageFragment
         ...GalleryNavbarFragment
@@ -33,6 +34,7 @@ export default function UserFeed({ username }: UserActivityProps) {
       username: username,
       interactionsFirst: NOTES_PER_PAGE,
       viewerLast: ITEMS_PER_PAGE,
+      visibleTokensPerFeedEvent: MAX_PIECES_DISPLAYED_PER_FEED_EVENT,
     }
   );
 

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
-import { ITEMS_PER_PAGE } from '~/components/Feed/constants';
+import { ITEMS_PER_PAGE, MAX_PIECES_DISPLAYED_PER_FEED_EVENT } from '~/components/Feed/constants';
 import { FeedMode } from '~/components/Feed/Feed';
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/NotesModal/NotesModal';
 import { FEED_MODE_KEY } from '~/constants/storageKeys';
@@ -21,6 +21,7 @@ export default function Home() {
         $globalBefore: String
         $viewerLast: Int!
         $viewerBefore: String
+        $visibleTokensPerFeedEvent: Int!
       ) {
         viewer {
           ... on Viewer {
@@ -38,6 +39,7 @@ export default function Home() {
       interactionsFirst: NOTES_PER_PAGE,
       globalLast: ITEMS_PER_PAGE,
       viewerLast: ITEMS_PER_PAGE,
+      visibleTokensPerFeedEvent: MAX_PIECES_DISPLAYED_PER_FEED_EVENT,
     }
   );
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -97,7 +97,6 @@ type ChainTokens {
     tokens: [Token]
 }
 
-
 input ChainAddressInput {
     address: Address! @goField(forceResolver: true)
     chain: Chain! @goField(forceResolver: true)
@@ -345,7 +344,7 @@ type Collection implements Node {
     gallery: Gallery @goField(forceResolver: true)
     layout: CollectionLayout
     hidden: Boolean
-    tokens: [CollectionToken] @goField(forceResolver: true)
+    tokens(limit: Int): [CollectionToken] @goField(forceResolver: true)
 }
 
 type Gallery implements Node {
@@ -435,14 +434,52 @@ type ViewerGallery {
     gallery: Gallery
 }
 
+type NotificationEdge {
+    node: Notification
+    cursor: String
+}
+
+type NotificationsConnection @goEmbedHelper {
+    edges: [NotificationEdge]
+    unseenCount: Int
+    pageInfo: PageInfo
+}
+
 type Viewer {
     user: GalleryUser @goField(forceResolver: true)
     viewerGalleries: [ViewerGallery] @goField(forceResolver: true)
     feed(before: String, after: String, first: Int, last: Int): FeedConnection @goField(forceResolver: true)
+
+    """
+    Returns a list of notifications in reverse chronological order.
+    Seen notifications come after unseen notifications
+    """
+    notifications(before: String, after: String, first: Int, last: Int): NotificationsConnection @goField(forceResolver: true)
+
+    notificationSettings: NotificationSettings @goField(forceResolver: true)
 }
+
+type NotificationSettings @goEmbedHelper {
+    user: GalleryUser
+
+    someoneFollowedYou: Boolean
+    someoneAdmiredYourUpdate: Boolean
+    someoneCommentedOnYourUpdate: Boolean
+    someoneViewedYourGallery: Boolean
+}
+
+input NotificationSettingsInput {
+    someoneFollowedYou: Boolean
+    someoneAdmiredYourUpdate: Boolean
+    someoneCommentedOnYourUpdate: Boolean
+    someoneViewedYourGallery: Boolean
+}
+
 union UserByUsernameOrError = GalleryUser | ErrUserNotFound | ErrInvalidInput
 
 union UserByIdOrError = GalleryUser | ErrUserNotFound | ErrInvalidInput
+
+union UserByAddressOrError = GalleryUser | ErrUserNotFound | ErrInvalidInput
 
 union ViewerOrError = Viewer | ErrNotAuthorized
 
@@ -549,6 +586,7 @@ type FeedEvent implements Node {
     eventData: FeedEventData @goField(forceResolver: true)
     admires(before: String, after: String, first: Int, last: Int): FeedEventAdmiresConnection @goField(forceResolver: true)
     comments(before: String, after: String, first: Int, last: Int): FeedEventCommentsConnection @goField(forceResolver: true)
+    caption: String
 
     # If supplied, typeFilter will only query for the requested interaction types.
     # If typeFilter is omitted, all interaction types will be queried.
@@ -607,6 +645,15 @@ type TokensAddedToCollectionFeedEventData implements FeedEventData @goEmbedHelpe
     isPreFeed: Boolean
 }
 
+type CollectionUpdatedFeedEventData implements FeedEventData @goEmbedHelper {
+    eventTime: Time
+    owner: GalleryUser @goField(forceResolver: true)
+    action: Action
+    collection: Collection @goField(forceResolver: true)
+    newCollectorsNote: String
+    newTokens: [CollectionToken] @goField(forceResolver: true)
+}
+
 type ErrUnknownAction implements Error {
     message: String!
 }
@@ -649,6 +696,7 @@ type Query {
     viewer: ViewerOrError @authRequired
     userByUsername(username: String!): UserByUsernameOrError
     userById(id: DBID!): UserByIdOrError
+    userByAddress(chainAddress: ChainAddressInput!): UserByAddressOrError
     usersWithTrait(trait: String!): [GalleryUser]
     membershipTiers(forceRefresh: Boolean): [MembershipTier]
     collectionById(id: DBID!): CollectionByIdOrError
@@ -684,6 +732,7 @@ input CreateCollectionInput {
     tokens: [DBID!]!
     layout: CollectionLayoutInput!
     tokenSettings: [CollectionTokenSettingsInput!]!
+    caption: String
 }
 
 union CreateCollectionPayloadOrError =
@@ -693,6 +742,7 @@ union CreateCollectionPayloadOrError =
 
 type CreateCollectionPayload {
     collection: Collection
+    feedEvent: FeedEvent @goField(forceResolver: true)
 }
 
 union DeleteCollectionPayloadOrError =
@@ -725,6 +775,7 @@ input UpdateCollectionTokensInput {
     tokens: [DBID!]!
     layout: CollectionLayoutInput!
     tokenSettings: [CollectionTokenSettingsInput!]!
+    caption: String
 }
 
 union UpdateCollectionTokensPayloadOrError =
@@ -734,6 +785,7 @@ union UpdateCollectionTokensPayloadOrError =
 
 type UpdateCollectionTokensPayload {
     collection: Collection
+    feedEvent: FeedEvent @goField(forceResolver: true)
 }
 
 input UpdateCollectionHiddenInput {
@@ -906,6 +958,7 @@ type ErrNotAuthorized implements Error {
     message: String!
     cause: AuthorizationError!
 }
+
 
 type ErrInvalidInput implements Error {
     message: String!
@@ -1094,6 +1147,109 @@ type RemoveCommentPayload {
   feedEvent: FeedEvent @goField(forceResolver: true)
 }
 
+interface Notification implements Node {
+    id: ID!
+    seen: Boolean
+    creationTime: Time
+    updatedTime: Time
+}
+
+interface GroupedNotification implements Notification & Node {
+    id: ID!
+    seen: Boolean
+    creationTime: Time
+    updatedTime: Time
+
+    count: Int
+}
+
+type GroupNotificationUserEdge {
+    node: GalleryUser
+    cursor: String
+}
+
+type GroupNotificationUsersConnection @goEmbedHelper {
+    edges:  [GroupNotificationUserEdge] 
+    pageInfo: PageInfo
+}
+
+type SomeoneFollowedYouNotification implements Notification & Node & GroupedNotification
+  @goEmbedHelper {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+  count: Int
+
+  followers(before: String, after: String, first: Int, last: Int): GroupNotificationUsersConnection @goField(forceResolver: true)
+}
+
+type SomeoneFollowedYouBackNotification implements Notification & Node & GroupedNotification
+  @goEmbedHelper {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+  count: Int
+
+  followers(before: String, after: String, first: Int, last: Int): GroupNotificationUsersConnection @goField(forceResolver: true)
+}
+
+type SomeoneAdmiredYourFeedEventNotification implements Notification & Node & GroupedNotification
+  @goEmbedHelper {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+  count: Int
+
+  feedEvent: FeedEvent @goField(forceResolver: true)
+  admirers(before: String, after: String, first: Int, last: Int): GroupNotificationUsersConnection @goField(forceResolver: true)
+}
+
+type SomeoneCommentedOnYourFeedEventNotification implements Notification & Node
+  @goEmbedHelper {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+
+  # Don't need a `who` here since the `comment` can provide that
+  # Do we want this comment to be the latest comment
+  comment: Comment @goField(forceResolver: true)
+  feedEvent: FeedEvent @goField(forceResolver: true)
+}
+
+type SomeoneViewedYourGalleryNotification implements Notification & Node & GroupedNotification
+  @goEmbedHelper {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+  count: Int
+
+  userViewers(before: String, after: String, first: Int, last: Int): GroupNotificationUsersConnection @goField(forceResolver: true)
+  nonUserViewerCount: Int
+  gallery: Gallery @goField(forceResolver: true)
+}
+
+type ClearAllNotificationsPayload {
+    notifications: [Notification]
+}
+
+type ViewGalleryPayload {
+    gallery: Gallery
+}
+
+union ViewGalleryPayloadOrError =
+    ViewGalleryPayload
+    | ErrAuthenticationFailed
+
 type Mutation {
     # User Mutations
     addUserWallet(chainAddress: ChainAddressInput!, authMechanism: AuthMechanism!): AddUserWalletPayloadOrError @authRequired
@@ -1132,4 +1288,15 @@ type Mutation {
     removeAdmire(admireId: DBID!): RemoveAdmirePayloadOrError @authRequired
     commentOnFeedEvent(feedEventId: DBID!, replyToID: DBID, comment: String!): CommentOnFeedEventPayloadOrError @authRequired
     removeComment(commentId: DBID!): RemoveCommentPayloadOrError @authRequired
+    
+    viewGallery(galleryId: DBID!): ViewGalleryPayloadOrError
+
+    clearAllNotifications: ClearAllNotificationsPayload @authRequired
+
+    updateNotificationSettings(settings: NotificationSettingsInput): NotificationSettings
+}
+
+type Subscription {
+    newNotification: Notification
+    notificationUpdated: Notification
 }

--- a/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -16,6 +16,7 @@ import { pluralize } from '~/utils/string';
 import { getTimeSince } from '~/utils/time';
 import unescape from '~/utils/unescape';
 
+import { MAX_PIECES_DISPLAYED_PER_FEED_EVENT } from '../constants';
 import FeedEventTokenPreviews, { TokenToPreview } from '../FeedEventTokenPreviews';
 import { StyledEvent, StyledEventHeader, StyledTime } from './EventStyles';
 
@@ -23,8 +24,6 @@ type Props = {
   eventDataRef: CollectionCreatedFeedEventFragment$key;
   queryRef: CollectionCreatedFeedEventQueryFragment$key;
 };
-
-const MAX_PIECES_DISPLAYED = 4;
 
 export default function CollectionCreatedFeedEvent({ eventDataRef, queryRef }: Props) {
   const event = useFragment(
@@ -62,12 +61,12 @@ export default function CollectionCreatedFeedEvent({ eventDataRef, queryRef }: P
   const tokens = event.newTokens;
 
   const tokensToPreview = useMemo(() => {
-    return removeNullValues(tokens).slice(0, MAX_PIECES_DISPLAYED);
+    return removeNullValues(tokens).slice(0, MAX_PIECES_DISPLAYED_PER_FEED_EVENT);
   }, [tokens]) as TokenToPreview[];
 
   const track = useTrack();
 
-  const numAdditionalPieces = tokens.length - MAX_PIECES_DISPLAYED;
+  const numAdditionalPieces = tokens.length - MAX_PIECES_DISPLAYED_PER_FEED_EVENT;
   const showAdditionalPiecesIndicator = numAdditionalPieces > 0;
 
   const collectionName = unescape(event.collection.name ?? '');

--- a/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -1,5 +1,4 @@
 import { Route } from 'nextjs-routes';
-import { useMemo } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
@@ -10,13 +9,11 @@ import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import { UnstyledLink } from '~/components/core/Link/UnstyledLink';
 import Markdown from '~/components/core/Markdown/Markdown';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM, BaseS } from '~/components/core/Text/Text';
+import { BaseM } from '~/components/core/Text/Text';
 import HoverCardOnUsername from '~/components/HoverCard/HoverCardOnUsername';
 import { useTrack } from '~/contexts/analytics/AnalyticsContext';
 import { CollectorsNoteAddedToCollectionFeedEventFragment$key } from '~/generated/CollectorsNoteAddedToCollectionFeedEventFragment.graphql';
 import { CollectorsNoteAddedToCollectionFeedEventQueryFragment$key } from '~/generated/CollectorsNoteAddedToCollectionFeedEventQueryFragment.graphql';
-import { removeNullValues } from '~/utils/removeNullValues';
-import { pluralize } from '~/utils/string';
 import { getTimeSince } from '~/utils/time';
 import unescape from '~/utils/unescape';
 
@@ -27,8 +24,6 @@ type Props = {
   eventDataRef: CollectorsNoteAddedToCollectionFeedEventFragment$key;
   queryRef: CollectorsNoteAddedToCollectionFeedEventQueryFragment$key;
 };
-
-const MAX_PIECES_DISPLAYED = 4;
 
 export default function CollectorsNoteAddedToCollectionFeedEvent({
   eventDataRef,
@@ -45,7 +40,7 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({
         collection @required(action: THROW) {
           dbid
           name
-          tokens @required(action: THROW) {
+          tokens(limit: $visibleTokensPerFeedEvent) @required(action: THROW) {
             token {
               dbid
             }
@@ -67,10 +62,6 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({
     queryRef
   );
 
-  const tokensToPreview = useMemo(() => {
-    return removeNullValues(event.collection.tokens).slice(0, MAX_PIECES_DISPLAYED);
-  }, [event.collection.tokens]) as TokenToPreview[];
-
   const collectionPagePath: Route = {
     pathname: '/[username]/[collectionId]',
     query: { username: event.owner.username as string, collectionId: event.collection.dbid },
@@ -78,8 +69,9 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({
 
   const track = useTrack();
 
-  const numAdditionalPieces = event.collection.tokens.length - MAX_PIECES_DISPLAYED;
-  const showAdditionalPiecesIndicator = numAdditionalPieces > 0;
+  // [GAL-608] Bring this back once we fix perf around tokenURI
+  // const numAdditionalPieces = event.collection.tokens.length - MAX_PIECES_DISPLAYED_PER_FEED_EVENT;
+  // const showAdditionalPiecesIndicator = numAdditionalPieces > 0;
 
   const collectionName = unescape(event.collection.name ?? '');
 
@@ -110,23 +102,25 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({
               <Markdown text={unescape(event.newCollectorsNote ?? '')} inheritLinkStyling />
             </StyledQuote>
           </VStack>
-          <FeedEventTokenPreviews tokensToPreview={tokensToPreview} />
+          <FeedEventTokenPreviews tokensToPreview={event.collection.tokens as TokenToPreview[]} />
+          {/* [GAL-608] Bring this back once we fix perf around tokenURI
           {showAdditionalPiecesIndicator && (
             <StyledAdditionalPieces>
               +{numAdditionalPieces} more {pluralize(numAdditionalPieces, 'piece')}
             </StyledAdditionalPieces>
-          )}
+          )} */}
         </VStack>
       </StyledEvent>
     </UnstyledLink>
   );
 }
 
-const StyledAdditionalPieces = styled(BaseS)`
-  text-align: end;
-  color: ${colors.metal};
-  padding-top: 8px;
-`;
+// [GAL-608] Bring this back once we fix perf around tokenURI
+// const StyledAdditionalPieces = styled(BaseS)`
+//   text-align: end;
+//   color: ${colors.metal};
+//   padding-top: 8px;
+// `;
 
 const StyledQuote = styled(BaseM)`
   color: ${colors.metal};

--- a/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -18,6 +18,7 @@ import { pluralize } from '~/utils/string';
 import { getTimeSince } from '~/utils/time';
 import unescape from '~/utils/unescape';
 
+import { MAX_PIECES_DISPLAYED_PER_FEED_EVENT } from '../constants';
 import FeedEventTokenPreviews, { TokenToPreview } from '../FeedEventTokenPreviews';
 import { StyledEvent, StyledEventHeader, StyledTime } from './EventStyles';
 
@@ -25,8 +26,6 @@ type Props = {
   eventDataRef: TokensAddedToCollectionFeedEventFragment$key;
   queryRef: TokensAddedToCollectionFeedEventQueryFragment$key;
 };
-
-const MAX_PIECES_DISPLAYED = 4;
 
 export default function TokensAddedToCollectionFeedEvent({ eventDataRef, queryRef }: Props) {
   const event = useFragment(
@@ -40,7 +39,7 @@ export default function TokensAddedToCollectionFeedEvent({ eventDataRef, queryRe
         collection @required(action: THROW) {
           dbid
           name
-          tokens @required(action: THROW) {
+          tokens(limit: $visibleTokensPerFeedEvent) @required(action: THROW) {
             token {
               dbid
             }
@@ -73,7 +72,7 @@ export default function TokensAddedToCollectionFeedEvent({ eventDataRef, queryRe
   const tokens = isPreFeed ? event.collection.tokens : event.newTokens;
 
   const tokensToPreview = useMemo(() => {
-    return removeNullValues(tokens).slice(0, MAX_PIECES_DISPLAYED);
+    return removeNullValues(tokens).slice(0, MAX_PIECES_DISPLAYED_PER_FEED_EVENT);
   }, [tokens]) as TokenToPreview[];
 
   const collectionPagePath: Route = {
@@ -82,7 +81,7 @@ export default function TokensAddedToCollectionFeedEvent({ eventDataRef, queryRe
   };
   const track = useTrack();
 
-  const numAdditionalPieces = tokens.length - MAX_PIECES_DISPLAYED;
+  const numAdditionalPieces = tokens.length - MAX_PIECES_DISPLAYED_PER_FEED_EVENT;
   const showAdditionalPiecesIndicator = numAdditionalPieces > 0;
 
   const collectionName = unescape(event.collection.name ?? '');

--- a/src/components/Feed/constants.ts
+++ b/src/components/Feed/constants.ts
@@ -1,1 +1,2 @@
 export const ITEMS_PER_PAGE = 24;
+export const MAX_PIECES_DISPLAYED_PER_FEED_EVENT = 4;


### PR DESCRIPTION
**Addressed**

Fetches a maximum of 4 tokens when referencing an existing collection.

![Screen Shot 2022-11-05 at 12 22 15 AM](https://user-images.githubusercontent.com/12162433/200100549-8b3e7cf2-db1e-4919-b5a7-245d82da0ea3.png)

![Screen Shot 2022-11-05 at 12 25 36 AM](https://user-images.githubusercontent.com/12162433/200100841-c380b12c-2c6e-4b4d-b886-fd5f4141c02c.png)


**Not Addressed**

- `GAL-609` Adding many tokens to a brand new collection still have a potential to cause perf issues
- `GAL-608` "number of additional tokens" feature has been disabled for one particular feed event. This will be addressed once above issue is implemented