### PR TITLE
increase input font size on mobile to prevent auto-zoom

### DIFF
--- a/apps/web/src/components/Email/EmailForm.tsx
+++ b/apps/web/src/components/Email/EmailForm.tsx
@@ -2,7 +2,6 @@ import { useRouter } from 'next/router';
 import { useCallback, useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import { SelectorStoreUpdater } from 'relay-runtime';
-import styled from 'styled-components';
 
 import { AdditionalContext, useReportError } from '~/contexts/errorReporting/ErrorReportingContext';
 import { useToastActions } from '~/contexts/toast/ToastContext';
@@ -12,7 +11,7 @@ import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
 import { EMAIL_FORMAT } from '~/utils/regex';
 
 import { Button } from '../core/Button/Button';
-import colors from '../core/colors';
+import { SlimInput } from '../core/Input/Input';
 import { HStack, VStack } from '../core/Spacer/Stack';
 
 type Props = {
@@ -157,7 +156,7 @@ function EmailForm({ setIsEditMode, queryRef, onClose }: Props) {
   return (
     <form onSubmit={handleFormSubmit}>
       <VStack gap={8}>
-        <StyledInput
+        <SlimInput
           onChange={handleEmailChange}
           placeholder="Email address"
           defaultValue={savedEmail || ''}
@@ -182,13 +181,5 @@ function EmailForm({ setIsEditMode, queryRef, onClose }: Props) {
     </form>
   );
 }
-
-const StyledInput = styled.input`
-  border: 0;
-  background-color: ${colors.faint};
-  padding: 6px 12px;
-  width: 100%;
-  height: 32px;
-`;
 
 export default EmailForm;

--- a/apps/web/src/components/WalletSelector/multichain/MagicLinkLogin.tsx
+++ b/apps/web/src/components/WalletSelector/multichain/MagicLinkLogin.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { Button } from '~/components/core/Button/Button';
-import colors from '~/components/core/colors';
+import { SlimInput } from '~/components/core/Input/Input';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import { Spinner } from '~/components/core/Spinner/Spinner';
 import ErrorText from '~/components/core/Text/ErrorText';
@@ -116,7 +116,7 @@ export default function MagicLinkLogin({ reset }: Props) {
         </VStack>
         <form>
           <VStack gap={8}>
-            <StyledInput
+            <SlimInput
               onChange={handleInputChange}
               placeholder="Email"
               autoFocus
@@ -144,14 +144,6 @@ export default function MagicLinkLogin({ reset }: Props) {
 
 const StyledText = styled(BaseM)`
   text-align: left;
-`;
-
-const StyledInput = styled.input`
-  border: 0;
-  background-color: ${colors.faint};
-  padding: 6px 12px;
-  width: 100%;
-  height: 32px;
 `;
 
 const StyledErrorText = styled(ErrorText)`

--- a/apps/web/src/components/core/Input/Input.tsx
+++ b/apps/web/src/components/core/Input/Input.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import noop from '~/utils/noop';
 
+import breakpoints from '../breakpoints';
 import colors from '../colors';
 import { VStack } from '../Spacer/Stack';
 import ErrorText from '../Text/ErrorText';
@@ -55,6 +56,21 @@ const StyledBigInput = styled.input<{ variant: Props['variant'] }>`
 
   ::placeholder {
     opacity: 0.5;
+  }
+`;
+
+export const SlimInput = styled.input`
+  font-family: 'ABC Diatype', Helvetica, Arial, sans-serif;
+  border: 0;
+  background-color: ${colors.faint};
+  padding: 6px 12px;
+  width: 100%;
+  height: 32px;
+
+  font-size: 16px; // on mobile, if input font is < 16px, OS will zoom automatically on the input which we dont want
+
+  @media only screen and ${breakpoints.desktop} {
+    font-size: 14px;
   }
 `;
 


### PR DESCRIPTION
## Description

iOS automatically zooms in on an input if the font size is < 16px. 
This made signing in via email a bit annoying because the screen zoomed in immediately after clicking the "Email" option.

The Fix: changes input font size from 14px to 16px on mobile

I also made a new styled component, SlimInput that we can share between the Magic Link input and the "Set your email" input 

Before:

https://user-images.githubusercontent.com/80802871/217430335-2be47576-658b-4733-a70d-5251f2db9568.mp4


After:

https://user-images.githubusercontent.com/80802871/217430364-ac9d2ace-885f-43c6-86f7-364e4d246079.mp4

Verification that the new styled component works in the Set Your Email Input  too
<img width="470" alt="Screen Shot 2023-02-08 at 12 45 22" src="https://user-images.githubusercontent.com/80802871/217430630-3c1618ef-5cbd-4879-bd3f-afd561bc2b8b.png">

