### PR TITLE
/settings route with popover redirect

### DIFF
--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -11,6 +11,7 @@ import { homeQuery } from '~/generated/homeQuery.graphql';
 import usePersistedState from '~/hooks/usePersistedState';
 import GalleryRoute from '~/scenes/_Router/GalleryRoute';
 import HomeScene from '~/scenes/Home/Home';
+import useOpenSettingsModal from '~/scenes/Modals/useOpenSettingsModal';
 import { PreloadQueryArgs } from '~/types/PageComponentPreloadQuery';
 
 const homeQueryNode = graphql`
@@ -33,6 +34,7 @@ const homeQueryNode = graphql`
 
     ...HomeFragment
     ...FeedNavbarFragment
+    ...useOpenSettingsModalFragment
   }
 `;
 
@@ -56,6 +58,8 @@ export default function Home() {
       setFeedMode('WORLDWIDE');
     }
   }, [viewerUserId, feedMode, setFeedMode]);
+
+  useOpenSettingsModal(query);
 
   return (
     <GalleryRoute

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,0 +1,5 @@
+import GalleryRedirect from '~/scenes/_Router/GalleryRedirect';
+
+export default function Settings() {
+  return <GalleryRedirect to={{ pathname: '/home', query: { settings: 'true' } }} />;
+}

--- a/src/components/FadeTransitioner/FadeTransitioner.tsx
+++ b/src/components/FadeTransitioner/FadeTransitioner.tsx
@@ -75,6 +75,10 @@ export function useStabilizedRouteTransitionKey() {
     if (pathname === '/[username]/[collectionId]/[tokenId]') {
       return `/${query.username}/${query.collectionId}`;
     }
+    // keep location stable if settings modal is open
+    if (query.settings === 'true') {
+      return pathname;
+    }
     return asPath;
   }, [asPath, pathname, query]);
 

--- a/src/hooks/useAuthModal.tsx
+++ b/src/hooks/useAuthModal.tsx
@@ -39,7 +39,7 @@ export const AuthModal = ({ queryRef, variant }: ModalProps) => {
 
   useEffect(() => {
     if (isAuthenticated) {
-      hideModal();
+      hideModal({ id: 'auth' });
     }
   }, [isAuthenticated, hideModal]);
 
@@ -74,6 +74,10 @@ export default function useAuthModal() {
   );
 
   return useCallback(() => {
-    showModal({ content: <AuthModal queryRef={query} />, headerText: 'Connect your wallet' });
+    showModal({
+      id: 'auth',
+      content: <AuthModal queryRef={query} />,
+      headerText: 'Connect your wallet',
+    });
   }, [query, showModal]);
 }

--- a/src/scenes/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/scenes/Modals/SettingsModal/SettingsModal.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
@@ -61,6 +62,17 @@ function SettingsModal({
     `,
     queryRef
   );
+
+  // drop settings param from URL once modal has been opened
+  const { pathname, query: urlQuery, replace } = useRouter();
+  useEffect(() => {
+    const params = new URLSearchParams(urlQuery as Record<string, string>);
+    if (params.has('settings')) {
+      params.delete('settings');
+      // @ts-expect-error we're simply replacing the current page with the same path
+      replace({ pathname, query: params.toString() }, undefined, { shallow: true });
+    }
+  }, [pathname, replace, urlQuery]);
 
   const updateEmailNotificationSettings = useUpdateEmailNotificationSettings();
 


### PR DESCRIPTION
Introduce a new `/settings` route that displays the settings popover
- If logged out, it'll prompt you to log in, and display settings afterwards
- If logged in, it'll open the popover from the home screen

https://user-images.githubusercontent.com/12162433/212435238-e4db29ad-79a8-4868-bbf5-7b85c59d40dd.mov

