### PR TITLE
Add Delegate Cash as a wallet option, with coming soon message

### DIFF
--- a/public/icons/delegate_cash_logo.svg
+++ b/public/icons/delegate_cash_logo.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 480.9 509.1" style="enable-background:new 0 0 480.9 509.1;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFC300;}
+	.st1{fill:#04724D;}
+	/* .st2{fill:none;stroke:#17FF93;stroke-width:0.5;stroke-miterlimit:10;}
+	.st3{fill:#17FF93;} */
+</style>
+<path class="st1" d="M321.2,249.6c58-47.7,113.7-93.6,148.4-145.3c-6.8-9.4-16.2-16.9-27-21.5L254.3,2.9C250.1,1,245.6,0,240.9,0
+	c-4.6,0-9.2,1-13.3,2.9L39.2,82.8c-22,9.3-38.4,31-39.2,56.3c1.2,83.2,29.5,222.6,137.9,314.6C170,374,246.8,310.9,321.2,249.6z"/>
+<path class="st0" d="M267.3,503.2c172.3-82.5,213.1-264,213.6-364.1c0.1-12.9-4.2-24.9-11.3-34.8C435,156,379.2,201.9,321.2,249.6
+	C246.8,310.9,170,374,137.9,453.7c22.1,18.7,47.4,35.5,76.6,49.5C231.2,511.1,250.6,511.1,267.3,503.2z"/>
+</svg>

--- a/src/components/WalletSelector/multichain/DelegateCashMessage.tsx
+++ b/src/components/WalletSelector/multichain/DelegateCashMessage.tsx
@@ -1,0 +1,55 @@
+import styled from 'styled-components';
+
+import { Button } from '~/components/core/Button/Button';
+import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
+import { VStack } from '~/components/core/Spacer/Stack';
+import { BaseM, TitleS } from '~/components/core/Text/Text';
+import transitions from '~/components/core/transitions';
+import { EmptyState } from '~/components/EmptyState/EmptyState';
+import { GALLERY_DISCORD, GALLERY_TWITTER } from '~/constants/urls';
+
+import { walletIconMap } from './WalletButton';
+
+type Props = {
+  reset: () => void;
+};
+
+export default function DelegateCashMessage({ reset }: Props) {
+  return (
+    <EmptyState title="Coming Soon">
+      <VStack gap={24}>
+        <VStack align="center" gap={8}>
+          <Icon src={walletIconMap['delegate_cash']} />
+          <BaseM>We are currently building support for delegate.cash.</BaseM>
+        </VStack>
+        <VStack align="flex-start">
+          <TitleS>New Users:</TitleS>
+          <BaseM>Please first create a Gallery account with a hot wallet.</BaseM>
+        </VStack>
+        <VStack align="flex-start">
+          <TitleS>Existing Users:</TitleS>
+          <StyledText>
+            If you’d like to connect your cold wallet to an existing Gallery account, please reach
+            out to the Gallery team via{' '}
+            <InteractiveLink href={GALLERY_DISCORD}>Discord</InteractiveLink> or{' '}
+            <InteractiveLink href={GALLERY_TWITTER}>Twitter</InteractiveLink>.
+          </StyledText>
+        </VStack>
+        <Button onClick={reset}>Return to wallet selection</Button>
+      </VStack>
+    </EmptyState>
+  );
+}
+
+const StyledText = styled(BaseM)`
+  text-align: left;
+`;
+
+const Icon = styled.img`
+  width: 24px;
+  height: 24px;
+  margin: 5px;
+
+  transform: scale(1);
+  transition: transform ${transitions.cubic};
+`;

--- a/src/components/WalletSelector/multichain/DelegateCashMessage.tsx
+++ b/src/components/WalletSelector/multichain/DelegateCashMessage.tsx
@@ -16,11 +16,11 @@ type Props = {
 
 export default function DelegateCashMessage({ reset }: Props) {
   return (
-    <EmptyState title="Coming Soon">
+    <EmptyState title="">
       <VStack gap={24}>
         <VStack align="center" gap={4}>
           <Icon src={walletIconMap['delegate_cash']} />
-          <BaseM>We&#39;re currently building support for delegate.cash</BaseM>
+          <TitleS>Delegate Cash Coming Soon</TitleS>
         </VStack>
         <VStack align="flex-start">
           <TitleS>What is it?</TitleS>
@@ -31,7 +31,7 @@ export default function DelegateCashMessage({ reset }: Props) {
           </StyledText>
         </VStack>
         <VStack align="flex-start">
-          <TitleS>New Users</TitleS>
+          <TitleS>New users</TitleS>
           <StyledText>
             Please create a Gallery account with your delegated hot wallet, then reach out to our
             team via <InteractiveLink href={GALLERY_DISCORD}>Discord</InteractiveLink> or{' '}
@@ -39,7 +39,7 @@ export default function DelegateCashMessage({ reset }: Props) {
           </StyledText>
         </VStack>
         <VStack align="flex-start">
-          <TitleS>Existing Users</TitleS>
+          <TitleS>Existing users</TitleS>
           <StyledText>
             If you’d like to connect your cold wallet to an existing Gallery account, please reach
             out to the Gallery team via{' '}
@@ -47,7 +47,7 @@ export default function DelegateCashMessage({ reset }: Props) {
             <InteractiveLink href={GALLERY_TWITTER}>Twitter</InteractiveLink>.
           </StyledText>
         </VStack>
-        <Button onClick={reset}>Return to wallet selection</Button>
+        <Button onClick={reset}>Back</Button>
       </VStack>
     </EmptyState>
   );

--- a/src/components/WalletSelector/multichain/DelegateCashMessage.tsx
+++ b/src/components/WalletSelector/multichain/DelegateCashMessage.tsx
@@ -18,16 +18,28 @@ export default function DelegateCashMessage({ reset }: Props) {
   return (
     <EmptyState title="Coming Soon">
       <VStack gap={24}>
-        <VStack align="center" gap={8}>
+        <VStack align="center" gap={4}>
           <Icon src={walletIconMap['delegate_cash']} />
-          <BaseM>We are currently building support for delegate.cash.</BaseM>
+          <BaseM>We&#39;re currently building support for delegate.cash</BaseM>
         </VStack>
         <VStack align="flex-start">
-          <TitleS>New Users:</TitleS>
-          <StyledText>Please first create a Gallery account with a hot wallet.</StyledText>
+          <TitleS>What is it?</TitleS>
+          <StyledText>
+            <InteractiveLink href={'https://delegate.cash'}>Delegate Cash</InteractiveLink> is a
+            decentralized service that allows you to designate a hot wallet to act and sign on
+            behalf of your cold wallet.
+          </StyledText>
         </VStack>
         <VStack align="flex-start">
-          <TitleS>Existing Users:</TitleS>
+          <TitleS>New Users</TitleS>
+          <StyledText>
+            Please create a Gallery account with your delegated hot wallet, then reach out to our
+            team via <InteractiveLink href={GALLERY_DISCORD}>Discord</InteractiveLink> or{' '}
+            <InteractiveLink href={GALLERY_TWITTER}>Twitter</InteractiveLink> for next steps.
+          </StyledText>
+        </VStack>
+        <VStack align="flex-start">
+          <TitleS>Existing Users</TitleS>
           <StyledText>
             If you’d like to connect your cold wallet to an existing Gallery account, please reach
             out to the Gallery team via{' '}

--- a/src/components/WalletSelector/multichain/DelegateCashMessage.tsx
+++ b/src/components/WalletSelector/multichain/DelegateCashMessage.tsx
@@ -24,7 +24,7 @@ export default function DelegateCashMessage({ reset }: Props) {
         </VStack>
         <VStack align="flex-start">
           <TitleS>New Users:</TitleS>
-          <BaseM>Please first create a Gallery account with a hot wallet.</BaseM>
+          <StyledText>Please first create a Gallery account with a hot wallet.</StyledText>
         </VStack>
         <VStack align="flex-start">
           <TitleS>Existing Users:</TitleS>

--- a/src/components/WalletSelector/multichain/MultichainWalletSelector.tsx
+++ b/src/components/WalletSelector/multichain/MultichainWalletSelector.tsx
@@ -144,16 +144,6 @@ export default function MultichainWalletSelector({
               );
             }}
           />
-          {connectionMode !== CONNECT_WALLET_ONLY ? (
-            <WalletButton
-              label={supportedAuthMethods.gnosisSafe.name}
-              icon="gnosis_safe"
-              onClick={() => {
-                console.log('connecting to gnosis safe via walletconnect');
-                setSelectedAuthMethod(supportedAuthMethods.gnosisSafe);
-              }}
-            />
-          ) : null}
           <WalletButton
             label="Tezos"
             icon="tezos"
@@ -169,8 +159,18 @@ export default function MultichainWalletSelector({
                 });
             }}
           />
+          {connectionMode !== CONNECT_WALLET_ONLY ? (
+            <WalletButton
+              label={supportedAuthMethods.gnosisSafe.name}
+              icon="gnosis_safe"
+              onClick={() => {
+                console.log('connecting to gnosis safe via walletconnect');
+                setSelectedAuthMethod(supportedAuthMethods.gnosisSafe);
+              }}
+            />
+          ) : null}
           <WalletButton
-            label="delegate.cash"
+            label={supportedAuthMethods.delegateCash.name}
             icon="delegate_cash"
             onClick={() => {
               setSelectedAuthMethod(supportedAuthMethods.delegateCash);

--- a/src/components/WalletSelector/multichain/MultichainWalletSelector.tsx
+++ b/src/components/WalletSelector/multichain/MultichainWalletSelector.tsx
@@ -10,6 +10,7 @@ import { MultichainWalletSelectorFragment$key } from '~/generated/MultichainWall
 import { ADD_WALLET_TO_USER, AUTH, CONNECT_WALLET_ONLY } from '~/types/Wallet';
 
 import { ConnectionMode } from '../WalletSelector';
+import DelegateCashMessage from './DelegateCashMessage';
 import { EthereumAddWallet } from './EthereumAddWallet';
 import { EthereumAuthenticateWallet } from './EthereumAuthenticateWallet';
 import { GnosisSafeAddWallet } from './GnosisSafeAddWallet';
@@ -109,6 +110,14 @@ export default function MultichainWalletSelector({
     }
   }
 
+  if (selectedAuthMethod === supportedAuthMethods.delegateCash) {
+    return (
+      <WalletSelectorWrapper>
+        <DelegateCashMessage reset={reset} />
+      </WalletSelectorWrapper>
+    );
+  }
+
   return (
     <WalletSelectorWrapper gap={24}>
       <VStack gap={16}>
@@ -160,7 +169,13 @@ export default function MultichainWalletSelector({
                 });
             }}
           />
-          <WalletButton label="Solana" icon="solana" disabled />
+          <WalletButton
+            label="delegate.cash"
+            icon="delegate_cash"
+            onClick={() => {
+              setSelectedAuthMethod(supportedAuthMethods.delegateCash);
+            }}
+          />
         </VStack>
       </VStack>
     </WalletSelectorWrapper>

--- a/src/components/WalletSelector/multichain/WalletButton.tsx
+++ b/src/components/WalletSelector/multichain/WalletButton.tsx
@@ -12,7 +12,7 @@ export const walletIconMap = {
   gnosis_safe: '/icons/gnosis_safe.svg',
   ethereum: '/icons/ethereum_logo.svg',
   tezos: '/icons/tezos_logo.svg',
-  solana: '/icons/solana_logo.svg',
+  delegate_cash: 'icons/delegate_cash_logo.svg',
 };
 
 type WalletButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {

--- a/src/components/WalletSelector/multichain/supportedAuthMethods.ts
+++ b/src/components/WalletSelector/multichain/supportedAuthMethods.ts
@@ -1,14 +1,13 @@
-export type SupportedAuthMethodKey = 'ethereum' | 'gnosisSafe' | 'tezos';
+export type SupportedAuthMethodKey = 'ethereum' | 'gnosisSafe' | 'tezos' | 'delegateCash';
 
 export type SupportedAuthMethod = {
   name: string;
   // TODO: icon?
 };
 
-export const supportedAuthMethods: Readonly<Record<
-  SupportedAuthMethodKey,
-  Readonly<SupportedAuthMethod>
->> = {
+export const supportedAuthMethods: Readonly<
+  Record<SupportedAuthMethodKey, Readonly<SupportedAuthMethod>>
+> = {
   ethereum: {
     name: 'Ethereum',
   },
@@ -17,5 +16,8 @@ export const supportedAuthMethods: Readonly<Record<
   },
   tezos: {
     name: 'Tezos',
+  },
+  delegateCash: {
+    name: 'delegate.cash',
   },
 };

--- a/src/components/WalletSelector/multichain/supportedAuthMethods.ts
+++ b/src/components/WalletSelector/multichain/supportedAuthMethods.ts
@@ -18,6 +18,6 @@ export const supportedAuthMethods: Readonly<
     name: 'Tezos',
   },
   delegateCash: {
-    name: 'delegate.cash',
+    name: 'Delegate Cash',
   },
 };


### PR DESCRIPTION
## Description
This PR adds "Delegate Cash" as a wallet option. Clicking on it will display a coming soon message with instructions for New and Existing Users to assist them with using a cold wallet with Gallery.
There is a back button that allows them to return to the wallet selection menu.

![image](https://user-images.githubusercontent.com/12162433/214389530-42247bb0-82af-4d9a-94ad-0abf197ca17b.png)

![image](https://user-images.githubusercontent.com/12162433/214389581-2961002b-c5bb-4d84-a9fe-974ea8b2c598.png)



## Todos
[ ] Add event to button click
