### PR TITLE
chore: sentry improvements

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -12,7 +12,7 @@ const IS_PROD = ENV === 'production';
 
 const SENTRY_TRACING_ORIGIN = IS_PROD ? 'api.gallery.so' : 'api.dev.gallery.so';
 
-const SENTRY_TRACING_SAMPLE_RATE = IS_PROD ? 0.2 : 1.0;
+const SENTRY_TRACING_SAMPLE_RATE = IS_PROD ? 0.05 : 1.0;
 
 Sentry.init({
   // DSNs are safe to keep public because they only allow submission of

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -6,9 +6,9 @@ import * as Sentry from '@sentry/nextjs';
 
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
-const SENTRY_ENV = process.env.NEXT_PUBLIC_VERCEL_ENV;
+const ENV = process.env.NEXT_PUBLIC_VERCEL_ENV;
 
-const IS_PROD = SENTRY_ENV === 'production';
+const IS_PROD = ENV === 'production';
 
 const SENTRY_TRACING_ORIGIN = IS_PROD ? 'api.gallery.so' : 'api.dev.gallery.so';
 
@@ -32,6 +32,9 @@ Sentry.init({
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
-  environment: SENTRY_ENV || 'local',
+  environment: ENV || 'local',
   tunnel: 'https://monitoring.gallery.so/bugs',
+  // disable sentry reporting by default if in local development.
+  // NEXT_PUBLIC_VERCEL_ENV is only set in a deployed environment.
+  enabled: ENV !== undefined,
 });

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -8,6 +8,8 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 const ENV = process.env.NEXT_PUBLIC_VERCEL_ENV;
 
+const SENTRY_TRACING_SAMPLE_RATE = ENV === 'production' ? 0.05 : 1.0;
+
 Sentry.init({
   // DSNs are safe to keep public because they only allow submission of
   // new events and related event data; they do not allow read access to
@@ -16,7 +18,7 @@ Sentry.init({
   // want, this is a rare occurrence.
   dsn: SENTRY_DSN || 'https://bd40a4affc1740e8b7516502389262fe@o1135798.ingest.sentry.io/6187637',
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1.0,
+  tracesSampleRate: SENTRY_TRACING_SAMPLE_RATE,
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/nextjs';
 
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
-const SENTRY_ENV = process.env.NEXT_PUBLIC_VERCEL_ENV;
+const ENV = process.env.NEXT_PUBLIC_VERCEL_ENV;
 
 Sentry.init({
   // DSNs are safe to keep public because they only allow submission of
@@ -21,5 +21,8 @@ Sentry.init({
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
-  environment: SENTRY_ENV || 'local',
+  environment: ENV || 'local',
+  // disable sentry reporting by default if in local development.
+  // NEXT_PUBLIC_VERCEL_ENV is only set in a deployed environment.
+  enabled: ENV !== undefined,
 });


### PR DESCRIPTION
- [x] disable sentry reporting by default on localhost
  - the biggest offender to our quota was `/__nextjs_original-stack-frame`, which was only being reported from localhost
- [x] reduce sample rate to 5%