### PR TITLE
Fix user description line clamp in safari

### DIFF
--- a/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -259,12 +259,17 @@ const StyledCollectorsNote = styled(BaseM)<{ showMore: boolean }>`
           -webkit-line-clamp: 2;
 
           p {
+            display: inline;
             padding-bottom: 0 !important;
           }
 
           // We only care about line clamping on mobile
           @media only screen and ${breakpoints.tablet} {
             -webkit-line-clamp: unset;
+
+            p {
+              display: inline-block;
+            }
 
             p:not(:last-child) {
               padding-bottom: 12px !important;


### PR DESCRIPTION
This issue only happens on safari

**Before**

https://user-images.githubusercontent.com/4480258/202072954-72f6972a-e448-459b-9c10-03f9e3bfa139.mp4


**After**


https://user-images.githubusercontent.com/4480258/202072678-c03c0688-f29e-4bac-b0b6-91f1c6734026.mp4


