### PR TITLE
Cleanup settings modal

### DIFF
--- a/src/scenes/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/scenes/Modals/SettingsModal/SettingsModal.tsx
@@ -7,7 +7,7 @@ import { Button } from '~/components/core/Button/Button';
 import colors from '~/components/core/colors';
 import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM, TitleDiatypeL, TitleDiatypeM } from '~/components/core/Text/Text';
+import { BaseM, TitleDiatypeL } from '~/components/core/Text/Text';
 import Toggle from '~/components/core/Toggle/Toggle';
 import EmailManager from '~/components/Email/EmailManager';
 import ManageWallets from '~/components/ManageWallets/ManageWallets';

--- a/src/scenes/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/scenes/Modals/SettingsModal/SettingsModal.tsx
@@ -160,9 +160,8 @@ function SettingsModal({
   return (
     <StyledManageWalletsModal gap={24}>
       <VStack gap={16}>
-        <TitleDiatypeL>Never miss a moment</TitleDiatypeL>
         <VStack>
-          <TitleDiatypeM>Email notifications</TitleDiatypeM>
+          <TitleDiatypeL>Email notifications</TitleDiatypeL>
           <HStack justify="space-between" align="center">
             <SettingsRowDescription>
               Receive weekly recaps that show your most recent admires, comments, and followers.


### PR DESCRIPTION
Settings modal felt a bit too cluttered

<img width="1433" alt="Screen Shot 2022-12-24 at 12 33 11 AM" src="https://user-images.githubusercontent.com/12162433/209422987-28cab69e-9aa9-4300-82ad-2764ee3bff23.png">
