### PR TITLE
[GAL-703] feat: add deep linking in home collections

### DIFF
--- a/pages/[username]/[collectionId]/[tokenId]/index.tsx
+++ b/pages/[username]/[collectionId]/[tokenId]/index.tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { Route } from 'nextjs-routes';
 import { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 
@@ -19,23 +20,27 @@ type NftDetailPageProps = MetaTagProps & {
 };
 
 export default function NftDetailPage({ username, collectionId, tokenId }: NftDetailPageProps) {
-  const { push } = useRouter();
+  const { push, query } = useRouter();
 
   // the default "back" behavior from the NFT Detail Page
-  // is a redirect to the Collection Page
-  const collectionRoute = useMemo(
-    () => ({
+  // is a redirect to the Collection Page or a valid returnTo route
+  const returnToRoute = useMemo<Route>(() => {
+    if (query?.returnTo === 'home') {
+      return {
+        pathname: '/home',
+      };
+    }
+    return {
       pathname: '/[username]/[collectionId]',
       query: { username, collectionId },
-    }),
-    [username, collectionId]
-  );
+    };
+  }, [username, collectionId, query?.returnTo]);
 
-  const handleReturnToCollectionPage = useCallback(() => {
-    push(collectionRoute);
-  }, [collectionRoute, push]);
+  const handleReturnToRoute = useCallback(() => {
+    push(returnToRoute);
+  }, [returnToRoute, push]);
 
-  useKeyDown('Escape', handleReturnToCollectionPage);
+  useKeyDown('Escape', handleReturnToRoute);
 
   if (!tokenId) {
     // Something went horribly wrong
@@ -44,7 +49,7 @@ export default function NftDetailPage({ username, collectionId, tokenId }: NftDe
 
   return (
     <>
-      <Link href={collectionRoute}>
+      <Link href={returnToRoute}>
         <StyledDecoratedCloseIcon />
       </Link>
       <GalleryRoute

--- a/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
+++ b/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
@@ -45,16 +45,20 @@ function FeedEventNftPreviewWrapper({ tokenRef, maxWidth, maxHeight }: Props) {
 
   const { showModal } = useModalActions();
 
-  const handleClick = useCallback(() => {
-    showModal({
-      content: (
-        <StyledNftDetailViewPopover>
-          <NftDetailView authenticatedUserOwnsAsset={false} queryRef={token} />
-        </StyledNftDetailViewPopover>
-      ),
-      isFullPage: true,
-    });
-  }, [showModal, token]);
+  const handleClick = useCallback(
+    ({ onClose }: { onClose?: () => void }) => {
+      showModal({
+        content: (
+          <StyledNftDetailViewPopover>
+            <NftDetailView authenticatedUserOwnsAsset={false} queryRef={token} />
+          </StyledNftDetailViewPopover>
+        ),
+        isFullPage: true,
+        onClose,
+      });
+    },
+    [showModal, token]
+  );
 
   const isMobile = useIsMobileOrMobileLargeWindowWidth();
 

--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import { route } from 'nextjs-routes';
 import { useCallback, useMemo } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
@@ -17,6 +18,7 @@ import NftDetailAnimation from '~/scenes/NftDetailPage/NftDetailAnimation';
 import NftDetailGif from '~/scenes/NftDetailPage/NftDetailGif';
 import NftDetailVideo from '~/scenes/NftDetailPage/NftDetailVideo';
 import { isFirefox } from '~/utils/browser';
+import { historyReplaceState } from '~/utils/browserHistory';
 import getVideoOrImageUrlForNftPreview from '~/utils/graphql/getVideoOrImageUrlForNftPreview';
 import isSvg from '~/utils/isSvg';
 import { getBackgroundColorOverrideForContract } from '~/utils/token';
@@ -28,7 +30,7 @@ type Props = {
   tokenRef: NftPreviewFragment$key;
   previewSize: number;
   ownerUsername?: string;
-  onClick?: () => void;
+  onClick?: ({ onClose }: { onClose?: () => void }) => void;
   hideLabelOnMobile?: boolean;
   disableLiverender?: boolean;
   columns?: number;
@@ -127,10 +129,31 @@ function NftPreview({
     (event: React.MouseEvent<HTMLElement>) => {
       if (onClick && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey) {
         event.preventDefault();
-        onClick();
+
+        // Replace the URL without triggering a page load
+        historyReplaceState(
+          route({
+            pathname: '/[username]/[collectionId]/[tokenId]',
+            query: {
+              username: username as string,
+              collectionId,
+              tokenId: token.dbid,
+              returnTo: 'home',
+            },
+          })
+        );
+
+        onClick({
+          onClose: () =>
+            historyReplaceState(
+              route({
+                pathname: '/home',
+              })
+            ),
+        });
       }
     },
-    [onClick]
+    [onClick, collectionId, token.dbid, username]
   );
 
   const shouldLiverender = tokenSettings?.renderLive;

--- a/src/contexts/modal/AnimatedModal.tsx
+++ b/src/contexts/modal/AnimatedModal.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useMemo } from 'react';
+import { ReactElement, useCallback, useEffect, useMemo } from 'react';
 import styled, { css, keyframes } from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
@@ -31,6 +31,7 @@ type Props = {
   headerText: string;
   headerVariant: ModalPaddingVariant;
   hideClose?: boolean;
+  onClose?: () => void;
 };
 
 function AnimatedModal({
@@ -44,6 +45,7 @@ function AnimatedModal({
   headerText,
   headerVariant,
   hideClose,
+  onClose,
 }: Props) {
   useEffect(() => {
     if (!isActive) {
@@ -81,9 +83,14 @@ function AnimatedModal({
     return 'unset';
   }, [isFullPage, isMobile]);
 
+  const handleClose = useCallback(() => {
+    onClose?.();
+    hideModal();
+  }, [hideModal, onClose]);
+
   return (
     <_ToggleFade isActive={isActive}>
-      <Overlay onClick={hideModal} />
+      <Overlay onClick={handleClose} />
       <StyledContentContainer isFullPage={isFullPage}>
         <_ToggleTranslate isActive={isActive}>
           <StyledContent
@@ -98,7 +105,7 @@ function AnimatedModal({
               <StyledModalActions align="center">
                 {headerActions}
                 {hideClose ? null : (
-                  <DecoratedCloseIcon onClick={hideModal} variant={headerVariant} />
+                  <DecoratedCloseIcon onClick={handleClose} variant={headerVariant} />
                 )}
               </StyledModalActions>
             </StyledHeader>

--- a/src/utils/browserHistory.ts
+++ b/src/utils/browserHistory.ts
@@ -1,0 +1,11 @@
+export function historyPushState(url: string) {
+  if (typeof window !== 'undefined') {
+    window.history.pushState({}, '', url);
+  }
+}
+
+export function historyReplaceState(url: string) {
+  if (typeof window !== 'undefined') {
+    window.history.replaceState({}, '', url);
+  }
+}

--- a/src/utils/browserHistory.ts
+++ b/src/utils/browserHistory.ts
@@ -1,10 +1,10 @@
-export function historyPushState(url: string) {
+export function historyPushState(url: string | URL) {
   if (typeof window !== 'undefined') {
     window.history.pushState({}, '', url);
   }
 }
 
-export function historyReplaceState(url: string) {
+export function historyReplaceState(url: string | URL) {
   if (typeof window !== 'undefined') {
     window.history.replaceState({}, '', url);
   }

--- a/src/utils/browserHistory.ts
+++ b/src/utils/browserHistory.ts
@@ -1,9 +1,3 @@
-export function historyPushState(url: string | URL) {
-  if (typeof window !== 'undefined') {
-    window.history.pushState({}, '', url);
-  }
-}
-
 export function historyReplaceState(url: string | URL) {
   if (typeof window !== 'undefined') {
     window.history.replaceState({}, '', url);


### PR DESCRIPTION
The collections in the `/home` route now will replace the URL with the collection route. When refreshed the close button will correctly send the user back to the `/home` route (done via a new "returnTo" param). The refresh causes the lost of the scroll position - I think its possible to add scroll restoration later on.