### PR TITLE
Bump max allowed wallet addresses from 10 to 15

### DIFF
--- a/src/components/ManageWallets/ManageWallets.tsx
+++ b/src/components/ManageWallets/ManageWallets.tsx
@@ -23,7 +23,7 @@ type Props = {
   onTezosAddWalletSuccess?: () => void;
 };
 
-const MAX_ALLOWED_ADDRESSES = 10;
+const MAX_ALLOWED_ADDRESSES = 15;
 
 function ManageWallets({
   newAddress,


### PR DESCRIPTION
As per request from a user with more than 10 wallets, this bumps the limit up to 15!