### PR TITLE
add sign up button next to sign in button

### DIFF
--- a/apps/web/src/components/Feed/Socialize/AdmireButton.tsx
+++ b/apps/web/src/components/Feed/Socialize/AdmireButton.tsx
@@ -192,6 +192,7 @@ export function AdmireButton({ eventRef, queryRef }: AdmireButtonProps) {
     if (query.viewer?.__typename !== 'Viewer') {
       showModal({
         content: <AuthModal queryRef={query} />,
+        headerText: 'Sign In',
       });
 
       return;
@@ -273,7 +274,18 @@ export function AdmireButton({ eventRef, queryRef }: AdmireButtonProps) {
         });
       }
     }
-  }, [admire, event.dbid, event.id, interactionsConnection, notesModalConnection, pushToast, query, reportError, showModal, track]);
+  }, [
+    admire,
+    event.dbid,
+    event.id,
+    interactionsConnection,
+    notesModalConnection,
+    pushToast,
+    query,
+    reportError,
+    showModal,
+    track,
+  ]);
 
   const hasViewerAdmiredEvent = Boolean(event.viewerAdmire);
 

--- a/apps/web/src/components/Feed/Socialize/CommentBox/CommentBoxIcon.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentBox/CommentBoxIcon.tsx
@@ -75,6 +75,7 @@ export function CommentBoxIcon({ queryRef, eventRef }: Props) {
       if (!query.viewer?.user) {
         showModal({
           content: <AuthModal queryRef={query} />,
+          headerText: 'Sign In',
         });
 
         return;

--- a/apps/web/src/components/Follow/FollowButton.tsx
+++ b/apps/web/src/components/Follow/FollowButton.tsx
@@ -64,7 +64,7 @@ export default function FollowButton({ queryRef, userRef, className }: Props) {
   const followUser = useFollowUser();
   const unfollowUser = useUnfollowUser();
   const { pushToast } = useToastActions();
-  const showAuthModal = useAuthModal();
+  const showAuthModal = useAuthModal('signIn');
   const track = useTrack();
 
   const handleFollowClick = useCallback(async () => {

--- a/apps/web/src/components/Follow/FollowButton.tsx
+++ b/apps/web/src/components/Follow/FollowButton.tsx
@@ -64,7 +64,7 @@ export default function FollowButton({ queryRef, userRef, className }: Props) {
   const followUser = useFollowUser();
   const unfollowUser = useUnfollowUser();
   const { pushToast } = useToastActions();
-  const showAuthModal = useAuthModal('signIn');
+  const showAuthModal = useAuthModal('sign-in');
   const track = useTrack();
 
   const handleFollowClick = useCallback(async () => {

--- a/apps/web/src/components/WalletSelector/WalletSelector.tsx
+++ b/apps/web/src/components/WalletSelector/WalletSelector.tsx
@@ -56,7 +56,7 @@ export default function WalletSelector({
 
   const numOptionsToShow: number = useMemo(
     () => (showEmail ? NUM_OPTIONS_SUPPORTED : NUM_OPTIONS_SUPPORTED - 1),
-    []
+    [showEmail]
   );
 
   const fallback = useMemo(
@@ -71,7 +71,7 @@ export default function WalletSelector({
         </VStack>
       </WalletSelectorWrapper>
     ),
-    []
+    [numOptionsToShow]
   );
 
   return (

--- a/apps/web/src/components/WalletSelector/WalletSelector.tsx
+++ b/apps/web/src/components/WalletSelector/WalletSelector.tsx
@@ -27,6 +27,7 @@ type Props = {
   variant?: WalletSelectorVariant;
   onEthAddWalletSuccess?: () => void;
   onTezosAddWalletSuccess?: () => void;
+  showEmail?: boolean;
 };
 
 // number of connection options supported; list available in `MultichainWalletSelector.tsx`
@@ -38,6 +39,7 @@ export default function WalletSelector({
   variant,
   onEthAddWalletSuccess,
   onTezosAddWalletSuccess,
+  showEmail = true,
 }: Props) {
   // Usually we'd want to pass in a query variable and use @skip to conditionally
   // return certain data fragments, but in this case, we have lots of queries that
@@ -52,11 +54,16 @@ export default function WalletSelector({
     queryRef
   );
 
+  const numOptionsToShow: number = useMemo(
+    () => (showEmail ? NUM_OPTIONS_SUPPORTED : NUM_OPTIONS_SUPPORTED - 1),
+    []
+  );
+
   const fallback = useMemo(
     () => (
       <WalletSelectorWrapper>
         <VStack gap={8}>
-          {Array.from({ length: NUM_OPTIONS_SUPPORTED }).map(() => {
+          {Array.from({ length: numOptionsToShow }).map(() => {
             // We don't have anything relevant to key off of here
             // eslint-disable-next-line react/jsx-key
             return <Skeleton width="100%" height="52px" />;
@@ -77,6 +84,7 @@ export default function WalletSelector({
             variant={variant}
             onEthAddWalletSuccess={onEthAddWalletSuccess}
             onTezosAddWalletSuccess={onTezosAddWalletSuccess}
+            showEmail={showEmail}
           />
         </EthereumProviders>
       </BeaconProvider>

--- a/apps/web/src/components/WalletSelector/multichain/MultichainWalletSelector.tsx
+++ b/apps/web/src/components/WalletSelector/multichain/MultichainWalletSelector.tsx
@@ -30,6 +30,7 @@ type Props = {
   variant?: WalletSelectorVariant;
   onEthAddWalletSuccess?: () => void;
   onTezosAddWalletSuccess?: () => void;
+  showEmail?: boolean;
 };
 
 export default function MultichainWalletSelector({
@@ -38,6 +39,7 @@ export default function MultichainWalletSelector({
   variant = 'default',
   onEthAddWalletSuccess,
   onTezosAddWalletSuccess,
+  showEmail = true,
 }: Props) {
   const query = useFragment(
     graphql`
@@ -185,7 +187,7 @@ export default function MultichainWalletSelector({
               setSelectedAuthMethod(supportedAuthMethods.delegateCash);
             }}
           />
-          {connectionMode === AUTH ? (
+          {connectionMode === AUTH && showEmail ? (
             <WalletButton
               label={supportedAuthMethods.magicLink.name}
               onClick={() => {

--- a/apps/web/src/components/WalletSelector/multichain/MultichainWalletSelector.tsx
+++ b/apps/web/src/components/WalletSelector/multichain/MultichainWalletSelector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
@@ -22,7 +22,7 @@ import { TezosAuthenticateWallet } from './tezos/TezosAuthenticateWallet';
 import { useConnectEthereum } from './useConnectEthereum';
 import WalletButton from './WalletButton';
 
-export type WalletSelectorVariant = 'default' | 'tezos-announcement';
+export type WalletSelectorVariant = 'sign-in' | 'sign-up';
 
 type Props = {
   connectionMode?: ConnectionMode;
@@ -36,7 +36,7 @@ type Props = {
 export default function MultichainWalletSelector({
   queryRef,
   connectionMode = AUTH,
-  variant = 'default',
+  variant = 'sign-in',
   onEthAddWalletSuccess,
   onTezosAddWalletSuccess,
   showEmail = true,
@@ -60,6 +60,17 @@ export default function MultichainWalletSelector({
 
   const connectEthereum = useConnectEthereum();
   const { requestPermissions: connectTezos } = useBeaconActions();
+
+  const subheading = useMemo(() => {
+    switch (variant) {
+      case 'sign-in':
+        return 'Sign in to your Gallery account using a wallet or email.';
+      case 'sign-up':
+        return 'Join Gallery today to curate and display your NFT collection.';
+      default:
+        return '';
+    }
+  }, [variant]);
 
   if (selectedAuthMethod === supportedAuthMethods.ethereum) {
     if (connectionMode === ADD_WALLET_TO_USER) {
@@ -132,12 +143,7 @@ export default function MultichainWalletSelector({
   return (
     <WalletSelectorWrapper gap={24}>
       <VStack gap={16}>
-        {variant === 'tezos-announcement' && (
-          <StyledDescription>
-            If you’re a new user, connect your Tezos wallet. If you’re an existing user, sign in
-            with your Ethereum address before adding your Tezos wallet.
-          </StyledDescription>
-        )}
+        <StyledDescription>{subheading}</StyledDescription>
         <VStack justify="center" gap={8}>
           <WalletButton
             label={supportedAuthMethods.ethereum.name}

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
@@ -6,6 +6,7 @@ import { graphql, useFragment } from 'react-relay';
 import { HStack } from '~/components/core/Spacer/Stack';
 import { useTrack } from '~/contexts/analytics/AnalyticsContext';
 import { HomeNavbarFragment$key } from '~/generated/HomeNavbarFragment.graphql';
+import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 
 import { NavbarLink } from '../NavbarLink';
 import { ProfileDropdown } from '../ProfileDropdown/ProfileDropdown';
@@ -58,6 +59,8 @@ export function HomeNavbar({ queryRef }: Props) {
   const latestFollowingRoute: Route = { pathname: '/latest/following', query: {} };
   const featuredRoute: Route = { pathname: '/featured', query: {} };
 
+  const isMobile = useIsMobileWindowWidth();
+
   return (
     <StandardNavbarContainer>
       <NavbarLeftContent>
@@ -100,7 +103,7 @@ export function HomeNavbar({ queryRef }: Props) {
           <>
             <HStack gap={8} align="center">
               <SignInButton />
-              <SignUpButton />
+              {!isMobile && <SignUpButton />}
             </HStack>
           </>
         )}

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
@@ -100,12 +100,10 @@ export function HomeNavbar({ queryRef }: Props) {
       {/* Strictly here to keep spacing consistent */}
       <NavbarRightContent>
         {isLoggedIn ? null : (
-          <>
-            <HStack gap={8} align="center">
-              <SignInButton />
-              {!isMobile && <SignUpButton />}
-            </HStack>
-          </>
+          <HStack gap={8} align="center">
+            <SignInButton />
+            {!isMobile && <SignUpButton />}
+          </HStack>
         )}
       </NavbarRightContent>
     </StandardNavbarContainer>

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
@@ -10,6 +10,7 @@ import { HomeNavbarFragment$key } from '~/generated/HomeNavbarFragment.graphql';
 import { NavbarLink } from '../NavbarLink';
 import { ProfileDropdown } from '../ProfileDropdown/ProfileDropdown';
 import { SignInButton } from '../SignInButton';
+import { SignUpButton } from '../SignUpButton';
 import {
   NavbarCenterContent,
   NavbarLeftContent,
@@ -94,7 +95,16 @@ export function HomeNavbar({ queryRef }: Props) {
       </NavbarCenterContent>
 
       {/* Strictly here to keep spacing consistent */}
-      <NavbarRightContent>{isLoggedIn ? null : <SignInButton />}</NavbarRightContent>
+      <NavbarRightContent>
+        {isLoggedIn ? null : (
+          <>
+            <HStack gap={8} align="center">
+              <SignInButton />
+              <SignUpButton />
+            </HStack>
+          </>
+        )}
+      </NavbarRightContent>
     </StandardNavbarContainer>
   );
 }

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
@@ -102,6 +102,7 @@ export function HomeNavbar({ queryRef }: Props) {
         {isLoggedIn ? null : (
           <HStack gap={8} align="center">
             <SignInButton />
+            {/* Don't show Sign Up btn on mobile bc it doesnt fit alongside Sign In, and onboarding isn't mobile optimized yet */}
             {!isMobile && <SignUpButton />}
           </HStack>
         )}

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/SignInButton.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/SignInButton.tsx
@@ -7,7 +7,7 @@ import transitions from '~/components/core/transitions';
 import useAuthModal from '~/hooks/useAuthModal';
 
 export function SignInButton() {
-  const showAuthModal = useAuthModal('signIn');
+  const showAuthModal = useAuthModal('sign-in');
 
   return <SignInWrapper text="Sign In" onClick={showAuthModal} />;
 }

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/SignInButton.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/SignInButton.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import breakpoints from '~/components/core/breakpoints';
 
 import TextButton from '~/components/core/Button/TextButton';
 import colors from '~/components/core/colors';
@@ -12,9 +13,11 @@ export function SignInButton() {
 }
 
 const SignInWrapper = styled(TextButton)`
-  padding: 8px 16px;
-  transition: background-color ${transitions.cubic};
-  &:hover {
-    background-color: ${colors.faint};
+  @media only screen and ${breakpoints.tablet} {
+    padding: 8px 16px;
+    transition: background-color ${transitions.cubic};
+    &:hover {
+      background-color: ${colors.faint};
+    }
   }
 `;

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/SignInButton.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/SignInButton.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
-import breakpoints from '~/components/core/breakpoints';
 
+import breakpoints from '~/components/core/breakpoints';
 import TextButton from '~/components/core/Button/TextButton';
 import colors from '~/components/core/colors';
 import transitions from '~/components/core/transitions';

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/SignInButton.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/SignInButton.tsx
@@ -1,31 +1,20 @@
 import styled from 'styled-components';
 
-import breakpoints from '~/components/core/breakpoints';
+import TextButton from '~/components/core/Button/TextButton';
 import colors from '~/components/core/colors';
-import { Paragraph } from '~/components/core/Text/Text';
+import transitions from '~/components/core/transitions';
 import useAuthModal from '~/hooks/useAuthModal';
 
 export function SignInButton() {
-  const showAuthModal = useAuthModal();
+  const showAuthModal = useAuthModal('signIn');
 
-  return (
-    <SignInText role="button" onClick={showAuthModal} color={colors.shadow}>
-      Sign in
-    </SignInText>
-  );
+  return <SignInWrapper text="Sign In" onClick={showAuthModal} />;
 }
 
-const SignInText = styled(Paragraph)`
-  font-family: 'ABC Diatype';
-  font-style: normal;
-  font-weight: 500;
-  line-height: 21px;
-  letter-spacing: -0.04em;
-
-  cursor: pointer;
-
-  font-size: 16px;
-  @media only screen and ${breakpoints.tablet} {
-    font-size: 18px;
+const SignInWrapper = styled(TextButton)`
+  padding: 8px 16px;
+  transition: background-color ${transitions.cubic};
+  &:hover {
+    background-color: ${colors.faint};
   }
 `;

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/SignUpButton.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/SignUpButton.tsx
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+import { Button } from '~/components/core/Button/Button';
+import useAuthModal from '~/hooks/useAuthModal';
+
+export function SignUpButton() {
+  const showAuthModal = useAuthModal('signUp');
+
+  return <StyledButton onClick={showAuthModal}>Sign up</StyledButton>;
+}
+
+const StyledButton = styled(Button)`
+  padding: 8px 16px;
+`;

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/SignUpButton.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/SignUpButton.tsx
@@ -4,7 +4,7 @@ import { Button } from '~/components/core/Button/Button';
 import useAuthModal from '~/hooks/useAuthModal';
 
 export function SignUpButton() {
-  const showAuthModal = useAuthModal('signUp');
+  const showAuthModal = useAuthModal('sign-up');
 
   return <StyledButton onClick={showAuthModal}>Sign up</StyledButton>;
 }

--- a/apps/web/src/hooks/useAuthModal.tsx
+++ b/apps/web/src/hooks/useAuthModal.tsx
@@ -90,19 +90,11 @@ export default function useAuthModal(authType: AuthType) {
     {}
   );
 
-  const headerText = useMemo(() => {
-    if (authType === 'signUp') {
-      return 'Sign up';
-    }
-
-    return 'Sign In';
-  }, []);
-
   return useCallback(() => {
     showModal({
       id: 'auth',
       content: <AuthModal queryRef={query} authType={authType} />,
-      headerText,
+      headerText: authType === 'signUp' ? 'Sign Up' : 'Sign In',
     });
   }, [query, showModal]);
 }

--- a/apps/web/src/hooks/useAuthModal.tsx
+++ b/apps/web/src/hooks/useAuthModal.tsx
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 import styled from 'styled-components';
+
 import { VStack } from '~/components/core/Spacer/Stack';
 import { BaseM } from '~/components/core/Text/Text';
-
 import { WalletSelectorVariant } from '~/components/WalletSelector/multichain/MultichainWalletSelector';
 import WalletSelector from '~/components/WalletSelector/WalletSelector';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { useAuthModalFragment$key } from '~/generated/useAuthModalFragment.graphql';
 import { useAuthModalQuery } from '~/generated/useAuthModalQuery.graphql';
+
 type AuthType = 'signIn' | 'signUp';
 
 type ModalProps = {
@@ -56,7 +57,7 @@ export const AuthModal = ({ queryRef, variant, authType = 'signIn' }: ModalProps
       default:
         return '';
     }
-  }, []);
+  }, [authType]);
 
   return (
     <Container>
@@ -96,5 +97,5 @@ export default function useAuthModal(authType: AuthType) {
       content: <AuthModal queryRef={query} authType={authType} />,
       headerText: authType === 'signUp' ? 'Sign Up' : 'Sign In',
     });
-  }, [query, showModal]);
+  }, [query, authType, showModal]);
 }

--- a/apps/web/src/hooks/useAuthModal.tsx
+++ b/apps/web/src/hooks/useAuthModal.tsx
@@ -1,24 +1,20 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect } from 'react';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 import styled from 'styled-components';
 
 import { VStack } from '~/components/core/Spacer/Stack';
-import { BaseM } from '~/components/core/Text/Text';
 import { WalletSelectorVariant } from '~/components/WalletSelector/multichain/MultichainWalletSelector';
 import WalletSelector from '~/components/WalletSelector/WalletSelector';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { useAuthModalFragment$key } from '~/generated/useAuthModalFragment.graphql';
 import { useAuthModalQuery } from '~/generated/useAuthModalQuery.graphql';
 
-type AuthType = 'signIn' | 'signUp';
-
 type ModalProps = {
   queryRef: useAuthModalFragment$key;
   variant?: WalletSelectorVariant;
-  authType?: AuthType;
 };
 
-export const AuthModal = ({ queryRef, variant, authType = 'signIn' }: ModalProps) => {
+export const AuthModal = ({ queryRef, variant = 'sign-in' }: ModalProps) => {
   const { hideModal } = useModalActions();
 
   const query = useFragment(
@@ -48,22 +44,10 @@ export const AuthModal = ({ queryRef, variant, authType = 'signIn' }: ModalProps
     }
   }, [isAuthenticated, hideModal]);
 
-  const subheading = useMemo(() => {
-    switch (authType) {
-      case 'signIn':
-        return 'Sign in to your Gallery account using a wallet or email.';
-      case 'signUp':
-        return 'Join Gallery today to curate and display your NFT collection.';
-      default:
-        return '';
-    }
-  }, [authType]);
-
   return (
     <Container>
-      <VStack gap={16}>
-        <BaseM>{subheading}</BaseM>
-        <WalletSelector queryRef={query} variant={variant} showEmail={authType !== 'signUp'} />
+      <VStack gap={16} justify="center">
+        <WalletSelector queryRef={query} variant={variant} showEmail={variant !== 'sign-up'} />
       </VStack>
     </Container>
   );
@@ -79,7 +63,7 @@ const Container = styled.div`
   height: 100%;
 `;
 
-export default function useAuthModal(authType: AuthType) {
+export default function useAuthModal(variant: WalletSelectorVariant) {
   const { showModal } = useModalActions();
 
   const query = useLazyLoadQuery<useAuthModalQuery>(
@@ -94,8 +78,8 @@ export default function useAuthModal(authType: AuthType) {
   return useCallback(() => {
     showModal({
       id: 'auth',
-      content: <AuthModal queryRef={query} authType={authType} />,
-      headerText: authType === 'signUp' ? 'Sign Up' : 'Sign In',
+      content: <AuthModal queryRef={query} variant={variant} />,
+      headerText: variant === 'sign-up' ? 'Sign Up' : 'Sign In',
     });
-  }, [query, authType, showModal]);
+  }, [query, variant, showModal]);
 }

--- a/apps/web/src/scenes/MerchStorePage/MerchStorePage.tsx
+++ b/apps/web/src/scenes/MerchStorePage/MerchStorePage.tsx
@@ -99,7 +99,7 @@ export default function MerchStorePage({ queryRef }: Props) {
   );
 
   const { merchTokens } = query;
-  const showAuthModal = useAuthModal();
+  const showAuthModal = useAuthModal('signIn');
   const showRedeemModal = useRedeemModal(merchTokens);
 
   const loggedInUserId = useLoggedInUserId(userQuery);

--- a/apps/web/src/scenes/MerchStorePage/MerchStorePage.tsx
+++ b/apps/web/src/scenes/MerchStorePage/MerchStorePage.tsx
@@ -99,7 +99,7 @@ export default function MerchStorePage({ queryRef }: Props) {
   );
 
   const { merchTokens } = query;
-  const showAuthModal = useAuthModal('signIn');
+  const showAuthModal = useAuthModal('sign-in');
   const showRedeemModal = useRedeemModal(merchTokens);
 
   const loggedInUserId = useLoggedInUserId(userQuery);

--- a/apps/web/src/scenes/Modals/useOpenSettingsModal.tsx
+++ b/apps/web/src/scenes/Modals/useOpenSettingsModal.tsx
@@ -23,7 +23,7 @@ export default function useOpenSettingsModal(queryRef: useOpenSettingsModalFragm
 
   const router = useRouter();
   const { showModal } = useModalActions();
-  const showAuthModal = useAuthModal('signIn');
+  const showAuthModal = useAuthModal('sign-in');
   const { settings } = router.query;
 
   const isLoggedIn = query.viewer?.__typename === 'Viewer';

--- a/apps/web/src/scenes/Modals/useOpenSettingsModal.tsx
+++ b/apps/web/src/scenes/Modals/useOpenSettingsModal.tsx
@@ -23,7 +23,7 @@ export default function useOpenSettingsModal(queryRef: useOpenSettingsModalFragm
 
   const router = useRouter();
   const { showModal } = useModalActions();
-  const showAuthModal = useAuthModal();
+  const showAuthModal = useAuthModal('signIn');
   const { settings } = router.query;
 
   const isLoggedIn = query.viewer?.__typename === 'Viewer';


### PR DESCRIPTION
## Description
This PR adds a Sign Up button next to the Sign In button on the home page.
It also makes it possible to show slightly different content on the auth modal depending on whether its sign up vs sign in, like showing the Email Sign In option, and showing custom text.


## Changes
- Add a Sign Up button to home nav
- Add `authType` to `AuthModal` to display different content based on sign in vs sign up
   - don't show Magic Link option if sign up, because it's only for existing users
   - show different subheadings that are appropriate for each flow to improve user friendliness
   -`authType` doesn't affect flow logic, just the content of the modal. If an existing user connects their wallet via the "Sign Up" modal, they'll still be able to sign in (this is existing behavior)
   - Defaults to "Sign In", so other places the Auth Modal is used will say "Sign In" (such as when the user clicks the Admire button when signed out)
- On mobile, only show the Sign In button because there isn't enough horizontal space for both buttons. We also don't currently support mobile onboarding, so it wouldn't lead to a good experience.


https://user-images.githubusercontent.com/80802871/218967511-79e41442-a03c-4cac-996c-f2ead732121f.mp4

