### PR TITLE
[GAL-727] Fix feed image event overflow

### DIFF
--- a/src/components/Feed/dimensions.ts
+++ b/src/components/Feed/dimensions.ts
@@ -39,7 +39,7 @@ export const getFeedTokenDimensions = ({
     return {
       '1': 380,
       '2': 340,
-      '3': 340,
+      '3': 320,
       '4':
         (FEED_MAX_WIDTH - FEED_EVENT_TOKEN_MARGIN * 3 - FEED_EVENT_PADDING_DESKTOP * paddingCount) /
         4,


### PR DESCRIPTION
**Findings**

This bug only happens on desktop with 3 images. 




**Before 1**

![CleanShot 2022-11-29 at 11 08 57](https://user-images.githubusercontent.com/4480258/204429207-844d692f-6cc0-42c1-8d94-503359271368.png)


**After 1**

![CleanShot 2022-11-29 at 11 08 41](https://user-images.githubusercontent.com/4480258/204429175-211124f6-eab3-430b-99b4-3211af49cb25.png)


**Before 2**

![CleanShot 2022-11-29 at 11 10 20](https://user-images.githubusercontent.com/4480258/204429371-b97162b3-d9b6-40d6-96b2-15c93606574b.png)

**After 2**

![CleanShot 2022-11-29 at 11 10 35](https://user-images.githubusercontent.com/4480258/204429421-a7498192-347d-44cc-9ae7-dc00a93a7026.png)


