### PR TITLE
[GAL-701] Sort interaction by comment and admire

### DIFF
--- a/src/components/Feed/Socialize/NotesModal/NotesModal.tsx
+++ b/src/components/Feed/Socialize/NotesModal/NotesModal.tsx
@@ -75,6 +75,25 @@ export function NotesModal({ eventRef, fullscreen }: NotesModalProps) {
     return interactions;
   }, [feedEvent.interactions?.edges, hasPrevious]);
 
+  // sort interactions by comment and admire
+  const sortedInteractions = useMemo(() => {
+    return nonNullInteractionsAndSeeMore.sort((a, b) => {
+      if ('kind' in a || 'kind' in b) {
+        return 0;
+      }
+
+      if (a.__typename === 'Comment' && b.__typename === 'Admire') {
+        return 1;
+      }
+
+      if (a.__typename === 'Admire' && b.__typename === 'Comment') {
+        return -1;
+      }
+
+      return 0;
+    });
+  }, [nonNullInteractionsAndSeeMore]);
+
   const [measurerCache] = useState(() => {
     return new CellMeasurerCache({
       fixedWidth: true,
@@ -88,8 +107,7 @@ export function NotesModal({ eventRef, fullscreen }: NotesModalProps) {
 
   const rowRenderer = useCallback<ListRowRenderer>(
     ({ index, parent, key, style }) => {
-      const interaction =
-        nonNullInteractionsAndSeeMore[nonNullInteractionsAndSeeMore.length - index - 1];
+      const interaction = sortedInteractions[sortedInteractions.length - index - 1];
 
       return (
         <CellMeasurer
@@ -132,7 +150,7 @@ export function NotesModal({ eventRef, fullscreen }: NotesModalProps) {
         </CellMeasurer>
       );
     },
-    [handleSeeMore, measurerCache, nonNullInteractionsAndSeeMore]
+    [handleSeeMore, measurerCache, sortedInteractions]
   );
 
   return (


### PR DESCRIPTION
Sort the notes bt **comment** first and then **admire**. Both in `descending` order - `latest to oldest`

**Before**

<img width="633" alt="CleanShot 2022-11-23 at 12 37 00@2x" src="https://user-images.githubusercontent.com/4480258/203470141-12311c4c-6f6f-49ef-bbfb-a7818ed7d01a.png">


**After**

<img width="623" alt="CleanShot 2022-11-23 at 12 36 04@2x" src="https://user-images.githubusercontent.com/4480258/203470049-5ac67084-725b-4ed0-b3f1-a6e41ff81708.png">
