### PR TITLE
Increase line clamp for community pages

### DIFF
--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -147,19 +147,12 @@ const StyledCommunityPageContainer = styled.div`
 `;
 
 const StyledBaseM = styled(BaseM)<{ showExpandedDescription: boolean }>`
-  -webkit-line-clamp: ${({ showExpandedDescription }) => (showExpandedDescription ? 'initial' : 4)};
+  -webkit-line-clamp: ${({ showExpandedDescription }) => (showExpandedDescription ? 'initial' : 5)};
   display: -webkit-box;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  line-clamp: 4;
+  line-clamp: 5;
   display: -webkit-box;
-
-  // allows descriptions with multiple paragraphs to be line clamped properly
-  p,
-  ol,
-  li {
-    display: contents;
-  }
 `;
 
 const StyledDescriptionWrapper = styled(VStack)`

--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -93,7 +93,7 @@ export default function CommunityPageView({ communityRef, queryRef }: Props) {
       <StyledCommunityPageContainer>
         <HStack>
           <StyledHeader>
-            <HStack gap={4} align="center">
+            <HStack gap={8} align="center">
               <TitleL>{name}</TitleL>
               {badgeURL && <StyledBadge src={badgeURL} />}
             </HStack>


### PR DESCRIPTION
Also ensure line breaks are respected 

**Before**
<img width="700" alt="image" src="https://user-images.githubusercontent.com/12162433/208751074-9c14d8ec-ea32-4a66-9c9d-e47d95d6f08a.png">

**After**
<img width="661" alt="image" src="https://user-images.githubusercontent.com/12162433/208750800-620c5d4f-ca1c-45cd-b775-128eb5284aff.png">
