### PR TITLE
Clarify copy for manually redeemed items

### DIFF
--- a/src/scenes/MerchStorePage/Redemption/RedeemedItem.tsx
+++ b/src/scenes/MerchStorePage/Redemption/RedeemedItem.tsx
@@ -6,6 +6,8 @@ import { HStack } from '~/components/core/Spacer/Stack';
 import { TitleMonoM } from '~/components/core/Text/Text';
 import CopyIcon from '~/icons/CopyIcon';
 
+import { REDEEMED_STATUS } from '../constants';
+
 type Props = {
   name: string;
   discountCode: string;
@@ -17,11 +19,13 @@ export default function RedeemedItem({ name, discountCode }: Props) {
       <StyledRedeemItemText>{name}</StyledRedeemItemText>
       <HStack gap={16}>
         <TitleMonoM>{discountCode}</TitleMonoM>
-        <StyledCopyCodeButton>
-          <CopyToClipboard textToCopy={discountCode} successText="Copied.">
-            <CopyIcon color={colors.offBlack} />
-          </CopyToClipboard>
-        </StyledCopyCodeButton>
+        {discountCode === REDEEMED_STATUS ? null : (
+          <StyledCopyCodeButton>
+            <CopyToClipboard textToCopy={discountCode} successText="Copied.">
+              <CopyIcon color={colors.offBlack} />
+            </CopyToClipboard>
+          </StyledCopyCodeButton>
+        )}
       </HStack>
     </StyledRedeemItemContainer>
   );

--- a/src/scenes/MerchStorePage/Redemption/RedeemedPage.tsx
+++ b/src/scenes/MerchStorePage/Redemption/RedeemedPage.tsx
@@ -9,6 +9,7 @@ import { useModalActions } from '~/contexts/modal/ModalContext';
 import { RedeemedPageFragment$key } from '~/generated/RedeemedPageFragment.graphql';
 import ArrowUpRightIcon from '~/icons/ArrowUpRightIcon';
 
+import { REDEEMED_STATUS } from '../constants';
 import { getObjectName } from '../getObjectName';
 import RedeemedItem from './RedeemedItem';
 
@@ -53,7 +54,11 @@ export default function RedeemedPage({ merchTokenRefs }: Props) {
                 <RedeemedItem
                   key={token.tokenId}
                   name={name}
-                  discountCode={token.discountCode || ''}
+                  // if the backend returns a redeemed token but no discount code, this means
+                  // the token was manually marked as redeemed on the user's behalf (e.g. free
+                  // giveaway from NFT NYC). this prevents the user from redeeming further merch
+                  // from NFTs they'd received in the past.
+                  discountCode={token.discountCode || REDEEMED_STATUS}
                 />
               );
             })}

--- a/src/scenes/MerchStorePage/Redemption/ToRedeemPage.tsx
+++ b/src/scenes/MerchStorePage/Redemption/ToRedeemPage.tsx
@@ -114,7 +114,7 @@ export default function ToRedeemPage({ onToggle, merchTokenRefs }: Props) {
       ) : (
         <StyledToRedeemPageContainer>
           <StyledRedeemTextContainer>
-            <BaseM>You have not purchased any merchandise.</BaseM>
+            <BaseM>You do not have any merchandise to redeem.</BaseM>
           </StyledRedeemTextContainer>
           <StyledRedeemFooter>
             <StyledRedeemSubmitButton onClick={handleClose}>Close</StyledRedeemSubmitButton>

--- a/src/scenes/MerchStorePage/constants.ts
+++ b/src/scenes/MerchStorePage/constants.ts
@@ -1,1 +1,2 @@
 export const MAX_NFTS_PER_WALLET = 3;
+export const REDEEMED_STATUS = 'REDEEMED';


### PR DESCRIPTION
This PR handles the case where the user owns merch NFTs that have already been marked as `redeemed` on the user's behalf (e.g. for employees, people from NFT NYC who received a free one, etc.). Without this, the user would think they could redeem their existing, redeemed NFTs for more merch.

**Before**
This copy wasn't totally accurate; I _have_ merch NFTs, they've just been manually redeemed for me

<img width="534" alt="image" src="https://user-images.githubusercontent.com/12162433/208518165-babf3829-eb50-4802-945b-9f134421f011.png">

**After**

<img width="550" alt="Screen Shot 2022-12-19 at 3 34 06 PM" src="https://user-images.githubusercontent.com/12162433/208517285-3dc3b274-7774-47f1-9c8b-e254c264afc3.png">

**Before**
Copy icon displayed despite lack of discount codes

<img width="534" alt="image" src="https://user-images.githubusercontent.com/12162433/208518045-9f9a621d-9156-4e09-9934-1f7cdd37c91c.png">

**After**
Clearer status

<img width="548" alt="Screen Shot 2022-12-19 at 3 32 44 PM" src="https://user-images.githubusercontent.com/12162433/208517286-4c1c7f42-f103-409e-b765-63b0fea9ddc1.png">
