### PR TITLE
Pre Launch Fixes: GAL-666 GAL-650 GAL-680 GAL-639 GAL-685 GAL-629 GAL-628 GAL-625

### DIFF
--- a/src/components/Email/EmailForm.tsx
+++ b/src/components/Email/EmailForm.tsx
@@ -164,7 +164,7 @@ function EmailForm({ setIsEditMode, queryRef, onClose }: Props) {
           autoFocus
           disabled={savePending}
         />
-        <HStack justify={showCancelButton ? 'space-between' : 'flex-end'} align="flex-end">
+        <HStack justify="flex-end" align="flex-end" gap={8}>
           {showCancelButton && (
             <Button variant="secondary" disabled={savePending} onClick={handleCancelClick}>
               Cancel

--- a/src/components/Email/EmailVerificationStatus.tsx
+++ b/src/components/Email/EmailVerificationStatus.tsx
@@ -122,11 +122,14 @@ function EmailVerificationStatus({ setIsEditMode, queryRef }: Props) {
         );
     }
   }, [resendEmailButton, verificationStatus]);
+
   return (
     <HStack justify="space-between">
       <VStack>
         <BaseM>{savedEmail}</BaseM>
-        <HStack gap={4}>{verificationStatusIndicator}</HStack>
+        <HStack gap={4} align="center">
+          {verificationStatusIndicator}
+        </HStack>
       </VStack>
       <StyledButton variant="secondary" onClick={handleEditClick}>
         EDIT

--- a/src/components/Email/EmailVerificationStatus.tsx
+++ b/src/components/Email/EmailVerificationStatus.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo } from 'react';
-import { graphql, useFragment } from 'react-relay';
+import { useCallback, useEffect, useMemo } from 'react';
+import { graphql, useRefetchableFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { EmailVerificationStatusFragment$key } from '~/generated/EmailVerificationStatusFragment.graphql';
 import { EmailVerificationStatusMutation } from '~/generated/EmailVerificationStatusMutation.graphql';
+import { RefetchableEmailVerificationStatusFragment } from '~/generated/RefetchableEmailVerificationStatusFragment.graphql';
 import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
 import AlertTriangleIcon from '~/icons/AlertTriangleIcon';
 import CircleCheckIcon from '~/icons/CircleCheckIcon';
@@ -15,15 +16,21 @@ import colors from '../core/colors';
 import { HStack, VStack } from '../core/Spacer/Stack';
 import { BaseM, BaseS } from '../core/Text/Text';
 
+const POLLING_INTERVAL_MS = 5000;
+
 type Props = {
   setIsEditMode: (editMode: boolean) => void;
   queryRef: EmailVerificationStatusFragment$key;
 };
 
 function EmailVerificationStatus({ setIsEditMode, queryRef }: Props) {
-  const query = useFragment(
+  const [query, refetch] = useRefetchableFragment<
+    RefetchableEmailVerificationStatusFragment,
+    EmailVerificationStatusFragment$key
+  >(
     graphql`
-      fragment EmailVerificationStatusFragment on Query {
+      fragment EmailVerificationStatusFragment on Query
+      @refetchable(queryName: "RefetchableEmailVerificationStatusFragment") {
         viewer {
           ... on Viewer {
             user {
@@ -86,6 +93,27 @@ function EmailVerificationStatus({ setIsEditMode, queryRef }: Props) {
       pushErrorToast();
     }
   }, [pushToast, resendVerificationEmail]);
+
+  useEffect(
+    function pollVerificationStatus() {
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+      async function fetchAndTimeout() {
+        await refetch({}, { fetchPolicy: 'store-and-network' });
+
+        timeoutId = setTimeout(fetchAndTimeout, POLLING_INTERVAL_MS);
+      }
+
+      timeoutId = setTimeout(fetchAndTimeout, POLLING_INTERVAL_MS);
+
+      return () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      };
+    },
+    [refetch]
+  );
 
   const resendEmailButton = useMemo(() => {
     return (

--- a/src/components/NftFailureFallback/NftFailureFallback.tsx
+++ b/src/components/NftFailureFallback/NftFailureFallback.tsx
@@ -68,7 +68,7 @@ export function NftFailureFallback({ onRetry, refreshing, size = 'medium' }: Pro
             onMouseDown={handleMouseDown}
             onClick={handleClick}
           >
-            <IconContainer icon={<RefreshIcon />} />
+            <IconContainer size="sm" icon={<RefreshIcon />} />
             <RefreshTooltip active={showTooltip} text="Refresh" />
           </IconButton>
         )}

--- a/src/components/NotificationsModal/Notification.tsx
+++ b/src/components/NotificationsModal/Notification.tsx
@@ -110,6 +110,7 @@ export function Notification({ notificationRef, queryRef }: NotificationProps) {
           <NotificationUserListModal notificationId={notification.id} fullscreen={isMobile} />
         ),
         isFullPage: isMobile,
+        hideClose: true,
         isPaddingDisabled: true,
         headerVariant: 'standard',
       });

--- a/src/components/NotificationsModal/NotificationEmailAlert.tsx
+++ b/src/components/NotificationsModal/NotificationEmailAlert.tsx
@@ -52,7 +52,7 @@ export function NotificationEmailAlert({ onDismiss, queryRef }: Props) {
         <HStack align="center" gap={8}>
           <InteractiveLink onClick={handleEnableEmails}>Enable</InteractiveLink>
           <StyledCloseButton onClick={handleDismiss}>
-            <CloseIcon isActive />
+            <CloseIcon />
           </StyledCloseButton>
         </HStack>
       </StyledAlert>
@@ -80,4 +80,5 @@ const StyledCloseButton = styled.button`
   background: none;
   border: none;
   padding: 0;
+  color: ${colors.offBlack};
 `;

--- a/src/components/NotificationsModal/NotificationUserListModal.tsx
+++ b/src/components/NotificationsModal/NotificationUserListModal.tsx
@@ -1,16 +1,16 @@
-import { Suspense, useCallback } from 'react';
+import { Suspense } from 'react';
 import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
+import { HStack } from '~/components/core/Spacer/Stack';
 import { USERS_PER_PAGE } from '~/components/NotificationsModal/constants';
 import { NotificationUserList } from '~/components/NotificationsModal/NotificationUserList/NotificationUserList';
 import { NotificationUserListTitle } from '~/components/NotificationsModal/NotificationUserListTitle';
-import { MODAL_PADDING_PX } from '~/contexts/modal/constants';
-import { NotificationUserListModalQuery } from '~/generated/NotificationUserListModalQuery.graphql';
 import { BackButton } from '~/contexts/globalLayout/GlobalNavbar/BackButton';
-import { HStack } from '~/components/core/Spacer/Stack';
+import { MODAL_PADDING_PX } from '~/contexts/modal/constants';
 import { useModalActions } from '~/contexts/modal/ModalContext';
+import { NotificationUserListModalQuery } from '~/generated/NotificationUserListModalQuery.graphql';
 
 type NotificationUserListModalProps = {
   notificationId: string;

--- a/src/components/NotificationsModal/NotificationUserListModal.tsx
+++ b/src/components/NotificationsModal/NotificationUserListModal.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import { Suspense, useCallback } from 'react';
 import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
@@ -8,6 +8,9 @@ import { NotificationUserList } from '~/components/NotificationsModal/Notificati
 import { NotificationUserListTitle } from '~/components/NotificationsModal/NotificationUserListTitle';
 import { MODAL_PADDING_PX } from '~/contexts/modal/constants';
 import { NotificationUserListModalQuery } from '~/generated/NotificationUserListModalQuery.graphql';
+import { BackButton } from '~/contexts/globalLayout/GlobalNavbar/BackButton';
+import { HStack } from '~/components/core/Spacer/Stack';
+import { useModalActions } from '~/contexts/modal/ModalContext';
 
 type NotificationUserListModalProps = {
   notificationId: string;
@@ -32,12 +35,17 @@ export function NotificationUserListModal({
     { notificationId, notificationUsersLast: USERS_PER_PAGE }
   );
 
+  const { hideModal } = useModalActions();
+
   return (
     <ModalContent fullscreen={fullscreen}>
       <StyledHeader>
-        <Suspense fallback={null}>
-          <NotificationUserListTitle queryRef={query} />
-        </Suspense>
+        <HStack align="center" gap={8}>
+          <BackButton onClick={hideModal} />
+          <Suspense fallback={null}>
+            <NotificationUserListTitle queryRef={query} />
+          </Suspense>
+        </HStack>
       </StyledHeader>
 
       <Suspense fallback={null}>

--- a/src/components/NotificationsModal/NotificationUserListModal.tsx
+++ b/src/components/NotificationsModal/NotificationUserListModal.tsx
@@ -3,13 +3,11 @@ import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
-import IconContainer from '~/components/core/Markdown/IconContainer';
 import { HStack } from '~/components/core/Spacer/Stack';
 import { USERS_PER_PAGE } from '~/components/NotificationsModal/constants';
 import { NotificationUserList } from '~/components/NotificationsModal/NotificationUserList/NotificationUserList';
 import { NotificationUserListTitle } from '~/components/NotificationsModal/NotificationUserListTitle';
 import { BackButton } from '~/contexts/globalLayout/GlobalNavbar/BackButton';
-import { MODAL_PADDING_PX } from '~/contexts/modal/constants';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { NotificationUserListModalQuery } from '~/generated/NotificationUserListModalQuery.graphql';
 

--- a/src/components/NotificationsModal/NotificationUserListModal.tsx
+++ b/src/components/NotificationsModal/NotificationUserListModal.tsx
@@ -3,6 +3,7 @@ import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
+import IconContainer from '~/components/core/Markdown/IconContainer';
 import { HStack } from '~/components/core/Spacer/Stack';
 import { USERS_PER_PAGE } from '~/components/NotificationsModal/constants';
 import { NotificationUserList } from '~/components/NotificationsModal/NotificationUserList/NotificationUserList';
@@ -43,21 +44,32 @@ export function NotificationUserListModal({
         <HStack align="center" gap={8}>
           <BackButton onClick={hideModal} />
           <Suspense fallback={null}>
-            <NotificationUserListTitle queryRef={query} />
+            <ModalTitle>
+              <NotificationUserListTitle queryRef={query} />
+            </ModalTitle>
           </Suspense>
         </HStack>
       </StyledHeader>
 
       <Suspense fallback={null}>
-        <NotificationUserList queryRef={query} />
+        <ModalBody>
+          <NotificationUserList queryRef={query} />
+        </ModalBody>
       </Suspense>
     </ModalContent>
   );
 }
 
+const ModalTitle = styled.div`
+  padding: 16px 0;
+`;
+
+const ModalBody = styled.div`
+  padding: 0 4px;
+`;
+
 const StyledHeader = styled.div`
-  padding-bottom: ${MODAL_PADDING_PX}px;
-  padding-left: 12px;
+  padding: 0 8px;
 `;
 
 const ModalContent = styled.div<{ fullscreen: boolean }>`
@@ -65,5 +77,4 @@ const ModalContent = styled.div<{ fullscreen: boolean }>`
   width: ${({ fullscreen }) => (fullscreen ? '100%' : '420px')};
   display: flex;
   flex-direction: column;
-  padding: ${MODAL_PADDING_PX}px 4px;
 `;

--- a/src/components/NotificationsModal/useNotificationsModal.tsx
+++ b/src/components/NotificationsModal/useNotificationsModal.tsx
@@ -3,6 +3,7 @@ import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
+import IconContainer from '~/components/core/Markdown/IconContainer';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { useNotificationsModalQuery } from '~/generated/useNotificationsModalQuery.graphql';
 import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
@@ -39,11 +40,7 @@ export default function useNotificationsModal() {
       });
     };
 
-    return (
-      <StyledCogButton onClick={handleSettingsClick}>
-        <CogIcon />
-      </StyledCogButton>
-    );
+    return <IconContainer onClick={handleSettingsClick} icon={<CogIcon />}></IconContainer>;
   }, [hideModal, showModal, query]);
 
   return useCallback(() => {

--- a/src/components/NotificationsModal/useNotificationsModal.tsx
+++ b/src/components/NotificationsModal/useNotificationsModal.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
-import styled from 'styled-components';
 
 import IconContainer from '~/components/core/Markdown/IconContainer';
 import { useModalActions } from '~/contexts/modal/ModalContext';
@@ -11,7 +10,6 @@ import CogIcon from '~/icons/CogIcon';
 import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
 import SettingsModal from '../../scenes/Modals/SettingsModal';
-import colors from '../core/colors';
 import { NotificationsModal } from './NotificationsModal';
 
 export default function useNotificationsModal() {
@@ -53,18 +51,3 @@ export default function useNotificationsModal() {
     });
   }, [isEmailFeatureEnabled, isMobile, notificationModalActions, showModal]);
 }
-
-const StyledCogButton = styled.button`
-  background: none;
-  border: none;
-  padding: 8px;
-  margin: 0;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  :hover {
-    background-color: ${colors.faint};
-  }
-`;

--- a/src/components/core/Markdown/Bold.tsx
+++ b/src/components/core/Markdown/Bold.tsx
@@ -60,6 +60,7 @@ export default function Bold({
 
   return (
     <IconContainer
+      size="sm"
       icon={
         <svg
           data-testid="markdown-icon"

--- a/src/components/core/Markdown/IconContainer.tsx
+++ b/src/components/core/Markdown/IconContainer.tsx
@@ -1,17 +1,25 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import colors from '../colors';
+
+type Size = 'sm' | 'md' | 'lg';
 
 export default function IconContainer({
   icon,
   className,
+  onClick,
+  size = 'md',
 }: {
+  onClick?: () => void;
   icon: React.ReactElement;
   className?: string;
+  size?: Size;
 }) {
   return (
     <StyledIcon
+      onClick={onClick}
+      size={size}
       className={className}
       onMouseDown={(e) => {
         // This will prevent the textarea from losing focus when user clicks a markdown icon
@@ -23,12 +31,35 @@ export default function IconContainer({
   );
 }
 
-const StyledIcon = styled.div`
+const StyledIcon = styled.div<{ size: Size }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   cursor: pointer;
-  height: 24px;
+
+  ${({ size }) => {
+    if (size === 'sm') {
+      return css`
+        height: 24px;
+        width: 24px;
+      `;
+    } else if (size === 'md') {
+      return css`
+        height: 32px;
+        width: 32px;
+      `;
+    } else if (size === 'lg') {
+      return css`
+        height: 40px;
+        width: 40px;
+      `;
+    }
+  }}
+
+  color: ${colors.offBlack};
 
   &:hover {
-    background: ${colors.porcelain};
+    background: ${colors.faint};
   }
 
   &:active {

--- a/src/components/core/Markdown/Link.tsx
+++ b/src/components/core/Markdown/Link.tsx
@@ -53,6 +53,7 @@ export default function Bold({
 
   return (
     <IconContainer
+      size="sm"
       icon={
         <svg
           data-testid="markdown-icon"

--- a/src/contexts/globalLayout/GlobalNavbar/BackButton.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/BackButton.tsx
@@ -1,24 +1,30 @@
 import styled from 'styled-components';
 
+import IconContainer from '~/components/core/Markdown/IconContainer';
+
 type Props = {
   onClick: () => void;
 };
 
 export function BackButton({ onClick }: Props) {
   return (
-    <StyledSvg
+    <IconContainer
+      size="md"
       onClick={onClick}
-      role="button"
-      width="32"
-      height="32"
-      viewBox="0 0 32 32"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <rect width="32" height="32" rx="1" fill="#FEFEFE" />
-      <path d="M14.6667 11.3334L10 16L14.6667 20.6667" stroke="black" strokeMiterlimit="10" />
-      <path d="M10 16H22.6667" stroke="black" strokeMiterlimit="10" />
-    </StyledSvg>
+      icon={
+        <StyledSvg
+          role="button"
+          width="32px"
+          height="32px"
+          viewBox="0 0 32 32"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M14.6667 11.3334L10 16L14.6667 20.6667" stroke="black" strokeMiterlimit="10" />
+          <path d="M10 16H22.6667" stroke="black" strokeMiterlimit="10" />
+        </StyledSvg>
+      }
+    />
   );
 }
 

--- a/src/contexts/globalLayout/GlobalNavbar/CollectionSaveButtonWithCaption.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/CollectionSaveButtonWithCaption.tsx
@@ -129,7 +129,7 @@ export function CollectionSaveButtonWithCaption({
           <>
             <HStack justify="flex-end">
               <StyledCloseButton onClick={handleCloseCaption}>
-                <CloseIcon isActive={true} />
+                <CloseIcon />
               </StyledCloseButton>
             </HStack>
             {hasUnsavedChange ? (
@@ -197,6 +197,7 @@ const StyledCloseButton = styled.button`
   border: none;
   padding: 0;
   cursor: pointer;
+  color: ${colors.offBlack};
 `;
 
 const StyledConfirmationContent = styled(VStack)`

--- a/src/contexts/modal/AnimatedModal.tsx
+++ b/src/contexts/modal/AnimatedModal.tsx
@@ -30,6 +30,7 @@ type Props = {
   headerActions?: JSX.Element | false;
   headerText: string;
   headerVariant: ModalPaddingVariant;
+  hideClose?: boolean;
 };
 
 function AnimatedModal({
@@ -42,6 +43,7 @@ function AnimatedModal({
   headerActions,
   headerText,
   headerVariant,
+  hideClose,
 }: Props) {
   useEffect(() => {
     if (!isActive) {
@@ -95,7 +97,9 @@ function AnimatedModal({
               {headerText ? <StyledTitleS>{headerText}</StyledTitleS> : null}
               <StyledModalActions align="center">
                 {headerActions}
-                <DecoratedCloseIcon onClick={hideModal} variant={headerVariant} />
+                {hideClose ? null : (
+                  <DecoratedCloseIcon onClick={hideModal} variant={headerVariant} />
+                )}
               </StyledModalActions>
             </StyledHeader>
             {content}

--- a/src/contexts/modal/ModalContext.tsx
+++ b/src/contexts/modal/ModalContext.tsx
@@ -42,6 +42,7 @@ type ShowModalFnProps = {
   headerText?: string;
   headerVariant?: ModalPaddingVariant;
   isFullPage?: boolean;
+  hideClose?: boolean;
   isPaddingDisabled?: boolean;
   onClose?: () => void;
   headerActions?: JSX.Element | false;
@@ -80,6 +81,7 @@ type Modal = {
   headerVariant: ModalPaddingVariant;
   isFullPage: boolean;
   isPaddingDisabled: boolean;
+  hideClose: boolean;
   onClose: () => void;
 };
 
@@ -100,6 +102,7 @@ function ModalProvider({ children }: Props) {
       content,
       headerActions,
       headerText = '',
+      hideClose = false,
       headerVariant = 'standard',
       isFullPage = false,
       isPaddingDisabled = false,
@@ -112,6 +115,7 @@ function ModalProvider({ children }: Props) {
           isActive: true,
           content,
           headerActions,
+          hideClose,
           headerText,
           headerVariant,
           isFullPage,
@@ -248,6 +252,7 @@ function ModalProvider({ children }: Props) {
             headerVariant,
             isFullPage,
             isPaddingDisabled,
+            hideClose,
           }) => {
             return (
               <AnimatedModal
@@ -259,6 +264,7 @@ function ModalProvider({ children }: Props) {
                 headerText={headerText}
                 isFullPage={isFullPage}
                 isPaddingDisabled={isPaddingDisabled}
+                hideClose={hideClose}
                 headerVariant={headerVariant}
                 headerActions={headerActions}
               />

--- a/src/contexts/toast/Toast.tsx
+++ b/src/contexts/toast/Toast.tsx
@@ -99,7 +99,7 @@ function Toast({ message, onClose, variant }: Props) {
         )}
         <BaseM>{message}</BaseM>
         <StyledClose onClick={handleClose}>
-          <CloseIcon isActive />
+          <CloseIcon />
         </StyledClose>
       </StyledToast>
     </ToastContainer>
@@ -132,6 +132,7 @@ const StyledClose = styled.button`
   align-items: center;
   margin-left: 8px;
   cursor: pointer;
+  color: ${colors.offBlack};
 
   background: none;
   border: none;

--- a/src/icons/CloseIcon.tsx
+++ b/src/icons/CloseIcon.tsx
@@ -1,30 +1,20 @@
-import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
-import colors from '~/components/core/colors';
-import {
-  MODAL_PADDING_PX,
-  MODAL_PADDING_THICC_PX,
-  ModalPaddingVariant,
-} from '~/contexts/modal/constants';
+import IconContainer from '~/components/core/Markdown/IconContainer';
+import { ModalPaddingVariant } from '~/contexts/modal/constants';
 
-type Props = {
-  isActive: boolean;
-};
-
-export default function CloseIcon({ isActive }: Props) {
+export default function CloseIcon() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M12.6667 3.33333L3.33333 12.6667"
-        stroke={isActive ? colors.offBlack : colors.shadow}
-        strokeMiterlimit="10"
-      />
-      <path
-        d="M3.33333 3.33333L12.6667 12.6667"
-        stroke={isActive ? colors.offBlack : colors.shadow}
-        strokeMiterlimit="10"
-      />
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M12.6667 3.33333L3.33333 12.6667" strokeMiterlimit="10" />
+      <path d="M3.33333 3.33333L12.6667 12.6667" strokeMiterlimit="10" />
     </svg>
   );
 }
@@ -40,31 +30,15 @@ export function DecoratedCloseIcon({
   onClick,
   variant = 'standard',
 }: DecoratedCloseIconProps) {
-  const [isHoveringOverCloseIcon, setIsHoveringOverCloseIcon] = useState(false);
-
-  const handleCloseHover = useCallback(() => {
-    setIsHoveringOverCloseIcon(true);
-  }, []);
-
-  const handleCloseLeave = useCallback(() => {
-    setIsHoveringOverCloseIcon(false);
-  }, []);
-
   return (
-    <StyledDecoratedCloseIcon
-      className={className}
-      onClick={onClick}
-      onMouseEnter={handleCloseHover}
-      onMouseLeave={handleCloseLeave}
-      variant={variant}
-    >
-      <CloseIcon isActive={isHoveringOverCloseIcon} />
+    <StyledDecoratedCloseIcon className={className} variant={variant}>
+      <IconContainer onClick={onClick} icon={<CloseIcon />} />
     </StyledDecoratedCloseIcon>
   );
 }
 
 const StyledDecoratedCloseIcon = styled.div<{ variant: DecoratedCloseIconProps['variant'] }>`
   cursor: pointer;
-  padding: ${({ variant }) =>
-    variant === 'standard' ? MODAL_PADDING_PX : MODAL_PADDING_THICC_PX}px;
+  padding: ${({ variant }) => (variant === 'standard' ? 8 : 16)}px;
+  padding-left: 0;
 `;

--- a/src/scenes/UserActivityPage/UserActivityFeed.tsx
+++ b/src/scenes/UserActivityPage/UserActivityFeed.tsx
@@ -7,6 +7,7 @@ import FeedList from '~/components/Feed/FeedList';
 import { UserActivityFeedFragment$key } from '~/generated/UserActivityFeedFragment.graphql';
 import { UserActivityFeedQueryFragment$key } from '~/generated/UserActivityFeedQueryFragment.graphql';
 import { UserFeedByUserIdPaginationQuery } from '~/generated/UserFeedByUserIdPaginationQuery.graphql';
+import { EmptyState } from '~/components/EmptyState/EmptyState';
 
 type Props = {
   userRef: UserActivityFeedFragment$key;
@@ -46,6 +47,7 @@ function UserActivityFeed({ userRef, queryRef }: Props) {
 
         feedEventById(id: $topEventId) {
           ... on FeedEvent {
+            __typename
             ...FeedListEventDataFragment
           }
         }
@@ -73,12 +75,21 @@ function UserActivityFeed({ userRef, queryRef }: Props) {
       }
     }
 
-    if (query.feedEventById) {
+    if (query.feedEventById?.__typename === 'FeedEvent') {
       events.push(query.feedEventById);
     }
 
     return events;
   }, [query.feedEventById, user.feed?.edges]);
+
+  if (feedData.length === 0) {
+    return (
+      <EmptyState
+        title={"It's quiet in here"}
+        description="This user doesn't seem to have any activity yet."
+      />
+    );
+  }
 
   return (
     <FeedList

--- a/src/scenes/UserActivityPage/UserActivityFeed.tsx
+++ b/src/scenes/UserActivityPage/UserActivityFeed.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useMemo } from 'react';
 import { graphql, useFragment, usePaginationFragment } from 'react-relay';
 
+import { EmptyState } from '~/components/EmptyState/EmptyState';
 import { useTrackLoadMoreFeedEvents } from '~/components/Feed/analytics';
 import { ITEMS_PER_PAGE } from '~/components/Feed/constants';
 import FeedList from '~/components/Feed/FeedList';
 import { UserActivityFeedFragment$key } from '~/generated/UserActivityFeedFragment.graphql';
 import { UserActivityFeedQueryFragment$key } from '~/generated/UserActivityFeedQueryFragment.graphql';
 import { UserFeedByUserIdPaginationQuery } from '~/generated/UserFeedByUserIdPaginationQuery.graphql';
-import { EmptyState } from '~/components/EmptyState/EmptyState';
 
 type Props = {
   userRef: UserActivityFeedFragment$key;


### PR DESCRIPTION
### Screenshots

#### Verification status alignment
<img width="502" alt="image" src="https://user-images.githubusercontent.com/6754223/202300896-bcb331a0-e35e-4e05-84ef-eb549c5a133e.png">

#### Cancel button right aligned
<img width="503" alt="image" src="https://user-images.githubusercontent.com/6754223/202301064-6ce7d87b-8cdd-4d8f-a7a7-42c64395eee4.png">

#### Modal close icons
All modals now use the design system icon container. I made sure the other usages of the icons were good and modal alignment was good

<img width="502" alt="image" src="https://user-images.githubusercontent.com/6754223/202301308-89f0b596-7d2f-4cfb-a8e0-961d29bbc809.png">

#### Back button on user list modal
<img width="420" alt="image" src="https://user-images.githubusercontent.com/6754223/202302187-1a37c436-f166-4529-ac40-1ec0bd849f88.png">

#### Verification Status Polling
I confirmed with my own account that this polling works

#### Loading more rows glitching fix

I want to call out why using `keyMapper` instead of blowing the `CellMeasurerCache` fixed the glitching problem when loading more results.

Previously, wiping the cache was a good workaround whenever new results loaded at the top of the list. Let's say we have item A at index 0 w/ a height of 420 px. When we refresh the feed, item B comes to the top of the list at index 0 w/ a height of 69px. You can see how caching the heights based on index becomes a problem. RV thinks that index 0 should have a height of 420px when it should clearly have a height of 69px. 

Completely blowing the cache works because RV will recompute the height for every item.

Now consider when we're at the bottom of the list and we load more things.  **The feed data has changed, so we wipe the measurement cache**. Okay, nbd so far. RV will recompute the row heights, **BUT ONLY THE ONES THAT ITS RENDERING IN THE VIEWPORT**. RV will assume a height of 400px for everything else not in the viewport. This cause RV's scroll position to get all fucked up because it doesn't know the true height of each item.

Using a keymapper lets us get the best of both worlds. We don't have to recompute all the items' heights and shifting content works perfectly