### PR TITLE
GAL-741 turn community link into clickable pill

### DIFF
--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -6,7 +6,7 @@ import breakpoints from '~/components/core/breakpoints';
 import colors from '~/components/core/colors';
 import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM } from '~/components/core/Text/Text';
+import { BaseM, TitleDiatypeM } from '~/components/core/Text/Text';
 import { NftPreviewLabelCollectionNameFragment$key } from '~/generated/NftPreviewLabelCollectionNameFragment.graphql';
 import { NftPreviewLabelFragment$key } from '~/generated/NftPreviewLabelFragment.graphql';
 import { getCommunityUrlForToken } from '~/utils/getCommunityUrlForToken';
@@ -46,7 +46,6 @@ function NftPreviewLabel({ className, tokenRef, interactive = true }: Props) {
   return (
     <StyledNftPreviewLabel className={className}>
       <HStack gap={4} justify={'flex-end'} align="center">
-        {token.chain === 'POAP' && <POAPLogo />}
         <VStack shrink>
           {
             // Since POAPs' collection names are the same as the
@@ -100,27 +99,43 @@ function CollectionName({ tokenRef, interactive }: CollectionNameProps) {
 
   if (token.chain === 'POAP') {
     return shouldDisplayLinkToCommunityPage ? (
-      <POAPTitle lines={2}>
-        <StyledInteractiveLink to={communityUrl}>{collectionName}</StyledInteractiveLink>
-      </POAPTitle>
+      <ClickablePill to={communityUrl}>
+        <HStack gap={4} align="center" justify="flex-end">
+          <POAPLogo />
+          <POAPTitle lines={1}>
+            <StyledTileDiatypeM lines={1} color={colors.white}>
+              {collectionName}
+            </StyledTileDiatypeM>
+          </POAPTitle>
+        </HStack>
+      </ClickablePill>
     ) : (
-      <POAPTitle color={colors.white} lines={2}>
-        {collectionName}
-      </POAPTitle>
+      <NonclickablePill>
+        <HStack gap={4} align="center" justify="flex-end">
+          <POAPLogo />
+          <POAPTitle color={colors.white} lines={1}>
+            {collectionName}
+          </POAPTitle>
+        </HStack>
+      </NonclickablePill>
     );
   }
 
   return shouldDisplayLinkToCommunityPage ? (
-    <HStack gap={4} align="center" justify="flex-end">
-      <StyledBaseM lines={2}>
-        <StyledInteractiveLink to={communityUrl}>{collectionName}</StyledInteractiveLink>
-      </StyledBaseM>
-      {token.contract?.badgeURL && <StyledBadge src={token.contract.badgeURL} />}
-    </HStack>
+    <ClickablePill to={communityUrl}>
+      <HStack gap={4} align="center" justify="flex-end">
+        {token.contract?.badgeURL && <StyledBadge src={token.contract.badgeURL} />}
+        <StyledTileDiatypeM lines={1} color={colors.white}>
+          {collectionName}
+        </StyledTileDiatypeM>
+      </HStack>
+    </ClickablePill>
   ) : (
-    <StyledBaseM color={colors.white} lines={2}>
-      {collectionName}
-    </StyledBaseM>
+    <NonclickablePill>
+      <StyledTileDiatypeM color={colors.white} lines={1}>
+        {collectionName}
+      </StyledTileDiatypeM>
+    </NonclickablePill>
   );
 }
 
@@ -128,8 +143,8 @@ const POAPLogo = styled.img.attrs({
   src: '/icons/poap_logo.svg',
   alt: 'POAP Logo',
 })`
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
 `;
 
 export const StyledNftPreviewLabel = styled.div`
@@ -183,12 +198,41 @@ const StyledBaseM = styled(BaseM)<{ lines: number }>`
     overflow: visible;
     text-overflow: unset;
   }
-}
+`;
+
+const StyledTileDiatypeM = styled(TitleDiatypeM)<{ lines: number }>`
+  word-wrap: break-word;
+  word-break: break-all;
+
+  margin: 0;
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.7);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-clamp: ${({ lines }) => lines};
+  -webkit-line-clamp: ${({ lines }) => lines};
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  padding-right: 16px;
+  margin-right: -16px;
+
+  @media only screen and ${breakpoints.mobileLarge} {
+    word-wrap: unset;
+    word-break: unset;
+  }
+
+  @media only screen and ${breakpoints.tablet} {
+    font-size: 14px;
+    line-height: 20px;
+    padding-right: 0;
+    margin-right: 0;
+  }
 `;
 
 const StyledBadge = styled.img`
-  width: 12px;
-  height: 12px;
+  width: 24px;
+  height: 24px;
 `;
 
 /**
@@ -207,18 +251,35 @@ const POAPTitle = styled(StyledBaseM)`
   overflow: hidden;
 `;
 
-const StyledInteractiveLink = styled(InteractiveLink)`
+const ClickablePill = styled(InteractiveLink)`
+  border: 1px solid rgba(254, 254, 254, 0.5);
+  padding: 0 12px;
+  border-radius: 24px;
   color: ${colors.white};
+  text-decoration: none;
   width: fit-content;
-  font-size: 12px;
+  align-self: end;
+  height: 32px;
+  display: flex;
+  align-items: center;
 
   &:hover {
-    color: ${colors.white};
+    background: rgba(254, 254, 254, 0.24);
+    backdrop-filter: blur(10px);
+    border-color: transparent;
   }
+`;
 
-  @media only screen and ${breakpoints.tablet} {
-    font-size: 14px;
-  }
+const NonclickablePill = styled.div`
+  border: 1px solid rgba(254, 254, 254, 0.5);
+  padding: 0 12px;
+  border-radius: 24px;
+  color: ${colors.white};
+  width: fit-content;
+  align-self: end;
+  height: 32px;
+  display: flex;
+  align-items: center;
 `;
 
 export default NftPreviewLabel;

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -258,7 +258,6 @@ const ClickablePill = styled(InteractiveLink)`
   color: ${colors.white};
   text-decoration: none;
   width: fit-content;
-  // align-self: end;
   height: 32px;
   display: flex;
   align-items: center;
@@ -275,8 +274,8 @@ const NonclickablePill = styled.div`
   padding: 0 12px;
   border-radius: 24px;
   color: ${colors.white};
+  text-decoration: none;
   width: fit-content;
-  align-self: end;
   height: 32px;
   display: flex;
   align-items: center;

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -217,7 +217,6 @@ const StyledTileDiatypeM = styled(TitleDiatypeM)<{ lines: number }>`
 
   @media only screen and ${breakpoints.mobileLarge} {
     word-wrap: unset;
-    word-break: unset;
   }
 
   @media only screen and ${breakpoints.tablet} {
@@ -225,7 +224,6 @@ const StyledTileDiatypeM = styled(TitleDiatypeM)<{ lines: number }>`
     line-height: 20px;
     padding-right: 0;
     margin-right: 0;
-    display: unset;
   }
 `;
 
@@ -248,6 +246,7 @@ const POAPTitle = styled(StyledTileDiatypeM)`
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  display: block;
 `;
 
 const ClickablePill = styled(InteractiveLink)`

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -46,7 +46,7 @@ function NftPreviewLabel({ className, tokenRef, interactive = true }: Props) {
   return (
     <StyledNftPreviewLabel className={className}>
       <HStack gap={4} justify={'flex-end'} align="center">
-        <VStack align="flex-end" shrink>
+        <VStack gap={4} align="flex-end" shrink>
           {
             // Since POAPs' collection names are the same as the
             // token name, we don't want to show duplicate information

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -123,16 +123,16 @@ function CollectionName({ tokenRef, interactive }: CollectionNameProps) {
     <ClickablePill to={communityUrl}>
       <HStack gap={4} align="center" justify="flex-end">
         {token.contract?.badgeURL && <StyledBadge src={token.contract.badgeURL} />}
-        <StyledTileDiatypeM lines={1} color={colors.white}>
+        <StyledTitleDiatypeM lines={1} color={colors.white}>
           {collectionName}
-        </StyledTileDiatypeM>
+        </StyledTitleDiatypeM>
       </HStack>
     </ClickablePill>
   ) : (
     <NonclickablePill>
-      <StyledTileDiatypeM color={colors.white} lines={1}>
+      <StyledTitleDiatypeM color={colors.white} lines={1}>
         {collectionName}
-      </StyledTileDiatypeM>
+      </StyledTitleDiatypeM>
     </NonclickablePill>
   );
 }
@@ -198,7 +198,7 @@ const StyledBaseM = styled(BaseM)<{ lines: number }>`
   }
 `;
 
-const StyledTileDiatypeM = styled(TitleDiatypeM)<{ lines: number }>`
+const StyledTitleDiatypeM = styled(TitleDiatypeM)<{ lines: number }>`
   word-wrap: break-word;
   word-break: break-all;
 
@@ -240,7 +240,7 @@ const StyledBadge = styled.img`
  * of the text and multiline text causes unnecessary
  * extra width to show up
  */
-const POAPTitle = styled(StyledTileDiatypeM)`
+const POAPTitle = styled(StyledTitleDiatypeM)`
   line-clamp: 1;
   -webkit-line-clamp: 1;
   white-space: nowrap;

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -100,23 +100,21 @@ function CollectionName({ tokenRef, interactive }: CollectionNameProps) {
   if (token.chain === 'POAP') {
     return shouldDisplayLinkToCommunityPage ? (
       <ClickablePill to={communityUrl}>
-        <HStack gap={4} align="center" justify="flex-end">
-          <POAPLogo />
-          <POAPTitle lines={1}>
-            <StyledTileDiatypeM lines={1} color={colors.white}>
-              {collectionName}
-            </StyledTileDiatypeM>
-          </POAPTitle>
-        </HStack>
-      </ClickablePill>
-    ) : (
-      <NonclickablePill>
-        <HStack gap={4} align="center" justify="flex-end">
+        <POAPWrapperHStack gap={4} align="center" justify="flex-end">
           <POAPLogo />
           <POAPTitle color={colors.white} lines={1}>
             {collectionName}
           </POAPTitle>
-        </HStack>
+        </POAPWrapperHStack>
+      </ClickablePill>
+    ) : (
+      <NonclickablePill>
+        <POAPWrapperHStack gap={4} align="center" justify="flex-end">
+          <POAPLogo />
+          <POAPTitle color={colors.white} lines={1}>
+            {collectionName}
+          </POAPTitle>
+        </POAPWrapperHStack>
       </NonclickablePill>
     );
   }
@@ -227,6 +225,7 @@ const StyledTileDiatypeM = styled(TitleDiatypeM)<{ lines: number }>`
     line-height: 20px;
     padding-right: 0;
     margin-right: 0;
+    display: unset;
   }
 `;
 
@@ -243,7 +242,7 @@ const StyledBadge = styled.img`
  * of the text and multiline text causes unnecessary
  * extra width to show up
  */
-const POAPTitle = styled(StyledBaseM)`
+const POAPTitle = styled(StyledTileDiatypeM)`
   line-clamp: 1;
   -webkit-line-clamp: 1;
   white-space: nowrap;
@@ -261,12 +260,17 @@ const ClickablePill = styled(InteractiveLink)`
   height: 32px;
   display: flex;
   align-items: center;
+  max-width: -webkit-fill-available;
 
   &:hover {
     background: rgba(254, 254, 254, 0.24);
     backdrop-filter: blur(10px);
     border-color: transparent;
   }
+`;
+
+const POAPWrapperHStack = styled(HStack)`
+  width: 100%;
 `;
 
 const NonclickablePill = styled.div`
@@ -279,6 +283,7 @@ const NonclickablePill = styled.div`
   height: 32px;
   display: flex;
   align-items: center;
+  max-width: -webkit-fill-available;
 `;
 
 export default NftPreviewLabel;

--- a/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/src/components/NftPreview/NftPreviewLabel.tsx
@@ -46,7 +46,7 @@ function NftPreviewLabel({ className, tokenRef, interactive = true }: Props) {
   return (
     <StyledNftPreviewLabel className={className}>
       <HStack gap={4} justify={'flex-end'} align="center">
-        <VStack shrink>
+        <VStack align="flex-end" shrink>
           {
             // Since POAPs' collection names are the same as the
             // token name, we don't want to show duplicate information
@@ -258,7 +258,7 @@ const ClickablePill = styled(InteractiveLink)`
   color: ${colors.white};
   text-decoration: none;
   width: fit-content;
-  align-self: end;
+  // align-self: end;
   height: 32px;
   display: flex;
   align-items: center;

--- a/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
@@ -75,6 +75,7 @@ const UnknownMediaResponse: NftDetailAssetTestQueryQuery = {
           chain: Chain.Ethereum,
           address: '0x0Ff979fB365e20c09bE06676D569EF581a46621D',
         },
+        badgeURL: 'http://someurl.com',
       },
     },
   },

--- a/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -5,11 +5,12 @@ import styled from 'styled-components';
 import breakpoints, { size } from '~/components/core/breakpoints';
 import { Button } from '~/components/core/Button/Button';
 import TextButton from '~/components/core/Button/TextButton';
+import colors from '~/components/core/colors';
 import HorizontalBreak from '~/components/core/HorizontalBreak/HorizontalBreak';
 import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import Markdown from '~/components/core/Markdown/Markdown';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM, TitleM, TitleXS } from '~/components/core/Text/Text';
+import { BaseM, TitleDiatypeM, TitleM, TitleXS } from '~/components/core/Text/Text';
 import { useTrack } from '~/contexts/analytics/AnalyticsContext';
 import { useGlobalNavbarHeight } from '~/contexts/globalLayout/GlobalNavbar/useGlobalNavbarHeight';
 import { NftDetailTextFragment$key } from '~/generated/NftDetailTextFragment.graphql';
@@ -110,15 +111,20 @@ function NftDetailText({ tokenRef }: Props) {
   return (
     <StyledDetailLabel horizontalLayout={horizontalLayout} navbarHeight={navbarHeight}>
       <VStack gap={isMobile ? 32 : 24}>
-        <VStack gap={4}>
+        <VStack gap={8}>
           {token.name && <TitleM>{decodedTokenName}</TitleM>}
           <HStack align="center" gap={4}>
-            {token.chain === 'POAP' && <PoapLogo />}
-
             {communityUrl && token.contract?.name ? (
-              <InteractiveLink to={communityUrl}>{token.contract.name}</InteractiveLink>
+              <ClickablePill to={communityUrl}>
+                <HStack gap={4} align="center" justify="flex-end">
+                  {token.chain === 'POAP' && <PoapLogo />}
+                  <TitleDiatypeM>{token.contract.name}</TitleDiatypeM>
+                </HStack>
+              </ClickablePill>
             ) : (
-              <BaseM>{token.contract?.name}</BaseM>
+              <NonclickablePill>
+                <TitleDiatypeM>{token.contract?.name}</TitleDiatypeM>
+              </NonclickablePill>
             )}
           </HStack>
         </VStack>
@@ -166,8 +172,8 @@ function NftDetailText({ tokenRef }: Props) {
 }
 
 const PoapLogo = styled.img.attrs({ src: '/icons/poap_logo.svg', alt: 'POAP Logo' })`
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
 `;
 
 const StyledDetailLabel = styled.div<{ horizontalLayout: boolean; navbarHeight: number }>`
@@ -199,6 +205,37 @@ const StyledInteractiveLink = styled(InteractiveLink)`
 
 const StyledButton = styled(Button)`
   width: 100%;
+`;
+
+const ClickablePill = styled(InteractiveLink)`
+  border: 1px solid ${colors.porcelain};
+  padding: 0 12px;
+  border-radius: 24px;
+  color: ${colors.offBlack};
+  text-decoration: none;
+  width: fit-content;
+  align-self: end;
+  height: 32px;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    background: ${colors.porcelain};
+    backdrop-filter: blur(10px);
+    border-color: transparent;
+  }
+`;
+
+const NonclickablePill = styled.div`
+  border: 1px solid ${colors.porcelain};
+  padding: 0 12px;
+  border-radius: 24px;
+  color: ${colors.offBlack};
+  width: fit-content;
+  align-self: end;
+  height: 32px;
+  display: flex;
+  align-items: center;
 `;
 
 export default NftDetailText;

--- a/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -50,6 +50,7 @@ function NftDetailText({ tokenRef }: Props) {
           contractAddress {
             address
           }
+          badgeURL
         }
 
         ...NftAdditionalDetailsFragment
@@ -118,6 +119,7 @@ function NftDetailText({ tokenRef }: Props) {
               <ClickablePill to={communityUrl}>
                 <HStack gap={4} align="center" justify="flex-end">
                   {token.chain === 'POAP' && <PoapLogo />}
+                  {token.contract?.badgeURL && <StyledBadge src={token.contract.badgeURL} />}
                   <TitleDiatypeM>{token.contract.name}</TitleDiatypeM>
                 </HStack>
               </ClickablePill>
@@ -172,6 +174,11 @@ function NftDetailText({ tokenRef }: Props) {
 }
 
 const PoapLogo = styled.img.attrs({ src: '/icons/poap_logo.svg', alt: 'POAP Logo' })`
+  width: 24px;
+  height: 24px;
+`;
+
+const StyledBadge = styled.img`
   width: 24px;
   height: 24px;
 `;


### PR DESCRIPTION
### Description

This PR turns the community link into a clickable pill.  Also updated the NFT Detail Page to display badges.


### Screenshots

NFT preview text
Wtihout badge, default (no hover)
![Screen Shot 2022-12-07 at 19 19 52](https://user-images.githubusercontent.com/80802871/206152887-a46d3fc3-e917-411f-ad4e-19eb990007d5.png)


Without Badge, on hover
![Screen Shot 2022-12-07 at 19 16 14](https://user-images.githubusercontent.com/80802871/206152946-51eee4f7-f5fe-4db0-8385-891d4275b094.png)



With Badge, On hover
![Screen Shot 2022-12-07 at 19 16 18](https://user-images.githubusercontent.com/80802871/206152731-93744424-0e90-4eeb-ab22-0eecfd0b484d.png)


Non-link text (non-clickable)
![Screen Shot 2022-12-07 at 19 16 57](https://user-images.githubusercontent.com/80802871/206152592-23faddb3-d8ea-4099-b339-47cc68d93ae8.png)


NFT Detail Page
Default
![Screen Shot 2022-12-07 at 19 17 46](https://user-images.githubusercontent.com/80802871/206152505-66ae9376-47fc-4873-84ab-c9832a5f6a9e.png)

Hover
![Screen Shot 2022-12-07 at 19 17 50](https://user-images.githubusercontent.com/80802871/206152480-fe60210f-af1d-4bd5-8665-96d71c53c24c.png)


Editor
Pill is non clickable
![Screen Shot 2022-12-07 at 19 22 24](https://user-images.githubusercontent.com/80802871/206153511-80e755ff-1e5a-4e61-ab84-828b5fdf0d81.png)

Pill content adapts if text is wider than NFT
![Screen Shot 2022-12-07 at 19 29 24](https://user-images.githubusercontent.com/80802871/206156481-0bdaf71e-b9aa-4f53-843a-5fe0a9d54b31.png)
