### PR TITLE
[GAL-718] Fix save button for toggle live render

### DIFF
--- a/src/components/ManageGallery/OrganizeCollection/Editor/CollectionEditor.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Editor/CollectionEditor.tsx
@@ -21,8 +21,8 @@ import Directions from '../Directions';
 import Sidebar from '../Sidebar/Sidebar';
 import { EditModeToken, EditModeTokenChild, StagedCollection } from '../types';
 import EditorMenu from './EditorMenu';
-import { formatStagedCollection } from './formatStagedCollection';
 import StagingArea from './StagingArea';
+import useCheckUnsavedChanges from './useCheckUnsavedChanges';
 
 function convertNftsToEditModeTokens(
   tokens: EditModeTokenChild[],
@@ -110,6 +110,7 @@ function CollectionEditor({ queryRef, onValidChange, onHasUnsavedChange }: Props
 
   useNotOptimizedForMobileWarning();
   useConfirmationMessageBeforeClose();
+  useCheckUnsavedChanges(onHasUnsavedChange);
 
   const stagedCollectionState = useStagedCollectionState();
   const sidebarTokens = useSidebarTokensState();
@@ -122,32 +123,6 @@ function CollectionEditor({ queryRef, onValidChange, onHasUnsavedChange }: Props
     },
     [stagedCollectionState, onValidChange]
   );
-
-  // Check if the collection has unsaved changes
-  const initialStagedCollection = useRef({});
-  const isStagedCollectionInitialized = useRef(false);
-
-  // Initialize the lastStagedCollection ref
-  useEffect(() => {
-    if (Object.keys(stagedCollectionState).length === 0 || isStagedCollectionInitialized.current) {
-      return;
-    }
-
-    isStagedCollectionInitialized.current = true;
-    initialStagedCollection.current = formatStagedCollection(stagedCollectionState);
-  }, [stagedCollectionState]);
-
-  useEffect(() => {
-    const formattedStagedCollection = formatStagedCollection(stagedCollectionState);
-
-    if (
-      JSON.stringify(formattedStagedCollection) !== JSON.stringify(initialStagedCollection.current)
-    ) {
-      onHasUnsavedChange(true);
-      return;
-    }
-    onHasUnsavedChange(false);
-  }, [onHasUnsavedChange, stagedCollectionState]);
 
   const { setSidebarTokens, unstageTokens, setStagedCollectionState, setActiveSectionIdState } =
     useCollectionEditorActions();

--- a/src/components/ManageGallery/OrganizeCollection/Editor/useCheckUnsavedChanges.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Editor/useCheckUnsavedChanges.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+
+import {
+  useCollectionMetadataState,
+  useStagedCollectionState,
+} from '~/contexts/collectionEditor/CollectionEditorContext';
+
+import { formatStagedCollection } from './formatStagedCollection';
+
+export default function useCheckUnsavedChanges(
+  onHasUnsavedChange: (hasUnsavedChanges: boolean) => void
+) {
+  const initialStagedCollection = useRef({});
+  const initialCollectionMetadata = useRef({});
+  const isStagedCollectionInitialized = useRef(false);
+
+  const stagedCollectionState = useStagedCollectionState();
+  const collectionMetadataState = useCollectionMetadataState();
+
+  // Initialize the staged collection and collection metadata ref
+  useEffect(() => {
+    if (Object.keys(stagedCollectionState).length === 0 || isStagedCollectionInitialized.current) {
+      return;
+    }
+
+    isStagedCollectionInitialized.current = true;
+    initialStagedCollection.current = formatStagedCollection(stagedCollectionState);
+    initialCollectionMetadata.current = collectionMetadataState;
+  }, [collectionMetadataState, stagedCollectionState]);
+
+  // Check if the staged collection or collection metadata has changed
+  useEffect(() => {
+    const formattedStagedCollection = formatStagedCollection(stagedCollectionState);
+
+    if (
+      JSON.stringify(formattedStagedCollection) !==
+        JSON.stringify(initialStagedCollection.current) ||
+      JSON.stringify(collectionMetadataState) !== JSON.stringify(initialCollectionMetadata.current)
+    ) {
+      onHasUnsavedChange(true);
+      return;
+    }
+    onHasUnsavedChange(false);
+  }, [collectionMetadataState, onHasUnsavedChange, stagedCollectionState]);
+}


### PR DESCRIPTION
**Changes**
- Add `collectionMetadataState` too to keep track of token metadata change
- Move the check unsaved part into own hook


**Demo**

https://user-images.githubusercontent.com/4480258/202956927-1a4884d1-1d87-4852-80ad-e70bf4a8debc.mp4



