### PR TITLE
fix long community pill content spill

### DIFF
--- a/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -115,15 +115,15 @@ function NftDetailText({ tokenRef }: Props) {
           <HStack align="center" gap={4}>
             {communityUrl && token.contract?.name ? (
               <ClickablePill to={communityUrl}>
-                <HStack gap={4} align="center" justify="flex-end">
+                <StyledPillContent gap={4} align="center" justify="flex-end">
                   {token.chain === 'POAP' && <PoapLogo />}
                   {token.contract?.badgeURL && <StyledBadge src={token.contract.badgeURL} />}
-                  <TitleDiatypeM>{token.contract.name}</TitleDiatypeM>
-                </HStack>
+                  <StyledContractName>{token.contract.name}</StyledContractName>
+                </StyledPillContent>
               </ClickablePill>
             ) : (
               <NonclickablePill>
-                <TitleDiatypeM>{token.contract?.name}</TitleDiatypeM>
+                <StyledContractName>{token.contract?.name}</StyledContractName>
               </NonclickablePill>
             )}
           </HStack>
@@ -220,6 +220,7 @@ const ClickablePill = styled(InteractiveLink)`
   color: ${colors.offBlack};
   text-decoration: none;
   width: fit-content;
+  max-width: 100%;
   align-self: end;
   height: 32px;
   display: flex;
@@ -235,10 +236,22 @@ const ClickablePill = styled(InteractiveLink)`
 const NonclickablePill = styled.div`
   color: ${colors.offBlack};
   width: fit-content;
+  max-width: 100%;
   align-self: end;
   height: 32px;
   display: flex;
   align-items: center;
+`;
+
+const StyledPillContent = styled(HStack)`
+  width: 100%;
+`;
+
+const StyledContractName = styled(TitleDiatypeM)`
+  overflow: hidden;
+  white-space: nowrap;
+  width: 100%;
+  text-overflow: ellipsis;
 `;
 
 export default NftDetailText;


### PR DESCRIPTION
## Description
Fixes a small visual bug on the NFT Detail Page where long community names were wrapping and spilling outside of the pill

**Before**
![Screen Shot 2023-01-27 at 21 26 39](https://user-images.githubusercontent.com/80802871/215087059-f4601c24-6f09-40a6-9872-243a1e7171a9.png)

**After**
![Screen Shot 2023-01-27 at 21 28 45](https://user-images.githubusercontent.com/80802871/215087144-e4a9496a-8d4e-4567-a626-9fe5ce09e06f.png)


**Regression checks**
POAPs  (name with poap icon)
![Screen Shot 2023-01-27 at 21 26 29](https://user-images.githubusercontent.com/80802871/215087158-1e5d0eb7-42bb-42a5-a1c9-5a47649d5a81.png)

Badges (name with badge)
![Screen Shot 2023-01-27 at 21 26 13](https://user-images.githubusercontent.com/80802871/215087189-9d983341-e3a6-4639-8f99-ac01e081db6d.png)

Normal and shorter community name 
![Screen Shot 2023-01-27 at 21 26 24](https://user-images.githubusercontent.com/80802871/215087248-d334cd35-73b6-4f52-8a1c-b612e2484683.png)
