### PR TITLE
Add collection updated component

### DIFF
--- a/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
@@ -1,0 +1,137 @@
+import { Route } from 'nextjs-routes';
+import { useMemo } from 'react';
+import { useFragment } from 'react-relay';
+import { graphql } from 'relay-runtime';
+import styled from 'styled-components';
+
+import breakpoints from '~/components/core/breakpoints';
+import colors from '~/components/core/colors';
+import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
+import { UnstyledLink } from '~/components/core/Link/UnstyledLink';
+import Markdown from '~/components/core/Markdown/Markdown';
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { BaseM, BaseS } from '~/components/core/Text/Text';
+import HoverCardOnUsername from '~/components/HoverCard/HoverCardOnUsername';
+import { useTrack } from '~/contexts/analytics/AnalyticsContext';
+import { CollectionUpdatedFeedEventFragment$key } from '~/generated/CollectionUpdatedFeedEventFragment.graphql';
+import { CollectionUpdatedFeedEventQueryFragment$key } from '~/generated/CollectionUpdatedFeedEventQueryFragment.graphql';
+import { removeNullValues } from '~/utils/removeNullValues';
+import { pluralize } from '~/utils/string';
+import { getTimeSince } from '~/utils/time';
+import unescape from '~/utils/unescape';
+
+import { MAX_PIECES_DISPLAYED_PER_FEED_EVENT } from '../constants';
+import FeedEventTokenPreviews, { TokenToPreview } from '../FeedEventTokenPreviews';
+import { StyledEvent, StyledEventHeader, StyledTime } from './EventStyles';
+
+type Props = {
+  eventDataRef: CollectionUpdatedFeedEventFragment$key;
+  queryRef: CollectionUpdatedFeedEventQueryFragment$key;
+};
+
+export default function CollectionUpdatedFeedEvent({ eventDataRef, queryRef }: Props) {
+  const event = useFragment(
+    graphql`
+      fragment CollectionUpdatedFeedEventFragment on CollectionUpdatedFeedEventData {
+        eventTime
+        owner @required(action: THROW) {
+          username
+          ...HoverCardOnUsernameFragment
+        }
+        collection @required(action: THROW) {
+          dbid
+          name
+          tokens(limit: $visibleTokensPerFeedEvent) @required(action: THROW) {
+            token {
+              dbid
+            }
+            ...EventMediaFragment
+          }
+        }
+        newCollectorsNote @required(action: THROW)
+        newTokens @required(action: THROW) {
+          token {
+            dbid
+          }
+          ...EventMediaFragment
+        }
+      }
+    `,
+    eventDataRef
+  );
+
+  const query = useFragment(
+    graphql`
+      fragment CollectionUpdatedFeedEventQueryFragment on Query {
+        ...HoverCardOnUsernameFollowFragment
+      }
+    `,
+    queryRef
+  );
+
+  const tokensToPreview = useMemo(() => {
+    return removeNullValues(event.newTokens).slice(0, MAX_PIECES_DISPLAYED_PER_FEED_EVENT);
+  }, [event.newTokens]) as TokenToPreview[];
+
+  const collectionPagePath: Route = {
+    pathname: '/[username]/[collectionId]',
+    query: { username: event.owner.username as string, collectionId: event.collection.dbid },
+  };
+  const track = useTrack();
+
+  const numAdditionalPieces = event.newTokens.length - MAX_PIECES_DISPLAYED_PER_FEED_EVENT;
+  const showAdditionalPiecesIndicator = numAdditionalPieces > 0;
+
+  const collectionName = unescape(event.collection.name ?? '');
+
+  if (!event.newTokens.length) {
+    throw new Error('Tried to render CollectionUpdatedFeedEvent without any tokens');
+  }
+
+  return (
+    <UnstyledLink
+      href={collectionPagePath}
+      onClick={() => track('Feed: Clicked collection updated event')}
+    >
+      <StyledEvent>
+        <VStack gap={16}>
+          <StyledEventHeader>
+            <HStack gap={4} inline>
+              <BaseM>
+                <HoverCardOnUsername userRef={event.owner} queryRef={query} /> made updates to
+                {collectionName ? ' ': 'their collection'}
+                <InteractiveLink to={collectionPagePath}>{collectionName}</InteractiveLink>
+              </BaseM>
+              <StyledTime>{getTimeSince(event.eventTime)}</StyledTime>
+            </HStack>
+          </StyledEventHeader>
+            <StyledQuote>
+              <Markdown text={unescape(event.newCollectorsNote ?? '')} inheritLinkStyling />
+            </StyledQuote>
+          <VStack gap={8}>
+            <FeedEventTokenPreviews tokensToPreview={tokensToPreview} />
+            {showAdditionalPiecesIndicator && (
+              <StyledAdditionalPieces>
+                +{numAdditionalPieces} more {pluralize(numAdditionalPieces, 'piece')}
+              </StyledAdditionalPieces>
+            )}
+          </VStack>
+        </VStack>
+      </StyledEvent>
+    </UnstyledLink>
+  );
+}
+
+const StyledAdditionalPieces = styled(BaseS)`
+  text-align: end;
+  color: ${colors.metal};
+`
+const StyledQuote = styled(BaseM)`
+  color: ${colors.metal};
+  border-left: 2px solid ${colors.porcelain};
+  padding-left: 8px;
+
+  @media only screen and ${breakpoints.tablet} {
+    max-width: 50%;
+  };
+`

--- a/src/components/Feed/FeedEvent.tsx
+++ b/src/components/Feed/FeedEvent.tsx
@@ -11,6 +11,7 @@ import { FeedEventWithErrorBoundaryQueryFragment$key } from '~/generated/FeedEve
 import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
 import CollectionCreatedFeedEvent from './Events/CollectionCreatedFeedEvent';
+import CollectionUpdatedFeedEvent from './Events/CollectionUpdatedFeedEvent';
 import CollectorsNoteAddedToCollectionFeedEvent from './Events/CollectorsNoteAddedToCollectionFeedEvent';
 import CollectorsNoteAddedToTokenFeedEvent from './Events/CollectorsNoteAddedToTokenFeedEvent';
 import TokensAddedToCollectionFeedEvent from './Events/TokensAddedToCollectionFeedEvent';
@@ -50,6 +51,12 @@ function FeedEvent({ eventRef, queryRef, feedMode }: FeedEventProps) {
           ... on CollectorsNoteAddedToCollectionFeedEventData {
             ...CollectorsNoteAddedToCollectionFeedEventFragment
           }
+          ... on CollectorsNoteAddedToCollectionFeedEventData {
+            ...CollectorsNoteAddedToCollectionFeedEventFragment
+          }
+          ... on CollectionUpdatedFeedEventData {
+            ...CollectionUpdatedFeedEventFragment
+          }
         }
       }
     `,
@@ -64,6 +71,7 @@ function FeedEvent({ eventRef, queryRef, feedMode }: FeedEventProps) {
         ...CollectorsNoteAddedToCollectionFeedEventQueryFragment
         ...CollectionCreatedFeedEventQueryFragment
         ...CollectorsNoteAddedToTokenFeedEventQueryFragment
+        ...CollectionUpdatedFeedEventQueryFragment
       }
     `,
     queryRef
@@ -78,6 +86,8 @@ function FeedEvent({ eventRef, queryRef, feedMode }: FeedEventProps) {
           queryRef={query}
         />
       );
+    case 'CollectionUpdatedFeedEventData':
+      return <CollectionUpdatedFeedEvent eventDataRef={event.eventData} queryRef={query} />;
     case 'CollectorsNoteAddedToTokenFeedEventData':
       return (
         <CollectorsNoteAddedToTokenFeedEvent eventDataRef={event.eventData} queryRef={query} />


### PR DESCRIPTION
Adds the component to handle the `CollectionUpdatedFeedEvent`. This event always guarantees that there will be a new collectors note and new tokens, otherwise it'll be categorized as their respective feed events by the backend, so no need to handle the cases where either is missing.

Please tear it apart and let me know if I did anything wrong 😄 

The event in all its glory:

<img width="841" alt="Screen Shot 2022-11-09 at 9 28 19 PM" src="https://user-images.githubusercontent.com/20363846/201008594-6110dbf2-3f3d-46df-b9f9-071231dccdd8.png">
