### PR TITLE
Fix double swipe bug w/ Swiper

### DIFF
--- a/src/components/Featured/FeaturedList.tsx
+++ b/src/components/Featured/FeaturedList.tsx
@@ -70,8 +70,8 @@ export default function FeaturedList({ trendingUsersRef, queryRef }: Props) {
       <div>
         <Swiper
           ref={swiperRef}
-          mousewheel={{ forceToAxis: true }}
-          modules={[Mousewheel, Pagination]}
+          direction="horizontal"
+          cssMode
           spaceBetween={50}
           slidesPerView={1}
           onSlideChange={handleSlideChange}

--- a/src/components/Featured/FeaturedList.tsx
+++ b/src/components/Featured/FeaturedList.tsx
@@ -5,7 +5,6 @@ import chunk from 'lodash.chunk';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled, { css } from 'styled-components';
-import { Mousewheel, Pagination } from 'swiper';
 import SwiperType from 'swiper';
 import { Swiper, SwiperRef, SwiperSlide } from 'swiper/react';
 


### PR DESCRIPTION
Seems like the issue is kind of not solvable. The workaround is to use `cssMode` (author's response here https://github.com/nolimits4web/swiper/issues/5471#issuecomment-1041465412).

The animations when using a mouse feel a little bit worse but it fixes the double swipe.