### PR TITLE
Handle custom display names

### DIFF
--- a/src/components/Follow/NavActionFollow.tsx
+++ b/src/components/Follow/NavActionFollow.tsx
@@ -8,7 +8,7 @@ import { HStack } from '~/components/core/Spacer/Stack';
 import { BreadcrumbLink } from '~/contexts/globalLayout/GlobalNavbar/ProfileDropdown/Breadcrumbs';
 import { NavActionFollowQueryFragment$key } from '~/generated/NavActionFollowQueryFragment.graphql';
 import { NavActionFollowUserFragment$key } from '~/generated/NavActionFollowUserFragment.graphql';
-import { isUsername3ac } from '~/hooks/oneOffs/useIs3acProfilePage';
+import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 
 import colors from '../core/colors';
 import FollowButton from './FollowButton';
@@ -39,13 +39,14 @@ export default function NavActionFollow({ userRef, queryRef }: Props) {
     queryRef
   );
   const { pathname } = useRouter();
-
-  if (!user.username) {
+  const { username } = user;
+  if (!username) {
     return null;
   }
 
-  const is3ac = isUsername3ac(user.username);
-  const usernameRoute: Route = { pathname: '/[username]', query: { username: user.username } };
+  const displayName = handleCustomDisplayName(username);
+
+  const usernameRoute: Route = { pathname: '/[username]', query: { username: username } };
 
   return (
     <HStack gap={8} align="center">
@@ -54,7 +55,7 @@ export default function NavActionFollow({ userRef, queryRef }: Props) {
           href={route(usernameRoute)}
           mainGalleryPage={pathname === '/[username]'}
         >
-          {is3ac ? 'The Unofficial 3AC Gallery' : user.username}
+          {displayName}
         </UsernameBreadcrumbLink>
       </Link>
       <FollowButton queryRef={loggedInUserQuery} userRef={user} />

--- a/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -32,6 +32,7 @@ import FollowButton from '~/components/Follow/FollowButton';
 import { HoverCardOnUsernameFollowFragment$key } from '~/generated/HoverCardOnUsernameFollowFragment.graphql';
 import { HoverCardOnUsernameFragment$key } from '~/generated/HoverCardOnUsernameFragment.graphql';
 import { useLoggedInUserId } from '~/hooks/useLoggedInUserId';
+import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 
 const HOVER_POPUP_DELAY = 100;
 
@@ -122,6 +123,12 @@ export default function HoverCardOnUsername({ children, userRef, queryRef }: Pro
     return { pathname: '/[username]', query: { username: user.username as string } };
   }, [user]);
 
+  if (!user.username) {
+    return null;
+  }
+
+  const displayName = handleCustomDisplayName(user.username);
+
   return (
     <StyledContainer>
       <StyledLinkContainer ref={reference} {...getReferenceProps()}>
@@ -129,7 +136,7 @@ export default function HoverCardOnUsername({ children, userRef, queryRef }: Pro
           {children ? (
             children
           ) : (
-            <TitleDiatypeM onClick={handleUsernameClick}>{user.username}</TitleDiatypeM>
+            <TitleDiatypeM onClick={handleUsernameClick}>{displayName}</TitleDiatypeM>
           )}
         </Link>
       </StyledLinkContainer>
@@ -163,7 +170,7 @@ export default function HoverCardOnUsername({ children, userRef, queryRef }: Pro
                     <StyledCardHeader>
                       <HStack align="center" gap={4}>
                         <HStack align="center" gap={6}>
-                          <StyledCardUsername>{user.username}</StyledCardUsername>
+                          <StyledCardUsername>{displayName}</StyledCardUsername>
 
                           {userBadges.map((badge) => (
                             // Might need to rethink this layout when we have more badges

--- a/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavbar.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavbar.tsx
@@ -20,8 +20,8 @@ import {
   StandardNavbarContainer,
 } from '~/contexts/globalLayout/GlobalNavbar/StandardNavbarContainer';
 import { GalleryNavbarFragment$key } from '~/generated/GalleryNavbarFragment.graphql';
-import { isUsername3ac } from '~/hooks/oneOffs/useIs3acProfilePage';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
+import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 
 type Props = {
   username: string;
@@ -45,7 +45,7 @@ export function GalleryNavbar({ queryRef, username }: Props) {
     queryRef
   );
 
-  const is3ac = isUsername3ac(username);
+  const displayName = handleCustomDisplayName(username);
   const isMobile = useIsMobileOrMobileLargeWindowWidth();
   const { pathname } = useRouter();
 
@@ -65,7 +65,7 @@ export function GalleryNavbar({ queryRef, username }: Props) {
                   mainGalleryPage={pathname === '/[username]'}
                   href={route(userGalleryRoute)}
                 >
-                  {is3ac ? 'The Unofficial 3AC Gallery' : username}
+                  {displayName}
                 </UsernameBreadcrumbLink>
               </Link>
               {query.userByUsername && (

--- a/src/scenes/UserGalleryPage/UserGalleryHeader.tsx
+++ b/src/scenes/UserGalleryPage/UserGalleryHeader.tsx
@@ -16,6 +16,7 @@ import { UserGalleryHeaderFragment$key } from '~/generated/UserGalleryHeaderFrag
 import useIs3acProfilePage from '~/hooks/oneOffs/useIs3acProfilePage';
 import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import LinkToNftDetailView from '~/scenes/NftDetailPage/LinkToNftDetailView';
+import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 import unescape from '~/utils/unescape';
 
 import MobileLayoutToggle from './MobileLayoutToggle';
@@ -66,15 +67,19 @@ function UserGalleryHeader({
     setShowMore((previous) => !previous);
   }, []);
 
+  if (!username) {
+    return null;
+  }
+
+  const displayName = handleCustomDisplayName(username);
+
   return (
     <StyledUserGalleryHeader gap={2}>
       <HStack align="center" gap={6}>
         {isMobile ? (
-          <StyledUsernameMobile>
-            {is3ac ? 'The Unofficial 3AC Gallery' : username}
-          </StyledUsernameMobile>
+          <StyledUsernameMobile>{displayName}</StyledUsernameMobile>
         ) : (
-          <StyledUsername>{is3ac ? 'The Unofficial 3AC Gallery' : username}</StyledUsername>
+          <StyledUsername>{displayName}</StyledUsername>
         )}
 
         {userBadges.map((badge) => (badge ? <Badge key={badge.name} badgeRef={badge} /> : null))}
@@ -139,7 +144,7 @@ const NftDetailViewer = ({ href, children }: NftDetailViewerProps) => {
   const [, username, collectionId, tokenId] = href.split('/');
   return (
     <LinkToNftDetailView
-      username={username ?? ''}
+      username={username}
       collectionId={collectionId}
       tokenId={tokenId}
       originPage="gallery"

--- a/src/utils/handleCustomDisplayName.ts
+++ b/src/utils/handleCustomDisplayName.ts
@@ -1,0 +1,8 @@
+// hackily handle very specific cases where we display usernames in the app.
+// in the future, we'll add a `display_name` field to the user model that's separate from `username`
+export default function handleCustomDisplayName(username: string) {
+  const lowered = username.toLowerCase();
+  if (lowered === '3ac') return 'The Unofficial 3AC Gallery';
+  if (lowered === 'loyd') return 'Løyd';
+  return username;
+}


### PR DESCRIPTION
Handle custom display name for løyd. We actually did something similar already for the 3AC gallery, so this PR establishes a hacky pattern for using custom display names in certain places.

This is a stop gap until we have backend support for display names.

![image](https://user-images.githubusercontent.com/12162433/211692111-32c9af9f-f2df-461f-9aa5-2dd606587153.png)

![image](https://user-images.githubusercontent.com/12162433/211692141-9c064b97-f8a1-4fbd-89c5-d242f60d4ad9.png)
