### PR TITLE
support html text media

### DIFF
--- a/src/components/NftPreview/NftPreview.tsx
+++ b/src/components/NftPreview/NftPreview.tsx
@@ -156,6 +156,7 @@ function NftPreview({
     if (isIFrameLiveDisplay) {
       return <NftDetailAnimation onLoad={handleNftLoaded} mediaRef={token} />;
     }
+
     return (
       <NftPreviewAsset
         onLoad={handleNftLoaded}

--- a/src/components/NftPreview/NftPreviewAsset.tsx
+++ b/src/components/NftPreview/NftPreviewAsset.tsx
@@ -43,6 +43,11 @@ function NftPreviewAsset({ tokenRef, size, onLoad }: Props) {
               large @required(action: NONE)
             }
           }
+          ... on TextMedia {
+            previewURLs @required(action: NONE) {
+              large @required(action: NONE)
+            }
+          }
           ... on AudioMedia {
             previewURLs @required(action: NONE) {
               large @required(action: NONE)

--- a/src/scenes/NftDetailPage/NftDetailAnimation.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAnimation.tsx
@@ -23,6 +23,10 @@ function NftDetailAnimation({ mediaRef, onLoad }: Props) {
             __typename
             contentRenderURL @required(action: THROW)
           }
+          ... on TextMedia {
+            __typename
+            mediaURL
+          }
           ... on UnknownMedia {
             __typename
             contentRenderURL @required(action: THROW)
@@ -36,6 +40,14 @@ function NftDetailAnimation({ mediaRef, onLoad }: Props) {
   const contentRenderURL = useMemo(() => {
     if (token.media.__typename === 'HtmlMedia' || token.media.__typename === 'UnknownMedia') {
       return token.media.contentRenderURL;
+    } else if (token.media.__typename === 'TextMedia') {
+      if (token.media.mediaURL?.startsWith('data:')) {
+        const mimeType = token.media.mediaURL.split('data:')[1]?.split(';')[0];
+
+        if (mimeType === 'text/html') {
+          return token.media.mediaURL;
+        }
+      }
     }
 
     return '';

--- a/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -50,6 +50,9 @@ export function NftDetailAssetComponent({ tokenRef, onLoad }: NftDetailAssetComp
           ... on AudioMedia {
             __typename
           }
+          ... on TextMedia {
+            __typename
+          }
           ... on GltfMedia {
             __typename
             ...NftDetailModelFragment


### PR DESCRIPTION
Provide basic support for `TextMedia` by
- Fetching the type for preview urls
- Decoding the text media url for an `iframe` on the `NftDetailAsset`

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/6754223/210866586-8a3730ce-9667-43b6-a50a-c47583979a50.png">

<img width="1090" alt="image" src="https://user-images.githubusercontent.com/6754223/210866608-9ec84a04-2cc7-4275-afc6-5698540ef2d7.png">
