### PR TITLE
Remove beta from footer

### DIFF
--- a/src/contexts/globalLayout/GlobalFooter/GlobalFooter.tsx
+++ b/src/contexts/globalLayout/GlobalFooter/GlobalFooter.tsx
@@ -30,7 +30,6 @@ function GlobalFooter() {
           <Link href={{ pathname: '/' }}>
             <StyledLogo src="/icons/logo-large.svg" />
           </Link>
-          <BaseS>BETA</BaseS>
         </HStack>
         <HStack gap={8} wrap="wrap">
           <StyledFooterLink href={GALLERY_FAQ}>FAQ</StyledFooterLink>


### PR DESCRIPTION
We are out of beta!

before
<img width="385" alt="Screen Shot 2022-11-23 at 19 11 23" src="https://user-images.githubusercontent.com/80802871/203520864-90e09c8a-e70f-41cc-b12f-855d93cafe30.png">

after
<img width="400" alt="Screen Shot 2022-11-23 at 19 11 13" src="https://user-images.githubusercontent.com/80802871/203520887-c3c83060-e1cb-47da-9e2c-dd703574d6d5.png">
