### PR TITLE
disable reporting of nft errors

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -58,7 +58,7 @@ Sentry.init({
   tunnel: 'https://monitoring.gallery.so/bugs',
   // disable sentry reporting by default if in local development.
   // NEXT_PUBLIC_VERCEL_ENV is only set in a deployed environment.
-  enabled: true,
+  enabled: ENV !== undefined,
 });
 
 Sentry.configureScope((scope) => {

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -2,6 +2,8 @@
 // The config you add here will be used whenever a page is visited.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+import { Breadcrumbs, Dedupe, HttpContext, LinkedErrors } from '@sentry/browser';
+import { Integrations as CoreIntegrations } from '@sentry/core';
 import * as Sentry from '@sentry/nextjs';
 
 import { ErrorWithSentryMetadata } from './src/errors/ErrorWithSentryMetadata';
@@ -17,17 +19,35 @@ const SENTRY_TRACING_ORIGIN = IS_PROD ? 'api.gallery.so' : 'api.dev.gallery.so';
 const SENTRY_TRACING_SAMPLE_RATE = IS_PROD ? 0.05 : 1.0;
 
 Sentry.init({
+  defaultIntegrations: false,
+  integrations: [
+    // Defaults from Sentry
+    // https://sourcegraph.com/github.com/getsentry/sentry-javascript@36488ec3ef5394c97dcf3c3ef25c09bab266e5ea/-/blob/packages/browser/src/sdk.ts?L23
+    new CoreIntegrations.InboundFilters(),
+    new CoreIntegrations.FunctionToString(),
+    new Breadcrumbs(),
+    new LinkedErrors(),
+    new Dedupe(),
+    new HttpContext(),
+
+    // The defaults include these two but we want to disable them to ensure
+    // that errors thrown during a render don't get double reported
+    // new TryCatch(),
+    // new GlobalHandlers(),
+
+    // This gives us extra metadata about HTTP requests, page navigation, etc.
+    new Sentry.BrowserTracing({
+      tracingOrigins: [SENTRY_TRACING_ORIGIN, 'localhost'],
+    }),
+  ],
+
   // DSNs are safe to keep public because they only allow submission of
   // new events and related event data; they do not allow read access to
   // any information. While there is a risk of abusing a DSN, where any
   // user can send events to your organization with any information they
   // want, this is a rare occurrence.
   dsn: SENTRY_DSN || 'https://bd40a4affc1740e8b7516502389262fe@o1135798.ingest.sentry.io/6187637',
-  integrations: [
-    new Sentry.BrowserTracing({
-      tracingOrigins: [SENTRY_TRACING_ORIGIN, 'localhost'],
-    }),
-  ],
+
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: SENTRY_TRACING_SAMPLE_RATE,
   // ...

--- a/src/contexts/NftErrorContext.tsx
+++ b/src/contexts/NftErrorContext.tsx
@@ -81,21 +81,6 @@ export function NftErrorProvider({ children }: PropsWithChildren) {
         });
       }
 
-      const commonTags = {
-        tokenId,
-        alreadyRefreshed: token.refreshed,
-      };
-
-      if (error instanceof CouldNotRenderNftError) {
-        reportError('NftLoadError: ' + error.message, {
-          tags: { ...commonTags, ...error.metadata },
-        });
-      } else {
-        reportError('NftLoadError: Could not load nft', {
-          tags: commonTags,
-        });
-      }
-
       setTokens((previous) => {
         const next = { ...previous };
 

--- a/src/contexts/NftErrorContext.tsx
+++ b/src/contexts/NftErrorContext.tsx
@@ -14,7 +14,6 @@ import { graphql } from 'relay-runtime';
 
 import { useReportError } from '~/contexts/errorReporting/ErrorReportingContext';
 import { useToastActions } from '~/contexts/toast/ToastContext';
-import { CouldNotRenderNftError } from '~/errors/CouldNotRenderNftError';
 import { NftErrorContextRetryMutation } from '~/generated/NftErrorContextRetryMutation.graphql';
 import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
 
@@ -66,6 +65,8 @@ export function NftErrorProvider({ children }: PropsWithChildren) {
 
   const handleNftError = useCallback<NftErrorContextType['handleNftError']>(
     (tokenId: string, error: Error) => {
+      addBreadcrumb({ category: 'nft error', message: error.message, level: 'error' });
+
       const token = { ...(tokens[tokenId] ?? defaultTokenErrorState()) };
 
       token.isFailed = true;
@@ -89,7 +90,7 @@ export function NftErrorProvider({ children }: PropsWithChildren) {
         return next;
       });
     },
-    [pushToast, reportError, tokens]
+    [pushToast, tokens]
   );
 
   const environment = useRelayEnvironment();

--- a/src/contexts/boundary/ReportingErrorBoundary.tsx
+++ b/src/contexts/boundary/ReportingErrorBoundary.tsx
@@ -9,6 +9,7 @@ import {
 import { Primitive } from 'relay-runtime/lib/store/RelayStoreTypes';
 
 import { ErrorReportingContext } from '~/contexts/errorReporting/ErrorReportingContext';
+import { CouldNotRenderNftError } from '~/errors/CouldNotRenderNftError';
 import { ErrorWithSentryMetadata } from '~/errors/ErrorWithSentryMetadata';
 
 export type ReportingErrorBoundaryFallbackProps = { error: Error };
@@ -36,10 +37,14 @@ export class ReportingErrorBoundary extends Component<ReportingErrorBoundaryProp
   }
 
   componentDidCatch(error: Error) {
-    this.context?.(error);
-
     if (error instanceof ErrorWithSentryMetadata) {
       error.addMetadata(this.props.additionalTags ?? {});
+    }
+
+    // Temporarily disable the reporting of Nft failures
+    // since they're eating up our sentry credits.
+    if (!(error instanceof CouldNotRenderNftError)) {
+      this.context?.(error);
     }
 
     this.props.onError?.(error);

--- a/src/errors/CouldNotRenderNftError.ts
+++ b/src/errors/CouldNotRenderNftError.ts
@@ -6,7 +6,7 @@ export class CouldNotRenderNftError extends ErrorWithSentryMetadata {
   public componentName: string;
 
   constructor(componentName: string, reason: string, metadata?: Record<string, Primitive>) {
-    super(`${componentName}: ${reason}`, metadata ?? {});
+    super(`Could not render NFT`, { ...metadata, componentName, reason });
 
     this.componentName = componentName;
 


### PR DESCRIPTION
The goal of this PR is to stop NFT errors from making their way to Sentry.

A core part of how our fallback system works is letting any function throw a `CouldNotRenderNftError` while trying to render. 

The problem is, whether or not we catch that with an error boundary, the error will get reported to Sentry via the `TryCatch` and `GlobalHandlers` integrations. 

Turning those integrations off makes us a bit more vulnerable to things like uncaught exceptions in callback functions, etc. Historically, these features have not been all that helpful to us so we're moving forward understanding this tradeoff.