### PR TITLE
Fix shop owned quantity

### DIFF
--- a/src/scenes/MerchStorePage/ItemPreview.tsx
+++ b/src/scenes/MerchStorePage/ItemPreview.tsx
@@ -18,12 +18,14 @@ export default function ItemPreview({
   title,
   description,
   tokenId,
+  quantity,
 }: {
   label: string;
   image: string;
   title: string;
   description: string;
   tokenId: number;
+  quantity: number;
 }) {
   const { showModal } = useModalActions();
   const handleClick = useCallback(() => {
@@ -45,7 +47,7 @@ export default function ItemPreview({
 
   const contract = useMintMerchContract();
 
-  const { soldOut, userOwnedSupply } = useMintContractWithQuantity({
+  const { soldOut } = useMintContractWithQuantity({
     // @ts-expect-error: fix this later, related to web3 lib upgrade
     contract,
     tokenId,
@@ -63,9 +65,7 @@ export default function ItemPreview({
         <FlippingImage src={image} isInPreview isFlipped={isFlipped} />
       </StyledImageContainer>
       <StyledTopRightLabels>
-        {typeof userOwnedSupply == 'number' && userOwnedSupply > 0 && (
-          <StyledOwnedText>You Own {userOwnedSupply}</StyledOwnedText>
-        )}
+        {quantity > 0 && <StyledOwnedText>You Own {quantity}</StyledOwnedText>}
         {soldOut && <StyledSoldOutText>Sold Out</StyledSoldOutText>}
       </StyledTopRightLabels>
       <StyledBottomText>

--- a/src/scenes/MerchStorePage/ListMerchItems.tsx
+++ b/src/scenes/MerchStorePage/ListMerchItems.tsx
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import breakpoints from '~/components/core/breakpoints';
+import { ListMerchItemsFragment$key } from '~/generated/ListMerchItemsFragment.graphql';
+import { removeNullValues } from '~/utils/removeNullValues';
+
+import ItemPreview from './ItemPreview';
+import { merchItems } from './MerchStorePage';
+
+type Props = {
+  queryRef: ListMerchItemsFragment$key;
+};
+
+export default function ListMerchItems({ queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment ListMerchItemsFragment on MerchTokensPayload {
+        tokens {
+          objectType
+        }
+      }
+    `,
+    queryRef
+  );
+
+  const { tokens } = query;
+  const nonNullTokens = useMemo(() => removeNullValues(tokens), [tokens]);
+
+  const merchItemsWithQuantity = useMemo(() => {
+    const merchItemsWithQuantity = merchItems.map((item) => {
+      const matchingToken = nonNullTokens.filter((token) => token.objectType === item.type);
+      return {
+        ...item,
+        quantity: matchingToken.length,
+      };
+    });
+    return merchItemsWithQuantity;
+  }, [nonNullTokens]);
+
+  console.log('merchItemsWithQuantity', merchItemsWithQuantity);
+
+  return (
+    <StyledItemsContainer>
+      {merchItemsWithQuantity.map((item) => (
+        <ItemPreview {...item} key={item.label} />
+      ))}
+    </StyledItemsContainer>
+  );
+}
+
+const StyledItemsContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  place-items: center;
+
+  @media only screen and ${breakpoints.tablet} {
+    flex-direction: row;
+    padding: 0;
+  }
+`;

--- a/src/scenes/MerchStorePage/MerchStorePage.tsx
+++ b/src/scenes/MerchStorePage/MerchStorePage.tsx
@@ -17,7 +17,7 @@ import LogoBracketLeft from '~/icons/LogoBracketLeft';
 import LogoBracketRight from '~/icons/LogoBracketRight';
 
 import Countdown from './Countdown';
-import ItemPreview from './ItemPreview';
+import ListMerchItems from './ListMerchItems';
 import useRedeemModal from './Redemption/useRedeemModal';
 
 export type MerchItemTypes = {
@@ -38,6 +38,7 @@ export const merchItems = [
       'Black short sleeve cotton t-shirt with puff-print design on left chest and both puff-print and screen-print design on full back.\nThe first entry in the (OBJECTS) Gallery merch collection.\nThis token may be used to claim 1 physical corresponding merch item during the redemption period.',
     price: '0.05',
     tokenId: 0,
+    type: 'TShirt',
   },
   {
     label: 'Hat',
@@ -47,6 +48,7 @@ export const merchItems = [
       'Black hat with embroidered text design at center front and embroidered Gallery logo at center back.\nThe second entry in the (OBJECTS) Gallery merch collection.\nThis token may be used to claim 1 physical corresponding merch item during the redemption period.',
     price: '0.06',
     tokenId: 1,
+    type: 'Hat',
   },
   {
     label: 'Card',
@@ -56,6 +58,7 @@ export const merchItems = [
       'Metallic membership card laser etched with the Gallery logo on the front and text design on the back.\nThe third entry in the (OBJECTS) Gallery merch collection.\nThis token may be used to claim 1 physical corresponding merch item during the redemption period.',
     price: '0.08',
     tokenId: 2,
+    type: 'Card',
   },
 ];
 
@@ -71,6 +74,7 @@ export default function MerchStorePage({ queryRef }: Props) {
         merchTokens: getMerchTokens(wallet: $wallet) @required(action: THROW) {
           __typename
           ...useRedeemModalQueryFragment
+          ...ListMerchItemsFragment
         }
 
         viewer {
@@ -124,11 +128,7 @@ export default function MerchStorePage({ queryRef }: Props) {
       </StyledButtonContainer>
       <StyledContent gap={32} align="center">
         <TitleMonoM>Physical redemption is now available.</TitleMonoM>
-        <StyledItemsContainer>
-          {merchItems.map((item) => (
-            <ItemPreview {...item} key={item.label} />
-          ))}
-        </StyledItemsContainer>
+        <ListMerchItems queryRef={merchTokens} />
       </StyledContent>
     </StyledPage>
   );
@@ -191,17 +191,4 @@ const StyledLogoBracketLeft = styled(LogoBracketLeft)`
 const StyledLogoBracketRight = styled(LogoBracketRight)`
   width: 8px;
   height: 26px;
-`;
-
-const StyledItemsContainer = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  place-items: center;
-
-  @media only screen and ${breakpoints.tablet} {
-    flex-direction: row;
-    padding: 0;
-  }
 `;


### PR DESCRIPTION
**Notes**
This scenario only happens if the users transferred out his merch nft after they minted. 

**Changes**
Instead of getting the quantity from the **contract**,  we used the existing `getMerch` backend to map all the value

Example: My wallet only have 1 Merch NFT (TShirt)

**Before**

![CleanShot 2022-12-21 at 13 57 17](https://user-images.githubusercontent.com/4480258/208832253-103fd12f-b07e-4747-898c-d636d56e4a8b.png)


**After**

![CleanShot 2022-12-21 at 13 56 36](https://user-images.githubusercontent.com/4480258/208832270-66b02cca-45f5-4843-b18f-a8a995cf8d1b.png)

