### PR TITLE
[GAL-738] Fix cut off text on hover card and remove bold

### DIFF
--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -252,4 +252,8 @@ const StyledCardDescription = styled.div`
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  -webkit-box-pack: end;
+  p {
+    display: inline;
+  }
 `;

--- a/src/components/NotificationsModal/notifications/SomeoneAdmiredYourFeedEvent.tsx
+++ b/src/components/NotificationsModal/notifications/SomeoneAdmiredYourFeedEvent.tsx
@@ -98,19 +98,17 @@ export function SomeoneAdmiredYourFeedEvent({
 
   return (
     <BaseM>
-      <strong>
-        {count > 1 ? (
-          <>{notification.count} collectors</>
-        ) : (
-          <>
-            {firstAdmirer ? (
-              <HoverCardOnUsername userRef={firstAdmirer} queryRef={query} />
-            ) : (
-              'Someone'
-            )}
-          </>
-        )}
-      </strong>
+      {count > 1 ? (
+        <strong>{notification.count} collectors</strong>
+      ) : (
+        <>
+          {firstAdmirer ? (
+            <HoverCardOnUsername userRef={firstAdmirer} queryRef={query} />
+          ) : (
+            <strong>Someone</strong>
+          )}
+        </>
+      )}
       {` ${verb} `}
       {collection ? <CollectionLink collectionRef={collection} /> : <>your collection</>}
     </BaseM>

--- a/src/components/NotificationsModal/notifications/SomeoneFollowedYou.tsx
+++ b/src/components/NotificationsModal/notifications/SomeoneFollowedYou.tsx
@@ -43,19 +43,17 @@ export function SomeoneFollowedYou({ notificationRef, queryRef }: SomeoneFollowe
 
   return (
     <BaseM>
-      <strong>
-        {count > 1 ? (
-          <>{count} collectors</>
-        ) : (
-          <>
-            {lastFollower ? (
-              <HoverCardOnUsername userRef={lastFollower} queryRef={query} />
-            ) : (
-              'Someone'
-            )}
-          </>
-        )}
-      </strong>{' '}
+      {count > 1 ? (
+        <strong>{count} collectors</strong>
+      ) : (
+        <>
+          {lastFollower ? (
+            <HoverCardOnUsername userRef={lastFollower} queryRef={query} />
+          ) : (
+            <strong>Someone</strong>
+          )}
+        </>
+      )}{' '}
       followed you
     </BaseM>
   );


### PR DESCRIPTION

The bold UI regression only happens on **following** and **admire** event

**Before**

![CleanShot 2022-12-22 at 12 49 54](https://user-images.githubusercontent.com/4480258/209060702-f4c6efcf-e31b-41c6-a1f5-b0752763fb98.png)


**After**

![CleanShot 2022-12-22 at 12 49 21](https://user-images.githubusercontent.com/4480258/209060711-ca5644ff-bfc9-4d1c-810c-a1a5ba81c290.png)


**Text cut-off**

**Before**

![CleanShot 2022-12-22 at 13 04 00](https://user-images.githubusercontent.com/4480258/209060898-09599f69-ec25-4cd3-971f-393f1896f984.png)


**After**

![CleanShot 2022-12-22 at 13 02 42](https://user-images.githubusercontent.com/4480258/209060841-cd3ddf1a-ecaa-452d-8b23-3728b5a1a95a.png)

