### PR TITLE
Fix sidebar infinite loop

### DIFF
--- a/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarTokens.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarTokens.tsx
@@ -118,12 +118,11 @@ export const SidebarTokens = ({
     if (shouldUseCollectionGrouping) {
       const groups = groupCollectionsByAddress({ tokens, editModeTokens });
 
-      return createVirtualizedRowsFromGroups({ groups, erroredTokenIds, collapsedCollections });
+      return createVirtualizedRowsFromGroups({ groups, collapsedCollections });
     } else {
       return createVirtualizedRowsFromTokens({
         tokens,
         editModeTokens,
-        erroredTokenIds,
       });
     }
   }, [collapsedCollections, editModeTokens, erroredTokenIds, shouldUseCollectionGrouping, tokens]);

--- a/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarTokens.tsx
+++ b/src/components/ManageGallery/OrganizeCollection/Sidebar/SidebarTokens.tsx
@@ -74,7 +74,7 @@ export const SidebarTokens = ({
     [tokens, setSpamPreference]
   );
 
-  const [erroredTokenIds, setErroredTokenIds] = useState<Set<string>>(new Set());
+  const [, setErroredTokenIds] = useState<Set<string>>(new Set());
   const [collapsedCollections, setCollapsedCollections] = useState<Set<string>>(new Set());
 
   const handleMarkErroredTokenId = useCallback((id: string) => {
@@ -125,7 +125,7 @@ export const SidebarTokens = ({
         editModeTokens,
       });
     }
-  }, [collapsedCollections, editModeTokens, erroredTokenIds, shouldUseCollectionGrouping, tokens]);
+  }, [collapsedCollections, editModeTokens, shouldUseCollectionGrouping, tokens]);
 
   useEffect(
     function resetCollapsedSectionsWhileSearching() {

--- a/src/components/ManageGallery/OrganizeCollection/Sidebar/createVirtualizedRowsFromGroups.ts
+++ b/src/components/ManageGallery/OrganizeCollection/Sidebar/createVirtualizedRowsFromGroups.ts
@@ -10,39 +10,24 @@ import { SidebarTokensFragment$data } from '~/generated/SidebarTokensFragment.gr
 
 type createVirtualizedRowsFromGroupsArgs = {
   groups: CollectionGroup[];
-  erroredTokenIds: Set<string>;
   collapsedCollections: Set<string>;
 };
 
 export function createVirtualizedRowsFromGroups({
   groups,
-  erroredTokenIds,
   collapsedCollections,
 }: createVirtualizedRowsFromGroupsArgs): VirtualizedRow[] {
   const rows: VirtualizedRow[] = [];
 
   for (const group of groups) {
-    const tokensSortedByErrored: TokenAndEditModeToken[] = [...group.tokens].sort((a, b) => {
-      const aIsErrored = erroredTokenIds.has(a.token.dbid);
-      const bIsErrored = erroredTokenIds.has(b.token.dbid);
-
-      if (aIsErrored === bIsErrored) {
-        return 0;
-      } else if (aIsErrored) {
-        return 1;
-      } else {
-        return -1;
-      }
-    });
-
     // Default to expanded
     const expanded = !collapsedCollections.has(group.address);
 
     rows.push({ type: 'collection-title', expanded, address: group.address, title: group.title });
 
     const COLUMNS_PER_ROW = 3;
-    for (let i = 0; i < tokensSortedByErrored.length; i += COLUMNS_PER_ROW) {
-      const rowTokens = tokensSortedByErrored.slice(i, i + COLUMNS_PER_ROW);
+    for (let i = 0; i < group.tokens.length; i += COLUMNS_PER_ROW) {
+      const rowTokens = group.tokens.slice(i, i + COLUMNS_PER_ROW);
 
       rows.push({ type: 'tokens', tokens: rowTokens, expanded });
     }
@@ -54,38 +39,21 @@ export function createVirtualizedRowsFromGroups({
 type createVirtualizedRowsFromTokensArgs = {
   tokens: SidebarTokensFragment$data;
   editModeTokens: EditModeToken[];
-  erroredTokenIds: Set<string>;
 };
 
 export function createVirtualizedRowsFromTokens({
   tokens,
   editModeTokens,
-  erroredTokenIds,
 }: createVirtualizedRowsFromTokensArgs): VirtualizedRow[] {
   const rows: VirtualizedRow[] = [];
   const tokensKeyedById = keyBy(tokens, (token) => token.dbid);
 
-  const editModeTokensSortedByErrored = [...editModeTokens].sort((a, b) => {
-    const aIsErrored = erroredTokenIds.has(a.id);
-    const bIsErrored = erroredTokenIds.has(b.id);
-
-    if (aIsErrored === bIsErrored) {
-      return 0;
-    } else if (aIsErrored) {
-      return 1;
-    } else {
-      return -1;
-    }
+  const tokensSortedByErrored: TokenAndEditModeToken[] = editModeTokens.map((editModeToken) => {
+    return {
+      editModeToken,
+      token: tokensKeyedById[editModeToken.id],
+    };
   });
-
-  const tokensSortedByErrored: TokenAndEditModeToken[] = editModeTokensSortedByErrored.map(
-    (editModeToken) => {
-      return {
-        editModeToken,
-        token: tokensKeyedById[editModeToken.id],
-      };
-    }
-  );
 
   const COLUMNS_PER_ROW = 3;
   for (let i = 0; i < tokensSortedByErrored.length; i += COLUMNS_PER_ROW) {

--- a/src/components/NftFailureFallback/NftFailureBoundary.tsx
+++ b/src/components/NftFailureFallback/NftFailureBoundary.tsx
@@ -1,4 +1,4 @@
-import { createElement, useContext, useMemo } from 'react';
+import { createElement, useMemo } from 'react';
 
 import {
   ReportingErrorBoundary,
@@ -26,7 +26,7 @@ export function NftFailureBoundary({ tokenId, additionalTags, ...rest }: Props) 
     if (typeof fallback === 'function') {
       return createElement(fallback, { error: new Error() });
     } else {
-      return fallback ?? null;
+      return <>{fallback}</>;
     }
   }
 

--- a/src/components/NftFailureFallback/NftFailureBoundary.tsx
+++ b/src/components/NftFailureFallback/NftFailureBoundary.tsx
@@ -1,21 +1,34 @@
-import { useMemo } from 'react';
+import { createElement, useContext, useMemo } from 'react';
 
 import {
   ReportingErrorBoundary,
   ReportingErrorBoundaryProps,
 } from '~/contexts/boundary/ReportingErrorBoundary';
+import { useNftErrorContext } from '~/contexts/NftErrorContext';
 
 type Props = {
   tokenId: string;
 } & ReportingErrorBoundaryProps;
 
 export function NftFailureBoundary({ tokenId, additionalTags, ...rest }: Props) {
+  const { tokens } = useNftErrorContext();
+
   const tagsToSendThrough = useMemo(() => {
     return {
       ...additionalTags,
       tokenId,
     };
   }, [additionalTags, tokenId]);
+
+  if (tokens[tokenId]?.isFailed) {
+    const fallback = rest.fallback;
+
+    if (typeof fallback === 'function') {
+      return createElement(fallback, { error: new Error() });
+    } else {
+      return fallback ?? null;
+    }
+  }
 
   return <ReportingErrorBoundary {...rest} additionalTags={tagsToSendThrough} />;
 }

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -2,6 +2,7 @@ import { Environment, RelayEnvironmentProvider } from 'react-relay';
 
 import Debugger from '~/components/Debugger/Debugger';
 import { GalleryNavigationProvider } from '~/contexts/navigation/GalleryNavigationProvider';
+import { NftErrorProvider } from '~/contexts/NftErrorContext';
 import { SyncTokensLockProvider } from '~/contexts/SyncTokensLockContext';
 import isProduction from '~/utils/isProduction';
 
@@ -33,14 +34,16 @@ export default function AppProvider({ children, relayEnvironment }: Props) {
                 <SwrProvider>
                   <GalleryNavigationProvider>
                     <ModalProvider>
-                      <SyncTokensLockProvider>
-                        <SnowProvider>
-                          <GlobalLayoutContextProvider>
-                            {isProd ? null : <Debugger />}
-                            {children}
-                          </GlobalLayoutContextProvider>
-                        </SnowProvider>
-                      </SyncTokensLockProvider>
+                      <NftErrorProvider>
+                        <SyncTokensLockProvider>
+                          <SnowProvider>
+                            <GlobalLayoutContextProvider>
+                              {isProd ? null : <Debugger />}
+                              {children}
+                            </GlobalLayoutContextProvider>
+                          </SnowProvider>
+                        </SyncTokensLockProvider>
+                      </NftErrorProvider>
                     </ModalProvider>
                   </GalleryNavigationProvider>
                 </SwrProvider>

--- a/src/contexts/NftErrorContext.tsx
+++ b/src/contexts/NftErrorContext.tsx
@@ -109,7 +109,7 @@ export function NftErrorProvider({ children }: PropsWithChildren) {
 
   const environment = useRelayEnvironment();
   const FragmentResource = getFragmentResourceForEnvironment(environment);
-  const retryToken = useCallback<NftErrorContextType['retryToken']>(
+  const retryToken = useCallback(
     (tokenId: string) => {
       addBreadcrumb({
         message: 'Trying to clear the Relay FragmentResource cache',

--- a/src/contexts/NftErrorContext.tsx
+++ b/src/contexts/NftErrorContext.tsx
@@ -1,0 +1,246 @@
+import { addBreadcrumb } from '@sentry/nextjs';
+import {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { useRelayEnvironment } from 'react-relay';
+// @ts-expect-error We're in untyped territory
+import { getFragmentResourceForEnvironment } from 'react-relay/lib/relay-hooks/FragmentResource';
+import { graphql } from 'relay-runtime';
+
+import { useReportError } from '~/contexts/errorReporting/ErrorReportingContext';
+import { useToastActions } from '~/contexts/toast/ToastContext';
+import { CouldNotRenderNftError } from '~/errors/CouldNotRenderNftError';
+import { NftErrorContextRetryMutation } from '~/generated/NftErrorContextRetryMutation.graphql';
+import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
+
+type TokenErrorState = {
+  isFailed: boolean;
+  retryKey: number;
+  refreshed: boolean;
+  refreshingMetadata: boolean;
+};
+
+type TokenErrorMap = Record<string, TokenErrorState>;
+
+type NftErrorContextType = {
+  tokens: TokenErrorMap;
+
+  markTokenAsLoaded: (tokenId: string) => void;
+  handleNftError: (tokenId: string, error: Error) => void;
+  refreshToken: (tokenId: string) => Promise<void>;
+};
+
+const NftErrorContext = createContext<NftErrorContextType | undefined>(undefined);
+
+export function defaultTokenErrorState(): TokenErrorState {
+  return {
+    isFailed: false,
+    retryKey: 0,
+    refreshed: false,
+    refreshingMetadata: false,
+  };
+}
+
+export function NftErrorProvider({ children }: PropsWithChildren) {
+  const reportError = useReportError();
+  const { pushToast } = useToastActions();
+  const [tokens, setTokens] = useState<TokenErrorMap>(() => ({}));
+
+  const markTokenAsLoaded = useCallback<NftErrorContextType['markTokenAsLoaded']>(
+    (tokenId: string) => {
+      setTokens((previous) => {
+        const next: TokenErrorMap = { ...previous };
+
+        delete next[tokenId];
+
+        return next;
+      });
+    },
+    []
+  );
+
+  const handleNftError = useCallback<NftErrorContextType['handleNftError']>(
+    (tokenId: string, error: Error) => {
+      const token = { ...(tokens[tokenId] ?? defaultTokenErrorState()) };
+
+      token.isFailed = true;
+
+      // If the user refreshed the metadata and there was another failure,
+      // we'll show them a new toast telling them things failed to load,
+      // and we're looking into the issue asap.
+      if (token.refreshed) {
+        pushToast({
+          message:
+            'This piece has failed to load. This issue has been reported to the Gallery team.',
+          autoClose: true,
+        });
+      }
+
+      const commonTags = {
+        tokenId,
+        alreadyRefreshed: token.refreshed,
+      };
+
+      if (error instanceof CouldNotRenderNftError) {
+        reportError('NftLoadError: ' + error.message, {
+          tags: { ...commonTags, ...error.metadata },
+        });
+      } else {
+        reportError('NftLoadError: Could not load nft', {
+          tags: commonTags,
+        });
+      }
+
+      setTokens((previous) => {
+        const next = { ...previous };
+
+        next[tokenId] = token;
+
+        return next;
+      });
+    },
+    [pushToast, reportError, tokens]
+  );
+
+  const environment = useRelayEnvironment();
+  const FragmentResource = getFragmentResourceForEnvironment(environment);
+  const retryToken = useCallback<NftErrorContextType['retryToken']>(
+    (tokenId: string) => {
+      addBreadcrumb({
+        message: 'Trying to clear the Relay FragmentResource cache',
+        level: 'info',
+      });
+
+      // Wrapping this in a try catch since we have no idea
+      // if Relay wil introduce a breaking change here.
+      try {
+        /**
+         * WARNING: DO NOT COPY THIS CODE UNLESS YOU KNOW WHAT YOU ARE DOING
+         *
+         * There is a bug in Relay where fragments are not receiving updates
+         * if an underlying object's typename changes.
+         *
+         * We should report this at some point [GAL-371]
+         */
+        FragmentResource._cache._map.clear();
+      } catch (e) {
+        if (e instanceof Error || typeof e === 'string') {
+          reportError(e);
+        }
+      }
+
+      const token = { ...(tokens[tokenId] ?? defaultTokenErrorState()) };
+
+      token.isFailed = false;
+      token.refreshed = true;
+      token.retryKey++;
+
+      setTokens((previous) => {
+        const next = { ...previous };
+
+        next[tokenId] = token;
+
+        return next;
+      });
+    },
+    // Make sure this dep is `FragmentResource`, this is all untyped
+    // `FragmentResource._cache._map` might cause a HUGE ERROR
+    [FragmentResource, reportError, tokens]
+  );
+
+  const [refresh] = usePromisifiedMutation<NftErrorContextRetryMutation>(graphql`
+    mutation NftErrorContextRetryMutation($tokenId: DBID!) {
+      refreshToken(tokenId: $tokenId) {
+        ... on RefreshTokenPayload {
+          __typename
+          token {
+            # Ensure we're reloading the necessary data
+            ...NftPreviewTokenFragment
+            ...SidebarNftIconPreviewAsset
+            ...NftDetailAssetTokenFragment
+            ...BigNftFragment
+            ...CollectionRowCompactNftsFragment
+            ...StagingAreaFragment
+          }
+        }
+      }
+    }
+  `);
+
+  const refreshToken = useCallback<NftErrorContextType['refreshToken']>(
+    async (tokenId: string) => {
+      function pushErrorToast() {
+        pushToast({
+          message:
+            'There was an error while refreshing your piece. We have been notified and are looking into it.',
+          autoClose: true,
+        });
+      }
+
+      pushToast({
+        message: 'This piece is loading. This may take up to a few minutes.',
+        autoClose: true,
+      });
+
+      try {
+        setTokens((previous) => {
+          const next = { ...previous };
+
+          next[tokenId] = { ...next[tokenId], refreshingMetadata: true };
+
+          return next;
+        });
+
+        const response = await refresh({ variables: { tokenId } });
+
+        if (response.refreshToken?.__typename === 'RefreshTokenPayload') {
+          retryToken(tokenId);
+        } else {
+          pushErrorToast();
+          reportError('GraphQL Error while refreshing nft metadata', {
+            tags: { tokenId, typename: response.refreshToken?.__typename },
+          });
+        }
+      } catch (e) {
+        reportError('GraphQL Error while refreshing nft metadata', { tags: { tokenId } });
+        pushErrorToast();
+      } finally {
+        setTokens((previous) => {
+          const next = { ...previous };
+
+          next[tokenId] = { ...next[tokenId], refreshingMetadata: false };
+
+          return next;
+        });
+      }
+    },
+    [pushToast, refresh, reportError, retryToken]
+  );
+
+  const value = useMemo((): NftErrorContextType => {
+    return {
+      tokens,
+
+      markTokenAsLoaded,
+      refreshToken,
+      handleNftError,
+    };
+  }, [handleNftError, markTokenAsLoaded, refreshToken, tokens]);
+
+  return <NftErrorContext.Provider value={value}>{children}</NftErrorContext.Provider>;
+}
+
+export function useNftErrorContext() {
+  const value = useContext(NftErrorContext);
+
+  if (!value) {
+    throw new Error('Tried to use an NftErrorContext without a Provider');
+  }
+
+  return value;
+}

--- a/src/hooks/useNftRetry.tsx
+++ b/src/hooks/useNftRetry.tsx
@@ -1,17 +1,9 @@
-import { addBreadcrumb } from '@sentry/nextjs';
 import { useCallback, useContext, useMemo, useState } from 'react';
-import { useRelayEnvironment } from 'react-relay';
-// @ts-expect-error We're in untyped territory
-import { getFragmentResourceForEnvironment } from 'react-relay/lib/relay-hooks/FragmentResource';
-import { graphql } from 'relay-runtime';
 import { Primitive } from 'relay-runtime/lib/store/RelayStoreTypes';
 
-import { useReportError } from '~/contexts/errorReporting/ErrorReportingContext';
+import { defaultTokenErrorState, useNftErrorContext } from '~/contexts/NftErrorContext';
 import { ContentIsLoadedEvent, ShimmerActionContext } from '~/contexts/shimmer/ShimmerContext';
-import { useToastActions } from '~/contexts/toast/ToastContext';
 import { CouldNotRenderNftError } from '~/errors/CouldNotRenderNftError';
-import { useNftRetryMutation } from '~/generated/useNftRetryMutation.graphql';
-import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
 import { isIosSafari } from '~/utils/browser';
 
 type useNftRetryArgs = {
@@ -28,147 +20,40 @@ type useNftRetryResult = {
 };
 
 export function useNftRetry({ tokenId }: useNftRetryArgs): useNftRetryResult {
-  const reportError = useReportError();
-  const { pushToast } = useToastActions();
   const shimmerContext = useContext(ShimmerActionContext);
-
-  const [isFailed, setIsFailed] = useState(false);
-  const [retryKey, setRetryKey] = useState(0);
-  const [refreshed, setRefreshed] = useState(false);
-  const [refreshingMetadata, setRefreshingMetadata] = useState(false);
+  const {
+    handleNftError: contextHandleNftError,
+    refreshToken,
+    markTokenAsLoaded,
+    tokens,
+  } = useNftErrorContext();
 
   const handleNftLoaded = useCallback<ContentIsLoadedEvent>(
     (event) => {
       shimmerContext?.setContentIsLoaded(event);
-      setIsFailed(false);
+
+      markTokenAsLoaded(tokenId);
     },
-    [shimmerContext]
+    [markTokenAsLoaded, shimmerContext, tokenId]
   );
 
   const handleNftError = useCallback(
     (error: Error) => {
       // Give up and show the failure state
-      shimmerContext?.setContentIsLoaded(event);
-      setIsFailed(true);
+      shimmerContext?.setContentIsLoaded();
 
-      // If the user refreshed the metadata and there was another failure,
-      // we'll show them a new toast telling them things failed to load,
-      // and we're looking into the issue asap.
-      if (refreshed) {
-        pushToast({
-          message:
-            'This piece has failed to load. This issue has been reported to the Gallery team.',
-          autoClose: true,
-        });
-      }
-
-      const commonTags = {
-        tokenId,
-        alreadyRefreshed: refreshed,
-      };
-
-      if (error instanceof CouldNotRenderNftError) {
-        reportError('NftLoadError: ' + error.message, {
-          tags: { ...commonTags, ...error.metadata },
-        });
-      } else {
-        reportError('NftLoadError: Could not load nft', {
-          tags: commonTags,
-        });
-      }
+      contextHandleNftError(tokenId, error);
     },
-    [pushToast, refreshed, reportError, shimmerContext, tokenId]
+    [contextHandleNftError, shimmerContext, tokenId]
   );
-
-  const environment = useRelayEnvironment();
-  const FragmentResource = getFragmentResourceForEnvironment(environment);
-
-  const retry = useCallback(
-    () => {
-      addBreadcrumb({
-        message: 'Trying to clear the Relay FragmentResource cache',
-        level: 'info',
-      });
-
-      // Wrapping this in a try catch since we have no idea
-      // if Relay wil introduce a breaking change here.
-      try {
-        /**
-         * WARNING: DO NOT COPY THIS CODE UNLESS YOU KNOW WHAT YOU ARE DOING
-         *
-         * There is a bug in Relay where fragments are not receiving updates
-         * if an underlying object's typename changes.
-         *
-         * We should report this at some point [GAL-371]
-         */
-        FragmentResource._cache._map.clear();
-      } catch (e) {
-        if (e instanceof Error || typeof e === 'string') {
-          reportError(e);
-        }
-      }
-
-      setIsFailed(false);
-      setRefreshed(true);
-      setRetryKey((previous) => previous + 1);
-    },
-    // Make sure this dep is `FragmentResource`, this is all untyped
-    // `FragmentResource._cache._map` might cause a HUGE ERROR
-    [FragmentResource, reportError]
-  );
-
-  const [refresh] = usePromisifiedMutation<useNftRetryMutation>(graphql`
-    mutation useNftRetryMutation($tokenId: DBID!) {
-      refreshToken(tokenId: $tokenId) {
-        ... on RefreshTokenPayload {
-          __typename
-          token {
-            # Ensure we're reloading the necessary data
-            ...NftPreviewTokenFragment
-            ...SidebarNftIconPreviewAsset
-            ...NftDetailAssetTokenFragment
-            ...BigNftFragment
-            ...CollectionRowCompactNftsFragment
-            ...StagingAreaFragment
-          }
-        }
-      }
-    }
-  `);
 
   const refreshMetadata = useCallback(async () => {
-    function pushErrorToast() {
-      pushToast({
-        message:
-          'There was an error while refreshing your piece. We have been notified and are looking into it.',
-        autoClose: true,
-      });
-    }
+    await refreshToken(tokenId);
+  }, [refreshToken, tokenId]);
 
-    pushToast({
-      message: 'This piece is loading. This may take up to a few minutes.',
-      autoClose: true,
-    });
-
-    try {
-      setRefreshingMetadata(true);
-      const response = await refresh({ variables: { tokenId } });
-
-      if (response.refreshToken?.__typename === 'RefreshTokenPayload') {
-        retry();
-      } else {
-        pushErrorToast();
-        reportError('GraphQL Error while refreshing nft metadata', {
-          tags: { tokenId, typename: response.refreshToken?.__typename },
-        });
-      }
-    } catch (e) {
-      reportError('GraphQL Error while refreshing nft metadata', { tags: { tokenId } });
-      pushErrorToast();
-    } finally {
-      setRefreshingMetadata(false);
-    }
-  }, [pushToast, refresh, reportError, retry, tokenId]);
+  const { retryKey, isFailed, refreshingMetadata } = useMemo(() => {
+    return tokens[tokenId] ?? defaultTokenErrorState();
+  }, [tokenId, tokens]);
 
   return useMemo(() => {
     return {

--- a/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
@@ -8,7 +8,7 @@ import NftDetailView from '~/scenes/NftDetailPage/NftDetailView';
 import {
   Chain,
   NftDetailAssetTestQueryQuery,
-  UseNftRetryMutationMutation,
+  NftErrorContextRetryMutationMutation,
 } from '~/tests/__generated__/operations';
 import { mockGraphqlQuery } from '~/tests/graphql/mockGraphqlQuery';
 import { mockProviderQueries } from '~/tests/graphql/mockProviderQueries';
@@ -81,7 +81,7 @@ const UnknownMediaResponse: NftDetailAssetTestQueryQuery = {
   },
 };
 
-const RetryImageMediaResponse: UseNftRetryMutationMutation = {
+const RetryImageMediaResponse: NftErrorContextRetryMutationMutation = {
   __typename: 'Mutation',
   refreshToken: {
     __typename: 'RefreshTokenPayload',
@@ -122,7 +122,7 @@ describe('NftDetailAsset', () => {
     mockGraphqlQuery('NftDetailAssetTestQuery', UnknownMediaResponse);
 
     // Mock the retry for when they hit the button
-    mockGraphqlQuery('useNftRetryMutation', RetryImageMediaResponse);
+    mockGraphqlQuery('NftErrorContextRetryMutation', RetryImageMediaResponse);
 
     const relayEnvironment = createEmptyRelayEnvironment();
     const { findByText, findByTestId, findByAltText } = render(


### PR DESCRIPTION
The root cause here is that RV isn't reusing component state since keys are based off of the index. I think this is solved in React Window.

Either way, the solution is to hoist the error state to a higher up context so that even if the component gets wiped, its state is saved elsewhere. 

UNIT TESTS ARE STILL PASSING WHICH IS HUGE VALUE