### PR TITLE
[GAL-601] fix: unusual redirects in edit flow

### DIFF
--- a/pages/gallery/[galleryId]/edit.tsx
+++ b/pages/gallery/[galleryId]/edit.tsx
@@ -28,7 +28,7 @@ export default function EditGalleryPage() {
     {}
   );
 
-  const { push, back, query: urlQuery } = useRouter();
+  const { push, query: urlQuery } = useRouter();
 
   const handleAddCollection = useCallback(() => {
     if (!urlQuery.galleryId) {
@@ -55,16 +55,13 @@ export default function EditGalleryPage() {
     [push, urlQuery.galleryId]
   );
 
-  const canGoBack = useCanGoBack();
   const handleDone = useCallback(() => {
-    if (canGoBack) {
-      back();
-    } else if (query.viewer?.user?.username) {
+    if (query.viewer?.user?.username) {
       push({ pathname: '/[username]', query: { username: query.viewer.user.username } });
     } else {
       push({ pathname: '/home' });
     }
-  }, [back, canGoBack, push, query.viewer?.user?.username]);
+  }, [push, query.viewer?.user?.username]);
 
   return (
     <FullPageStep navbar={<GalleryEditNavbar onDone={handleDone} />}>

--- a/pages/gallery/[galleryId]/edit.tsx
+++ b/pages/gallery/[galleryId]/edit.tsx
@@ -8,7 +8,6 @@ import breakpoints from '~/components/core/breakpoints';
 import { OrganizeGallery } from '~/components/ManageGallery/OrganizeGallery/OrganizeGallery';
 import FullPageStep from '~/components/Onboarding/FullPageStep';
 import { GalleryEditNavbar } from '~/contexts/globalLayout/GlobalNavbar/GalleryEditNavbar/GalleryEditNavbar';
-import { useCanGoBack } from '~/contexts/navigation/GalleryNavigationProvider';
 import { editGalleryPageQuery } from '~/generated/editGalleryPageQuery.graphql';
 
 export default function EditGalleryPage() {


### PR DESCRIPTION
**Previous behavior**

Clicking "Done" after creating a new collection would send the user back to create a new collection

**Root cause**

We deprecated the wizard and replaced it with routes. In a world where each step in the editor is its own route, `canGoBack` would tell us that we should go to the previous route, which would be the literal `/collection/create` route as opposed to the pre-editor page.

Addressing the above with `replace` would not fix the issue, since `canGoBack()` pairs poorly with routes that are reached via `router.replace` vs. `router.push`. Even though `router.replace` doesn't impact nextjs router's history, it adds to our internal stack that we track manually. This would cause the "Done" button to mistakenly think that the _current page_ was the previous page, and would go "back" to the same spot.

**Long term fix**

The current solution of returning the user to their main profile after editing their gallery should solve the vast majority of use cases. Longer term, we could utilize some kind of `returnTo` param.

**Tests**
- [x] Return user to their profile after editing
- [x] Test creation flow
- [x] Test edit flow
- [x] Editing a collection directly from the collection page should return the user to that page
- [x] Editing a collection directly from the gallery page should return the user to that pag
- [x] Onboarding is not affected, since that's a different route