### PR TITLE
Prevent navigating to old editor

### DIFF
--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionRightContent.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionRightContent.tsx
@@ -102,7 +102,7 @@ export function CollectionRightContent({
 
     if (galleryId) {
       return {
-        pathname: '/gallery/[galleryId]/collection/[collectionId]/edit',
+        pathname: '/gallery/[galleryId]/edit',
         query: { collectionId, galleryId },
       };
     }

--- a/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
+++ b/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
@@ -176,7 +176,7 @@ function CollectionGalleryHeader({
                   {!shouldDisplayMobileLayoutToggle && (
                     <DropdownLink
                       href={{
-                        pathname: '/gallery/[galleryId]/collection/[collectionId]/edit',
+                        pathname: '/gallery/[galleryId]/edit',
                         query: { galleryId, collectionId },
                       }}
                       onClick={() => {

--- a/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryPage.tsx
+++ b/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryPage.tsx
@@ -86,7 +86,7 @@ function CollectionGalleryPage({ username, queryRef }: CollectionGalleryPageProp
     if (isModalOpenRef.current) return;
     if (userOwnsCollection) {
       void push({
-        pathname: '/gallery/[galleryId]/collection/[collectionId]/edit',
+        pathname: '/gallery/[galleryId]/edit',
         query: { galleryId, collectionId },
       });
     } else {


### PR DESCRIPTION
Certain sequences would land the user on the old editor (e.g. clicking "Edit Collection" directly from a collection-focused page)