### PR TITLE
Show early access status in settings popover

### DIFF
--- a/src/components/ManageWallets/ManageWallets.tsx
+++ b/src/components/ManageWallets/ManageWallets.tsx
@@ -5,12 +5,12 @@ import styled from 'styled-components';
 import { Button } from '~/components/core/Button/Button';
 import { VStack } from '~/components/core/Spacer/Stack';
 import ErrorText from '~/components/core/Text/ErrorText';
-import { BaseM } from '~/components/core/Text/Text';
 import { USER_SIGNIN_ADDRESS_LOCAL_STORAGE_KEY } from '~/constants/storageKeys';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { ManageWalletsFragment$key } from '~/generated/ManageWalletsFragment.graphql';
 import useAddWalletModal from '~/hooks/useAddWalletModal';
 import usePersistedState from '~/hooks/usePersistedState';
+import SettingsRowDescription from '~/scenes/Modals/SettingsModal/SettingsRowDescription';
 import { removeNullValues } from '~/utils/removeNullValues';
 import { truncateAddress } from '~/utils/wallet';
 
@@ -92,8 +92,10 @@ function ManageWallets({
     <VStack gap={16}>
       <VStack gap={16}>
         <VStack>
-          <BaseM>Add more wallets to access your other NFTs.</BaseM>
-          <BaseM>You&apos;ll also be able to sign in using any connected wallet.</BaseM>
+          <SettingsRowDescription>
+            Add more wallets to access your other NFTs. You&apos;ll also be able to sign in using
+            any connected wallet.
+          </SettingsRowDescription>
           {errorMessage && <StyledErrorText message={errorMessage} />}
         </VStack>
         <VStack>

--- a/src/components/NotificationsModal/NotificationEmailAlert.tsx
+++ b/src/components/NotificationsModal/NotificationEmailAlert.tsx
@@ -7,7 +7,7 @@ import { useModalActions } from '~/contexts/modal/ModalContext';
 import { NotificationEmailAlertQueryFragment$key } from '~/generated/NotificationEmailAlertQueryFragment.graphql';
 import CloseIcon from '~/icons/CloseIcon';
 import InfoCircleIcon from '~/icons/InfoCircleIcon';
-import SettingsModal from '~/scenes/Modals/SettingsModal';
+import SettingsModal from '~/scenes/Modals/SettingsModal/SettingsModal';
 
 import colors from '../core/colors';
 import InteractiveLink from '../core/InteractiveLink/InteractiveLink';

--- a/src/components/NotificationsModal/useNotificationsModal.tsx
+++ b/src/components/NotificationsModal/useNotificationsModal.tsx
@@ -9,7 +9,7 @@ import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import CogIcon from '~/icons/CogIcon';
 import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
-import SettingsModal from '../../scenes/Modals/SettingsModal';
+import SettingsModal from '../../scenes/Modals/SettingsModal/SettingsModal';
 import { NotificationsModal } from './NotificationsModal';
 
 export default function useNotificationsModal() {

--- a/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdownContent.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdownContent.tsx
@@ -23,7 +23,7 @@ import { useModalActions } from '~/contexts/modal/ModalContext';
 import { ProfileDropdownContentFragment$key } from '~/generated/ProfileDropdownContentFragment.graphql';
 import usePersistedState from '~/hooks/usePersistedState';
 import ManageWalletsModal from '~/scenes/Modals/ManageWalletsModal';
-import SettingsModal from '~/scenes/Modals/SettingsModal';
+import SettingsModal from '~/scenes/Modals/SettingsModal/SettingsModal';
 import { getEditGalleryUrl } from '~/utils/getEditGalleryUrl';
 import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 

--- a/src/scenes/Modals/SettingsModal.tsx
+++ b/src/scenes/Modals/SettingsModal.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
 import { Button } from '~/components/core/Button/Button';
+import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import { BaseM, TitleDiatypeL, TitleDiatypeM } from '~/components/core/Text/Text';
 import Toggle from '~/components/core/Toggle/Toggle';
@@ -12,6 +13,8 @@ import ManageWallets from '~/components/ManageWallets/ManageWallets';
 import { useReportError } from '~/contexts/errorReporting/ErrorReportingContext';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { SettingsModalFragment$key } from '~/generated/SettingsModalFragment.graphql';
+import AlertTriangleIcon from '~/icons/AlertTriangleIcon';
+import CircleCheckIcon from '~/icons/CircleCheckIcon';
 
 import useUpdateEmailNotificationSettings from '../../components/Email/useUpdateEmailNotificationSettings';
 
@@ -42,6 +45,9 @@ function SettingsModal({
                 unsubscribedFromAll
                 unsubscribedFromNotifications
               }
+            }
+            user {
+              roles
             }
           }
         }
@@ -145,6 +151,10 @@ function SettingsModal({
     return isEmailNotificationChecked;
   }, [isEmailNotificationChecked, isEmailNotificationSubscribed, isEmailUnverified, userEmail]);
 
+  const hasEarlyAccess = useMemo(() => {
+    return query.viewer?.user?.roles?.includes('EARLY_ACCESS');
+  }, [query]);
+
   return (
     <StyledManageWalletsModal gap={24}>
       <VStack gap={16}>
@@ -171,6 +181,33 @@ function SettingsModal({
             </StyledButton>
           )}
         </StyledButtonContainer>
+      </VStack>
+      <StyledHr />
+      <VStack>
+        <TitleDiatypeL>Early Access</TitleDiatypeL>
+        <HStack justify="space-between" align="center" gap={8}>
+          <span>
+            <BaseM>
+              Try select features early by holding a{' '}
+              <InteractiveLink href="https://opensea.io/collection/gallery-membership-cards">
+                Premium Gallery Membership Card.
+              </InteractiveLink>
+            </BaseM>
+          </span>
+          <HStack align="center" gap={4} shrink={false}>
+            {hasEarlyAccess ? (
+              <>
+                <CircleCheckIcon />
+                <BaseM>Active</BaseM>
+              </>
+            ) : (
+              <>
+                <AlertTriangleIcon />
+                <BaseM>Not Active</BaseM>
+              </>
+            )}
+          </HStack>
+        </HStack>
       </VStack>
       <StyledHr />
       <VStack>

--- a/src/scenes/Modals/SettingsModal.tsx
+++ b/src/scenes/Modals/SettingsModal.tsx
@@ -15,6 +15,7 @@ import { useToastActions } from '~/contexts/toast/ToastContext';
 import { SettingsModalFragment$key } from '~/generated/SettingsModalFragment.graphql';
 import AlertTriangleIcon from '~/icons/AlertTriangleIcon';
 import CircleCheckIcon from '~/icons/CircleCheckIcon';
+import { GALLERY_OS_ADDRESS } from '~/utils/getOpenseaExternalUrl';
 
 import useUpdateEmailNotificationSettings from '../../components/Email/useUpdateEmailNotificationSettings';
 
@@ -188,10 +189,13 @@ function SettingsModal({
         <HStack justify="space-between" align="center" gap={8}>
           <span>
             <BaseM>
-              Try select features early by holding a{' '}
-              <InteractiveLink href="https://opensea.io/collection/gallery-membership-cards">
-                Premium Gallery Membership Card.
+              Get early access to select features by holding a{' '}
+              <InteractiveLink
+                href={`https://opensea.io/collection/gallery-membership-cards?ref=${GALLERY_OS_ADDRESS}`}
+              >
+                Premium Gallery Membership Card
               </InteractiveLink>
+              .
             </BaseM>
           </span>
           <HStack align="center" gap={4} shrink={false}>

--- a/src/scenes/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/scenes/Modals/SettingsModal/SettingsModal.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
 import { Button } from '~/components/core/Button/Button';
+import colors from '~/components/core/colors';
 import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import { BaseM, TitleDiatypeL, TitleDiatypeM } from '~/components/core/Text/Text';
@@ -13,7 +14,6 @@ import ManageWallets from '~/components/ManageWallets/ManageWallets';
 import { useReportError } from '~/contexts/errorReporting/ErrorReportingContext';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { SettingsModalFragment$key } from '~/generated/SettingsModalFragment.graphql';
-import AlertTriangleIcon from '~/icons/AlertTriangleIcon';
 import CircleCheckIcon from '~/icons/CircleCheckIcon';
 import { GALLERY_OS_ADDRESS } from '~/utils/getOpenseaExternalUrl';
 
@@ -206,10 +206,7 @@ function SettingsModal({
                 <BaseM>Active</BaseM>
               </>
             ) : (
-              <>
-                <AlertTriangleIcon />
-                <BaseM>Not Active</BaseM>
-              </>
+              <BaseM color={colors.metal}>Inactive</BaseM>
             )}
           </HStack>
         </HStack>

--- a/src/scenes/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/scenes/Modals/SettingsModal/SettingsModal.tsx
@@ -17,7 +17,8 @@ import AlertTriangleIcon from '~/icons/AlertTriangleIcon';
 import CircleCheckIcon from '~/icons/CircleCheckIcon';
 import { GALLERY_OS_ADDRESS } from '~/utils/getOpenseaExternalUrl';
 
-import useUpdateEmailNotificationSettings from '../../components/Email/useUpdateEmailNotificationSettings';
+import useUpdateEmailNotificationSettings from '../../../components/Email/useUpdateEmailNotificationSettings';
+import SettingsRowDescription from './SettingsRowDescription';
 
 type Props = {
   queryRef: SettingsModalFragment$key;
@@ -162,10 +163,10 @@ function SettingsModal({
         <TitleDiatypeL>Never miss a moment</TitleDiatypeL>
         <VStack>
           <TitleDiatypeM>Email notifications</TitleDiatypeM>
-          <HStack>
-            <BaseM>
+          <HStack justify="space-between" align="center">
+            <SettingsRowDescription>
               Receive weekly recaps that show your most recent admires, comments, and followers.
-            </BaseM>
+            </SettingsRowDescription>
             <Toggle
               checked={isToggleChecked}
               isPending={isPending || isEmailUnverified}
@@ -188,7 +189,7 @@ function SettingsModal({
         <TitleDiatypeL>Early Access</TitleDiatypeL>
         <HStack justify="space-between" align="center" gap={8}>
           <span>
-            <BaseM>
+            <SettingsRowDescription>
               Get early access to select features by holding a{' '}
               <InteractiveLink
                 href={`https://opensea.io/collection/gallery-membership-cards?ref=${GALLERY_OS_ADDRESS}`}
@@ -196,7 +197,7 @@ function SettingsModal({
                 Premium Gallery Membership Card
               </InteractiveLink>
               .
-            </BaseM>
+            </SettingsRowDescription>
           </span>
           <HStack align="center" gap={4} shrink={false}>
             {hasEarlyAccess ? (

--- a/src/scenes/Modals/SettingsModal/SettingsRowDescription.tsx
+++ b/src/scenes/Modals/SettingsModal/SettingsRowDescription.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+import { BaseM } from '~/components/core/Text/Text';
+
+export default styled(BaseM)`
+  max-width: 380px;
+`;

--- a/src/scenes/Modals/useOpenSettingsModal.tsx
+++ b/src/scenes/Modals/useOpenSettingsModal.tsx
@@ -6,7 +6,7 @@ import { useModalActions } from '~/contexts/modal/ModalContext';
 import { useOpenSettingsModalFragment$key } from '~/generated/useOpenSettingsModalFragment.graphql';
 import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
-import SettingsModal from './SettingsModal';
+import SettingsModal from './SettingsModal/SettingsModal';
 
 export default function useOpenSettingsModal(queryRef: useOpenSettingsModalFragment$key) {
   const query = useFragment(

--- a/src/utils/getOpenseaExternalUrl.ts
+++ b/src/utils/getOpenseaExternalUrl.ts
@@ -1,4 +1,4 @@
-const GALLERY_OS_ADDRESS = '0x8914496dc01efcc49a2fa340331fb90969b6f1d2';
+export const GALLERY_OS_ADDRESS = '0x8914496dc01efcc49a2fa340331fb90969b6f1d2';
 
 // The backend converts all token IDs to hexadecimals; here, we convert back
 // https://stackoverflow.com/a/53751162


### PR DESCRIPTION
### Description
Show the user's Early Access status (whether or not they are holding a Premium card) in the settings popover


### Screenshots
Early Access active (desktop)
<img width="518" alt="Screen Shot 2022-12-23 at 12 54 19" src="https://user-images.githubusercontent.com/80802871/209301258-9476bcc2-220f-4b87-940d-dfa6f61df6a3.png">


Early Access active (mobile)
<img width="391" alt="Screen Shot 2022-12-23 at 16 30 35" src="https://user-images.githubusercontent.com/80802871/209301272-34991e71-feb4-4d2e-9954-513477875b54.png">


Early Access not active (desktop)
<img width="513" alt="Screen Shot 2022-12-23 at 12 55 40" src="https://user-images.githubusercontent.com/80802871/209301291-dde577ec-9b82-4393-91c6-9ab80cbf16f2.png">


Early Access not active (mobile)
<img width="364" alt="Screen Shot 2022-12-23 at 16 30 44" src="https://user-images.githubusercontent.com/80802871/209301313-1611cf43-1459-4477-89b4-0f5290eb3b92.png">

