### PR TITLE
[GAL-682] Visual polish for sidebar for hidden nfts

### DIFF
--- a/src/components/ManageGallery/OrganizeCollection/Sidebar/SearchBar.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Sidebar/SearchBar.tsx
@@ -78,7 +78,7 @@ const StyledSearchInput = styled.input`
   border: none;
   width: 100%;
   padding: 8px;
-  padding-left: 16px;
+  padding-left: 12px;
   color: ${colors.metal};
   background: ${colors.offWhite};
   height: 36px;

--- a/src/components/ManageGallery/OrganizeCollection/Sidebar/Sidebar.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Sidebar/Sidebar.tsx
@@ -197,24 +197,26 @@ function Sidebar({ tokensRef, sidebarTokens, queryRef }: Props) {
     <StyledSidebar navbarHeight={navbarHeight}>
       <StyledSidebarContainer gap={8}>
         <Header>
-          <TitleS>All pieces</TitleS>
+          <TitleS>Add pieces</TitleS>
         </Header>
         <SearchBar
           tokensRef={nonNullTokens}
           setSearchResults={setSearchResults}
           setDebouncedSearchQuery={setDebouncedSearchQuery}
         />
-        <SidebarViewSelector selectedView={selectedView} setSelectedView={setSelectedView} />
         {!isSearching && (
           <>
-            <SidebarChainSelector
-              ownsWalletFromSelectedChain={ownsWalletFromSelectedChain}
-              queryRef={query}
-              selected={selectedChain}
-              onChange={setSelectedChain}
-              handleRefresh={handleRefresh}
-              isRefreshingNfts={isLocked}
-            />
+            <div>
+              <SidebarViewSelector selectedView={selectedView} setSelectedView={setSelectedView} />
+              <SidebarChainSelector
+                ownsWalletFromSelectedChain={ownsWalletFromSelectedChain}
+                queryRef={query}
+                selected={selectedChain}
+                onChange={setSelectedChain}
+                handleRefresh={handleRefresh}
+                isRefreshingNfts={isLocked}
+              />
+            </div>
             {ownsWalletFromSelectedChain && (
               <AddBlankSpaceButton onClick={handleAddBlankBlockClick} variant="secondary">
                 ADD BLANK SPACE
@@ -222,33 +224,34 @@ function Sidebar({ tokensRef, sidebarTokens, queryRef }: Props) {
             )}
           </>
         )}
-      </StyledSidebarContainer>
 
-      {ownsWalletFromSelectedChain ? (
-        <SidebarTokens
-          isSearching={isSearching}
-          tokenRefs={nonNullTokens}
-          selectedChain={selectedChain}
-          selectedView={selectedView}
-          editModeTokens={tokensToDisplay}
-        />
-      ) : (
-        <AddWalletSidebar
-          selectedChain={selectedChain}
-          queryRef={query}
-          handleRefresh={handleRefresh}
-        />
-      )}
+        {ownsWalletFromSelectedChain ? (
+          <SidebarTokens
+            isSearching={isSearching}
+            tokenRefs={nonNullTokens}
+            selectedChain={selectedChain}
+            selectedView={selectedView}
+            editModeTokens={tokensToDisplay}
+          />
+        ) : (
+          <AddWalletSidebar
+            selectedChain={selectedChain}
+            queryRef={query}
+            handleRefresh={handleRefresh}
+          />
+        )}
+      </StyledSidebarContainer>
     </StyledSidebar>
   );
 }
 
 const StyledSidebarContainer = styled(VStack)`
-  padding: 0 16px;
+  padding: 0 4px;
+  height: 100%;
 `;
 
 const AddBlankSpaceButton = styled(Button)`
-  margin-bottom: 8px;
+  margin: 0 12px;
 `;
 
 const StyledSidebar = styled.div<{ navbarHeight: number }>`
@@ -267,10 +270,10 @@ const StyledSidebar = styled.div<{ navbarHeight: number }>`
 `;
 
 const Header = styled.div`
+  padding: 0 12px 8px;
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  min-height: 32px;
 `;
 
 export default memo(Sidebar);

--- a/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarChainSelector.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarChainSelector.tsx
@@ -154,5 +154,5 @@ const Container = styled.div`
   display: flex;
   justify-content: space-between;
 
-  padding: 16px 0;
+  padding: 16px 12px;
 `;

--- a/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarList.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarList.tsx
@@ -241,7 +241,7 @@ export function SidebarList({
           <List
             className="SidebarTokenList"
             ref={virtualizedListRef}
-            style={{ outline: 'none', padding: '0 16px' }}
+            style={{ outline: 'none', padding: '0 4px' }}
             rowRenderer={rowRenderer}
             rowCount={rows.length}
             rowHeight={rowHeightCalculator}
@@ -289,6 +289,7 @@ const StyledListTokenContainer = styled.div<{ shouldUseCollectionGrouping: boole
 `;
 
 const Selection = styled.div`
+  padding: 0 12px;
   display: flex;
   grid-gap: ${SIDEBAR_ICON_GAP}px;
 `;

--- a/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarViewSelector.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarViewSelector.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
+import colors from '~/components/core/colors';
 import { Dropdown } from '~/components/core/Dropdown/Dropdown';
 import { DropdownItem } from '~/components/core/Dropdown/DropdownItem';
 import { DropdownSection } from '~/components/core/Dropdown/DropdownSection';
@@ -27,9 +28,9 @@ export function SidebarViewSelector({ selectedView, setSelectedView }: SidebarVi
 
   return (
     <Container>
-      <Selector onClick={() => setIsDropdownOpen(true)}>
+      <Selector isDropdownOpen={isDropdownOpen} onClick={() => setIsDropdownOpen(true)}>
         <BaseM>{selectedView}</BaseM>
-        <StyledArrowsIcon />
+        <DoubleArrowsIcon />
       </Selector>
       <Dropdown
         position="full-width"
@@ -47,15 +48,18 @@ export function SidebarViewSelector({ selectedView, setSelectedView }: SidebarVi
 
 const Container = styled.div`
   position: relative;
-  padding-top: 16px;
 `;
 
-const Selector = styled.div`
+const Selector = styled.div<{ isDropdownOpen: boolean }>`
   display: flex;
   justify-content: space-between;
   cursor: pointer;
-`;
+  padding: 8px 12px;
+  align-items: center;
 
-const StyledArrowsIcon = styled(DoubleArrowsIcon)`
-  margin-right: 4px;
+  ${({ isDropdownOpen }) => isDropdownOpen && `background-color: ${colors.faint};`}
+
+  &:hover {
+    background-color: ${colors.faint};
+  }
 `;


### PR DESCRIPTION
This PR addresses visual polish items ahead of launching hidden nfts

- [x] sidebar global padding should be 4px (some items within the sidebar have more padding)
- [x] add hover state to collected/hidden selector
- [x] vertically align text for sidebar items

Hover state:
![Screen Shot 2022-11-16 at 16 52 07](https://user-images.githubusercontent.com/80802871/202120094-602e709d-d307-4a26-acc4-21bf5ee7b0de.png)
Added the hover state for when the dropdown is open too, so it still appears "pressed down" after you hover off
![Screen Shot 2022-11-16 at 16 52 10](https://user-images.githubusercontent.com/80802871/202120120-defaeb85-bf15-45f6-b6bd-2f526b295347.png)


4px padding:
(search bar + hidden dropdown + collected selector have 4px padding, other items have more)
![Screen Shot 2022-11-16 at 16 51 34](https://user-images.githubusercontent.com/80802871/202119893-cc914162-7f6f-44dc-a8d9-8dadd4532f05.png)


Vertically aligned text:
(the drop shadow in the screenshot is cus I used another browser window as a straightedge lol)
![Screen Shot 2022-11-16 at 16 51 58](https://user-images.githubusercontent.com/80802871/202119855-a847aed1-a974-4ca5-a385-71be5578ee33.png)
