### PR TITLE
Fix overactive redirects in GalleryRedirect

### DIFF
--- a/apps/web/src/scenes/_Router/GalleryRedirect.tsx
+++ b/apps/web/src/scenes/_Router/GalleryRedirect.tsx
@@ -10,10 +10,12 @@ type Props = {
 // 1) enables redirect without erroring
 // 2) wraps in Page component to prevent footer from flashing
 export default function GalleryRedirect({ to }: Props) {
-  const { replace } = useRouter();
+  const { push } = useRouter();
   useEffect(() => {
-    void replace(to);
-  }, [replace, to]);
+    void push(to);
+    // prevent unnecessary successive redirects
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return <Placeholder />;
 }


### PR DESCRIPTION
The dependency array in `GalleryRedirect` was causing significant and unnecessary redirects, in turn causing a flood of network requests in certain scenarios

_Before_
<img width="877" alt="image" src="https://user-images.githubusercontent.com/12162433/216735524-988bf269-a601-4a91-a59f-09170c4a8866.png">


_After_
<img width="869" alt="image" src="https://user-images.githubusercontent.com/12162433/216735436-ac74daba-dc02-4152-826a-f3148eae96e5.png">
