### PR TITLE
[GAL-728] Fix editor icon misalign

### DIFF
--- a/src/components/core/Markdown/List.tsx
+++ b/src/components/core/Markdown/List.tsx
@@ -85,6 +85,7 @@ export default function List({
 
   return (
     <IconContainer
+      size="sm"
       icon={
         <svg
           data-testid="markdown-icon"

--- a/src/components/core/TextArea/TextArea.tsx
+++ b/src/components/core/TextArea/TextArea.tsx
@@ -247,6 +247,6 @@ const StyledCharacterCounter = styled(BaseM)<{ error: boolean; hasPadding: boole
 const StyledMarkdownContainer = styled.div<{ hasPadding: boolean }>`
   position: absolute;
   background: none;
-  bottom: ${({ hasPadding }) => (hasPadding ? '12px' : '0')};
+  bottom: ${({ hasPadding }) => (hasPadding ? '8px' : '0')};
   left: ${({ hasPadding }) => (hasPadding ? '8px' : '0')};
 `;


### PR DESCRIPTION
**Before**

![CleanShot 2022-11-25 at 08 05 55@2x](https://user-images.githubusercontent.com/4480258/203876541-4c83d74a-ad47-4525-898f-b6497d93e6f0.png)


**After**

<img width="618" alt="CleanShot 2022-11-25 at 08 05 36@2x" src="https://user-images.githubusercontent.com/4480258/203876517-b05dad7b-7ac1-4614-b16f-e4fc85c50a60.png">
