### PR TITLE
[GAL-649] make nav username gray if viewing a different tab

### DIFF
--- a/src/components/Follow/NavActionFollow.tsx
+++ b/src/components/Follow/NavActionFollow.tsx
@@ -46,20 +46,20 @@ export default function NavActionFollow({ userRef, queryRef }: Props) {
 
   const is3ac = isUsername3ac(user.username);
   const usernameRoute: Route = { pathname: '/[username]', query: { username: user.username } };
-  const isViewingProfile = pathname === '/[username]';
+  const mainGalleryPage = pathname === '/[username]';
 
   return (
     <HStack gap={8} align="center">
       <Link href={usernameRoute}>
-        <StyledBreadcrumbLink href={route(usernameRoute)} focused={isViewingProfile}>
+        <UsernameBreadcrumbLink href={route(usernameRoute)} mainGalleryPage={mainGalleryPage}>
           {is3ac ? 'The Unofficial 3AC Gallery' : user.username}
-        </StyledBreadcrumbLink>
+        </UsernameBreadcrumbLink>
       </Link>
       <FollowButton queryRef={loggedInUserQuery} userRef={user} />
     </HStack>
   );
 }
 
-const StyledBreadcrumbLink = styled(BreadcrumbLink)<{ focused: boolean }>`
-  color: ${({ focused }) => (focused ? colors.offBlack : colors.shadow)};
+const UsernameBreadcrumbLink = styled(BreadcrumbLink)<{ mainGalleryPage: boolean }>`
+  color: ${({ mainGalleryPage }) => (mainGalleryPage ? colors.offBlack : colors.shadow)};
 `;

--- a/src/components/Follow/NavActionFollow.tsx
+++ b/src/components/Follow/NavActionFollow.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { Route, route } from 'nextjs-routes';
 import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
 
 import { HStack } from '~/components/core/Spacer/Stack';
 import { BreadcrumbLink } from '~/contexts/globalLayout/GlobalNavbar/ProfileDropdown/Breadcrumbs';
@@ -8,6 +10,7 @@ import { NavActionFollowQueryFragment$key } from '~/generated/NavActionFollowQue
 import { NavActionFollowUserFragment$key } from '~/generated/NavActionFollowUserFragment.graphql';
 import { isUsername3ac } from '~/hooks/oneOffs/useIs3acProfilePage';
 
+import colors from '../core/colors';
 import FollowButton from './FollowButton';
 
 type Props = {
@@ -35,6 +38,7 @@ export default function NavActionFollow({ userRef, queryRef }: Props) {
     `,
     queryRef
   );
+  const { pathname } = useRouter();
 
   if (!user.username) {
     return null;
@@ -42,15 +46,20 @@ export default function NavActionFollow({ userRef, queryRef }: Props) {
 
   const is3ac = isUsername3ac(user.username);
   const usernameRoute: Route = { pathname: '/[username]', query: { username: user.username } };
+  const isViewingProfile = pathname === '/[username]';
 
   return (
     <HStack gap={8} align="center">
       <Link href={usernameRoute}>
-        <BreadcrumbLink href={route(usernameRoute)}>
+        <StyledBreadcrumbLink href={route(usernameRoute)} focused={isViewingProfile}>
           {is3ac ? 'The Unofficial 3AC Gallery' : user.username}
-        </BreadcrumbLink>
+        </StyledBreadcrumbLink>
       </Link>
       <FollowButton queryRef={loggedInUserQuery} userRef={user} />
     </HStack>
   );
 }
+
+const StyledBreadcrumbLink = styled(BreadcrumbLink)<{ focused: boolean }>`
+  color: ${({ focused }) => (focused ? colors.offBlack : colors.shadow)};
+`;

--- a/src/components/Follow/NavActionFollow.tsx
+++ b/src/components/Follow/NavActionFollow.tsx
@@ -46,12 +46,14 @@ export default function NavActionFollow({ userRef, queryRef }: Props) {
 
   const is3ac = isUsername3ac(user.username);
   const usernameRoute: Route = { pathname: '/[username]', query: { username: user.username } };
-  const mainGalleryPage = pathname === '/[username]';
 
   return (
     <HStack gap={8} align="center">
       <Link href={usernameRoute}>
-        <UsernameBreadcrumbLink href={route(usernameRoute)} mainGalleryPage={mainGalleryPage}>
+        <UsernameBreadcrumbLink
+          href={route(usernameRoute)}
+          mainGalleryPage={pathname === '/[username]'}
+        >
           {is3ac ? 'The Unofficial 3AC Gallery' : user.username}
         </UsernameBreadcrumbLink>
       </Link>


### PR DESCRIPTION
This PR makes the username in the navbar turn gray if the user is viewing a different tab such as Galleries or Activities.
This already existed on mobile, so the changes are for desktop and follow the existing pattern used for mobile.

before:
![Screen Shot 2022-11-16 at 13 17 54](https://user-images.githubusercontent.com/80802871/202082450-d102f2ac-d0ad-484d-a5bf-a46c6be49240.png)



After:
![Screen Shot 2022-11-16 at 13 14 45](https://user-images.githubusercontent.com/80802871/202082420-a128f6ad-c2b4-44f9-94c8-e07146d3f3e1.png)

