### PR TITLE
GAL-516 add "add email" component and step

### DIFF
--- a/pages/onboarding/add-email.tsx
+++ b/pages/onboarding/add-email.tsx
@@ -4,13 +4,12 @@ import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
-import { ButtonLink } from '~/components/core/Button/Button';
 import { VStack } from '~/components/core/Spacer/Stack';
-import { BaseM, BaseXL, TitleDiatypeL, TitleL } from '~/components/core/Text/Text';
-import EmailForm from '~/components/Email/EmailForm';
+import { BaseM, TitleDiatypeL, TitleL } from '~/components/core/Text/Text';
 import EmailManager from '~/components/Email/EmailManager';
 import FullPageCenteredStep from '~/components/Onboarding/FullPageCenteredStep';
 import { OnboardingFooter } from '~/components/Onboarding/OnboardingFooter';
+import { addEmailQuery } from '~/generated/addEmailQuery.graphql';
 
 export default function AddEmail() {
   const query = useLazyLoadQuery<addEmailQuery>(
@@ -22,6 +21,9 @@ export default function AddEmail() {
 
             user {
               username
+            }
+            email {
+              email
             }
           }
         }
@@ -37,19 +39,17 @@ export default function AddEmail() {
     );
   }
 
-  const { push, back, query: urlQuery } = useRouter();
+  const { push, back } = useRouter();
 
   const username = query?.viewer?.user?.username;
-  console.log(username);
+  const savedEmail = query?.viewer?.email?.email;
 
   const handleNext = useCallback(() => {
     // track('');
-
     push({
-      pathname: '/onboarding/organize-collection',
-      query: { ...query },
+      pathname: `/${username}`,
     });
-  }, []);
+  }, [push, username]);
 
   return (
     <VStack>
@@ -69,7 +69,8 @@ export default function AddEmail() {
       <OnboardingFooter
         step={'add-email'}
         onNext={handleNext}
-        // isNextEnabled={}
+        previousTextOverride="Skip"
+        isNextEnabled={!!savedEmail}
         onPrevious={back}
       />
     </VStack>
@@ -78,8 +79,4 @@ export default function AddEmail() {
 
 const StyledBodyText = styled(BaseM)`
   max-width: 400px;
-`;
-
-const FixedWidthButtonLink = styled(ButtonLink)`
-  min-width: 200px;
 `;

--- a/pages/onboarding/add-email.tsx
+++ b/pages/onboarding/add-email.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
-import { useCallback } from 'react';
+import { Route } from 'nextjs-routes';
+import { useCallback, useMemo } from 'react';
 import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
@@ -44,12 +45,19 @@ export default function AddEmail() {
   const username = query?.viewer?.user?.username;
   const savedEmail = query?.viewer?.email?.email;
 
+  if (!username) {
+    throw new Error(`AddEmail expected non-null username, but got: ${username}`);
+  }
+
+  const userGalleryRoute: Route = useMemo(
+    () => ({ pathname: '/[username]', query: { username } }),
+    [username]
+  );
+
   const handleNext = useCallback(() => {
     // track('');
-    push({
-      pathname: `/${username}`,
-    });
-  }, [push, username]);
+    push(userGalleryRoute);
+  }, [push, userGalleryRoute]);
 
   return (
     <VStack>

--- a/pages/onboarding/add-email.tsx
+++ b/pages/onboarding/add-email.tsx
@@ -10,6 +10,7 @@ import { BaseM, TitleDiatypeL, TitleL } from '~/components/core/Text/Text';
 import EmailManager from '~/components/Email/EmailManager';
 import FullPageCenteredStep from '~/components/Onboarding/FullPageCenteredStep';
 import { OnboardingFooter } from '~/components/Onboarding/OnboardingFooter';
+import { useTrack } from '~/contexts/analytics/AnalyticsContext';
 import { addEmailQuery } from '~/generated/addEmailQuery.graphql';
 
 export default function AddEmail() {
@@ -40,7 +41,8 @@ export default function AddEmail() {
     );
   }
 
-  const { push, back } = useRouter();
+  const track = useTrack();
+  const { push } = useRouter();
 
   const username = query?.viewer?.user?.username;
   const savedEmail = query?.viewer?.email?.email;
@@ -55,9 +57,14 @@ export default function AddEmail() {
   );
 
   const handleNext = useCallback(() => {
-    // track('');
+    track('Onboarding: add-email Done click');
     push(userGalleryRoute);
-  }, [push, userGalleryRoute]);
+  }, [push, track, userGalleryRoute]);
+
+  const handleSkip = useCallback(() => {
+    track('Onboarding: add-email Skip click');
+    push(userGalleryRoute);
+  }, [push, track, userGalleryRoute]);
 
   return (
     <VStack>
@@ -79,7 +86,7 @@ export default function AddEmail() {
         onNext={handleNext}
         previousTextOverride="Skip"
         isNextEnabled={!!savedEmail}
-        onPrevious={back}
+        onPrevious={handleSkip}
       />
     </VStack>
   );

--- a/pages/onboarding/add-email.tsx
+++ b/pages/onboarding/add-email.tsx
@@ -1,0 +1,85 @@
+import { useRouter } from 'next/router';
+import { useCallback } from 'react';
+import { useLazyLoadQuery } from 'react-relay';
+import { graphql } from 'relay-runtime';
+import styled from 'styled-components';
+
+import { ButtonLink } from '~/components/core/Button/Button';
+import { VStack } from '~/components/core/Spacer/Stack';
+import { BaseM, BaseXL, TitleDiatypeL, TitleL } from '~/components/core/Text/Text';
+import EmailForm from '~/components/Email/EmailForm';
+import EmailManager from '~/components/Email/EmailManager';
+import FullPageCenteredStep from '~/components/Onboarding/FullPageCenteredStep';
+import { OnboardingFooter } from '~/components/Onboarding/OnboardingFooter';
+
+export default function AddEmail() {
+  const query = useLazyLoadQuery<addEmailQuery>(
+    graphql`
+      query addEmailQuery {
+        viewer {
+          ... on Viewer {
+            __typename
+
+            user {
+              username
+            }
+          }
+        }
+        ...EmailManagerFragment
+      }
+    `,
+    {}
+  );
+
+  if (query.viewer?.__typename !== 'Viewer') {
+    throw new Error(
+      `AddEmail expected Viewer to be type 'Viewer' but got: ${query.viewer?.__typename}`
+    );
+  }
+
+  const { push, back, query: urlQuery } = useRouter();
+
+  const username = query?.viewer?.user?.username;
+  console.log(username);
+
+  const handleNext = useCallback(() => {
+    // track('');
+
+    push({
+      pathname: '/onboarding/organize-collection',
+      query: { ...query },
+    });
+  }, []);
+
+  return (
+    <VStack>
+      <FullPageCenteredStep>
+        <VStack gap={16}>
+          <TitleL>Welcome to Gallery</TitleL>
+          <VStack>
+            <TitleDiatypeL>Never miss a moment</TitleDiatypeL>
+            <StyledBodyText>
+              Receive weekly emails that recap your most recent admires, comments, and followers.
+              You can always change this later in account settings.
+            </StyledBodyText>
+          </VStack>
+          <EmailManager queryRef={query} />
+        </VStack>
+      </FullPageCenteredStep>
+      <OnboardingFooter
+        step={'add-email'}
+        onNext={handleNext}
+        // isNextEnabled={}
+        onPrevious={back}
+      />
+    </VStack>
+  );
+}
+
+const StyledBodyText = styled(BaseM)`
+  max-width: 400px;
+`;
+
+const FixedWidthButtonLink = styled(ButtonLink)`
+  min-width: 200px;
+`;

--- a/pages/onboarding/organize-gallery.tsx
+++ b/pages/onboarding/organize-gallery.tsx
@@ -37,7 +37,7 @@ export default function OrganizeGalleryPage() {
     [push, urlQuery]
   );
 
-  const isEmailFeatureEnabled = isFeatureEnabled(FeatureFlag.WHITE_RINO, query);
+  const isEmailFeatureEnabled = isFeatureEnabled(FeatureFlag.EMAIL, query);
 
   const handleNext = useCallback(() => {
     const pathname = isEmailFeatureEnabled

--- a/pages/onboarding/organize-gallery.tsx
+++ b/pages/onboarding/organize-gallery.tsx
@@ -6,12 +6,14 @@ import { OrganizeGallery } from '~/components/ManageGallery/OrganizeGallery/Orga
 import FullPageStep from '~/components/Onboarding/FullPageStep';
 import { OnboardingGalleryEditorNavbar } from '~/contexts/globalLayout/GlobalNavbar/OnboardingGalleryEditorNavbar/OnboardingGalleryEditorNavbar';
 import { organizeGalleryQuery } from '~/generated/organizeGalleryQuery.graphql';
+import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
 export default function OrganizeGalleryPage() {
   const query = useLazyLoadQuery<organizeGalleryQuery>(
     graphql`
       query organizeGalleryQuery {
         ...OrganizeGalleryFragment
+        ...isFeatureEnabledFragment
       }
     `,
     {}
@@ -35,9 +37,14 @@ export default function OrganizeGalleryPage() {
     [push, urlQuery]
   );
 
+  const isEmailFeatureEnabled = isFeatureEnabled(FeatureFlag.WHITE_RINO, query);
+
   const handleNext = useCallback(() => {
-    return push({ pathname: '/onboarding/congratulations', query: { ...urlQuery } });
-  }, [push, urlQuery]);
+    const pathname = isEmailFeatureEnabled
+      ? '/onboarding/add-email'
+      : '/onboarding/congratulations';
+    return push({ pathname, query: { ...urlQuery } });
+  }, [isEmailFeatureEnabled, push, urlQuery]);
 
   return (
     <FullPageStep navbar={<OnboardingGalleryEditorNavbar onBack={back} onNext={handleNext} />}>

--- a/schema.graphql
+++ b/schema.graphql
@@ -487,6 +487,11 @@ enum EmailVerificationStatus {
     Admin
 }
 
+enum EmailUnsubscriptionType {
+    All
+    Notifications
+}
+
 type UserEmail {
     email: String
     verificationStatus: EmailVerificationStatus
@@ -501,6 +506,11 @@ type EmailNotificationSettings {
 input UpdateEmailNotificationSettingsInput {
     unsubscribedFromAll: Boolean!
     unsubscribedFromNotifications: Boolean!
+}
+
+input UnsubscribeFromEmailTypeInput {
+    type: EmailUnsubscriptionType!
+    token: String!
 }
 
 union UserByUsernameOrError = GalleryUser | ErrUserNotFound | ErrInvalidInput
@@ -1314,6 +1324,14 @@ union UpdateEmailNotificationSettingsPayloadOrError =
     UpdateEmailNotificationSettingsPayload
     | ErrInvalidInput
 
+type UnsubscribeFromEmailTypePayload {
+    viewer: Viewer
+}
+
+union UnsubscribeFromEmailTypePayloadOrError =
+    UnsubscribeFromEmailTypePayload
+    | ErrInvalidInput
+
 type Mutation {
     # User Mutations
     addUserWallet(chainAddress: ChainAddressInput!, authMechanism: AuthMechanism!): AddUserWalletPayloadOrError @authRequired
@@ -1346,6 +1364,7 @@ type Mutation {
     updateEmail(input: UpdateEmailInput!): UpdateEmailPayloadOrError @authRequired
     resendVerificationEmail: ResendVerificationEmailPayloadOrError @authRequired
     updateEmailNotificationSettings(input: UpdateEmailNotificationSettingsInput!): UpdateEmailNotificationSettingsPayloadOrError @authRequired
+    unsubscribeFromEmailType(input: UnsubscribeFromEmailTypeInput!): UnsubscribeFromEmailTypePayloadOrError
     login(authMechanism: AuthMechanism!): LoginPayloadOrError
     logout: LogoutPayload
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -494,9 +494,14 @@ type UserEmail {
 }
 
 type EmailNotificationSettings {
-    unsubscribedFromAll: Boolean
+    unsubscribedFromAll: Boolean!
+    unsubscribedFromNotifications: Boolean!
 }
 
+input UpdateEmailNotificationSettingsInput {
+    unsubscribedFromAll: Boolean!
+    unsubscribedFromNotifications: Boolean!
+}
 
 union UserByUsernameOrError = GalleryUser | ErrUserNotFound | ErrInvalidInput
 
@@ -1293,6 +1298,22 @@ union UpdateEmailPayloadOrError =
     UpdateEmailPayload
     | ErrInvalidInput
 
+type ResendVerificationEmailPayload {
+    viewer: Viewer
+}
+
+union ResendVerificationEmailPayloadOrError =
+    ResendVerificationEmailPayload
+    | ErrInvalidInput
+
+type UpdateEmailNotificationSettingsPayload {
+    viewer: Viewer
+}
+
+union UpdateEmailNotificationSettingsPayloadOrError =
+    UpdateEmailNotificationSettingsPayload
+    | ErrInvalidInput
+
 type Mutation {
     # User Mutations
     addUserWallet(chainAddress: ChainAddressInput!, authMechanism: AuthMechanism!): AddUserWalletPayloadOrError @authRequired
@@ -1323,6 +1344,8 @@ type Mutation {
 
     createUser(authMechanism: AuthMechanism!, username: String!, bio: String, email: String): CreateUserPayloadOrError
     updateEmail(input: UpdateEmailInput!): UpdateEmailPayloadOrError @authRequired
+    resendVerificationEmail: ResendVerificationEmailPayloadOrError @authRequired
+    updateEmailNotificationSettings(input: UpdateEmailNotificationSettingsInput!): UpdateEmailNotificationSettingsPayloadOrError @authRequired
     login(authMechanism: AuthMechanism!): LoginPayloadOrError
     logout: LogoutPayload
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -446,34 +446,57 @@ type NotificationsConnection @goEmbedHelper {
 }
 
 type Viewer {
-    user: GalleryUser @goField(forceResolver: true)
-    viewerGalleries: [ViewerGallery] @goField(forceResolver: true)
-    feed(before: String, after: String, first: Int, last: Int): FeedConnection @goField(forceResolver: true)
+  user: GalleryUser @goField(forceResolver: true)
+  viewerGalleries: [ViewerGallery] @goField(forceResolver: true)
+  feed(before: String, after: String, first: Int, last: Int): FeedConnection
+    @goField(forceResolver: true)
 
-    """
-    Returns a list of notifications in reverse chronological order.
-    Seen notifications come after unseen notifications
-    """
-    notifications(before: String, after: String, first: Int, last: Int): NotificationsConnection @goField(forceResolver: true)
+  email: UserEmail @goField(forceResolver: true)
+  """
+  Returns a list of notifications in reverse chronological order.
+  Seen notifications come after unseen notifications
+  """
+  notifications(
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): NotificationsConnection @goField(forceResolver: true)
 
-    notificationSettings: NotificationSettings @goField(forceResolver: true)
+  notificationSettings: NotificationSettings @goField(forceResolver: true)
 }
 
-type NotificationSettings @goEmbedHelper {
-    user: GalleryUser
-
-    someoneFollowedYou: Boolean
-    someoneAdmiredYourUpdate: Boolean
-    someoneCommentedOnYourUpdate: Boolean
-    someoneViewedYourGallery: Boolean
+type NotificationSettings {
+  someoneFollowedYou: Boolean
+  someoneAdmiredYourUpdate: Boolean
+  someoneCommentedOnYourUpdate: Boolean
+  someoneViewedYourGallery: Boolean
 }
 
 input NotificationSettingsInput {
-    someoneFollowedYou: Boolean
-    someoneAdmiredYourUpdate: Boolean
-    someoneCommentedOnYourUpdate: Boolean
-    someoneViewedYourGallery: Boolean
+  someoneFollowedYou: Boolean
+  someoneAdmiredYourUpdate: Boolean
+  someoneCommentedOnYourUpdate: Boolean
+  someoneViewedYourGallery: Boolean
 }
+
+enum EmailVerificationStatus {
+    Unverified
+    Verified
+    Failed
+    Admin
+}
+
+type UserEmail {
+    email: String
+    verificationStatus: EmailVerificationStatus
+    emailNotificationSettings: EmailNotificationSettings
+}
+
+type EmailNotificationSettings {
+    unsubscribedFromAll: Boolean
+}
+
 
 union UserByUsernameOrError = GalleryUser | ErrUserNotFound | ErrInvalidInput
 
@@ -1250,6 +1273,26 @@ union ViewGalleryPayloadOrError =
     ViewGalleryPayload
     | ErrAuthenticationFailed
 
+type VerifyEmailPayload {
+    email: String
+}
+
+union VerifyEmailPayloadOrError =
+    VerifyEmailPayload
+    | ErrInvalidInput
+
+input UpdateEmailInput {
+    email: String!
+}
+
+type UpdateEmailPayload {
+    viewer: Viewer
+}
+
+union UpdateEmailPayloadOrError =
+    UpdateEmailPayload
+    | ErrInvalidInput
+
 type Mutation {
     # User Mutations
     addUserWallet(chainAddress: ChainAddressInput!, authMechanism: AuthMechanism!): AddUserWalletPayloadOrError @authRequired
@@ -1278,7 +1321,8 @@ type Mutation {
 
     getAuthNonce(chainAddress: ChainAddressInput!): GetAuthNoncePayloadOrError
 
-    createUser(authMechanism: AuthMechanism!, username: String!, bio:String): CreateUserPayloadOrError
+    createUser(authMechanism: AuthMechanism!, username: String!, bio: String, email: String): CreateUserPayloadOrError
+    updateEmail(input: UpdateEmailInput!): UpdateEmailPayloadOrError @authRequired
     login(authMechanism: AuthMechanism!): LoginPayloadOrError
     logout: LogoutPayload
 
@@ -1294,6 +1338,8 @@ type Mutation {
     clearAllNotifications: ClearAllNotificationsPayload @authRequired
 
     updateNotificationSettings(settings: NotificationSettingsInput): NotificationSettings
+
+    verifyEmail(token: String!): VerifyEmailPayloadOrError
 }
 
 type Subscription {

--- a/src/components/Email/EmailForm.tsx
+++ b/src/components/Email/EmailForm.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useMemo, useState } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import { useToastActions } from '~/contexts/toast/ToastContext';
+import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
+
+import { Button } from '../core/Button/Button';
+import colors from '../core/colors';
+import { HStack, VStack } from '../core/Spacer/Stack';
+
+type Props = {
+  savedEmail: string;
+  setIsEditMode: (editMode: boolean) => void;
+};
+
+function EmailForm({ savedEmail, setIsEditMode }: Props) {
+  // const query = useFragment(
+  //   graphql`
+  //     fragment EmailFormFragment on Query {
+  //       viewer {
+  //         ... on Viewer {
+  //           user {
+  //             id
+  //           }
+  //           email {
+  //             email
+  //           }
+  //         }
+  //       }
+  //     }
+  //   `,
+  //   queryRef
+  // );
+
+  const [updateEmail] = usePromisifiedMutation<EmailFormMutation>(graphql`
+    mutation EmailFormMutation($input: UpdateEmailInput!) @raw_response_type {
+      updateEmail(input: $input) {
+        ... on UpdateEmailPayload {
+          __typename
+          viewer {
+            email {
+              email
+            }
+          }
+        }
+        ... on ErrInvalidInput {
+          __typename
+        }
+      }
+    }
+  `);
+
+  const [email, setEmail] = useState(savedEmail ?? '');
+  const [savePending, setSavePending] = useState(false);
+
+  const showCancelButton = useMemo(() => !!savedEmail, [savedEmail]);
+  const { pushToast } = useToastActions();
+
+  const handleEmailChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(event.target.value);
+  }, []);
+
+  const handleCancelClick = useCallback(() => {
+    setIsEditMode(false);
+  }, [setIsEditMode]);
+
+  const handleSaveClick = useCallback(async () => {
+    console.log('saving', email);
+    setSavePending(true);
+    function pushErrorToast() {
+      pushToast({
+        autoClose: true,
+        message: `Something went wrong while saving your email address. We are looking into it.`,
+      });
+    }
+
+    // const errorMetadata: AdditionalContext['tags'] = {
+    //   userId: query.viewer.user.dbid,
+    // };
+
+    try {
+      const response = await updateEmail({ variables: { input: { email } } });
+
+      if (response.updateEmail?.__typename !== 'UpdateEmailPayload') {
+        // ERROR
+        pushErrorToast();
+
+        reportError(
+          `Could not save email address, typename was ${response.updateEmail?.__typename}`,
+          {
+            // tags: errorMetadata,
+          }
+        );
+      } else {
+        // SUCCESS
+        pushToast({
+          autoClose: true,
+          message: `We've sent you an email to verify your email address. You can complete onboarding in the meantime.`,
+        });
+        setIsEditMode(false);
+      }
+      setSavePending(false);
+    } catch (error) {
+      // errorr
+      setSavePending(false);
+      console.log(error);
+    }
+    // save email to backend
+    // set state
+    // handle error
+  }, [email, pushToast, setIsEditMode, updateEmail]);
+
+  const handleFormSubmit = useCallback(
+    (event) => {
+      event?.preventDefault();
+      handleSaveClick();
+    },
+    [handleSaveClick]
+  );
+
+  return (
+    // <div>
+    <form onSubmit={handleFormSubmit}>
+      <VStack gap={8}>
+        <StyledInput
+          onChange={handleEmailChange}
+          placeholder="Enter your email address..."
+          defaultValue={savedEmail}
+          autoFocus
+          disabled={savePending}
+        />
+        <HStack justify={showCancelButton ? 'space-between' : 'flex-end'} align="flex-end">
+          {showCancelButton && (
+            <Button variant="secondary" disabled={savePending} onClick={handleCancelClick}>
+              Cancel
+            </Button>
+          )}
+          <Button variant="primary" disabled={savePending} onClick={handleSaveClick}>
+            Save
+          </Button>
+        </HStack>
+      </VStack>
+    </form>
+    // </div>
+  );
+}
+
+const StyledInput = styled.input`
+  border: 0;
+  background-color: ${colors.faint};
+  padding: 6px 12px;
+  width: 100%;
+  height: 32px;
+`;
+
+export default EmailForm;

--- a/src/components/Email/EmailForm.tsx
+++ b/src/components/Email/EmailForm.tsx
@@ -14,24 +14,26 @@ type Props = {
   setIsEditMode: (editMode: boolean) => void;
 };
 
-function EmailForm({ savedEmail, setIsEditMode }: Props) {
-  // const query = useFragment(
-  //   graphql`
-  //     fragment EmailFormFragment on Query {
-  //       viewer {
-  //         ... on Viewer {
-  //           user {
-  //             id
-  //           }
-  //           email {
-  //             email
-  //           }
-  //         }
-  //       }
-  //     }
-  //   `,
-  //   queryRef
-  // );
+function EmailForm({ savedEmail, setIsEditMode, queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment EmailFormFragment on Query {
+        viewer {
+          ... on Viewer {
+            user {
+              id
+            }
+            email {
+              email
+            }
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  console.log('query', query);
 
   const [updateEmail] = usePromisifiedMutation<EmailFormMutation>(graphql`
     mutation EmailFormMutation($input: UpdateEmailInput!) @raw_response_type {

--- a/src/components/Email/EmailForm.tsx
+++ b/src/components/Email/EmailForm.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { AdditionalContext, useReportError } from '~/contexts/errorReporting/ErrorReportingContext';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { EmailFormFragment$key } from '~/generated/EmailFormFragment.graphql';
+import { EmailFormMutation } from '~/generated/EmailFormMutation.graphql';
 import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
 
 import { Button } from '../core/Button/Button';

--- a/src/components/Email/EmailForm.tsx
+++ b/src/components/Email/EmailForm.tsx
@@ -8,6 +8,7 @@ import { useToastActions } from '~/contexts/toast/ToastContext';
 import { EmailFormFragment$key } from '~/generated/EmailFormFragment.graphql';
 import { EmailFormMutation } from '~/generated/EmailFormMutation.graphql';
 import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
+import { EMAIL_FORMAT } from '~/utils/regex';
 
 import { Button } from '../core/Button/Button';
 import colors from '../core/colors';
@@ -68,7 +69,7 @@ function EmailForm({ setIsEditMode, queryRef }: Props) {
     setEmail(event.target.value);
   }, []);
 
-  const isValidEmail = useMemo(() => /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/.test(email), [email]);
+  const isValidEmail = useMemo(() => EMAIL_FORMAT.test(email), [email]);
 
   const reportError = useReportError();
 

--- a/src/components/Email/EmailForm.tsx
+++ b/src/components/Email/EmailForm.tsx
@@ -38,7 +38,7 @@ function EmailForm({ setIsEditMode, queryRef }: Props) {
   );
 
   const [updateEmail] = usePromisifiedMutation<EmailFormMutation>(graphql`
-    mutation EmailFormMutation($input: UpdateEmailInput!) @raw_response_type {
+    mutation EmailFormMutation($input: UpdateEmailInput!) {
       updateEmail(input: $input) {
         ... on UpdateEmailPayload {
           __typename
@@ -77,7 +77,6 @@ function EmailForm({ setIsEditMode, queryRef }: Props) {
   }, [setIsEditMode]);
 
   const { route } = useRouter();
-  // console.log(asPath, route, pathname);
   const isOnboarding = route === '/onboarding/add-email';
   const toastSuccessCopy = isOnboarding
     ? `We've sent you an email to verify your email address. You can complete onboarding in the meantime.`

--- a/src/components/Email/EmailForm.tsx
+++ b/src/components/Email/EmailForm.tsx
@@ -87,7 +87,7 @@ function EmailForm({ setIsEditMode, queryRef }: Props) {
     setSavePending(true);
     function pushErrorToast() {
       pushToast({
-        autoClose: true,
+        autoClose: false,
         message: `Something went wrong while saving your email address. We are looking into it.`,
       });
     }
@@ -112,7 +112,7 @@ function EmailForm({ setIsEditMode, queryRef }: Props) {
       } else {
         // SUCCESS
         pushToast({
-          autoClose: true,
+          autoClose: false,
           message: toastSuccessCopy,
         });
         setIsEditMode(false);

--- a/src/components/Email/EmailForm.tsx
+++ b/src/components/Email/EmailForm.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { useCallback, useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
@@ -75,6 +76,13 @@ function EmailForm({ setIsEditMode, queryRef }: Props) {
     setIsEditMode(false);
   }, [setIsEditMode]);
 
+  const { route } = useRouter();
+  // console.log(asPath, route, pathname);
+  const isOnboarding = route === '/onboarding/add-email';
+  const toastSuccessCopy = isOnboarding
+    ? `We've sent you an email to verify your email address. You can complete onboarding in the meantime.`
+    : `We've sent you an email to verify your email address.`;
+
   const handleSaveClick = useCallback(async () => {
     setSavePending(true);
     function pushErrorToast() {
@@ -105,7 +113,7 @@ function EmailForm({ setIsEditMode, queryRef }: Props) {
         // SUCCESS
         pushToast({
           autoClose: true,
-          message: `We've sent you an email to verify your email address. You can complete onboarding in the meantime.`,
+          message: toastSuccessCopy,
         });
         setIsEditMode(false);
       }
@@ -114,7 +122,7 @@ function EmailForm({ setIsEditMode, queryRef }: Props) {
       pushErrorToast();
       setSavePending(false);
     }
-  }, [email, pushToast, reportError, setIsEditMode, updateEmail, userId]);
+  }, [email, pushToast, reportError, setIsEditMode, toastSuccessCopy, updateEmail, userId]);
 
   const handleFormSubmit = useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
@@ -142,7 +150,7 @@ function EmailForm({ setIsEditMode, queryRef }: Props) {
           )}
           <Button
             variant="primary"
-            disabled={!isValidEmail || savePending}
+            disabled={!isValidEmail || savePending || savedEmail === email}
             onClick={handleSaveClick}
           >
             Save

--- a/src/components/Email/EmailForm.tsx
+++ b/src/components/Email/EmailForm.tsx
@@ -137,7 +137,7 @@ function EmailForm({ setIsEditMode, queryRef }: Props) {
       <VStack gap={8}>
         <StyledInput
           onChange={handleEmailChange}
-          placeholder="Enter your email address..."
+          placeholder="Email address"
           defaultValue={savedEmail || ''}
           autoFocus
           disabled={savePending}

--- a/src/components/Email/EmailManager.tsx
+++ b/src/components/Email/EmailManager.tsx
@@ -2,14 +2,14 @@ import { useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
-import colors from '../core/colors';
+import { EmailManagerFragment$key } from '~/generated/EmailManagerFragment.graphql';
+
 import EmailForm from './EmailForm';
 import EmailVerificationStatus from './EmailVerificationStatus';
 
-// import Input from '../core/Input/Input';
-
 type Props = {
   emailAddress: string;
+  queryRef: EmailManagerFragment$key;
 };
 
 function EmailManager({ queryRef }: Props) {
@@ -25,41 +25,30 @@ function EmailManager({ queryRef }: Props) {
           }
         }
         ...EmailFormFragment
+        ...EmailVerificationStatusFragment
       }
     `,
     queryRef
   );
 
-  // const savedEmail = query.viewer.email?.email;
-  const savedEmail = 'test@test.com';
+  const savedEmail = query?.viewer?.email?.email;
 
   const [isEditMode, setIsEditMode] = useState(false);
 
   const showInput = useMemo(() => {
-    // Show input only if there's no email address, or the user has opted to edit
     return !savedEmail || isEditMode;
   }, [savedEmail, isEditMode]);
-
-  console.log('showInput', showInput);
 
   return (
     <StyledEmailManager>
       {showInput ? (
-        <EmailForm queryRef={query} savedEmail={savedEmail} setIsEditMode={setIsEditMode} />
+        <EmailForm queryRef={query} setIsEditMode={setIsEditMode} />
       ) : (
-        <EmailVerificationStatus savedEmail={savedEmail} setIsEditMode={setIsEditMode} />
+        <EmailVerificationStatus queryRef={query} setIsEditMode={setIsEditMode} />
       )}
     </StyledEmailManager>
   );
 }
-
-const EditEmailButton = styled.button`
-  background: ${colors.white};
-  border: 1px solid ${colors.porcelain};
-  color: ${colors.offBlack};
-  padding: 8px 12px;
-  cursor: pointer;
-`;
 
 const StyledEmailManager = styled.div`
   height: 72px; // set fixed height so changing modes doesnt shift page content

--- a/src/components/Email/EmailManager.tsx
+++ b/src/components/Email/EmailManager.tsx
@@ -24,7 +24,7 @@ function EmailManager({ queryRef }: Props) {
             }
           }
         }
-        # ...EmailFormFragment
+        ...EmailFormFragment
       }
     `,
     queryRef
@@ -45,7 +45,7 @@ function EmailManager({ queryRef }: Props) {
   return (
     <StyledEmailManager>
       {showInput ? (
-        <EmailForm savedEmail={savedEmail} setIsEditMode={setIsEditMode} />
+        <EmailForm queryRef={query} savedEmail={savedEmail} setIsEditMode={setIsEditMode} />
       ) : (
         <EmailVerificationStatus savedEmail={savedEmail} setIsEditMode={setIsEditMode} />
       )}

--- a/src/components/Email/EmailManager.tsx
+++ b/src/components/Email/EmailManager.tsx
@@ -8,7 +8,6 @@ import EmailForm from './EmailForm';
 import EmailVerificationStatus from './EmailVerificationStatus';
 
 type Props = {
-  emailAddress: string;
   queryRef: EmailManagerFragment$key;
 };
 

--- a/src/components/Email/EmailManager.tsx
+++ b/src/components/Email/EmailManager.tsx
@@ -1,0 +1,68 @@
+import { useMemo, useState } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import colors from '../core/colors';
+import EmailForm from './EmailForm';
+import EmailVerificationStatus from './EmailVerificationStatus';
+
+// import Input from '../core/Input/Input';
+
+type Props = {
+  emailAddress: string;
+};
+
+function EmailManager({ queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment EmailManagerFragment on Query {
+        viewer {
+          ... on Viewer {
+            email {
+              email
+              verificationStatus
+            }
+          }
+        }
+        # ...EmailFormFragment
+      }
+    `,
+    queryRef
+  );
+
+  // const savedEmail = query.viewer.email?.email;
+  const savedEmail = 'test@test.com';
+
+  const [isEditMode, setIsEditMode] = useState(false);
+
+  const showInput = useMemo(() => {
+    // Show input only if there's no email address, or the user has opted to edit
+    return !savedEmail || isEditMode;
+  }, [savedEmail, isEditMode]);
+
+  console.log('showInput', showInput);
+
+  return (
+    <StyledEmailManager>
+      {showInput ? (
+        <EmailForm savedEmail={savedEmail} setIsEditMode={setIsEditMode} />
+      ) : (
+        <EmailVerificationStatus savedEmail={savedEmail} setIsEditMode={setIsEditMode} />
+      )}
+    </StyledEmailManager>
+  );
+}
+
+const EditEmailButton = styled.button`
+  background: ${colors.white};
+  border: 1px solid ${colors.porcelain};
+  color: ${colors.offBlack};
+  padding: 8px 12px;
+  cursor: pointer;
+`;
+
+const StyledEmailManager = styled.div`
+  height: 72px; // set fixed height so changing modes doesnt shift page content
+`;
+
+export default EmailManager;

--- a/src/components/Email/EmailVerificationStatus.tsx
+++ b/src/components/Email/EmailVerificationStatus.tsx
@@ -48,7 +48,7 @@ function EmailVerificationStatus({ setIsEditMode, queryRef }: Props) {
   }, [setIsEditMode]);
 
   const [resendVerificationEmail] = usePromisifiedMutation<EmailVerificationStatusMutation>(graphql`
-    mutation EmailVerificationStatusMutation @raw_response_type {
+    mutation EmailVerificationStatusMutation {
       resendVerificationEmail {
         ... on ResendVerificationEmailPayload {
           __typename

--- a/src/components/Email/EmailVerificationStatus.tsx
+++ b/src/components/Email/EmailVerificationStatus.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useMemo } from 'react';
+
+import AlertTriangleIcon from '~/icons/AlertTriangleIcon';
+import CircleCheckIcon from '~/icons/CircleCheckIcon';
+import ClockIcon from '~/icons/ClockIcon';
+
+import { Button } from '../core/Button/Button';
+import { HStack, VStack } from '../core/Spacer/Stack';
+import { BaseM, BaseS } from '../core/Text/Text';
+
+const UNVERIFIED = Symbol('UNVERIFIED');
+const VERIFIED = Symbol('VERIFIED');
+const FAILED = Symbol('FAILED');
+const ADMIN = Symbol('ADMIN');
+
+type Props = {
+  savedEmail: string;
+  setIsEditMode: (editMode: boolean) => void;
+};
+
+// can we use graphql enum for this
+type VerificationStatus = typeof UNVERIFIED | typeof VERIFIED | typeof FAILED | typeof ADMIN;
+
+function EmailVerificationStatus({ setIsEditMode, savedEmail }: Props) {
+  const handleEditClick = useCallback(() => {
+    setIsEditMode(true);
+  }, [setIsEditMode]);
+
+  const verificationStatus = UNVERIFIED;
+
+  const verificationStatusIndicator = useMemo(() => {
+    switch (verificationStatus) {
+      case UNVERIFIED:
+        return (
+          <>
+            <ClockIcon />
+            <BaseS>Pending verification</BaseS>
+          </>
+        );
+      case VERIFIED:
+        return (
+          <>
+            <CircleCheckIcon />
+            <BaseS>Verified</BaseS>
+          </>
+        );
+      case FAILED:
+        return (
+          <>
+            <AlertTriangleIcon />
+            <BaseS>Could not verify.</BaseS>
+          </>
+        );
+    }
+  }, [verificationStatus]);
+  return (
+    <HStack justify="space-between">
+      <VStack>
+        <BaseM>{savedEmail}</BaseM>
+        <HStack gap={4}>{verificationStatusIndicator}</HStack>
+      </VStack>
+      <Button variant="secondary" onClick={handleEditClick}>
+        EDIT
+      </Button>
+    </HStack>
+  );
+}
+
+export default EmailVerificationStatus;

--- a/src/components/Email/EmailVerificationStatus.tsx
+++ b/src/components/Email/EmailVerificationStatus.tsx
@@ -79,7 +79,7 @@ function EmailVerificationStatus({ setIsEditMode, queryRef }: Props) {
       } else {
         pushToast({
           autoClose: true,
-          message: `We've resent you an email to verify your email address. You can complete onboarding in the meantime.`,
+          message: `We've resent you an email to verify your email address.`,
         });
       }
     } catch (error) {

--- a/src/components/Email/EmailVerificationStatus.tsx
+++ b/src/components/Email/EmailVerificationStatus.tsx
@@ -65,7 +65,7 @@ function EmailVerificationStatus({ setIsEditMode, queryRef }: Props) {
   const handleResendClick = useCallback(async () => {
     function pushErrorToast() {
       pushToast({
-        autoClose: true,
+        autoClose: false,
         message: `Something went wrong while sending a verification email. We are looking into it.`,
       });
     }
@@ -78,7 +78,7 @@ function EmailVerificationStatus({ setIsEditMode, queryRef }: Props) {
         );
       } else {
         pushToast({
-          autoClose: true,
+          autoClose: false,
           message: `We've resent you an email to verify your email address.`,
         });
       }

--- a/src/components/Onboarding/OnboardingFooter.tsx
+++ b/src/components/Onboarding/OnboardingFooter.tsx
@@ -10,9 +10,16 @@ type Props = {
   onNext: () => void | Promise<unknown>;
   isNextEnabled: boolean;
   onPrevious: () => void;
+  previousTextOverride?: string;
 };
 
-export function OnboardingFooter({ onNext, onPrevious, step, isNextEnabled }: Props) {
+export function OnboardingFooter({
+  onNext,
+  onPrevious,
+  step,
+  isNextEnabled,
+  previousTextOverride,
+}: Props) {
   const stepIndex = getStepIndex(step);
   const isFirstStep = stepIndex === 0;
 
@@ -22,7 +29,7 @@ export function OnboardingFooter({ onNext, onPrevious, step, isNextEnabled }: Pr
     <WizardFooter
       isNextEnabled={isNextEnabled}
       nextText={nextButtonText}
-      previousText={isFirstStep ? 'Cancel' : 'Back'}
+      previousText={previousTextOverride || (isFirstStep ? 'Cancel' : 'Back')}
       onNext={onNext}
       onPrevious={onPrevious}
     />

--- a/src/components/Onboarding/constants.ts
+++ b/src/components/Onboarding/constants.ts
@@ -8,6 +8,7 @@ export const STEPS = [
   'organize-gallery',
   'edit-collection',
   'congratulations',
+  'add-email',
 ] as const;
 
 export type StepName = typeof STEPS[number];
@@ -20,6 +21,7 @@ export const ONBOARDING_NEXT_BUTTON_TEXT_MAP: { [key in StepName]: string } = {
   'edit-collection': 'Save',
   'organize-gallery': 'Publish Gallery',
   congratulations: 'Done',
+  'add-email': 'Done',
 };
 
 export function getStepIndex(step: StepName) {

--- a/src/icons/AlertTriangleIcon.tsx
+++ b/src/icons/AlertTriangleIcon.tsx
@@ -1,0 +1,23 @@
+import colors from '~/components/core/colors';
+
+type Props = {
+  className?: string;
+  color?: colors;
+};
+
+export default function AlertTriangleIcon({ className, color = colors.red }: Props) {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M8 6.33333V10" stroke={color} />
+      <path d="M8 11.6667V11" stroke={color} />
+      <path d="M7.99999 2L14.6667 13.3333H1.33333L7.99999 2Z" stroke={color} />
+    </svg>
+  );
+}

--- a/src/icons/CircleCheckIcon.tsx
+++ b/src/icons/CircleCheckIcon.tsx
@@ -1,0 +1,25 @@
+import colors from '~/components/core/colors';
+
+type Props = {
+  className?: string;
+  color?: colors;
+};
+
+export default function CircleCheckIcon({ className, color = colors.offBlack }: Props) {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7.99999 14.6667C11.6819 14.6667 14.6667 11.6819 14.6667 8C14.6667 4.3181 11.6819 1.33333 7.99999 1.33333C4.3181 1.33333 1.33333 4.3181 1.33333 8C1.33333 11.6819 4.3181 14.6667 7.99999 14.6667Z"
+        stroke={color}
+      />
+      <path d="M5.33333 8L7.33333 10L10.6667 6.66667" stroke={color} />
+    </svg>
+  );
+}

--- a/src/icons/ClockIcon.tsx
+++ b/src/icons/ClockIcon.tsx
@@ -1,0 +1,28 @@
+import colors from '~/components/core/colors';
+
+type Props = {
+  className?: string;
+  color?: colors;
+};
+
+export default function ClockIcon({ className, color = colors.offBlack }: Props) {
+  return (
+    <svg
+      className={className}
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M8 4V8.33333L6 10.6667" stroke={color} />
+      <path d="M1.43333 9.16C1.56748 9.92558 1.83607 10.6614 2.22667 11.3333" stroke={color} />
+      <path d="M2.22667 4.66667C1.83607 5.33863 1.56748 6.07442 1.43333 6.84" stroke={color} />
+      <path d="M5.72 1.73333C4.99086 2.00056 4.31402 2.39313 3.72 2.89333" stroke={color} />
+      <path
+        d="M3.71333 13.1067C4.53427 13.7956 5.50919 14.2765 6.55548 14.5085C7.60177 14.7406 8.68859 14.7169 9.72381 14.4397C10.759 14.1624 11.7121 13.6396 12.5024 12.9156C13.2926 12.1917 13.8966 11.2879 14.2633 10.2808C14.63 9.27381 14.7484 8.19322 14.6087 7.13065C14.4689 6.06809 14.0751 5.05488 13.4605 4.1769C12.8459 3.29892 12.0287 2.58205 11.0781 2.08705C10.1276 1.59205 9.07171 1.3335 8 1.33333"
+        stroke={color}
+      />
+    </svg>
+  );
+}

--- a/src/utils/graphql/isFeatureEnabled.tsx
+++ b/src/utils/graphql/isFeatureEnabled.tsx
@@ -7,24 +7,28 @@ export enum FeatureFlag {
   ART_GOBBLERS = 'ART_GOBBLERS',
   ADMIRE_COMMENT = 'ADMIRE_COMMENT',
   WHITE_RINO = 'WHITE_RINO',
+  EMAIL = 'EMAIL',
 }
 
 const PROD_FLAGS: Record<FeatureFlag, boolean> = {
   ART_GOBBLERS: false,
   ADMIRE_COMMENT: false,
   WHITE_RINO: false,
+  EMAIL: false,
 };
 
 const DEV_FLAGS: Record<FeatureFlag, boolean> = {
   ART_GOBBLERS: true,
   ADMIRE_COMMENT: true,
   WHITE_RINO: true,
+  EMAIL: true,
 };
 
 const EMPLOYEE_FLAGS: Record<FeatureFlag, boolean> = {
   ART_GOBBLERS: false,
   ADMIRE_COMMENT: true,
   WHITE_RINO: true,
+  EMAIL: true,
 };
 
 const EMPLOYEE_USER_IDS = new Set(

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -5,4 +5,8 @@ export const NO_CONSECUTIVE_PERIODS_OR_UNDERSCORES = /^(?=[\w.]*$)(?!.*[_.]{2})[
 // ends with =s256, =s128, etc.
 export const GOOGLE_CONTENT_IMG_URL = /=s\d{3}$/;
 
-export const VALID_URL = /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9(@:%_\+.~#?&\/=]*)/;
+export const VALID_URL =
+  /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9(@:%_\+.~#?&\/=]*)/;
+
+// standard email format x@x.xx
+export const EMAIL_FORMAT = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/;


### PR DESCRIPTION
This PR adds the "Add Email" component, and adds it as a step to the onboarding flow. This step replaces the "Congratulations" last step of the existing onboarding flow. The White Rhino feature flag controls which step is shown.

![Screen Shot 2022-11-09 at 23 56 10](https://user-images.githubusercontent.com/80802871/200864874-e94cd73f-8ae8-4935-a514-0e3aa842540c.png)

The default state before an email address has been added is to show an input.
![Screen Shot 2022-11-09 at 23 22 03](https://user-images.githubusercontent.com/80802871/200865115-6f64190a-6c23-47ff-843e-52ea638e8051.png)


Once an email is entered, it will be in an unverified state, required the user to verify via an email they receive.
![Screen Shot 2022-11-10 at 0 05 16](https://user-images.githubusercontent.com/80802871/200865955-38206d06-a5b6-4b39-bd4c-3ec231271a19.png)



The EmailVerificationStatus component reflects the various verification states:
verified
![Screen Shot 2022-11-10 at 0 05 20](https://user-images.githubusercontent.com/80802871/200865914-95c465d4-c2ce-4434-b79f-4342b3ade7eb.png)

error
![Screen Shot 2022-11-10 at 0 05 26](https://user-images.githubusercontent.com/80802871/200865891-e9018c3c-52d9-4711-b978-d70401ccd90e.png)





- [x] Add "Add email" input
- [x] Add simple email address format validation to input
- [x] Add verification state for unverified, verified, error states
- [x] Enable editing a previously added email address
- [x] Add these components to a new step in onboarding
- [x] Put step behind feature flag


