### PR TITLE
Add tokenId to errors so we know the context

### DIFF
--- a/src/components/ManageGallery/OrganizeCollection/Editor/SortableStagedNft.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Editor/SortableStagedNft.tsx
@@ -5,9 +5,9 @@ import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import Gradient from '~/components/core/Gradient/Gradient';
+import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
 import { StyledNftPreviewLabel } from '~/components/NftPreview/NftPreviewLabel';
-import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
 import { SPACE_BETWEEN_ITEMS } from '~/contexts/collectionEditor/useDndDimensions';
 import { SortableStagedNftFragment$key } from '~/generated/SortableStagedNftFragment.graphql';
 import { useNftRetry } from '~/hooks/useNftRetry';
@@ -81,8 +81,9 @@ function SortableStagedNft({ tokenRef, size, mini }: Props) {
       style={style}
       backgroundColorOverride={backgroundColorOverride}
     >
-      <ReportingErrorBoundary
+      <NftFailureBoundary
         key={retryKey}
+        tokenId={token.dbid}
         fallback={
           <FallbackContainer ref={setNodeRef} size={size} {...attributes} {...listeners}>
             <NftFailureFallback onRetry={refreshMetadata} refreshing={refreshingMetadata} />
@@ -99,7 +100,7 @@ function SortableStagedNft({ tokenRef, size, mini }: Props) {
           {...attributes}
           {...listeners}
         />
-      </ReportingErrorBoundary>
+      </NftFailureBoundary>
       <StyledUnstageButton id={id} />
       {isLiveType && <LiveDisplayButton id={id} />}
       <StyledGradient type="top" direction="up" height={mini ? 40 : 64} />

--- a/src/components/ManageGallery/OrganizeCollection/Editor/StagedItemDragging.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Editor/StagedItemDragging.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import colors from '~/components/core/colors';
 import { BaseM } from '~/components/core/Text/Text';
+import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
 import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
 import { StagedItemDraggingFragment$key } from '~/generated/StagedItemDraggingFragment.graphql';
@@ -62,13 +63,14 @@ function StagedNftImageDraggingWrapper({ tokenRef, size }: StagedNftImageDraggin
   });
 
   return (
-    <ReportingErrorBoundary
+    <NftFailureBoundary
       key={retryKey}
+      tokenId={token.dbid}
       fallback={<NftFailureFallback refreshing={false} onRetry={noop} />}
       onError={handleNftError}
     >
       <StagedNftImageDragging onLoad={handleNftLoaded} tokenRef={token} size={size} />
-    </ReportingErrorBoundary>
+    </NftFailureBoundary>
   );
 }
 

--- a/src/components/ManageGallery/OrganizeCollection/Editor/StagedItemDragging.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Editor/StagedItemDragging.tsx
@@ -6,7 +6,6 @@ import colors from '~/components/core/colors';
 import { BaseM } from '~/components/core/Text/Text';
 import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
-import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
 import { StagedItemDraggingFragment$key } from '~/generated/StagedItemDraggingFragment.graphql';
 import { StagedItemDraggingWrapperFragment$key } from '~/generated/StagedItemDraggingWrapperFragment.graphql';
 import { useNftRetry } from '~/hooks/useNftRetry';

--- a/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import colors from '~/components/core/colors';
 import { BODY_FONT_FAMILY } from '~/components/core/Text/Text';
 import transitions from '~/components/core/transitions';
+import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
 import { SIDEBAR_ICON_DIMENSIONS } from '~/constants/sidebar';
 import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
@@ -166,8 +167,9 @@ function SidebarNftIcon({
   }
 
   return (
-    <ReportingErrorBoundary
+    <NftFailureBoundary
       key={retryKey}
+      tokenId={token.dbid}
       fallback={
         <StyledSidebarNftIcon backgroundColorOverride={backgroundColorOverride}>
           <NftFailureFallback
@@ -187,7 +189,7 @@ function SidebarNftIcon({
         />
         <StyledOutline onClick={handleClick} isSelected={isSelected} />
       </StyledSidebarNftIcon>
-    </ReportingErrorBoundary>
+    </NftFailureBoundary>
   );
 }
 

--- a/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarNftIcon.tsx
@@ -9,7 +9,6 @@ import transitions from '~/components/core/transitions';
 import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
 import { SIDEBAR_ICON_DIMENSIONS } from '~/constants/sidebar';
-import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
 import { useCollectionEditorActions } from '~/contexts/collectionEditor/CollectionEditorContext';
 import { useReportError } from '~/contexts/errorReporting/ErrorReportingContext';
 import { ContentIsLoadedEvent } from '~/contexts/shimmer/ShimmerContext';

--- a/src/components/ManageGallery/OrganizeGallery/BigNft.tsx
+++ b/src/components/ManageGallery/OrganizeGallery/BigNft.tsx
@@ -1,8 +1,8 @@
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
+import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
-import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
 import { CouldNotRenderNftError } from '~/errors/CouldNotRenderNftError';
 import { BigNftFragment$key } from '~/generated/BigNftFragment.graphql';
 import { BigNftPreviewFragment$key } from '~/generated/BigNftPreviewFragment.graphql';
@@ -37,13 +37,14 @@ export function BigNft({ tokenRef }: BigNftProps) {
 
   return (
     <BigNftContainer>
-      <ReportingErrorBoundary
+      <NftFailureBoundary
         key={retryKey}
+        tokenId={token.dbid}
         fallback={<NftFailureFallback onRetry={refreshMetadata} refreshing={refreshingMetadata} />}
         onError={handleNftError}
       >
         <BigNftPreview onLoad={handleNftLoaded} tokenRef={token} />
-      </ReportingErrorBoundary>
+      </NftFailureBoundary>
     </BigNftContainer>
   );
 }

--- a/src/components/NftFailureFallback/NftFailureBoundary.tsx
+++ b/src/components/NftFailureFallback/NftFailureBoundary.tsx
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+
+import {
+  ReportingErrorBoundary,
+  ReportingErrorBoundaryProps,
+} from '~/contexts/boundary/ReportingErrorBoundary';
+
+type Props = {
+  tokenId: string;
+} & ReportingErrorBoundaryProps;
+
+export function NftFailureBoundary({ tokenId, additionalTags, ...rest }: Props) {
+  const tagsToSendThrough = useMemo(() => {
+    return {
+      ...additionalTags,
+      tokenId,
+    };
+  }, [additionalTags, tokenId]);
+
+  return <ReportingErrorBoundary {...rest} additionalTags={tagsToSendThrough} />;
+}

--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import Gradient from '~/components/core/Gradient/Gradient';
 import transitions from '~/components/core/transitions';
+import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
 import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
 import { useContentState } from '~/contexts/shimmer/ShimmerContext';
@@ -189,8 +190,9 @@ function NftPreview({
   const { aspectRatio } = useContentState();
 
   return (
-    <ReportingErrorBoundary
+    <NftFailureBoundary
       key={retryKey}
+      tokenId={token.dbid}
       fallback={
         <NftFailureWrapper>
           <NftFailureFallback refreshing={refreshingMetadata} onRetry={refreshMetadata} />
@@ -222,7 +224,7 @@ function NftPreview({
           </StyledNftPreview>
         </StyledA>
       </LinkToNftDetailView>
-    </ReportingErrorBoundary>
+    </NftFailureBoundary>
   );
 }
 

--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -8,7 +8,6 @@ import Gradient from '~/components/core/Gradient/Gradient';
 import transitions from '~/components/core/transitions';
 import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
-import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
 import { useContentState } from '~/contexts/shimmer/ShimmerContext';
 import { NftPreviewFragment$key } from '~/generated/NftPreviewFragment.graphql';
 import { NftPreviewTokenFragment$key } from '~/generated/NftPreviewTokenFragment.graphql';

--- a/src/errors/ErrorWithSentryMetadata.ts
+++ b/src/errors/ErrorWithSentryMetadata.ts
@@ -10,4 +10,8 @@ export class ErrorWithSentryMetadata extends Error {
 
     Object.setPrototypeOf(this, ErrorWithSentryMetadata.prototype);
   }
+
+  addMetadata(metadata: Record<string, Primitive>) {
+    Object.assign(this.metadata, metadata);
+  }
 }

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -5,7 +5,6 @@ import breakpoints, { size } from '~/components/core/breakpoints';
 import { StyledImageWithLoading } from '~/components/LoadingAsset/ImageWithLoading';
 import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
-import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
 import { GLOBAL_FOOTER_HEIGHT } from '~/contexts/globalLayout/GlobalFooter/GlobalFooter';
 import { useContentState } from '~/contexts/shimmer/ShimmerContext';
 import { CouldNotRenderNftError } from '~/errors/CouldNotRenderNftError';

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import breakpoints, { size } from '~/components/core/breakpoints';
 import { StyledImageWithLoading } from '~/components/LoadingAsset/ImageWithLoading';
+import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
 import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
 import { GLOBAL_FOOTER_HEIGHT } from '~/contexts/globalLayout/GlobalFooter/GlobalFooter';
@@ -180,13 +181,14 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
       hasExtraPaddingForNote={hasExtraPaddingForNote}
       backgroundColorOverride={backgroundColorOverride}
     >
-      <ReportingErrorBoundary
+      <NftFailureBoundary
         key={retryKey}
+        tokenId={token.dbid}
         onError={handleNftError}
         fallback={<NftFailureFallback onRetry={refreshMetadata} refreshing={refreshingMetadata} />}
       >
         <NftDetailAssetComponent onLoad={handleNftLoaded} tokenRef={token} />
-      </ReportingErrorBoundary>
+      </NftFailureBoundary>
     </StyledAssetContainer>
   );
 }

--- a/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
+++ b/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 import breakpoints, { size } from '~/components/core/breakpoints';
 import { StyledImageWithLoading } from '~/components/LoadingAsset/ImageWithLoading';
+import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
-import { ReportingErrorBoundary } from '~/contexts/boundary/ReportingErrorBoundary';
 import { GLOBAL_FOOTER_HEIGHT } from '~/contexts/globalLayout/GlobalFooter/GlobalFooter';
 import { useContentState } from '~/contexts/shimmer/ShimmerContext';
 import { TokenDetailAssetFragment$key } from '~/generated/TokenDetailAssetFragment.graphql';
@@ -66,13 +66,14 @@ function TokenDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
       hasExtraPaddingForNote={hasExtraPaddingForNote}
       backgroundColorOverride={backgroundColorOverride}
     >
-      <ReportingErrorBoundary
+      <NftFailureBoundary
         key={retryKey}
+        tokenId={token.dbid}
         onError={handleNftError}
         fallback={<NftFailureFallback onRetry={refreshMetadata} refreshing={refreshingMetadata} />}
       >
         <NftDetailAssetComponent onLoad={handleNftLoaded} tokenRef={token} />
-      </ReportingErrorBoundary>
+      </NftFailureBoundary>
     </StyledAssetContainer>
   );
 }


### PR DESCRIPTION
We've seen a large increase in errors on Sentry re: the inability to render an NFT. Adding context to the errors w/ a token id will be helpful here.