### PR TITLE
fix regression showing untitled on user's gallery GAL-914

### DIFF
--- a/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -143,7 +143,7 @@ function UserGalleryCollection({
       <StyledCollectionHeader>
         <StyledCollectionTitleWrapper>
           <UnstyledLink href={collectionUrlPath}>
-            <StyledCollectorsTitle>{unescapedCollectionName || 'untitled'}</StyledCollectorsTitle>
+            <StyledCollectorsTitle>{unescapedCollectionName}</StyledCollectorsTitle>
           </UnstyledLink>
           <StyledOptionsContainer gap={16}>
             <StyledCopyToClipboard textToCopy={`${baseUrl}${collectionUrl}`}>


### PR DESCRIPTION
revert change where we show `untitled` on gallery page