### PR TITLE
Jakz/white rhino fix

### DIFF
--- a/src/components/Email/EmailVerificationStatus.tsx
+++ b/src/components/Email/EmailVerificationStatus.tsx
@@ -128,9 +128,9 @@ function EmailVerificationStatus({ setIsEditMode, queryRef }: Props) {
         <BaseM>{savedEmail}</BaseM>
         <HStack gap={4}>{verificationStatusIndicator}</HStack>
       </VStack>
-      <Button variant="secondary" onClick={handleEditClick}>
+      <StyledButton variant="secondary" onClick={handleEditClick}>
         EDIT
-      </Button>
+      </StyledButton>
     </HStack>
   );
 }
@@ -144,6 +144,10 @@ const ResendEmail = styled.button`
   &:hover {
     text-decoration: none;
   }
+`;
+
+const StyledButton = styled(Button)`
+  padding: 8px 12px;
 `;
 
 export default EmailVerificationStatus;

--- a/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -88,7 +88,7 @@ export default function CollectionCreatedFeedEvent({ caption, eventDataRef, quer
         <VStack gap={16}>
           <StyledEventHeader>
             <VStack gap={4}>
-              <HStack inline gap={2} align="center">
+              <StyledEventHeaderContainer>
                 <HoverCardOnUsername userRef={event.owner} queryRef={query} />{' '}
                 <BaseM>
                   added {tokens.length} {pluralize(tokens.length, 'piece')} to their new collection
@@ -110,7 +110,7 @@ export default function CollectionCreatedFeedEvent({ caption, eventDataRef, quer
                   )}
                   <StyledTime>{getTimeSince(event.eventTime)}</StyledTime>
                 </HStack>
-              </HStack>
+              </StyledEventHeaderContainer>
               {caption && (
                 <StyledCaptionContainer gap={8} align="center">
                   <BaseS>{caption}</BaseS>
@@ -131,6 +131,10 @@ export default function CollectionCreatedFeedEvent({ caption, eventDataRef, quer
     </UnstyledLink>
   );
 }
+
+const StyledEventHeaderContainer = styled.div`
+  display: inline;
+`;
 
 const StyledAdditionalPieces = styled(BaseS)`
   text-align: end;

--- a/src/components/Feed/Socialize/NotesModal/NotesModal.tsx
+++ b/src/components/Feed/Socialize/NotesModal/NotesModal.tsx
@@ -16,7 +16,7 @@ import { TitleDiatypeM, TitleXS } from '~/components/core/Text/Text';
 import { AdmireNote } from '~/components/Feed/Socialize/NotesModal/AdmireNote';
 import { CommentNote } from '~/components/Feed/Socialize/NotesModal/CommentNote';
 import { ListItem } from '~/components/Feed/Socialize/NotesModal/ListItem';
-import { MODAL_PADDING_THICC_PX } from '~/contexts/modal/constants';
+import { MODAL_PADDING_PX } from '~/contexts/modal/constants';
 import { NotesModalFragment$key } from '~/generated/NotesModalFragment.graphql';
 
 export const NOTES_PER_PAGE = 10;
@@ -168,7 +168,7 @@ const WrappingVStack = styled(VStack)`
 `;
 
 const StyledHeader = styled.div`
-  padding-bottom: ${MODAL_PADDING_THICC_PX}px;
+  padding-bottom: ${MODAL_PADDING_PX}px;
   padding-left: 12px;
 `;
 
@@ -177,5 +177,5 @@ const ModalContent = styled.div<{ fullscreen: boolean }>`
   width: ${({ fullscreen }) => (fullscreen ? '100%' : '540px')};
   display: flex;
   flex-direction: column;
-  padding: ${MODAL_PADDING_THICC_PX}px 8px;
+  padding: ${MODAL_PADDING_PX}px 8px;
 `;

--- a/src/components/Feed/Socialize/NotesModal/NotesModal.tsx
+++ b/src/components/Feed/Socialize/NotesModal/NotesModal.tsx
@@ -12,7 +12,7 @@ import styled from 'styled-components';
 
 import colors from '~/components/core/colors';
 import { VStack } from '~/components/core/Spacer/Stack';
-import { TitleXS } from '~/components/core/Text/Text';
+import { TitleDiatypeM, TitleXS } from '~/components/core/Text/Text';
 import { AdmireNote } from '~/components/Feed/Socialize/NotesModal/AdmireNote';
 import { CommentNote } from '~/components/Feed/Socialize/NotesModal/CommentNote';
 import { ListItem } from '~/components/Feed/Socialize/NotesModal/ListItem';
@@ -139,7 +139,7 @@ export function NotesModal({ eventRef, fullscreen }: NotesModalProps) {
     <ModalContent fullscreen={fullscreen}>
       <WrappingVStack>
         <StyledHeader>
-          <TitleXS>NOTES</TitleXS>
+          <TitleDiatypeM>Notes</TitleDiatypeM>
         </StyledHeader>
         <VStack grow>
           <AutoSizer>

--- a/src/components/NotificationsModal/Notification.tsx
+++ b/src/components/NotificationsModal/Notification.tsx
@@ -234,10 +234,9 @@ const Container = styled.div<{ isClickable: boolean }>`
     isClickable
       ? css`
           cursor: pointer;
+          :hover {
+            background-color: ${colors.faint};
+          }
         `
       : css``};
-
-  :hover {
-    background-color: ${colors.faint};
-  }
 `;

--- a/src/components/NotificationsModal/NotificationsModal.tsx
+++ b/src/components/NotificationsModal/NotificationsModal.tsx
@@ -9,7 +9,7 @@ import {
   NOTIFICATIONS_PER_PAGE,
 } from '~/components/NotificationsModal/NotificationList';
 import { useClearNotifications } from '~/components/NotificationsModal/useClearNotifications';
-import { MODAL_PADDING_THICC_PX } from '~/contexts/modal/constants';
+import { MODAL_PADDING_PX } from '~/contexts/modal/constants';
 import { NotificationsModalQuery } from '~/generated/NotificationsModalQuery.graphql';
 
 type NotificationsModalProps = {
@@ -49,7 +49,7 @@ export function NotificationsModal({ fullscreen }: NotificationsModalProps) {
 }
 
 const StyledHeader = styled.div`
-  padding-bottom: ${MODAL_PADDING_THICC_PX}px;
+  padding-bottom: ${MODAL_PADDING_PX}px;
   padding-left: 12px;
 `;
 
@@ -59,5 +59,5 @@ const ModalContent = styled.div<{ fullscreen: boolean }>`
   min-width: 420px;
   display: flex;
   flex-direction: column;
-  padding: ${MODAL_PADDING_THICC_PX}px 4px;
+  padding: ${MODAL_PADDING_PX}px 4px;
 `;

--- a/src/components/NotificationsModal/NotificationsModal.tsx
+++ b/src/components/NotificationsModal/NotificationsModal.tsx
@@ -55,7 +55,8 @@ const StyledHeader = styled.div`
 
 const ModalContent = styled.div<{ fullscreen: boolean }>`
   height: ${({ fullscreen }) => (fullscreen ? '100%' : '640px')};
-  width: ${({ fullscreen }) => (fullscreen ? '100%' : '420px')};
+  width: 100%;
+  min-width: 420px;
   display: flex;
   flex-direction: column;
   padding: ${MODAL_PADDING_THICC_PX}px 4px;

--- a/src/contexts/globalLayout/GlobalNavbar/FeedNavbar/FeedLeftContent.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/FeedNavbar/FeedLeftContent.tsx
@@ -13,6 +13,8 @@ import { ProfileDropdownContent } from '~/contexts/globalLayout/GlobalNavbar/Pro
 import { FeedLeftContentFragment$key } from '~/generated/FeedLeftContentFragment.graphql';
 import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
+import NavUpArrow from '../ProfileDropdown/NavUpArrow';
+
 type FeedLeftContentProps = {
   queryRef: FeedLeftContentFragment$key;
 };
@@ -84,7 +86,7 @@ export function FeedLeftContent({ queryRef }: FeedLeftContentProps) {
 
       <HomeText>Home</HomeText>
 
-      <NavDownArrow />
+      {showDropdown ? <NavUpArrow /> : <NavDownArrow />}
 
       <ProfileDropdownContent
         showDropdown={showDropdown}

--- a/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/NavUpArrow.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/NavUpArrow.tsx
@@ -1,0 +1,7 @@
+export default function NavUpArrow() {
+  return (
+    <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M13.7197 10.996L9.04857 6.33373L4.38631 11.0049" stroke="black" />
+    </svg>
+  );
+}

--- a/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdown.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdown.tsx
@@ -13,6 +13,7 @@ import { ProfileDropdownFragment$key } from '~/generated/ProfileDropdownFragment
 import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
 import { NotificationsCircle } from '../NotificationCircle';
+import NavUpArrow from './NavUpArrow';
 
 type ProfileDropdownProps = {
   queryRef: ProfileDropdownFragment$key;
@@ -90,10 +91,10 @@ export function ProfileDropdown({ queryRef, rightContent }: ProfileDropdownProps
         <LogoContainer gap={4} role="button" onClick={handleLoggedInLogoClick}>
           {isWhiteRhinoEnabled && notificationCount > 0 ? <NotificationsCircle /> : null}
 
-          <HStack gap={2}>
+          <HStack gap={2} align="center">
             <GLogo />
 
-            <NavDownArrow />
+            {showDropdown ? <NavUpArrow /> : <NavDownArrow />}
           </HStack>
         </LogoContainer>
       ) : (

--- a/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdownContent.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdownContent.tsx
@@ -120,7 +120,9 @@ export function ProfileDropdownContent({ showDropdown, onClose, queryRef }: Prop
             <NotificationsDropdownItem onClick={handleNotificationsClick}>
               <HStack align="center" gap={10}>
                 <div>NOTIFICATIONS</div>
-                {notificationCount > 0 && <CountText role="button">{notificationCount}</CountText>}
+                <CountText role="button" hasNotification={notificationCount > 0}>
+                  {notificationCount}
+                </CountText>
               </HStack>
             </NotificationsDropdownItem>
           )}
@@ -144,7 +146,7 @@ export function ProfileDropdownContent({ showDropdown, onClose, queryRef }: Prop
   );
 }
 
-const CountText = styled(BaseM)`
+const CountText = styled(BaseM)<{ hasNotification?: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -163,6 +165,8 @@ const CountText = styled(BaseM)`
   user-select: none;
 
   border-radius: 99999px;
+
+  opacity: ${({ hasNotification }) => (hasNotification ? 1 : 0)};
 `;
 
 const NotificationsDropdownItem = styled(DropdownItem)``;


### PR DESCRIPTION
**Incosistent feed event on mobile**

| Before  | After |
| ------------- | ------------- |
|  ![image (2)](https://user-images.githubusercontent.com/4480258/201620063-80044d36-7187-4668-b780-22f230f5adc4.png) | <img width="343" alt="CleanShot 2022-11-14 at 17 10 30@2x" src="https://user-images.githubusercontent.com/4480258/201620369-3ec82e99-c204-423f-9336-f113ee888c42.png">  |

**Edit Email button**

| Before  | After |
| ------------- | ------------- |
| <img width="288" alt="CleanShot 2022-11-14 at 17 11 34@2x" src="https://user-images.githubusercontent.com/4480258/201620598-75ce9a08-14bc-4714-bc15-313caaa36fa5.png">  | <img width="507" alt="CleanShot 2022-11-14 at 17 11 47@2x" src="https://user-images.githubusercontent.com/4480258/201620675-81a5c992-3810-4bc7-853a-61c84855af7a.png">  |

**Remove hover on non-clickable notification**
| Before  | After |
| ------------- | ------------- |
| <img width="540" alt="CleanShot 2022-11-14 at 17 14 08@2x" src="https://user-images.githubusercontent.com/4480258/201621267-49d53c7a-d51e-460d-922b-3c33376d01a2.png">  | <img width="500" alt="CleanShot 2022-11-14 at 17 13 28@2x" src="https://user-images.githubusercontent.com/4480258/201621327-51c65682-fce0-4c2c-ae59-7e77d1784921.png">  |

**Fix notification width on tablet**

| Before  | After |
| ------------- | ------------- |
| <img width="595" alt="CleanShot 2022-11-14 at 17 16 42@2x" src="https://user-images.githubusercontent.com/4480258/201622141-96ca5537-fc7d-4271-a444-5c35ccf949d1.png"> | <img width="593" alt="CleanShot 2022-11-14 at 17 16 58@2x" src="https://user-images.githubusercontent.com/4480258/201622117-6b45dfcd-5c9f-4f58-af87-bf9eeda7aaf3.png">  |

**Bold Notes header and center allign**

| Before  | After |
| ------------- | ------------- |
| ![image (4)](https://user-images.githubusercontent.com/4480258/201623804-d9990d28-2a8f-43c5-b7a1-70798f9f49b1.png) | <img width="604" alt="CleanShot 2022-11-14 at 17 25 12@2x" src="https://user-images.githubusercontent.com/4480258/201623878-2f18c77c-bc2f-4799-8d6f-971f44583905.png">   |

![CleanShot 2022-11-14 at 20 21 34](https://user-images.githubusercontent.com/4480258/201658826-b18bba62-b75a-4fd5-8c53-6343f72b1e6d.png)

**Navbar caret rotate when the dropdown opened**

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2022-11-14 at 20 39 33](https://user-images.githubusercontent.com/4480258/201662546-73f7d154-aa19-4dd9-ac1a-0c987b7d3af6.png) | ![CleanShot 2022-11-14 at 20 37 45](https://user-images.githubusercontent.com/4480258/201662596-d6743b67-6a47-4e4f-b026-06d3d68e544f.png) |

**Fix layout shift on notification dismiss** - same width

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2022-11-14 at 21 23 57](https://user-images.githubusercontent.com/4480258/201671240-b140ac45-3d15-49e1-ac42-1eaa3290fe10.png) | ![CleanShot 2022-11-14 at 21 23 23](https://user-images.githubusercontent.com/4480258/201671278-86e82411-6ef5-4d54-9c87-e202e8fc8a21.png)![CleanShot 2022-11-14 at 21 23 14](https://user-images.githubusercontent.com/4480258/201671294-c2353047-cbc2-41a7-a29f-139c37ee7591.png)|

**Gallery Views modal header should look more like bold + lowercase**

| Before  | After |
| ------------- | ------------- |
| ![image (5)](https://user-images.githubusercontent.com/4480258/201672512-888f855e-4657-42db-993e-6f48863a8d35.png)  | ![CleanShot 2022-11-14 at 21 29 10](https://user-images.githubusercontent.com/4480258/201672416-259882b1-f2c3-4e4d-b41d-a722160a9106.png)  |


