### PR TITLE
DONT LOOK AT THIS PR (Fix feed event styling)

### DIFF
--- a/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -120,7 +120,10 @@ export default function CollectionCreatedFeedEvent({ caption, eventDataRef, quer
               </StyledCaptionContainer>
             )}
             <VStack gap={8}>
-              <FeedEventTokenPreviews tokensToPreview={tokensToPreview} />
+              <FeedEventTokenPreviews
+                isInCaption={Boolean(caption)}
+                tokensToPreview={tokensToPreview}
+              />
               {showAdditionalPiecesIndicator && (
                 <StyledAdditionalPieces>
                   +{numAdditionalPieces} more {pluralize(numAdditionalPieces, 'piece')}

--- a/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
@@ -99,17 +99,17 @@ export default function CollectionUpdatedFeedEvent({ eventDataRef, queryRef }: P
             <HStack gap={4} inline>
               <BaseM>
                 <HoverCardOnUsername userRef={event.owner} queryRef={query} /> made updates to
-                {collectionName ? ' ': 'their collection'}
+                {collectionName ? ' ' : 'their collection'}
                 <InteractiveLink to={collectionPagePath}>{collectionName}</InteractiveLink>
               </BaseM>
               <StyledTime>{getTimeSince(event.eventTime)}</StyledTime>
             </HStack>
           </StyledEventHeader>
-            <StyledQuote>
-              <Markdown text={unescape(event.newCollectorsNote ?? '')} inheritLinkStyling />
-            </StyledQuote>
+          <StyledQuote>
+            <Markdown text={unescape(event.newCollectorsNote ?? '')} inheritLinkStyling />
+          </StyledQuote>
           <VStack gap={8}>
-            <FeedEventTokenPreviews tokensToPreview={tokensToPreview} />
+            <FeedEventTokenPreviews isInCaption={false} tokensToPreview={tokensToPreview} />
             {showAdditionalPiecesIndicator && (
               <StyledAdditionalPieces>
                 +{numAdditionalPieces} more {pluralize(numAdditionalPieces, 'piece')}
@@ -125,7 +125,7 @@ export default function CollectionUpdatedFeedEvent({ eventDataRef, queryRef }: P
 const StyledAdditionalPieces = styled(BaseS)`
   text-align: end;
   color: ${colors.metal};
-`
+`;
 const StyledQuote = styled(BaseM)`
   color: ${colors.metal};
   border-left: 2px solid ${colors.porcelain};
@@ -133,5 +133,5 @@ const StyledQuote = styled(BaseM)`
 
   @media only screen and ${breakpoints.tablet} {
     max-width: 50%;
-  };
-`
+  } ;
+`;

--- a/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -104,7 +104,10 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({
             <StyledQuote>
               <Markdown text={unescape(event.newCollectorsNote ?? '')} inheritLinkStyling />
             </StyledQuote>
-            <FeedEventTokenPreviews tokensToPreview={event.collection.tokens as TokenToPreview[]} />
+            <FeedEventTokenPreviews
+              isInCaption={Boolean(event.newCollectorsNote)}
+              tokensToPreview={event.collection.tokens as TokenToPreview[]}
+            />
           </StyledEventContent>
           {/* [GAL-608] Bring this back once we fix perf around tokenURI
           {showAdditionalPiecesIndicator && (

--- a/src/components/Feed/Events/EventStyles.tsx
+++ b/src/components/Feed/Events/EventStyles.tsx
@@ -1,12 +1,9 @@
 import { ReactNode } from 'react';
 import styled from 'styled-components';
 
-import breakpoints from '~/components/core/breakpoints';
 import colors from '~/components/core/colors';
 import { VStack } from '~/components/core/Spacer/Stack';
 import { BaseS } from '~/components/core/Text/Text';
-
-import { FEED_EVENT_ROW_WIDTH_DESKTOP } from '../dimensions';
 
 type StyledEventProps = {
   children: ReactNode;
@@ -16,39 +13,14 @@ type StyledEventProps = {
 
 export const StyledEvent = ({ children, className, onClick }: StyledEventProps) => {
   return (
-    <StyledEventWrapper className={className} onClick={onClick}>
-      <StyledInnerEvent>{children}</StyledInnerEvent>
-    </StyledEventWrapper>
+    <StyledInnerEvent onClick={onClick} className={className}>
+      {children}
+    </StyledInnerEvent>
   );
 };
 
 export const StyledInnerEvent = styled.div`
-  width: 100%;
-
-  @media only screen and ${breakpoints.desktop} {
-    max-width: initial;
-    width: ${FEED_EVENT_ROW_WIDTH_DESKTOP}px;
-  }
-`;
-
-// base styles for feed events
-export const StyledEventWrapper = styled.div`
-  width: 100%;
-
-  display: flex;
-  justify-content: center;
-
-  padding: 24px 16px;
-
-  @media only screen and ${breakpoints.tablet} {
-    padding: 16px 32px;
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    padding: 16px;
-  }
-
-  cursor: pointer;
+  flex-grow: 1;
 `;
 
 export const StyledEventHeader = styled.div`
@@ -75,5 +47,5 @@ export const StyledClickHandler = styled.a`
 
 export const StyledEventContent = styled(VStack)<{ hasCaption?: boolean }>`
   background-color: ${({ hasCaption }) => (hasCaption ? colors.offWhite : 'transparent')};
-  padding: 12px;
+  padding: ${({ hasCaption }) => (hasCaption ? '16px' : '0')};
 `;

--- a/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -122,7 +122,10 @@ export default function TokensAddedToCollectionFeedEvent({
                 <BaseM>{caption}</BaseM>
               </StyledCaptionContainer>
             )}
-            <FeedEventTokenPreviews tokensToPreview={tokensToPreview} />
+            <FeedEventTokenPreviews
+              isInCaption={Boolean(caption)}
+              tokensToPreview={tokensToPreview}
+            />
             {showAdditionalPiecesIndicator && !isPreFeed && (
               <StyledAdditionalPieces>
                 +{numAdditionalPieces} more {pluralize(numAdditionalPieces, 'piece')}

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -6,7 +6,6 @@ import breakpoints from '~/components/core/breakpoints';
 import { VStack } from '~/components/core/Spacer/Stack';
 import { FeedViewerFragment$key } from '~/generated/FeedViewerFragment.graphql';
 
-import { FEED_MAX_WIDTH } from './dimensions';
 import GlobalFeed from './GlobalFeed';
 import ViewerFeed from './ViewerFeed';
 
@@ -49,9 +48,5 @@ const StyledFeed = styled(VStack)`
 
   @media only screen and ${breakpoints.tablet} {
     padding-top: 24px;
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    width: ${FEED_MAX_WIDTH}px;
   }
 `;

--- a/src/components/Feed/FeedEvent.tsx
+++ b/src/components/Feed/FeedEvent.tsx
@@ -3,7 +3,9 @@ import { useCallback } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
+import breakpoints from '~/components/core/breakpoints';
 import { VStack } from '~/components/core/Spacer/Stack';
+import { FEED_EVENT_ROW_WIDTH_DESKTOP } from '~/components/Feed/dimensions';
 import { FeedEventSocializeSection } from '~/components/Feed/Socialize/FeedEventSocializeSection';
 import { FeedEventFragment$key } from '~/generated/FeedEventFragment.graphql';
 import { FeedEventQueryFragment$key } from '~/generated/FeedEventQueryFragment.graphql';
@@ -178,7 +180,7 @@ export default function FeedEventWithBoundary({
 
   return (
     <FeedEventErrorBoundary>
-      <FeedEventContainer>
+      <FeedEventContainer gap={16}>
         <FeedEvent eventRef={event} queryRef={query} feedMode={feedMode} />
 
         {shouldShowAdmireComment && (
@@ -196,5 +198,24 @@ export default function FeedEventWithBoundary({
 }
 
 const FeedEventContainer = styled(VStack)`
+  margin: 0 auto;
+
   border-bottom: 1px solid ${colors.faint};
+
+  padding: 24px 16px;
+
+  @media only screen and ${breakpoints.tablet} {
+    padding: 16px 32px;
+  }
+
+  @media only screen and ${breakpoints.desktop} {
+    padding: 16px;
+  }
+
+  cursor: pointer;
+
+  @media only screen and ${breakpoints.desktop} {
+    max-width: initial;
+    width: ${FEED_EVENT_ROW_WIDTH_DESKTOP}px;
+  }
 `;

--- a/src/components/Feed/FeedEventTokenPreviews.tsx
+++ b/src/components/Feed/FeedEventTokenPreviews.tsx
@@ -13,9 +13,10 @@ export type TokenToPreview = EventMediaFragment$key & {
 
 type Props = {
   tokensToPreview: TokenToPreview[];
+  isInCaption: boolean;
 };
 
-export default function FeedEventTokenPreviews({ tokensToPreview }: Props) {
+export default function FeedEventTokenPreviews({ tokensToPreview, isInCaption }: Props) {
   const breakpoint = useBreakpoint();
   const { width } = useWindowSize();
 
@@ -24,8 +25,9 @@ export default function FeedEventTokenPreviews({ tokensToPreview }: Props) {
       numTokens: `${tokensToPreview.length}` as NumTokens,
       maxWidth: width,
       breakpoint,
+      isInCaption,
     });
-  }, [breakpoint, tokensToPreview.length, width]);
+  }, [breakpoint, isInCaption, tokensToPreview.length, width]);
 
   return (
     <StyledFeedEventTokenPreviews>

--- a/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -3,9 +3,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
-import breakpoints from '~/components/core/breakpoints';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { FEED_EVENT_ROW_WIDTH_DESKTOP } from '~/components/Feed/dimensions';
 import { AdmireButton } from '~/components/Feed/Socialize/AdmireButton';
 import { CommentBox } from '~/components/Feed/Socialize/CommentBox';
 import { Interactions } from '~/components/Feed/Socialize/Interactions';
@@ -82,64 +80,34 @@ export function FeedEventSocializeSection({
   }, [query, showModal]);
 
   return (
-    <SocializeSectionWrapper>
-      <SocializedSectionPadding>
-        <HStack justify="space-between" align="flex-end" gap={24}>
-          <VStack shrink>
-            <Interactions
-              onPotentialLayoutShift={onPotentialLayoutShift}
-              eventRef={event}
-              queryRef={query}
-            />
-          </VStack>
+    <HStack justify="space-between" align="flex-start" gap={24}>
+      <VStack shrink>
+        <Interactions
+          onPotentialLayoutShift={onPotentialLayoutShift}
+          eventRef={event}
+          queryRef={query}
+        />
+      </VStack>
 
-          <HStack align="center">
-            <IconWrapper>
-              <AdmireButton eventRef={event} queryRef={query} />
-            </IconWrapper>
+      <HStack align="center">
+        <IconWrapper>
+          <AdmireButton eventRef={event} queryRef={query} />
+        </IconWrapper>
 
-            <IconWrapper>
-              <CommentIcon onClick={handleToggle} ref={commentIconRef} />
+        <IconWrapper>
+          <CommentIcon onClick={handleToggle} ref={commentIconRef} />
 
-              <CommentBox
-                onClose={handleClose}
-                eventRef={event}
-                queryRef={query}
-                active={showCommentBox}
-              />
-            </IconWrapper>
-          </HStack>
-        </HStack>
-      </SocializedSectionPadding>
-    </SocializeSectionWrapper>
+          <CommentBox
+            onClose={handleClose}
+            eventRef={event}
+            queryRef={query}
+            active={showCommentBox}
+          />
+        </IconWrapper>
+      </HStack>
+    </HStack>
   );
 }
-
-const SocializedSectionPadding = styled.div`
-  padding: 0 16px;
-
-  @media only screen and ${breakpoints.tablet} {
-    padding: 0 32px;
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    padding: 0 16px;
-  }
-`;
-
-// Modeled after StyledEventInner
-const SocializeSectionWrapper = styled.div`
-  width: 100%;
-
-  @media only screen and ${breakpoints.desktop} {
-    max-width: initial;
-    width: ${FEED_EVENT_ROW_WIDTH_DESKTOP}px;
-  }
-
-  // Center in space
-  margin: 0 auto;
-  padding-bottom: 16px;
-`;
 
 const IconWrapper = styled.div`
   position: relative;

--- a/src/components/Feed/dimensions.ts
+++ b/src/components/Feed/dimensions.ts
@@ -21,6 +21,7 @@ type getFeedTokenDimensionsProps = {
   numTokens: NumTokens;
   maxWidth: number;
   breakpoint: size;
+  isInCaption?: boolean;
 };
 
 export type NumTokens = '1' | '2' | '3' | '4';
@@ -30,13 +31,18 @@ export const getFeedTokenDimensions = ({
   numTokens,
   maxWidth,
   breakpoint,
+  isInCaption,
 }: getFeedTokenDimensionsProps): NumTokensToDimensionMap[NumTokens] => {
+  const paddingCount = isInCaption ? 4 : 2;
+
   if (breakpoint === size.desktop) {
     return {
       '1': 380,
       '2': 340,
       '3': 340,
-      '4': (FEED_MAX_WIDTH - FEED_EVENT_TOKEN_MARGIN * 3 - FEED_EVENT_PADDING_DESKTOP * 2) / 4,
+      '4':
+        (FEED_MAX_WIDTH - FEED_EVENT_TOKEN_MARGIN * 3 - FEED_EVENT_PADDING_DESKTOP * paddingCount) /
+        4,
     }[numTokens];
   }
 
@@ -44,15 +50,15 @@ export const getFeedTokenDimensions = ({
     return {
       '1': 380,
       '2': 320,
-      '3': (maxWidth - FEED_EVENT_TOKEN_MARGIN * 2 - FEED_EVENT_PADDING_TABLET * 2) / 3,
-      '4': (maxWidth - FEED_EVENT_TOKEN_MARGIN * 3 - FEED_EVENT_PADDING_TABLET * 2) / 4,
+      '3': (maxWidth - FEED_EVENT_TOKEN_MARGIN * 2 - FEED_EVENT_PADDING_TABLET * paddingCount) / 3,
+      '4': (maxWidth - FEED_EVENT_TOKEN_MARGIN * 3 - FEED_EVENT_PADDING_TABLET * paddingCount) / 4,
     }[numTokens];
   }
 
   return {
     '1': 320,
-    '2': (maxWidth - FEED_EVENT_TOKEN_MARGIN * 1 - FEED_EVENT_PADDING_MOBILE * 2) / 2,
-    '3': (maxWidth - FEED_EVENT_TOKEN_MARGIN * 2 - FEED_EVENT_PADDING_MOBILE * 2) / 3,
-    '4': (maxWidth - FEED_EVENT_TOKEN_MARGIN * 3 - FEED_EVENT_PADDING_MOBILE * 2) / 4,
+    '2': (maxWidth - FEED_EVENT_TOKEN_MARGIN * 1 - FEED_EVENT_PADDING_MOBILE * paddingCount) / 2,
+    '3': (maxWidth - FEED_EVENT_TOKEN_MARGIN * 2 - FEED_EVENT_PADDING_MOBILE * paddingCount) / 3,
+    '4': (maxWidth - FEED_EVENT_TOKEN_MARGIN * 3 - FEED_EVENT_PADDING_MOBILE * paddingCount) / 4,
   }[numTokens];
 };


### PR DESCRIPTION
`StyledEventWrapper` is old news now that we have `Interactions` involved. So a lot of the styles that were in `StyledEventWrapper` have now been moved to `FeedEventContainer` and we've completely removed `StyledEventWrapper`.

This consolidated some clashing styles between interactions / feed events and now the padding lives in one place.

## Nightmare logic
The `FeedEventTokenPreviews` has to manually manage widths right now due to reasons™️. I'm convinced we can make this better in the future, but not right now.

Those widths that are manually calculated now have to take into account that they can be inside of a captioned feed event which gets double padding. 

So we have this `isInCaption` which changes how many paddings we have to subtract from the total width.