### PR TITLE
Fix double creations of collections

### DIFF
--- a/src/components/GalleryEditor/GalleryEditorContext.tsx
+++ b/src/components/GalleryEditor/GalleryEditorContext.tsx
@@ -550,12 +550,16 @@ export function useGalleryEditorContext() {
   return value;
 }
 
-function convertCollectionToComparisonFriendlyObject(collection?: CollectionState) {
-  if (!collection) {
-    return null;
-  }
+type ComparisonFriendlyCollectionState = Omit<CollectionState, 'liveDisplayTokenIds'> & {
+  liveDisplayTokenIds: string[];
+};
+
+function convertCollectionToComparisonFriendlyObject(
+  collection: CollectionState
+): ComparisonFriendlyCollectionState {
   return {
     ...collection,
-    liveDisplayTokenIdsSize: [...collection.liveDisplayTokenIds].sort(),
+    activeSectionId: null,
+    liveDisplayTokenIds: [...collection.liveDisplayTokenIds].sort(),
   };
 }

--- a/src/components/GalleryEditor/GalleryEditorContext.tsx
+++ b/src/components/GalleryEditor/GalleryEditorContext.tsx
@@ -98,10 +98,10 @@ export function GalleryEditorProvider({
             dbid
             name
             description
+
+            ...getInitialCollectionsFromServerFragment
           }
         }
-
-        ...getInitialCollectionsFromServerFragment
       }
     `,
     queryRef
@@ -136,6 +136,8 @@ export function GalleryEditorProvider({
               # eslint-disable-next-line relay/must-colocate-fragment-spreads
               ...CollectionGalleryHeaderFragment
             }
+
+            ...getInitialCollectionsFromServerFragment
           }
         }
       }
@@ -152,7 +154,7 @@ export function GalleryEditorProvider({
   });
 
   const [collections, setCollections] = useState<CollectionMap>(() =>
-    getInitialCollectionsFromServer(query)
+    getInitialCollectionsFromServer(query.galleryById)
   );
 
   const [collectionIdBeingEdited, setCollectionIdBeingEdited] = useState<string | null>(() => {
@@ -348,7 +350,7 @@ export function GalleryEditorProvider({
       const order = [...Object.values(collections).map((collection) => collection.dbid)];
 
       try {
-        await save({
+        const { updateGallery } = await save({
           variables: {
             input: {
               galleryId,
@@ -366,11 +368,36 @@ export function GalleryEditorProvider({
           },
         });
 
+        if (updateGallery?.__typename !== 'UpdateGalleryPayload' || !updateGallery.gallery) {
+          throw new ErrorWithSentryMetadata(
+            'Update gallery response did not have the expected typename',
+            { __typename: updateGallery?.__typename }
+          );
+        }
+
+        const serverSourcedCollections = getInitialCollectionsFromServer(updateGallery.gallery);
+
         // Make sure we reset our "Has unsaved changes comparison point"
         setInitialName(name);
         setInitialDescription(description);
-        setInitialCollections(collections);
+        setInitialCollections(serverSourcedCollections);
 
+        // Make sure the UI is reflecting what the server tells us happened.
+        setCollections(serverSourcedCollections);
+
+        // Reset the deleted collection ids since we just deleted them
+        setDeletedCollectionIds(new Set());
+
+        // Ensure the same collection is still activated
+        const newCollectionIdBeingEdited = collectionIdBeingEdited
+          ? Object.keys(serverSourcedCollections)[
+              Object.keys(collections).indexOf(collectionIdBeingEdited)
+            ]
+          : null;
+
+        setCollectionIdBeingEdited(newCollectionIdBeingEdited);
+
+        // Flash a "Saved" message next to the "Done" button
         setHasSaved(true);
       } catch (error) {
         pushToast({

--- a/src/components/GalleryEditor/GalleryEditorContext.tsx
+++ b/src/components/GalleryEditor/GalleryEditorContext.tsx
@@ -417,6 +417,7 @@ export function GalleryEditorProvider({
       }
     },
     [
+      collectionIdBeingEdited,
       collections,
       deletedCollectionIds,
       description,

--- a/src/components/GalleryEditor/getInitialCollectionsFromServer.ts
+++ b/src/components/GalleryEditor/getInitialCollectionsFromServer.ts
@@ -13,46 +13,33 @@ import { generate12DigitId } from '~/utils/generate12DigitId';
 import { removeNullValues } from '~/utils/removeNullValues';
 
 export function getInitialCollectionsFromServer(
-  queryRef: getInitialCollectionsFromServerFragment$key
+  galleryRef: getInitialCollectionsFromServerFragment$key
 ): CollectionMap {
-  const query = readInlineData(
+  const gallery = readInlineData(
     graphql`
-      fragment getInitialCollectionsFromServerFragment on Query @inline {
-        galleryById(id: $galleryId) {
-          __typename
-          ... on Gallery {
-            dbid
-            collections {
+      fragment getInitialCollectionsFromServerFragment on Gallery @inline {
+        dbid
+        collections {
+          dbid
+          name
+          collectorsNote
+          hidden
+          layout {
+            ...collectionLayoutParseFragment
+          }
+          tokens {
+            tokenSettings {
+              renderLive
+            }
+            token {
               dbid
-              name
-              collectorsNote
-              hidden
-              layout {
-                ...collectionLayoutParseFragment
-              }
-              tokens {
-                tokenSettings {
-                  renderLive
-                }
-                token {
-                  dbid
-                }
-              }
             }
           }
         }
       }
     `,
-    queryRef
+    galleryRef
   );
-
-  const gallery = query.galleryById;
-
-  if (gallery?.__typename !== 'Gallery') {
-    throw new Error(
-      `Expected gallery to be typename 'Gallery', but received '${gallery?.__typename}'`
-    );
-  }
 
   const collections: CollectionMap = {};
 


### PR DESCRIPTION
Prior to this PR, we were not resetting the collection state in the context after a save.

I've updated the logic to make sure
- Collections from the server are shown to the user after hitting save
- Deleted collectionIds don't get sent twice
- Created collections get reset after saving

Bonus:
- Clicking on another section no longer causes the editor to think you have unsaved changes.