### PR TITLE
fix width of notifications popover

### DIFF
--- a/src/components/NotificationsModal/NotificationsModal.tsx
+++ b/src/components/NotificationsModal/NotificationsModal.tsx
@@ -12,6 +12,8 @@ import { useClearNotifications } from '~/components/NotificationsModal/useClearN
 import { MODAL_PADDING_PX } from '~/contexts/modal/constants';
 import { NotificationsModalQuery } from '~/generated/NotificationsModalQuery.graphql';
 
+import breakpoints from '../core/breakpoints';
+
 type NotificationsModalProps = {
   fullscreen: boolean;
 };
@@ -56,8 +58,11 @@ const StyledHeader = styled.div`
 const ModalContent = styled.div<{ fullscreen: boolean }>`
   height: ${({ fullscreen }) => (fullscreen ? '100%' : '640px')};
   width: 100%;
-  width: 420px;
   display: flex;
   flex-direction: column;
   padding: ${MODAL_PADDING_PX}px 4px;
+
+  @media only screen and ${breakpoints.tablet} {
+    width: 420px;
+  }
 `;

--- a/src/components/NotificationsModal/NotificationsModal.tsx
+++ b/src/components/NotificationsModal/NotificationsModal.tsx
@@ -56,7 +56,7 @@ const StyledHeader = styled.div`
 const ModalContent = styled.div<{ fullscreen: boolean }>`
   height: ${({ fullscreen }) => (fullscreen ? '100%' : '640px')};
   width: 100%;
-  min-width: 420px;
+  width: 420px;
   display: flex;
   flex-direction: column;
   padding: ${MODAL_PADDING_PX}px 4px;


### PR DESCRIPTION
This PR fixes the width of the notifications popover instead of using min-width, so that content does not stretch the popover out.
Before:
![Screen Shot 2022-11-16 at 14 50 33](https://user-images.githubusercontent.com/80802871/202094849-2d556fd0-447e-4105-8d0e-7ae2273afec1.png)

After:
![Screen Shot 2022-11-16 at 14 49 37](https://user-images.githubusercontent.com/80802871/202094857-933e1455-02ed-438c-81a2-5b71f27819fe.png)
