### PR TITLE
Specify early access qualifications in settings modal

### DIFF
--- a/src/scenes/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/scenes/Modals/SettingsModal/SettingsModal.tsx
@@ -194,8 +194,8 @@ function SettingsModal({
                 href={`https://opensea.io/collection/gallery-membership-cards?ref=${GALLERY_OS_ADDRESS}`}
               >
                 Premium Gallery Membership Card
-              </InteractiveLink>
-              .
+              </InteractiveLink>{' '}
+              and connecting your email address.
             </SettingsRowDescription>
           </span>
           <HStack align="center" gap={4} shrink={false}>


### PR DESCRIPTION
Require email address for early access

![image](https://user-images.githubusercontent.com/12162433/211478259-386737ff-b5ab-4c18-a242-0c8a551107ad.png)
