### PR TITLE
Add Primary Wallet selector

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -838,6 +838,8 @@ type Query {
   generalAllowlist: [ChainAddress!]
   galleryOfTheWeekWinners: [GalleryUser!]
   globalFeed(before: String, after: String, first: Int, last: Int): FeedConnection
+  # Paging forward i.e. providing the `first` argument will return events in order of descending popularity.
+  trendingFeed(before: String, after: String, first: Int, last: Int): FeedConnection
   feedEventById(id: DBID!): FeedEventByIdOrError
   getMerchTokens(wallet: Address!): MerchTokensPayloadOrError
   galleryById(id: DBID!): GalleryByIdPayloadOrError

--- a/src/components/ManageWallets/ManageWallets.tsx
+++ b/src/components/ManageWallets/ManageWallets.tsx
@@ -43,6 +43,7 @@ function ManageWallets({
                 chainAddress @required(action: THROW) {
                   address @required(action: THROW)
                   chain @required(action: THROW)
+                  ...ManageWalletsRow
                 }
               }
               primaryWallet @required(action: THROW) {
@@ -111,8 +112,8 @@ function ManageWallets({
       <VStack gap={16}>
         <VStack>
           <SettingsRowDescription>
-            Add wallets to access your pieces. You&apos;ll also be able to sign in using any
-            connected wallet.
+            Add wallets to access your pieces. You&apos;ll be able to sign in using any connected
+            wallet.
           </SettingsRowDescription>
           {errorMessage && <StyledErrorText message={errorMessage} />}
         </VStack>
@@ -134,11 +135,12 @@ function ManageWallets({
               userSigninAddress={userSigninAddress}
               setRemovedAddress={setRemovedAddress}
               isOnlyWalletConnected={nonPrimaryWallets.length === 1}
+              chainAddressRef={wallet.chainAddress}
             />
           ))}
         </VStack>
       </VStack>
-      <StyledButton onClick={handleSubmit} disabled={addWalletDisabled}>
+      <StyledButton onClick={handleSubmit} disabled={addWalletDisabled} variant="secondary">
         Add new wallet
       </StyledButton>
     </VStack>
@@ -146,8 +148,7 @@ function ManageWallets({
 }
 
 const StyledButton = styled(Button)`
-  align-self: flex-end;
-  width: 100%;
+  align-self: flex-start;
 `;
 
 const StyledErrorText = styled(ErrorText)`

--- a/src/components/ManageWallets/ManageWallets.tsx
+++ b/src/components/ManageWallets/ManageWallets.tsx
@@ -86,10 +86,6 @@ function ManageWallets({
   );
   const [userSigninAddress] = usePersistedState(USER_SIGNIN_ADDRESS_LOCAL_STORAGE_KEY, '');
 
-  // const primaryWallet = useMemo(() => {
-  //   return wallets.find((wallet) => wallet.dbid === viewer?.user.primaryWallet.dbid);
-  // }, [viewer?.user.primaryWallet, wallets]);
-
   useEffect(() => {
     if (removedAddress) {
       pushToast({

--- a/src/components/ManageWallets/ManageWalletsRow.tsx
+++ b/src/components/ManageWallets/ManageWalletsRow.tsx
@@ -1,15 +1,17 @@
-import { useCallback, useState } from 'react';
-import ReactTooltip from 'react-tooltip';
+import { useCallback } from 'react';
+import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import { Button } from '~/components/core/Button/Button';
 import { BaseM, BODY_MONO_FONT_FAMILY } from '~/components/core/Text/Text';
 import { walletIconMap } from '~/components/WalletSelector/multichain/WalletButton';
 import useRemoveWallet from '~/components/WalletSelector/mutations/useRemoveWallet';
+import { ManageWalletsRow$key } from '~/generated/ManageWalletsRow.graphql';
 import { isWeb3Error } from '~/types/Error';
-import { truncateAddress } from '~/utils/wallet';
+import { graphqlTruncateAddress } from '~/utils/wallet';
 
 import breakpoints from '../core/breakpoints';
+import { HStack } from '../core/Spacer/Stack';
 import { NewTooltip } from '../Tooltip/NewTooltip';
 import { useTooltipHover } from '../Tooltip/useTooltipHover';
 import useUpdatePrimaryWallet from '../WalletSelector/mutations/useUpdatePrimaryWallet';
@@ -22,25 +24,35 @@ type Props = {
   setErrorMessage: (message: string) => void;
   setRemovedAddress: (address: string) => void;
   isOnlyWalletConnected: boolean;
+  chainAddressRef: ManageWalletsRow$key;
 };
 
-function ManageWalletsRow({ walletId, address, chain, setErrorMessage, setRemovedAddress }: Props) {
-  const removeWallet = useRemoveWallet();
-  const updatePrimaryWallet = useUpdatePrimaryWallet();
-  const [isDisconnecting, setIsDisconnecting] = useState(false);
-  const [isPending, setIsPending] = useState(false);
+function ManageWalletsRow({
+  walletId,
+  address,
+  chain,
+  setErrorMessage,
+  setRemovedAddress,
+  chainAddressRef,
+}: Props) {
+  const chainAddress = useFragment(
+    graphql`
+      fragment ManageWalletsRow on ChainAddress {
+        ...walletTruncateAddressFragment
+      }
+    `,
+    chainAddressRef
+  );
+
+  const [removeWallet, isRemovingWallet] = useRemoveWallet();
+  const [updatePrimaryWallet, isUpdatingPrimaryWallet] = useUpdatePrimaryWallet();
 
   const handleDisconnectClick = useCallback(async () => {
-    ReactTooltip.hide();
     try {
       setErrorMessage('');
-      setIsDisconnecting(true);
-      setIsPending(true);
       await removeWallet(walletId);
       setRemovedAddress(address);
     } catch (error) {
-      setIsDisconnecting(false);
-      setIsPending(false);
       if (isWeb3Error(error)) {
         setErrorMessage('Error disconnecting wallet');
       }
@@ -50,14 +62,11 @@ function ManageWalletsRow({ walletId, address, chain, setErrorMessage, setRemove
   }, [setErrorMessage, removeWallet, walletId, setRemovedAddress, address]);
 
   const handleSetPrimaryClick = useCallback(async () => {
-    setIsPending(true);
     setErrorMessage('');
     try {
       await updatePrimaryWallet(walletId);
-      setIsPending(false);
     } catch {
       setErrorMessage(`There was an error while updating the primary wallet.`);
-      setIsPending(false);
     }
   }, [updatePrimaryWallet, walletId, setErrorMessage]);
 
@@ -67,12 +76,16 @@ function ManageWalletsRow({ walletId, address, chain, setErrorMessage, setRemove
 
   return (
     <StyledWalletRow>
-      <StyledWalletDetails>
+      <HStack gap={4} align="center">
         <Icon src={iconUrl} />
-        <StyledWalletAddress>{truncateAddress(address)}</StyledWalletAddress>
-      </StyledWalletDetails>
+        <StyledWalletAddress>{graphqlTruncateAddress(chainAddress)}</StyledWalletAddress>
+      </HStack>
       <StyledButtonContainer>
-        <StyledButton variant="secondary" onClick={handleSetPrimaryClick} disabled={isPending}>
+        <StyledButton
+          variant="secondary"
+          onClick={handleSetPrimaryClick}
+          disabled={isUpdatingPrimaryWallet || isRemovingWallet}
+        >
           Set Primary
         </StyledButton>
 
@@ -82,9 +95,9 @@ function ManageWalletsRow({ walletId, address, chain, setErrorMessage, setRemove
             onClick={handleDisconnectClick}
             data-tip
             data-for="global"
-            disabled={isPending}
+            disabled={isUpdatingPrimaryWallet || isRemovingWallet}
           >
-            {isDisconnecting ? 'Disconnecting...' : 'Disconnect'}
+            {isRemovingWallet ? 'Disconnecting...' : 'Disconnect'}
           </StyledButton>
         </div>
         <NewTooltip
@@ -108,13 +121,12 @@ const StyledWalletRow = styled.div`
   align-items: center;
 `;
 
-const StyledWalletDetails = styled.div`
-  display: flex;
-  gap: 12px;
-`;
-
 const StyledWalletAddress = styled(BaseM)`
   font-family: ${BODY_MONO_FONT_FAMILY};
+  font-size: 12px;
+  @media only screen and ${breakpoints.tablet} {
+    font-size: 14px;
+  }
 `;
 
 const Icon = styled.img`
@@ -128,9 +140,9 @@ const StyledButton = styled(Button)`
 
 const StyledButtonContainer = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+
   gap: 4px;
   @media only screen and ${breakpoints.tablet} {
-    flex-direction: row;
   }
 `;

--- a/src/components/ManageWallets/PrimaryWalletRow.tsx
+++ b/src/components/ManageWallets/PrimaryWalletRow.tsx
@@ -28,9 +28,9 @@ export default function PrimaryWalletRow({ address, chain }: PrimaryWalletProps)
           <StyledWalletAddress>{address}</StyledWalletAddress>
         </HStack>
         <div {...getReferenceProps()} ref={reference}>
-          <Button variant="warning" disabled>
+          <StyledButton variant="warning" disabled>
             Disconnect
-          </Button>
+          </StyledButton>
         </div>
         <NewTooltip
           {...getFloatingProps()}
@@ -55,4 +55,8 @@ const PrimaryWallet = styled(VStack)`
 
 const StyledWalletAddress = styled(BaseM)`
   font-family: ${BODY_MONO_FONT_FAMILY};
+`;
+
+const StyledButton = styled(Button)`
+  padding: 8px 12px;
 `;

--- a/src/components/ManageWallets/PrimaryWalletRow.tsx
+++ b/src/components/ManageWallets/PrimaryWalletRow.tsx
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+
+import { Button } from '../core/Button/Button';
+import colors from '../core/colors';
+import { HStack, VStack } from '../core/Spacer/Stack';
+import { BaseM, BODY_MONO_FONT_FAMILY, TitleDiatypeM } from '../core/Text/Text';
+import { NewTooltip } from '../Tooltip/NewTooltip';
+import { useTooltipHover } from '../Tooltip/useTooltipHover';
+import { walletIconMap } from '../WalletSelector/multichain/WalletButton';
+
+type PrimaryWalletProps = {
+  address: string | null;
+  chain: string;
+};
+
+export default function PrimaryWalletRow({ address, chain }: PrimaryWalletProps) {
+  const iconUrl = walletIconMap[chain.toLowerCase() as keyof typeof walletIconMap];
+
+  const { floating, reference, getFloatingProps, getReferenceProps, floatingStyle } =
+    useTooltipHover();
+
+  return (
+    <PrimaryWallet gap={12}>
+      <TitleDiatypeM>Primary</TitleDiatypeM>
+      <HStack align="center" justify="space-between">
+        <HStack gap={12} align="center">
+          <Icon src={iconUrl} />
+          <StyledWalletAddress>{address}</StyledWalletAddress>
+        </HStack>
+        <div {...getReferenceProps()} ref={reference}>
+          <Button variant="warning" disabled>
+            Disconnect
+          </Button>
+        </div>
+        <NewTooltip
+          {...getFloatingProps()}
+          style={floatingStyle}
+          ref={floating}
+          text="To disconnect your primary wallet, please select another wallet as the primary first."
+        />
+      </HStack>
+    </PrimaryWallet>
+  );
+}
+
+const Icon = styled.img`
+  width: 16px;
+  height: 16px;
+`;
+
+const PrimaryWallet = styled(VStack)`
+  background-color: ${colors.offWhite};
+  padding: 12px;
+`;
+
+const StyledWalletAddress = styled(BaseM)`
+  font-family: ${BODY_MONO_FONT_FAMILY};
+`;

--- a/src/components/ManageWallets/PrimaryWalletRow.tsx
+++ b/src/components/ManageWallets/PrimaryWalletRow.tsx
@@ -1,11 +1,8 @@
 import styled from 'styled-components';
 
-import { Button } from '../core/Button/Button';
 import colors from '../core/colors';
 import { HStack, VStack } from '../core/Spacer/Stack';
-import { BaseM, BODY_MONO_FONT_FAMILY, TitleDiatypeM } from '../core/Text/Text';
-import { NewTooltip } from '../Tooltip/NewTooltip';
-import { useTooltipHover } from '../Tooltip/useTooltipHover';
+import { BaseM, BaseS, BODY_MONO_FONT_FAMILY, TitleXS } from '../core/Text/Text';
 import { walletIconMap } from '../WalletSelector/multichain/WalletButton';
 
 type PrimaryWalletProps = {
@@ -16,29 +13,18 @@ type PrimaryWalletProps = {
 export default function PrimaryWalletRow({ address, chain }: PrimaryWalletProps) {
   const iconUrl = walletIconMap[chain.toLowerCase() as keyof typeof walletIconMap];
 
-  const { floating, reference, getFloatingProps, getReferenceProps, floatingStyle } =
-    useTooltipHover();
-
   return (
-    <PrimaryWallet gap={12}>
-      <TitleDiatypeM>Primary</TitleDiatypeM>
+    <PrimaryWallet gap={10}>
       <HStack align="center" justify="space-between">
-        <HStack gap={12} align="center">
+        <HStack gap={4} align="center">
           <Icon src={iconUrl} />
           <StyledWalletAddress>{address}</StyledWalletAddress>
         </HStack>
-        <div {...getReferenceProps()} ref={reference}>
-          <StyledButton variant="warning" disabled>
-            Disconnect
-          </StyledButton>
-        </div>
-        <NewTooltip
-          {...getFloatingProps()}
-          style={floatingStyle}
-          ref={floating}
-          text="To disconnect your primary wallet, please select another wallet as the primary first."
-        />
+        <BlueBox>
+          <TitleXS color={colors.activeBlue}>Primary</TitleXS>
+        </BlueBox>
       </HStack>
+      <BaseS>Disconnecting? First, set another wallet as your primary.</BaseS>
     </PrimaryWallet>
   );
 }
@@ -57,6 +43,8 @@ const StyledWalletAddress = styled(BaseM)`
   font-family: ${BODY_MONO_FONT_FAMILY};
 `;
 
-const StyledButton = styled(Button)`
-  padding: 8px 12px;
+const BlueBox = styled.div`
+  padding: 2px 4px;
+  border: 1px solid ${colors.activeBlue};
+  border-radius: 2px;
 `;

--- a/src/components/WalletSelector/mutations/useRemoveWallet.ts
+++ b/src/components/WalletSelector/mutations/useRemoveWallet.ts
@@ -5,7 +5,7 @@ import { useRemoveWalletMutation } from '~/generated/useRemoveWalletMutation.gra
 import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
 
 export default function useRemoveWallet() {
-  const [removeWallet] = usePromisifiedMutation<useRemoveWalletMutation>(
+  const [removeWallet, isMutating] = usePromisifiedMutation<useRemoveWalletMutation>(
     graphql`
       mutation useRemoveWalletMutation($walletIds: [DBID!]!) {
         removeUserWallets(walletIds: $walletIds) {
@@ -26,7 +26,7 @@ export default function useRemoveWallet() {
     `
   );
 
-  return useCallback(
+  const mutate = useCallback(
     async (walletId: string) => {
       const { removeUserWallets } = await removeWallet({
         variables: {
@@ -43,4 +43,6 @@ export default function useRemoveWallet() {
     },
     [removeWallet]
   );
+
+  return [mutate, isMutating] as const;
 }

--- a/src/components/WalletSelector/mutations/useUpdatePrimaryWallet.ts
+++ b/src/components/WalletSelector/mutations/useUpdatePrimaryWallet.ts
@@ -5,26 +5,27 @@ import { useUpdatePrimaryWalletMutation } from '~/generated/useUpdatePrimaryWall
 import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
 
 export default function useUpdatePrimaryWallet() {
-  const [updatePrimaryWalletAddress] = usePromisifiedMutation<useUpdatePrimaryWalletMutation>(
-    graphql`
-      mutation useUpdatePrimaryWalletMutation($walletId: DBID!) {
-        updatePrimaryWallet(walletID: $walletId) {
-          ... on UpdatePrimaryWalletPayload {
-            __typename
-            viewer {
-              user {
-                primaryWallet {
-                  dbid
+  const [updatePrimaryWalletAddress, isMutating] =
+    usePromisifiedMutation<useUpdatePrimaryWalletMutation>(
+      graphql`
+        mutation useUpdatePrimaryWalletMutation($walletId: DBID!) {
+          updatePrimaryWallet(walletID: $walletId) {
+            ... on UpdatePrimaryWalletPayload {
+              __typename
+              viewer {
+                user {
+                  primaryWallet {
+                    dbid
+                  }
                 }
               }
             }
           }
         }
-      }
-    `
-  );
+      `
+    );
 
-  return useCallback(
+  const mutate = useCallback(
     async (walletId: string) => {
       const { updatePrimaryWallet } = await updatePrimaryWalletAddress({
         variables: {
@@ -40,4 +41,6 @@ export default function useUpdatePrimaryWallet() {
     },
     [updatePrimaryWalletAddress]
   );
+
+  return [mutate, isMutating] as const;
 }

--- a/src/components/WalletSelector/mutations/useUpdatePrimaryWallet.ts
+++ b/src/components/WalletSelector/mutations/useUpdatePrimaryWallet.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+import { graphql } from 'react-relay';
+
+import { useUpdatePrimaryWalletMutation } from '~/generated/useUpdatePrimaryWalletMutation.graphql';
+import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
+
+export default function useUpdatePrimaryWallet() {
+  const [updatePrimaryWalletAddress] = usePromisifiedMutation<useUpdatePrimaryWalletMutation>(
+    graphql`
+      mutation useUpdatePrimaryWalletMutation($walletId: DBID!) {
+        updatePrimaryWallet(walletID: $walletId) {
+          ... on UpdatePrimaryWalletPayload {
+            __typename
+            viewer {
+              user {
+                primaryWallet {
+                  dbid
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+  );
+
+  return useCallback(
+    async (walletId: string) => {
+      const { updatePrimaryWallet } = await updatePrimaryWalletAddress({
+        variables: {
+          walletId: walletId,
+        },
+      });
+
+      if (updatePrimaryWallet?.__typename === 'UpdatePrimaryWalletPayload') {
+        return;
+      } else {
+        return;
+      }
+    },
+    [updatePrimaryWalletAddress]
+  );
+}

--- a/src/components/WalletSelector/mutations/useUpdatePrimaryWallet.ts
+++ b/src/components/WalletSelector/mutations/useUpdatePrimaryWallet.ts
@@ -35,7 +35,7 @@ export default function useUpdatePrimaryWallet() {
       if (updatePrimaryWallet?.__typename === 'UpdatePrimaryWalletPayload') {
         return;
       } else {
-        return;
+        throw new Error('Error updating primary wallet');
       }
     },
     [updatePrimaryWalletAddress]

--- a/src/components/core/Button/Button.tsx
+++ b/src/components/core/Button/Button.tsx
@@ -18,7 +18,7 @@ const alphaHex = (percentage: number) => {
 };
 
 type StyledButtonProps = {
-  variant?: 'primary' | 'secondary' | 'error';
+  variant?: 'primary' | 'secondary' | 'warning';
   disabled?: boolean;
 };
 
@@ -49,7 +49,6 @@ const StyledButton = styled.button<StyledButtonProps>`
 
   .Button-label {
     opacity: 1;
-    transition: all ${transitions.cubic};
   }
   &[aria-busy='true'] .Button-label {
     opacity: 0;
@@ -107,18 +106,17 @@ const StyledButton = styled.button<StyledButtonProps>`
       `;
     }
 
-    if (variant === 'error') {
+    if (variant === 'warning') {
       return css`
         background: transparent;
-        color: ${colors.shadow};
-        border: 1px solid transparent;
+        border: 1px solid ${colors.porcelain};
+        color: ${colors.red};
 
         &:hover:not(:disabled) {
           border-color: ${colors.red};
         }
 
         &:hover {
-          color: ${colors.red};
           border-color: ${colors.red};
         }
       `;

--- a/src/scenes/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/scenes/Modals/SettingsModal/SettingsModal.tsx
@@ -14,6 +14,7 @@ import EmailManager from '~/components/Email/EmailManager';
 import ManageWallets from '~/components/ManageWallets/ManageWallets';
 import { GALLERY_DISCORD } from '~/constants/urls';
 import { useReportError } from '~/contexts/errorReporting/ErrorReportingContext';
+import { useModalActions } from '~/contexts/modal/ModalContext';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { SettingsModalFragment$key } from '~/generated/SettingsModalFragment.graphql';
 import CircleCheckIcon from '~/icons/CircleCheckIcon';
@@ -95,6 +96,8 @@ function SettingsModal({
 
   const [isPending, setIsPending] = useState(false);
 
+  const { hideModal } = useModalActions();
+
   const handleEmailNotificationChange = useCallback(
     async (checked: boolean) => {
       const unsubscribedFromNotifications = checked;
@@ -153,6 +156,10 @@ function SettingsModal({
     }
   }, [userEmail]);
 
+  const handleDoneClick = useCallback(() => {
+    hideModal();
+  }, [hideModal]);
+
   const isEmailUnverified = useMemo(() => {
     return DISABLED_TOGGLE_BY_EMAIL_STATUS.includes(query?.viewer?.email?.verificationStatus ?? '');
   }, [query]);
@@ -171,70 +178,75 @@ function SettingsModal({
   }, [query]);
 
   return (
-    <StyledManageWalletsModal gap={24}>
-      <VStack gap={16}>
+    <StyledManageWalletsModal gap={12}>
+      <VStack gap={24}>
+        <VStack gap={16}>
+          <VStack>
+            <TitleDiatypeL>Email notifications</TitleDiatypeL>
+            <HStack justify="space-between" align="center">
+              <SettingsRowDescription>
+                Receive weekly recaps about product updates, airdrop opportunities, and your most
+                recent gallery admirers.
+              </SettingsRowDescription>
+              <Toggle
+                checked={isToggleChecked}
+                isPending={isPending || isEmailUnverified}
+                onChange={toggleEmailNotification}
+              />
+            </HStack>
+          </VStack>
+          <StyledButtonContainer>
+            {shouldDisplayAddEmailInput ? (
+              <EmailManager queryRef={query} onClose={handleCloseEmailManager} />
+            ) : (
+              <StyledButton variant="secondary" onClick={handleOpenEmailManager}>
+                add email address
+              </StyledButton>
+            )}
+          </StyledButtonContainer>
+        </VStack>
+        <StyledHr />
         <VStack>
-          <TitleDiatypeL>Email notifications</TitleDiatypeL>
-          <HStack justify="space-between" align="center">
-            <SettingsRowDescription>
-              Receive weekly recaps about product updates, airdrop opportunities, and your most
-              recent gallery admirers.
-            </SettingsRowDescription>
-            <Toggle
-              checked={isToggleChecked}
-              isPending={isPending || isEmailUnverified}
-              onChange={toggleEmailNotification}
-            />
+          <TitleDiatypeL>Members Club</TitleDiatypeL>
+          <HStack justify="space-between" align="center" gap={8}>
+            <span>
+              <SettingsRowDescription>
+                Unlock early access to features, a profile badge, and the members-only{' '}
+                <InteractiveLink href={GALLERY_DISCORD}>Discord channel</InteractiveLink> by holding
+                a{' '}
+                <InteractiveLink
+                  href={`https://opensea.io/collection/gallery-membership-cards?ref=${GALLERY_OS_ADDRESS}`}
+                >
+                  Premium Gallery Membership Card
+                </InteractiveLink>{' '}
+                and verifying your email address.
+              </SettingsRowDescription>
+            </span>
+            <HStack align="center" gap={4} shrink={false}>
+              {hasEarlyAccess ? (
+                <>
+                  <CircleCheckIcon />
+                  <BaseM>Active</BaseM>
+                </>
+              ) : (
+                <BaseM color={colors.metal}>Inactive</BaseM>
+              )}
+            </HStack>
           </HStack>
         </VStack>
-        <StyledButtonContainer>
-          {shouldDisplayAddEmailInput ? (
-            <EmailManager queryRef={query} onClose={handleCloseEmailManager} />
-          ) : (
-            <StyledButton variant="secondary" onClick={handleOpenEmailManager}>
-              add email address
-            </StyledButton>
-          )}
-        </StyledButtonContainer>
+        <StyledHr />
+        <VStack>
+          <TitleDiatypeL>Manage accounts</TitleDiatypeL>
+          <ManageWallets
+            queryRef={query}
+            newAddress={newAddress}
+            onTezosAddWalletSuccess={onTezosAddWalletSuccess}
+            onEthAddWalletSuccess={onEthAddWalletSuccess}
+          />
+        </VStack>
+        <StyledHr />
       </VStack>
-      <StyledHr />
-      <VStack>
-        <TitleDiatypeL>Members Club</TitleDiatypeL>
-        <HStack justify="space-between" align="center" gap={8}>
-          <span>
-            <SettingsRowDescription>
-              Unlock early access to features, a profile badge, and the members-only{' '}
-              <InteractiveLink href={GALLERY_DISCORD}>Discord channel</InteractiveLink> by holding a{' '}
-              <InteractiveLink
-                href={`https://opensea.io/collection/gallery-membership-cards?ref=${GALLERY_OS_ADDRESS}`}
-              >
-                Premium Gallery Membership Card
-              </InteractiveLink>{' '}
-              and verifying your email address.
-            </SettingsRowDescription>
-          </span>
-          <HStack align="center" gap={4} shrink={false}>
-            {hasEarlyAccess ? (
-              <>
-                <CircleCheckIcon />
-                <BaseM>Active</BaseM>
-              </>
-            ) : (
-              <BaseM color={colors.metal}>Inactive</BaseM>
-            )}
-          </HStack>
-        </HStack>
-      </VStack>
-      <StyledHr />
-      <VStack>
-        <TitleDiatypeL>Manage accounts</TitleDiatypeL>
-        <ManageWallets
-          queryRef={query}
-          newAddress={newAddress}
-          onTezosAddWalletSuccess={onTezosAddWalletSuccess}
-          onEthAddWalletSuccess={onEthAddWalletSuccess}
-        />
-      </VStack>
+      <DoneButton onClick={handleDoneClick}>Done</DoneButton>
     </StyledManageWalletsModal>
   );
 }
@@ -257,6 +269,10 @@ const StyledButtonContainer = styled.div`
 
 const StyledButton = styled(Button)`
   padding: 8px 12px;
+`;
+
+const DoneButton = styled(Button)`
+  align-self: flex-end;
 `;
 
 export default SettingsModal;

--- a/src/scenes/Modals/SettingsModal/SettingsModal.tsx
+++ b/src/scenes/Modals/SettingsModal/SettingsModal.tsx
@@ -240,8 +240,6 @@ function SettingsModal({
 }
 
 const StyledManageWalletsModal = styled(VStack)`
-  width: 300px;
-
   @media only screen and ${breakpoints.tablet} {
     width: 480px;
   }

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -47,7 +47,7 @@ export function graphqlTruncateAddress(chainAddressRef: walletTruncateAddressFra
   }
 
   if (chain === 'Tezos') {
-    return `${address.slice(0, 6)}....${address.slice(-6)}`;
+    return `${address.slice(0, 6)}...${address.slice(-6)}`;
   } else {
     return `${address.slice(0, 8)}...${address.slice(-4)}`;
   }

--- a/tests/graphql/mockGlobalLayoutQuery.ts
+++ b/tests/graphql/mockGlobalLayoutQuery.ts
@@ -15,6 +15,16 @@ export function mockGlobalLayoutQuery() {
         id: GALLERY_USER_ID,
         username: 'Test Gallery User',
         wallets: [],
+        primaryWallet: {
+          __typename: 'Wallet',
+          id: '123',
+          dbid: '123',
+          chainAddress: {
+            __typename: 'ChainAddress',
+            address: '0x123',
+            chain: null,
+          },
+        },
       },
     },
   };


### PR DESCRIPTION
## Description
This PR updates the Settings popover to add a way for users to set a primary wallet.

**details around behavior:**
- A primary wallet is required. A backend migration has set a default primary wallet for every user.
- A user cannot disconnect their primary wallet directly. They must first unset it as the primary, and then disconnect. A tooltip informs the user about this limitation.


**notable changes:**
- Added a new row to display the primary wallet, and updated the existing rows to only display non-primary wallets.
- Removed the logic around not letting users disconnect the wallet they signed in with. The only thing that matters is that they cannot disconnect their only wallet, which will also be their primary wallet.
- Updated some styling around the error/warning state of the button.


## Screenshots
Desktop
![Screen Shot 2023-01-26 at 17 45 01](https://user-images.githubusercontent.com/80802871/214792991-c57718f2-f29c-4995-8cdd-fda58b59ea2d.png)

Mobile (pending design approval)
![Screen Shot 2023-01-26 at 17 43 29](https://user-images.githubusercontent.com/80802871/214793041-b22ff037-010d-4246-a727-d51abf5d147b.png)

tooltip
![Screen Shot 2023-01-26 at 17 44 20](https://user-images.githubusercontent.com/80802871/214793108-70778657-e980-45c1-8282-2c5ca47e30bb.png)



