### PR TITLE
Fix unstyled gallery nav links and update copy

### DIFF
--- a/src/components/Featured/Featured.tsx
+++ b/src/components/Featured/Featured.tsx
@@ -46,7 +46,7 @@ export default function Featured({ queryRef }: Props) {
       {query.trendingUsersAllTime?.__typename === 'TrendingUsersPayload' && (
         <FeaturedSection
           title="Hall of Fame"
-          subTitle="Top collectors with the most all-time views"
+          subTitle="Top curators with the most all-time views"
           trendingUsersRef={query.trendingUsersAllTime}
           queryRef={query}
         />

--- a/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavLinks.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavLinks.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Route, route } from 'nextjs-routes';
 

--- a/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavLinks.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavLinks.tsx
@@ -3,7 +3,8 @@ import { useRouter } from 'next/router';
 import { Route, route } from 'nextjs-routes';
 
 import { HStack } from '~/components/core/Spacer/Stack';
-import { NavbarLink } from '~/contexts/globalLayout/GlobalNavbar/NavbarLink';
+
+import { NavbarLink } from '../NavbarLink';
 
 type Props = {
   username: string;
@@ -18,35 +19,29 @@ export function GalleryNavLinks({ username }: Props) {
 
   return (
     <HStack gap={8}>
-      <Link href={galleriesRoute}>
-        <NavbarLink
-          // @ts-expect-error We're not using the legacy Link
-          href={route(galleriesRoute)}
-          active={pathname === galleriesRoute.pathname}
-        >
-          Galleries
-        </NavbarLink>
-      </Link>
+      <NavbarLink
+        // @ts-expect-error We're not using the legacy Link
+        href={route(galleriesRoute)}
+        active={pathname === galleriesRoute.pathname}
+      >
+        Galleries
+      </NavbarLink>
 
-      <Link href={followersRoute}>
-        <NavbarLink
-          // @ts-expect-error We're not using the legacy Link
-          href={route(followersRoute)}
-          active={pathname === followersRoute.pathname}
-        >
-          Followers
-        </NavbarLink>
-      </Link>
+      <NavbarLink
+        // @ts-expect-error We're not using the legacy Link
+        href={route(followersRoute)}
+        active={pathname === followersRoute.pathname}
+      >
+        Followers
+      </NavbarLink>
 
-      <Link href={activityRoute}>
-        <NavbarLink
-          // @ts-expect-error We're not using the legacy Link
-          href={route(activityRoute)}
-          active={pathname === activityRoute.pathname}
-        >
-          Activity
-        </NavbarLink>
-      </Link>
+      <NavbarLink
+        // @ts-expect-error We're not using the legacy Link
+        href={route(activityRoute)}
+        active={pathname === activityRoute.pathname}
+      >
+        Activity
+      </NavbarLink>
     </HStack>
   );
 }

--- a/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
@@ -59,7 +59,6 @@ export function HomeNavbar({ queryRef }: Props) {
       <NavbarCenterContent>
         <HStack gap={8}>
           <NavbarLink
-            legacyBehavior={false}
             active={pathname === activityRoute.pathname}
             // @ts-expect-error We're not using the legacy Link
             href={route(activityRoute)}
@@ -69,7 +68,6 @@ export function HomeNavbar({ queryRef }: Props) {
           </NavbarLink>
 
           <NavbarLink
-            legacyBehavior={false}
             active={pathname === featuredRoute.pathname}
             // @ts-expect-error We're not using the legacy Link
             href={route(featuredRoute)}

--- a/src/contexts/globalLayout/GlobalNavbar/NavbarLink.tsx
+++ b/src/contexts/globalLayout/GlobalNavbar/NavbarLink.tsx
@@ -5,7 +5,8 @@ import breakpoints from '~/components/core/breakpoints';
 import colors from '~/components/core/colors';
 import { BODY_FONT_FAMILY } from '~/components/core/Text/Text';
 
-export const NavbarLink = styled(Link)<{ active: boolean }>`
+// legacyBehavior: false ensures these styles are applied to the link element
+export const NavbarLink = styled(Link).attrs({ legacyBehavior: false })<{ active: boolean }>`
   font-family: ${BODY_FONT_FAMILY};
   line-height: 21px;
   letter-spacing: -0.04em;


### PR DESCRIPTION
Fixed unstyled gallery nav links by setting `legacyBehavior` to false

Updated copy from "collector" to "curator"

![Screen Shot 2023-01-27 at 14 54 22](https://user-images.githubusercontent.com/80802871/215019131-7c0a0b0e-4eee-4a2f-80a4-c13642ab8077.png)
