### PR TITLE
On mobile, open dropdown on click

### DIFF
--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdown.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdown.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { ReactNode, useCallback, useEffect, useMemo } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
@@ -11,6 +11,7 @@ import { GLogo } from '~/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GLogo'
 import { NavDownArrow } from '~/contexts/globalLayout/GlobalNavbar/ProfileDropdown/NavDownArrow';
 import { ProfileDropdownContent } from '~/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdownContent';
 import { ProfileDropdownFragment$key } from '~/generated/ProfileDropdownFragment.graphql';
+import isTouchscreenDevice from '~/utils/isTouchscreenDevice';
 
 import { NotificationsCircle } from '../NotificationCircle';
 import NavUpArrow from './NavUpArrow';
@@ -46,14 +47,26 @@ export function ProfileDropdown({ queryRef, rightContent }: ProfileDropdownProps
     queryRef
   );
 
+  const isTouchscreen = useRef(isTouchscreenDevice());
+
   const { push, pathname, query: urlQuery } = useRouter();
 
-  const { handleDropdownMouseEnter, handleDropdownMouseLeave, closeDropdown, shouldShowDropdown } =
-    useDropdownHoverControls();
+  const {
+    handleDropdownMouseEnter,
+    handleDropdownMouseLeave,
+    showDropdown,
+    closeDropdown,
+    shouldShowDropdown,
+  } = useDropdownHoverControls();
 
   const handleHomeRedirect = useCallback(() => {
-    push({ pathname: '/trending' });
-  }, [push]);
+    if (isTouchscreen.current) {
+      // users cannot hover on touchscreen devices so open the dropdown via tap
+      shouldShowDropdown ? closeDropdown() : showDropdown();
+    } else {
+      push({ pathname: '/trending' });
+    }
+  }, [closeDropdown, push, shouldShowDropdown, showDropdown]);
 
   useEffect(
     function closeDropdownWhenRouteChanges() {


### PR DESCRIPTION
## Description
Today the nav dropdown opens upon hovering on the "G" icon. On mobile the dropdown doesn't open because you can't hover. 
This PR updates the behavior so that on touch screen devices, the dropdown opens by clicking (tapping) on the "G" icon. 

In summary: 
On Desktop:
- Hover on "G" to open dropdown
- Click on "G"to navigate to homepage

On Mobile:
- Click on "G"to open dropdown
- There won't be a shortcut to navigate to the homepage. You can still click on "Home" in the dropdown for the same result.

Before

https://user-images.githubusercontent.com/80802871/217223083-c8beb9d3-97f8-47b0-a788-7d2c9ea90b92.mp4



After

https://user-images.githubusercontent.com/80802871/217223065-82fbd50d-1585-48ae-8c43-49671deabff5.mp4

