### PR TITLE
Add Suggested Users section to Featured Page

### DIFF
--- a/apps/web/src/components/Featured/Featured.tsx
+++ b/apps/web/src/components/Featured/Featured.tsx
@@ -5,6 +5,7 @@ import { FeaturedFragment$key } from '~/generated/FeaturedFragment.graphql';
 
 import { VStack } from '../core/Spacer/Stack';
 import FeaturedSection from './FeaturedSection';
+import SuggestedSection from './SuggestedSection';
 
 type Props = {
   queryRef: FeaturedFragment$key;
@@ -27,7 +28,12 @@ export default function Featured({ queryRef }: Props) {
           }
         }
 
+        viewer {
+          __typename
+        }
+
         ...FeaturedSectionQueryFragment
+        ...SuggestedSectionQueryFragment
       }
     `,
     queryRef
@@ -35,6 +41,13 @@ export default function Featured({ queryRef }: Props) {
 
   return (
     <StyledFeaturedPage gap={48}>
+      {query.viewer?.__typename == 'Viewer' && (
+        <SuggestedSection
+          title="Suggested for you"
+          subTitle="Curators you may be interested in based on who you follow on Gallery"
+          queryRef={query}
+        />
+      )}
       {query.trendingUsers5Days?.__typename === 'TrendingUsersPayload' && (
         <FeaturedSection
           title="Weekly Leaderboard"

--- a/apps/web/src/components/Featured/Featured.tsx
+++ b/apps/web/src/components/Featured/Featured.tsx
@@ -41,7 +41,7 @@ export default function Featured({ queryRef }: Props) {
 
   return (
     <StyledFeaturedPage gap={48}>
-      {query.viewer?.__typename == 'Viewer' && (
+      {query.viewer?.__typename === 'Viewer' && (
         <SuggestedSection
           title="Suggested for you"
           subTitle="Curators you may be interested in based on who you follow on Gallery"

--- a/apps/web/src/components/Featured/Featured.tsx
+++ b/apps/web/src/components/Featured/Featured.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 import { FeaturedFragment$key } from '~/generated/FeaturedFragment.graphql';
 
 import { VStack } from '../core/Spacer/Stack';
-import FeaturedSection from './FeaturedSection';
 import SuggestedSection from './SuggestedSection';
+import TrendingSection from './TrendingSection';
 
 type Props = {
   queryRef: FeaturedFragment$key;
@@ -18,13 +18,13 @@ export default function Featured({ queryRef }: Props) {
         trendingUsers5Days: trendingUsers(input: { report: LAST_5_DAYS }) {
           ... on TrendingUsersPayload {
             __typename
-            ...FeaturedSectionFragment
+            ...TrendingSectionFragment
           }
         }
         trendingUsersAllTime: trendingUsers(input: { report: ALL_TIME }) {
           ... on TrendingUsersPayload {
             __typename
-            ...FeaturedSectionFragment
+            ...TrendingSectionFragment
           }
         }
 
@@ -32,7 +32,7 @@ export default function Featured({ queryRef }: Props) {
           __typename
         }
 
-        ...FeaturedSectionQueryFragment
+        ...TrendingSectionQueryFragment
         ...SuggestedSectionQueryFragment
       }
     `,
@@ -49,7 +49,7 @@ export default function Featured({ queryRef }: Props) {
         />
       )}
       {query.trendingUsers5Days?.__typename === 'TrendingUsersPayload' && (
-        <FeaturedSection
+        <TrendingSection
           title="Weekly Leaderboard"
           subTitle="Trending curators this week"
           trendingUsersRef={query.trendingUsers5Days}
@@ -57,7 +57,7 @@ export default function Featured({ queryRef }: Props) {
         />
       )}
       {query.trendingUsersAllTime?.__typename === 'TrendingUsersPayload' && (
-        <FeaturedSection
+        <TrendingSection
           title="Hall of Fame"
           subTitle="Top curators with the most all-time views"
           trendingUsersRef={query.trendingUsersAllTime}

--- a/apps/web/src/components/Featured/FeaturedList.tsx
+++ b/apps/web/src/components/Featured/FeaturedList.tsx
@@ -36,11 +36,9 @@ export default function FeaturedList({ trendingUsersRef, queryRef }: Props) {
 
   const trendingUsers = useFragment(
     graphql`
-      fragment FeaturedListFragment on TrendingUsersPayload {
-        users {
-          id
-          ...FeaturedUserCardFragment
-        }
+      fragment FeaturedListFragment on GalleryUser @relay(plural: true) {
+        id
+        ...FeaturedUserCardFragment
       }
     `,
     trendingUsersRef
@@ -55,9 +53,9 @@ export default function FeaturedList({ trendingUsersRef, queryRef }: Props) {
   }, []);
 
   const shortenedUserList = useMemo(() => {
-    const users = trendingUsers.users ?? [];
+    const users = trendingUsers ?? [];
     return users.slice(0, USERS_TO_SHOW);
-  }, [trendingUsers.users]);
+  }, [trendingUsers]);
 
   const chunkSize = isMobileOrMobileLargeWindowWidth ? 4 : 8;
   const chunks = chunk(shortenedUserList, chunkSize);

--- a/apps/web/src/components/Featured/FeaturedList.tsx
+++ b/apps/web/src/components/Featured/FeaturedList.tsx
@@ -18,13 +18,13 @@ import { HStack, VStack } from '../core/Spacer/Stack';
 import FeaturedUserCard from './FeaturedUserCard';
 
 type Props = {
-  trendingUsersRef: FeaturedListFragment$key;
+  featuredUsersRef: FeaturedListFragment$key;
   queryRef: FeaturedListQueryFragment$key;
 };
 
 const USERS_TO_SHOW = 24;
 
-export default function FeaturedList({ trendingUsersRef, queryRef }: Props) {
+export default function FeaturedList({ featuredUsersRef, queryRef }: Props) {
   const query = useFragment(
     graphql`
       fragment FeaturedListQueryFragment on Query {
@@ -34,14 +34,14 @@ export default function FeaturedList({ trendingUsersRef, queryRef }: Props) {
     queryRef
   );
 
-  const trendingUsers = useFragment(
+  const featuredUsers = useFragment(
     graphql`
       fragment FeaturedListFragment on GalleryUser @relay(plural: true) {
         id
         ...FeaturedUserCardFragment
       }
     `,
-    trendingUsersRef
+    featuredUsersRef
   );
 
   const isMobileOrMobileLargeWindowWidth = useIsMobileOrMobileLargeWindowWidth();
@@ -53,9 +53,9 @@ export default function FeaturedList({ trendingUsersRef, queryRef }: Props) {
   }, []);
 
   const shortenedUserList = useMemo(() => {
-    const users = trendingUsers ?? [];
+    const users = featuredUsers ?? [];
     return users.slice(0, USERS_TO_SHOW);
-  }, [trendingUsers]);
+  }, [featuredUsers]);
 
   const chunkSize = isMobileOrMobileLargeWindowWidth ? 4 : 8;
   const chunks = chunk(shortenedUserList, chunkSize);

--- a/apps/web/src/components/Featured/FeaturedPopoverList.tsx
+++ b/apps/web/src/components/Featured/FeaturedPopoverList.tsx
@@ -1,0 +1,114 @@
+import Link from 'next/link';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import { FeaturedPopoverListFragment$key } from '~/generated/FeaturedPopoverListFragment.graphql';
+import { FeaturedPopoverListQueryFragment$key } from '~/generated/FeaturedPopoverListQueryFragment.graphql';
+import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
+
+import breakpoints from '../core/breakpoints';
+import colors from '../core/colors';
+import Markdown from '../core/Markdown/Markdown';
+import { HStack, VStack } from '../core/Spacer/Stack';
+import { BaseM, TitleDiatypeL, TitleDiatypeM } from '../core/Text/Text';
+import FollowButton from '../Follow/FollowButton';
+
+type Props = {
+  featuredUsersRef: FeaturedPopoverListFragment$key;
+  queryRef: FeaturedPopoverListQueryFragment$key;
+};
+
+export default function FeaturedPopoverList({ featuredUsersRef, queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment FeaturedPopoverListQueryFragment on Query {
+        ...FollowButtonQueryFragment
+      }
+    `,
+    queryRef
+  );
+
+  const featuredUsers = useFragment(
+    graphql`
+      fragment FeaturedPopoverListFragment on GalleryUser @relay(plural: true) {
+        id
+        username
+        bio
+        ...FollowButtonUserFragment
+      }
+    `,
+    featuredUsersRef
+  );
+
+  const isMobile = useIsMobileWindowWidth();
+
+  return (
+    <StyledList fullscreen={isMobile} gap={24}>
+      <StyledHeading>Suggested curators for you</StyledHeading>
+      <VStack>
+        {featuredUsers.map((user) => (
+          // @ts-expect-error This is the future next/link version
+          <StyledRow legacyBehavior={false} key={user.id} href={`/${user.username}`}>
+            <StyledHStack justify="space-between" align="center" gap={8}>
+              <StyledVStack justify="center">
+                <TitleDiatypeM>{user.username}</TitleDiatypeM>
+                <StyledBio>{user.bio && <Markdown text={user.bio} />}</StyledBio>
+              </StyledVStack>
+              <StyledFollowButton userRef={user} queryRef={query} />
+            </StyledHStack>
+          </StyledRow>
+        ))}
+      </VStack>
+    </StyledList>
+  );
+}
+
+const StyledList = styled(VStack)<{ fullscreen: boolean }>`
+  width: 375px;
+  max-width: 375px;
+  padding: 52px 8px 4px 4px;
+  height: ${({ fullscreen }) => (fullscreen ? '100%' : '640px')};
+`;
+
+const StyledHeading = styled(TitleDiatypeL)`
+  padding: 0px 8px;
+`;
+
+const StyledRow = styled(Link)`
+  padding: 8px;
+  text-decoration: none;
+  min-height: 56px;
+  max-height: 56px;
+
+  &:hover {
+    background: ${colors.offWhite};
+  }
+`;
+
+const StyledHStack = styled(HStack)`
+  height: 100%;
+`;
+
+const StyledVStack = styled(VStack)`
+  width: 100%;
+`;
+
+const StyledBio = styled(BaseM)`
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  p {
+    padding-bottom: 0;
+  }
+`;
+
+const StyledFollowButton = styled(FollowButton)`
+  padding: 2px 8px;
+  width: 100%;
+
+  @media only screen and ${breakpoints.desktop} {
+    width: initial;
+  }
+`;

--- a/apps/web/src/components/Featured/FeaturedSection.tsx
+++ b/apps/web/src/components/Featured/FeaturedSection.tsx
@@ -29,7 +29,9 @@ export default function FeaturedSection({ trendingUsersRef, queryRef, title, sub
   const trendingUsers = useFragment(
     graphql`
       fragment FeaturedSectionFragment on TrendingUsersPayload {
-        ...FeaturedListFragment
+        users {
+          ...FeaturedListFragment
+        }
       }
     `,
     trendingUsersRef
@@ -41,7 +43,7 @@ export default function FeaturedSection({ trendingUsersRef, queryRef, title, sub
         <Title>{title}</Title>
         <TitleDiatypeL color={colors.metal}>{subTitle}</TitleDiatypeL>
       </VStack>
-      <FeaturedList trendingUsersRef={trendingUsers} queryRef={query} />
+      <FeaturedList trendingUsersRef={trendingUsers.users || []} queryRef={query} />
     </StyledFeaturedSection>
   );
 }

--- a/apps/web/src/components/Featured/FeaturedUserCard.tsx
+++ b/apps/web/src/components/Featured/FeaturedUserCard.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
@@ -98,7 +99,8 @@ export default function FeaturedUserCard({ userRef, queryRef }: Props) {
   }, [user.badges]);
 
   return (
-    <StyledFeaturedUserCard href={`/${user.username}`}>
+    // @ts-expect-error This is the future next/link version
+    <StyledFeaturedUserCard legacyBehavior={false} href={`/${user.username}`}>
       <StyledContent gap={12} justify="space-between">
         <TokenPreviewContainer>
           {tokenPreviews.map(
@@ -128,7 +130,7 @@ export default function FeaturedUserCard({ userRef, queryRef }: Props) {
   );
 }
 
-const StyledFeaturedUserCard = styled.a`
+const StyledFeaturedUserCard = styled(Link)`
   border-radius: 12px;
   background-color: ${colors.offWhite};
   padding: 12px;

--- a/apps/web/src/components/Featured/SuggestedSection.tsx
+++ b/apps/web/src/components/Featured/SuggestedSection.tsx
@@ -1,13 +1,16 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
+import { useModalActions } from '~/contexts/modal/ModalContext';
 import { SuggestedSectionQueryFragment$key } from '~/generated/SuggestedSectionQueryFragment.graphql';
 
 import colors from '../core/colors';
-import { VStack } from '../core/Spacer/Stack';
+import InteractiveLink from '../core/InteractiveLink/InteractiveLink';
+import { HStack, VStack } from '../core/Spacer/Stack';
 import { TitleDiatypeL } from '../core/Text/Text';
 import FeaturedList from './FeaturedList';
+import FeaturedPopoverList from './FeaturedPopoverList';
 
 type Props = {
   title: string;
@@ -31,6 +34,7 @@ export default function SuggestedSection({ queryRef, title, subTitle }: Props) {
                     __typename
 
                     ...FeaturedListFragment
+                    ...FeaturedPopoverListFragment
                   }
                 }
               }
@@ -38,6 +42,7 @@ export default function SuggestedSection({ queryRef, title, subTitle }: Props) {
           }
         }
         ...FeaturedListQueryFragment
+        ...FeaturedPopoverListQueryFragment
       }
     `,
     queryRef
@@ -56,12 +61,26 @@ export default function SuggestedSection({ queryRef, title, subTitle }: Props) {
     return users;
   }, [query.viewer.suggestedUsers?.edges]);
 
+  const { showModal } = useModalActions();
+
+  const handleSeeAllClick = useCallback(() => {
+    showModal({
+      content: <FeaturedPopoverList featuredUsersRef={nonNullUsers} queryRef={query} />,
+      isFullPage: false,
+      isPaddingDisabled: true,
+    });
+  }, [nonNullUsers, query, showModal]);
+
   return (
     <StyledSuggestedSection gap={32}>
-      <VStack gap={4}>
-        <Title>{title}</Title>
-        <TitleDiatypeL color={colors.metal}>{subTitle}</TitleDiatypeL>
-      </VStack>
+      <HStack justify="space-between" align="center">
+        <VStack gap={4}>
+          <Title>{title}</Title>
+          <TitleDiatypeL color={colors.metal}>{subTitle}</TitleDiatypeL>
+        </VStack>
+
+        <InteractiveLink onClick={handleSeeAllClick}>See all</InteractiveLink>
+      </HStack>
       <FeaturedList featuredUsersRef={nonNullUsers} queryRef={query} />
     </StyledSuggestedSection>
   );

--- a/apps/web/src/components/Featured/SuggestedSection.tsx
+++ b/apps/web/src/components/Featured/SuggestedSection.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import { SuggestedSectionQueryFragment$key } from '~/generated/SuggestedSectionQueryFragment.graphql';
+
+import colors from '../core/colors';
+import { VStack } from '../core/Spacer/Stack';
+import { TitleDiatypeL } from '../core/Text/Text';
+import FeaturedList from './FeaturedList';
+
+type Props = {
+  title: string;
+  subTitle: string;
+  queryRef: SuggestedSectionQueryFragment$key;
+};
+
+export default function SuggestedSection({ queryRef, title, subTitle }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment SuggestedSectionQueryFragment on Query {
+        viewer @required(action: THROW) {
+          ... on Viewer {
+            suggestedUsers(first: 24)
+              @connection(key: "FeaturedFragment_suggestedUsers")
+              @required(action: THROW) {
+              edges {
+                node {
+                  __typename
+                  ... on GalleryUser {
+                    __typename
+
+                    ...FeaturedListFragment
+                  }
+                }
+              }
+            }
+          }
+        }
+        ...FeaturedListQueryFragment
+      }
+    `,
+    queryRef
+  );
+
+  // map edge nodes to an array of GalleryUsers
+  const nonNullUsers = useMemo(() => {
+    const users = [];
+
+    for (const edge of query.viewer.suggestedUsers?.edges ?? []) {
+      if (edge?.node) {
+        users.push(edge.node);
+      }
+    }
+
+    return users;
+  }, [query.viewer.suggestedUsers?.edges]);
+
+  return (
+    <StyledSuggestedSection gap={32}>
+      <VStack gap={4}>
+        <Title>{title}</Title>
+        <TitleDiatypeL color={colors.metal}>{subTitle}</TitleDiatypeL>
+      </VStack>
+      <FeaturedList trendingUsersRef={nonNullUsers} queryRef={query} />
+    </StyledSuggestedSection>
+  );
+}
+
+const StyledSuggestedSection = styled(VStack)`
+  width: 100%;
+`;
+
+const Title = styled(TitleDiatypeL)`
+  font-size: 24px;
+`;

--- a/apps/web/src/components/Featured/SuggestedSection.tsx
+++ b/apps/web/src/components/Featured/SuggestedSection.tsx
@@ -62,7 +62,7 @@ export default function SuggestedSection({ queryRef, title, subTitle }: Props) {
         <Title>{title}</Title>
         <TitleDiatypeL color={colors.metal}>{subTitle}</TitleDiatypeL>
       </VStack>
-      <FeaturedList trendingUsersRef={nonNullUsers} queryRef={query} />
+      <FeaturedList featuredUsersRef={nonNullUsers} queryRef={query} />
     </StyledSuggestedSection>
   );
 }

--- a/apps/web/src/components/Featured/TrendingSection.tsx
+++ b/apps/web/src/components/Featured/TrendingSection.tsx
@@ -1,8 +1,8 @@
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
-import { FeaturedSectionFragment$key } from '~/generated/FeaturedSectionFragment.graphql';
-import { FeaturedSectionQueryFragment$key } from '~/generated/FeaturedSectionQueryFragment.graphql';
+import { TrendingSectionFragment$key } from '~/generated/TrendingSectionFragment.graphql';
+import { TrendingSectionQueryFragment$key } from '~/generated/TrendingSectionQueryFragment.graphql';
 
 import colors from '../core/colors';
 import { VStack } from '../core/Spacer/Stack';
@@ -12,14 +12,14 @@ import FeaturedList from './FeaturedList';
 type Props = {
   title: string;
   subTitle: string;
-  trendingUsersRef: FeaturedSectionFragment$key;
-  queryRef: FeaturedSectionQueryFragment$key;
+  trendingUsersRef: TrendingSectionFragment$key;
+  queryRef: TrendingSectionQueryFragment$key;
 };
 
-export default function FeaturedSection({ trendingUsersRef, queryRef, title, subTitle }: Props) {
+export default function TrendingSection({ trendingUsersRef, queryRef, title, subTitle }: Props) {
   const query = useFragment(
     graphql`
-      fragment FeaturedSectionQueryFragment on Query {
+      fragment TrendingSectionQueryFragment on Query {
         ...FeaturedListQueryFragment
       }
     `,
@@ -28,7 +28,7 @@ export default function FeaturedSection({ trendingUsersRef, queryRef, title, sub
 
   const trendingUsers = useFragment(
     graphql`
-      fragment FeaturedSectionFragment on TrendingUsersPayload {
+      fragment TrendingSectionFragment on TrendingUsersPayload {
         users {
           ...FeaturedListFragment
         }
@@ -38,17 +38,17 @@ export default function FeaturedSection({ trendingUsersRef, queryRef, title, sub
   );
 
   return (
-    <StyledFeaturedSection gap={32}>
+    <StyledTrendingSection gap={32}>
       <VStack gap={4}>
         <Title>{title}</Title>
         <TitleDiatypeL color={colors.metal}>{subTitle}</TitleDiatypeL>
       </VStack>
-      <FeaturedList trendingUsersRef={trendingUsers.users || []} queryRef={query} />
-    </StyledFeaturedSection>
+      <FeaturedList featuredUsersRef={trendingUsers.users || []} queryRef={query} />
+    </StyledTrendingSection>
   );
 }
 
-const StyledFeaturedSection = styled(VStack)`
+const StyledTrendingSection = styled(VStack)`
   width: 100%;
 `;
 

--- a/apps/web/src/components/core/Input/FadedInput.tsx
+++ b/apps/web/src/components/core/Input/FadedInput.tsx
@@ -36,7 +36,7 @@ const StyledInput = styled.input<{ variantSize: FadedInputSize }>`
   padding: 6px 12px;
 
   ${({ variantSize }) => {
-    if (variantSize == 'md') {
+    if (variantSize === 'md') {
       return css`
         font-family: ${BODY_FONT_FAMILY};
         font-size: 14px;

--- a/schema.graphql
+++ b/schema.graphql
@@ -3,6 +3,12 @@ directive @defer(
   if: Boolean = true
 ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"""
+Any field decorated with the @experimental directive should not be used in production.
+It will not conform to our rules around breaking changes.
+"""
+directive @experimental on FIELD_DEFINITION
+
 # Use @goField(forceResolver: true) to lazily handle recursive or expensive fields that shouldn't be
 # resolved unless the caller asks for them
 directive @goField(
@@ -74,6 +80,7 @@ type GalleryUser implements Node @goEmbedHelper {
   traits: String
   universal: Boolean
   roles: [Role] @goField(forceResolver: true)
+  socialAccounts: SocialAccounts @goField(forceResolver: true)
 
   # Returns all tokens owned by this user. Useful for retrieving all tokens without any duplicates,
   # as opposed to retrieving user -> wallets -> tokens, which would contain duplicates for any token
@@ -158,6 +165,8 @@ type PreviewURLSet {
   medium: String
   large: String
   srcSet: String
+  blurhash: String @experimental @goField(forceResolver: true)
+  aspectRatio: Float @experimental @goField(forceResolver: true)
 }
 
 type VideoURLSet {
@@ -486,9 +495,33 @@ type NotificationsConnection @goEmbedHelper {
   pageInfo: PageInfo
 }
 
+enum SocialAccountType {
+  Twitter
+}
+
+interface SocialAccount {
+  type: SocialAccountType!
+  social_id: String!
+  display: Boolean!
+}
+
+type SocialAccounts {
+  twitter: TwitterSocialAccount
+}
+
+type TwitterSocialAccount implements SocialAccount {
+  type: SocialAccountType!
+  social_id: String!
+  name: String!
+  username: String!
+  profileImageURL: String!
+  display: Boolean!
+}
+
 type Viewer implements Node @goGqlId(fields: ["userId"]) @goEmbedHelper {
   id: ID!
   user: GalleryUser @goField(forceResolver: true)
+  socialAccounts: SocialAccounts @goField(forceResolver: true)
   viewerGalleries: [ViewerGallery] @goField(forceResolver: true)
   feed(before: String, after: String, first: Int, last: Int): FeedConnection
     @goField(forceResolver: true)
@@ -504,6 +537,8 @@ type Viewer implements Node @goGqlId(fields: ["userId"]) @goEmbedHelper {
   notificationSettings: NotificationSettings @goField(forceResolver: true)
 
   userExperiences: [UserExperience!] @goField(forceResolver: true)
+  suggestedUsers(before: String, after: String, first: Int, last: Int): UsersConnection
+    @goField(forceResolver: true)
 }
 
 type NotificationSettings {
@@ -1188,6 +1223,21 @@ input MagicLinkAuth {
   token: String!
 }
 
+input SocialAuthMechanism {
+  twitter: TwitterAuth
+  debug: DebugSocialAuth
+}
+
+input TwitterAuth {
+  code: String!
+}
+
+input DebugSocialAuth {
+  provider: SocialAccountType!
+  id: String!
+  username: String!
+}
+
 input DeepRefreshInput {
   chain: Chain!
 }
@@ -1713,6 +1763,43 @@ union MoveCollectionToGalleryPayloadOrError =
   | ErrInvalidInput
   | ErrNotAuthorized
 
+type ConnectSocialAccountPayload {
+  viewer: Viewer
+}
+
+union ConnectSocialAccountPayloadOrError =
+    ConnectSocialAccountPayload
+  | ErrInvalidInput
+  | ErrNotAuthorized
+
+input UpdateSocialAccountDisplayedInput {
+  type: SocialAccountType!
+  displayed: Boolean!
+}
+
+type UpdateSocialAccountDisplayedPayload {
+  viewer: Viewer
+}
+
+union UpdateSocialAccountDisplayedPayloadOrError =
+    UpdateSocialAccountDisplayedPayload
+  | ErrInvalidInput
+  | ErrNotAuthorized
+
+input MintPremiumCardToWalletInput {
+  tokenId: String!
+  walletAddresses: [Address!]
+}
+
+type MintPremiumCardToWalletPayload {
+  tx: String!
+}
+
+union MintPremiumCardToWalletPayloadOrError =
+    MintPremiumCardToWalletPayload
+  | ErrInvalidInput
+  | ErrNotAuthorized
+
 type Mutation {
   # User Mutations
   addUserWallet(
@@ -1762,6 +1849,14 @@ type Mutation {
   login(authMechanism: AuthMechanism!): LoginPayloadOrError
   logout: LogoutPayload
 
+  connectSocialAccount(
+    input: SocialAuthMechanism!
+    display: Boolean! = true
+  ): ConnectSocialAccountPayloadOrError @authRequired
+  updateSocialAccountDisplayed(
+    input: UpdateSocialAccountDisplayedInput!
+  ): UpdateSocialAccountDisplayedPayloadOrError @authRequired
+
   followUser(userId: DBID!): FollowUserPayloadOrError @authRequired
   unfollowUser(userId: DBID!): UnfollowUserPayloadOrError @authRequired
 
@@ -1805,6 +1900,9 @@ type Mutation {
   syncTokensForUsername(username: String!, chains: [Chain!]!): SyncTokensForUsernamePayloadOrError
     @retoolAuth
   banUserFromFeed(username: String!, action: String!): BanUserFromFeedPayloadOrError @retoolAuth
+  mintPremiumCardToWallet(
+    input: MintPremiumCardToWalletInput!
+  ): MintPremiumCardToWalletPayloadOrError @retoolAuth
 
   # Gallery Frontend Deploy Persisted Queries
   uploadPersistedQueries(input: UploadPersistedQueriesInput): UploadPersistedQueriesPayloadOrError


### PR DESCRIPTION
This PR adds a Suggested Users section to the Featured Page.
This re-purposes the Featured Section that are currently displayed on the page, with a different list of users. 
It also introduces a "See All" button that opens a popover listing the users in vertical list format.

The backend changes ([PR](https://github.com/gallery-so/go-gallery/pull/811)) should be merged and deployed first.



TODOs

- [x]  add See More button

![Screen Shot 2023-02-21 at 18 11 34](https://user-images.githubusercontent.com/80802871/220300336-5e4b55b1-2872-45d9-88b5-314fef4d791e.png)

![Screen Shot 2023-02-21 at 18 11 37](https://user-images.githubusercontent.com/80802871/220300352-0959355f-f567-411d-94aa-bf4943124a49.png) 
