### PR TITLE
clicking on G logo should navigate home for non-authed users on mobile

### DIFF
--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdown.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/ProfileDropdown/ProfileDropdown.tsx
@@ -59,15 +59,6 @@ export function ProfileDropdown({ queryRef, rightContent }: ProfileDropdownProps
     shouldShowDropdown,
   } = useDropdownHoverControls();
 
-  const handleHomeRedirect = useCallback(() => {
-    if (isTouchscreen.current) {
-      // users cannot hover on touchscreen devices so open the dropdown via tap
-      shouldShowDropdown ? closeDropdown() : showDropdown();
-    } else {
-      push({ pathname: '/trending' });
-    }
-  }, [closeDropdown, push, shouldShowDropdown, showDropdown]);
-
   useEffect(
     function closeDropdownWhenRouteChanges() {
       closeDropdown();
@@ -76,6 +67,15 @@ export function ProfileDropdown({ queryRef, rightContent }: ProfileDropdownProps
   );
 
   const isLoggedIn = query.viewer?.__typename === 'Viewer';
+
+  const handleHomeRedirect = useCallback(() => {
+    if (isTouchscreen.current && isLoggedIn) {
+      // users cannot hover on touchscreen devices so open the dropdown via tap (only if signed in)
+      shouldShowDropdown ? closeDropdown() : showDropdown();
+    } else {
+      push({ pathname: '/trending' });
+    }
+  }, [closeDropdown, isLoggedIn, push, shouldShowDropdown, showDropdown]);
 
   const notificationCount = useMemo(() => {
     if (


### PR DESCRIPTION
## Description
this is a follow up to #1321  (on mobile, tapping "G" should open nav dropdown instead of navigating home")

On mobile if a user is signed out, there's no dropdown for them to open, so tapping "G" should navigate them home