### PR TITLE
GAL-730 remove side padding from feed events on mobile

### DIFF
--- a/src/components/Feed/FeedEvent.tsx
+++ b/src/components/Feed/FeedEvent.tsx
@@ -203,11 +203,12 @@ const FeedEventContainer = styled(VStack)`
 
   border-bottom: 1px solid ${colors.faint};
 
-  padding: 24px 16px;
+  padding: 24px 0px;
 
   cursor: pointer;
 
   @media only screen and ${breakpoints.desktop} {
+    padding: 24px 16px;
     max-width: initial;
     width: ${FEED_EVENT_ROW_WIDTH_DESKTOP}px;
   }


### PR DESCRIPTION
This PR removes the side padding from feed events on mobile, as requested by Design.
This also fixes an issue where images are clipped on mobile.

Before
![CleanShot 2022-12-13 at 21 04 40@2x](https://user-images.githubusercontent.com/80802871/207315060-92484595-26c5-4940-9f71-14fff4870143.png)

After
![CleanShot 2022-12-13 at 21 05 48@2x](https://user-images.githubusercontent.com/80802871/207315044-31f16878-15a7-47fd-b87f-6fe2898d5a18.png)

