### PR TITLE
update notion help article link

### DIFF
--- a/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionSidebar.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionSidebar.tsx
@@ -15,7 +15,7 @@ import { CollectionSidebarQueryFragment$key } from '~/generated/CollectionSideba
 import { QuestionMarkIcon } from '~/icons/QuestionMarkIcon';
 
 const NOTION_DOCS_URL =
-  'https://www.notion.so/gallery-so/Creating-a-new-gallery-and-organizing-your-NFTs-b407a174a2ee44748bb9952abd803290';
+  'https://gallery-so.notion.site/Creating-a-new-gallery-and-organizing-your-NFTs-b407a174a2ee44748bb9952abd803290';
 
 function TitleSection() {
   const { createCollection } = useGalleryEditorContext();


### PR DESCRIPTION
## Description

Previous url was our internal link so it didn't directly go to the public version and showed this instead:
<img width="1509" alt="Screen Shot 2023-02-08 at 16 25 53" src="https://user-images.githubusercontent.com/80802871/217462231-4394eb44-0f82-4d98-abac-1be053b48e57.png">


New url is the public url so it goes directly to the help article.