### PR TITLE
Fix stretched out badge for community page

### DIFF
--- a/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -93,7 +93,7 @@ export default function CommunityPageView({ communityRef, queryRef }: Props) {
       <StyledCommunityPageContainer>
         <HStack>
           <StyledHeader>
-            <HStack gap={8} align="center">
+            <HStack gap={12} align="center">
               <TitleL>{name}</TitleL>
               {badgeURL && <StyledBadge src={badgeURL} />}
             </HStack>
@@ -192,6 +192,7 @@ const StyledMemberListFilterContainer = styled.div<{ isMobile: boolean }>`
 `;
 
 const StyledBadge = styled.img`
-  height: 24px;
-  width: 24px;
+  max-height: 24px;
+  max-width: 24px;
+  width: 100%;
 `;


### PR DESCRIPTION
<img width="673" alt="image" src="https://user-images.githubusercontent.com/12162433/211934142-f2e57f07-67c0-4246-a594-89364043774e.png">
