### PR TITLE
Setup GraphQL Defer support on mobile

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -2,16 +2,14 @@ import "expo-dev-client";
 
 import {
   graphql,
-  GraphQLTaggedNode,
   RelayEnvironmentProvider,
   useFragment,
   useLazyLoadQuery,
-  useRelayEnvironment,
 } from "react-relay";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useState } from "react";
 import { createRelayEnvironment } from "./src/contexts/relay/RelayProvider";
 import { AppDeferredDataQuery } from "~/generated/relay/AppDeferredDataQuery.graphql";
-import { SafeAreaView, Text, View } from "react-native";
+import { SafeAreaView, Text } from "react-native";
 import { AppRobinFragment$key } from "~/generated/relay/AppRobinFragment.graphql";
 
 function RobinUser({ queryRef }: { queryRef: AppRobinFragment$key }) {
@@ -31,18 +29,17 @@ function RobinUser({ queryRef }: { queryRef: AppRobinFragment$key }) {
   return <Text>{query.userByUsername?.username}</Text>;
 }
 
+const QueryNode = graphql`
+  query AppDeferredDataQuery {
+    test: userByUsername(username: "xd") {
+      __typename
+    }
+    ...AppRobinFragment @defer(label: "RobinFragment")
+  }
+`;
+
 function DeferredData() {
-  const query = useLazyLoadQuery<AppDeferredDataQuery>(
-    graphql`
-      query AppDeferredDataQuery {
-        test: userByUsername(username: "xd") {
-          __typename
-        }
-        ...AppRobinFragment @defer(label: "RobinFragment")
-      }
-    `,
-    {}
-  );
+  const query = useLazyLoadQuery<AppDeferredDataQuery>(QueryNode, {});
 
   return (
     <SafeAreaView>

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,9 +1,57 @@
 import "expo-dev-client";
 
-import { RelayEnvironmentProvider } from "react-relay";
-import { Suspense, useState } from "react";
+import {
+  graphql,
+  GraphQLTaggedNode,
+  RelayEnvironmentProvider,
+  useFragment,
+  useLazyLoadQuery,
+  useRelayEnvironment,
+} from "react-relay";
+import { Suspense, useEffect, useState } from "react";
 import { createRelayEnvironment } from "./src/contexts/relay/RelayProvider";
-import { Text } from "react-native";
+import { AppDeferredDataQuery } from "~/generated/relay/AppDeferredDataQuery.graphql";
+import { SafeAreaView, Text, View } from "react-native";
+import { AppRobinFragment$key } from "~/generated/relay/AppRobinFragment.graphql";
+
+function RobinUser({ queryRef }: { queryRef: AppRobinFragment$key }) {
+  const query = useFragment(
+    graphql`
+      fragment AppRobinFragment on Query {
+        userByUsername(username: "robin") {
+          ... on GalleryUser {
+            username
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  return <Text>{query.userByUsername?.username}</Text>;
+}
+
+function DeferredData() {
+  const query = useLazyLoadQuery<AppDeferredDataQuery>(
+    graphql`
+      query AppDeferredDataQuery {
+        test: userByUsername(username: "xd") {
+          __typename
+        }
+        ...AppRobinFragment @defer(label: "RobinFragment")
+      }
+    `,
+    {}
+  );
+
+  return (
+    <SafeAreaView>
+      <Suspense fallback={<Text>Loading Robin...</Text>}>
+        <RobinUser queryRef={query} />
+      </Suspense>
+    </SafeAreaView>
+  );
+}
 
 export default function App() {
   const [relayEnvironment] = useState(() => createRelayEnvironment());
@@ -11,7 +59,7 @@ export default function App() {
   return (
     <RelayEnvironmentProvider environment={relayEnvironment}>
       <Suspense fallback={null}>
-        <Text>Hello, World!</Text>
+        <DeferredData />
       </Suspense>
     </RelayEnvironmentProvider>
   );

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -2,6 +2,14 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
-    plugins: ["babel-plugin-relay", "tsconfig-paths-module-resolver"],
+    plugins: [
+      [
+        "babel-plugin-relay",
+        {
+          artifactDirectory: "./__generated__/relay",
+        },
+      ],
+      "tsconfig-paths-module-resolver",
+    ],
   };
 };

--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -1,6 +1,12 @@
+// @ts-expect-error No type declarations
 import { polyfill as polyfillEncoding } from "react-native-polyfill-globals/src/encoding";
+// @ts-expect-error No type declarations
 import { polyfill as polyfillFetch } from "react-native-polyfill-globals/src/fetch";
+// @ts-expect-error No type declarations
 import { polyfill as polyfillReadableStream } from "react-native-polyfill-globals/src/readable-stream";
+
+// Unimportant warnings from the fetch polyfill
+LogBox.ignoreLogs(["The provided value 'moz", "The provided value 'ms-stream"]);
 
 polyfillEncoding();
 polyfillFetch();
@@ -9,5 +15,6 @@ polyfillReadableStream();
 import registerRootComponent from "expo/build/launch/registerRootComponent";
 
 import App from "./App";
+import { LogBox } from "react-native";
 
 registerRootComponent(App);

--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -1,3 +1,11 @@
+import { polyfill as polyfillEncoding } from "react-native-polyfill-globals/src/encoding";
+import { polyfill as polyfillFetch } from "react-native-polyfill-globals/src/fetch";
+import { polyfill as polyfillReadableStream } from "react-native-polyfill-globals/src/readable-stream";
+
+polyfillEncoding();
+polyfillFetch();
+polyfillReadableStream();
+
 import registerRootComponent from "expo/build/launch/registerRootComponent";
 
 import App from "./App";

--- a/apps/mobile/moon.yml
+++ b/apps/mobile/moon.yml
@@ -11,16 +11,16 @@ fileGroups:
 
 tasks:
   relay-watch:
-    command: relay-compiler --repersist --watch ../../relay.config.js
+    command: relay-compiler --project mobile --repersist --watch ../../relay.config.js
     local: true
 
   relay-codegen:
-    command: relay-compiler --repersist ../../relay.config.js
+    command: relay-compiler --project mobile --repersist ../../relay.config.js
     inputs:
       - "@group(source)"
 
   codegen-watch:
-    command: relay-compiler --repersist --watch ../../relay.config.js
+    command: relay-compiler --project mobile --repersist --watch ../../relay.config.js
 
   ios:
     command:

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,9 +12,13 @@
     "react": "18.1.0",
     "react-native": "0.70.5",
     "react-native-fast-image": "^8.6.3",
+    "react-native-fetch-api": "^3.0.0",
+    "react-native-polyfill-globals": "^3.1.0",
     "react-relay": "^14.1.0",
     "relay-runtime": "^14.1.0",
-    "typescript": "^4.9.4"
+    "text-encoding": "^0.7.0",
+    "typescript": "^4.9.4",
+    "web-streams-polyfill": "^3.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/apps/mobile/src/contexts/relay/RelayProvider.tsx
+++ b/apps/mobile/src/contexts/relay/RelayProvider.tsx
@@ -3,11 +3,11 @@ import { Network, RecordSource, Store } from "relay-runtime";
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment";
 import { RecordMap } from "relay-runtime/lib/store/RelayStoreTypes";
 import {
-  createRelayFetchFunction,
   createRelaySubscribeFunction,
   PersistedQueriesMap,
 } from "~/shared/relay/network";
 import persistedQueries from "../../../persisted_queries.json";
+import { createRelayFetchFunctionWithDefer } from "~/shared/relay/deferNetwork";
 
 const persistedQueriesMap = persistedQueries as PersistedQueriesMap;
 
@@ -15,7 +15,7 @@ const relaySubscribeFunction = createRelaySubscribeFunction({
   url: "wss://api.gallery.so/glry/graphql/query",
 });
 
-export const relayFetchFunction = createRelayFetchFunction({
+export const relayFetchFunction = createRelayFetchFunctionWithDefer({
   url: () => "https://gateway.gallery.so",
   persistedQueriesFetcher: async () => persistedQueriesMap,
 });

--- a/apps/mobile/src/contexts/relay/RelayProvider.tsx
+++ b/apps/mobile/src/contexts/relay/RelayProvider.tsx
@@ -16,7 +16,7 @@ const relaySubscribeFunction = createRelaySubscribeFunction({
 });
 
 export const relayFetchFunction = createRelayFetchFunction({
-  url: () => "https://api.gallery.so",
+  url: () => "https://gateway.gallery.so",
   persistedQueriesFetcher: async () => persistedQueriesMap,
 });
 

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -61,7 +61,7 @@ tasks:
     local: true
 
   relay-watch:
-    command: yarn relay-compiler --repersist --watch ../../relay.config.js
+    command: yarn relay-compiler --project web --repersist --watch ../../relay.config.js
     local: true
 
   graphql-codegen-watch:
@@ -74,7 +74,7 @@ tasks:
       - '@group(source)'
 
   relay-codegen:
-    command: yarn relay-compiler --repersist ../../relay.config.js
+    command: yarn relay-compiler --project web --repersist ../../relay.config.js
     inputs:
       - '@group(source)'
 

--- a/packages/shared/moon.yml
+++ b/packages/shared/moon.yml
@@ -4,13 +4,13 @@ fileGroups:
 
 tasks:
   relay-watch:
-    command: relay-compiler --repersist --watch ../../relay.config.js
+    command: relay-compiler --project shared --repersist --watch ../../relay.config.js
     local: true
 
   relay-codegen:
-    command: relay-compiler --repersist ../../relay.config.js
+    command: relay-compiler --project shared --repersist ../../relay.config.js
     inputs:
       - '@group(source)'
 
   codegen-watch:
-    command: relay-compiler --repersist --watch ../../relay.config.js
+    command: relay-compiler --project shared --repersist --watch ../../relay.config.js

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@types/relay-runtime": "^14.1.7",
+    "relay-compiler": "^14.1.0",
     "typescript": "^4.9.5"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "dependencies": {
+    "fetch-multipart-graphql": "^3.1.1",
     "graphql": "^16.6.0",
     "graphql-ws": "^5.11.3",
     "relay-runtime": "^14.1.0"

--- a/packages/shared/src/relay/deferNetwork.ts
+++ b/packages/shared/src/relay/deferNetwork.ts
@@ -55,6 +55,15 @@ function flattenDeferResponse(
     return false;
   });
 
+  if (anyOfTheResponsesAreTheLast) {
+    const lastPart = formatted[formatted.length - 1];
+
+    if (lastPart) {
+      // Shoutout the Coinbase folks https://github.com/facebook/relay/issues/3904
+      lastPart.extensions = { is_final: true };
+    }
+  }
+
   return { data: formatted, isLast: anyOfTheResponsesAreTheLast };
 }
 

--- a/packages/shared/src/relay/deferNetwork.ts
+++ b/packages/shared/src/relay/deferNetwork.ts
@@ -1,0 +1,188 @@
+import fetchMultipart from "fetch-multipart-graphql";
+import {
+  FetchFunction,
+  GraphQLSingularResponse,
+  Observable,
+} from "relay-runtime";
+import { isResponsePersistedQueryNotFound } from "./utils";
+
+export type PersistedQueriesMap = Record<string, string>;
+
+export type PersistedQueriesFetcher = () => Promise<PersistedQueriesMap>;
+
+type DeferResponse =
+  | {
+      hasNext?: boolean;
+      incremental: GraphQLSingularResponse[];
+    }
+  | { data: GraphQLSingularResponse; hasNext?: boolean }
+  | GraphQLSingularResponse;
+
+type InternalFetchFunction = (
+  createRelayFetchFunctionArgs: CreateRelayFetchFunctionArgs,
+  sinkHandlers: SinkHandlers,
+  ...args: Parameters<FetchFunction>
+) => ReturnType<typeof fetchMultipart<DeferResponse>>;
+
+type SinkHandlers = {
+  onError: (error: unknown) => void;
+  onNext: (data: DeferResponse[]) => void;
+  onComplete: () => void;
+};
+
+type FlattenedDeferResponse = {
+  data: ReadonlyArray<GraphQLSingularResponse>;
+  isLast: boolean;
+};
+function flattenDeferResponse(
+  responses: DeferResponse[]
+): FlattenedDeferResponse {
+  const formatted: ReadonlyArray<GraphQLSingularResponse> = responses.flatMap(
+    (part) => {
+      if ("incremental" in part) {
+        return part.incremental;
+      }
+
+      return [part];
+    }
+  );
+
+  const anyOfTheResponsesAreTheLast = responses.some((response) => {
+    if ("hasNext" in response) {
+      return !response.hasNext;
+    }
+
+    return false;
+  });
+
+  return { data: formatted, isLast: anyOfTheResponsesAreTheLast };
+}
+
+const fetchWithJustHash: InternalFetchFunction = async (
+  { url },
+  sinkHandlers,
+  request,
+  variables,
+  cacheConfig,
+  uploadables
+) => {
+  return fetchMultipart<DeferResponse>(
+    url(request, variables, cacheConfig, uploadables),
+    {
+      method: "POST",
+      credentials: "include",
+      body: JSON.stringify({
+        operationName: request.name,
+        extensions: {
+          persistedQuery: {
+            version: 1,
+            sha256Hash: request.id,
+          },
+        },
+        variables,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "multipart/mixed; deferSpec=20220824",
+      },
+      ...sinkHandlers,
+    }
+  );
+};
+
+const fetchWithHashAndQueryText: InternalFetchFunction = async (
+  { url, persistedQueriesFetcher },
+  sinkHandlers,
+  request,
+  variables,
+  cacheConfig,
+  uploadables
+) => {
+  const persisted_queries = await persistedQueriesFetcher();
+
+  // @ts-expect-error Types aren't lining up here
+  const queryText = persisted_queries[request.id] as string;
+
+  return fetchMultipart(url(request, variables, cacheConfig, uploadables), {
+    method: "POST",
+    credentials: "include",
+    body: JSON.stringify({
+      operationName: request.name,
+      query: queryText,
+      extensions: {
+        persistedQuery: {
+          version: 1,
+          sha256Hash: request.id,
+        },
+      },
+      variables,
+    }),
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "multipart/mixed; deferSpec=20220824",
+    },
+    ...sinkHandlers,
+  });
+};
+
+type CreateRelayFetchFunctionArgs = {
+  url: (...args: Parameters<FetchFunction>) => string;
+  persistedQueriesFetcher: PersistedQueriesFetcher;
+};
+
+export function createRelayFetchFunctionWithDefer(
+  args: CreateRelayFetchFunctionArgs
+): FetchFunction {
+  const relayFetchFunction: FetchFunction = (
+    request,
+    variables,
+    cacheConfig,
+    uploadables
+  ) => {
+    return Observable.create((sink) => {
+      const sinkHandlers: SinkHandlers = {
+        onComplete: () => sink.complete(),
+        onError: (error) => sink.error(error as Error),
+        onNext: (responses) => {
+          const wasPersistedQueryNotFound = responses.some((response) => {
+            if ("errors" in response) {
+              return isResponsePersistedQueryNotFound(response);
+            }
+
+            return false;
+          });
+
+          if (wasPersistedQueryNotFound) {
+            fetchWithHashAndQueryText(
+              args,
+              sinkHandlers,
+              request,
+              variables,
+              cacheConfig,
+              uploadables
+            );
+          } else {
+            const { data, isLast } = flattenDeferResponse(responses);
+
+            sink.next(data);
+
+            if (isLast) {
+              sink.complete();
+            }
+          }
+        },
+      };
+
+      fetchWithJustHash(
+        args,
+        sinkHandlers,
+        request,
+        variables,
+        cacheConfig,
+        uploadables
+      );
+    });
+  };
+
+  return relayFetchFunction;
+}

--- a/packages/shared/src/relay/network.ts
+++ b/packages/shared/src/relay/network.ts
@@ -1,3 +1,4 @@
+import fetchMultipart from "fetch-multipart-graphql";
 import { Client, createClient } from "graphql-ws";
 import { Observable, SubscribeFunction } from "relay-runtime";
 import {
@@ -58,24 +59,40 @@ const fetchWithHashAndQueryText: InternalFetchFunction = async (
   // @ts-expect-error Types aren't lining up here
   const queryText = persisted_queries[request.id] as string;
 
-  const response = await fetch(
+  const response = await fetchMultipart(
     url(request, variables, cacheConfig, uploadables),
     {
       method: "POST",
-      credentials: "include",
-      body: JSON.stringify({
-        operationName: request.name,
-        extensions: {
-          persistedQuery: {
-            version: 1,
-            sha256Hash: request.id,
-          },
-        },
-        query: queryText,
-        variables,
-      }),
       headers: {
-        "Content-Type": "application/json",
+        "content-type": "application/json",
+        Accept: "multipart/mixed; deferSpec=20220824",
+      },
+      body: JSON.stringify({ query: queryText, variables }),
+      credentials: "include",
+      onNext: (res) => {
+        const parts = res as (
+          | {
+              hasNext?: boolean;
+              incremental: {
+                path: string[];
+                label: string;
+                data: PayloadData;
+              }[];
+            }
+          | { data: PayloadData; hasNext?: boolean }
+        )[];
+        const formatted = parts.flatMap((part) => {
+          if ("incremental" in part) {
+            return part.incremental;
+          }
+          return part;
+        });
+        sink.next(formatted);
+      },
+      onError: (err) => sink.error(err),
+      onComplete: () => {
+        console.log(request.name, "Sink complete");
+        sink.complete();
       },
     }
   ).then((response) => response.json());
@@ -96,49 +113,61 @@ export function createRelayFetchFunction(
    * Since we don't currently have a GraphQL server, we're shimming a response as
    * an example.
    */
-  const relayFetchFunction: FetchFunction = async (
+  const relayFetchFunction: FetchFunction = (
     request,
     variables,
     cacheConfig,
     uploadables
   ) => {
-    try {
-      let response = await fetchWithJustHash(
-        args,
-        request,
-        variables,
-        cacheConfig,
-        uploadables
-      );
+    return Observable.create((sink) => {
+      args.persistedQueriesFetcher().then((persisted_queries) => {
+        // @ts-expect-error Types aren't lining up here
+        const queryText = persisted_queries[request.id] as string;
+        fetchMultipart(args.url(request, variables, cacheConfig, uploadables), {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            Accept: "multipart/mixed; deferSpec=20220824",
+          },
+          body: JSON.stringify({ query: queryText, variables }),
+          credentials: "include",
+          onNext: (res) => {
+            const parts = res as (
+              | {
+                  hasNext?: boolean;
+                  incremental: {
+                    path: string[];
+                    label: string;
+                    data: unknown;
+                  }[];
+                }
+              | { data: unknown; hasNext?: boolean }
+            )[];
 
-      if ("errors" in response) {
-        const persistedQueryWasNotFound = response.errors?.some(
-          (error) => error.message === "PersistedQueryNotFound"
-        );
+            const formatted = parts.flatMap((part) => {
+              if ("incremental" in part) {
+                return part.incremental;
+              }
+              return part;
+            });
 
-        if (persistedQueryWasNotFound) {
-          response = await fetchWithHashAndQueryText(
-            args,
-            request,
-            variables,
-            cacheConfig,
-            uploadables
-          );
-        }
-      }
+            sink.next(formatted);
 
-      return response;
-    } catch (error) {
-      const payloadError: PayloadError =
-        error instanceof Error
-          ? { message: error.message, severity: "CRITICAL" }
-          : {
-              message: "An unexpected error occurred in relayFetchFunction",
-              severity: "CRITICAL",
-            };
-
-      return { errors: [payloadError] };
-    }
+            if (parts.some((it) => !it.hasNext)) {
+              sink.complete();
+            }
+          },
+          onError: (err) => {
+            console.error(err);
+            sink.error(err);
+          },
+          onComplete: () => {
+            console.log(request.name, "Sink complete");
+            sink.complete();
+          },
+        });
+      });
+    });
   };
 
   return relayFetchFunction;

--- a/packages/shared/src/relay/subscription.ts
+++ b/packages/shared/src/relay/subscription.ts
@@ -1,0 +1,40 @@
+import { Client, createClient } from "graphql-ws";
+import { Observable, SubscribeFunction } from "relay-runtime";
+
+type CreateRelaySubscribeFunctionArgs = {
+  url: string;
+};
+
+export function createRelaySubscribeFunction({
+  url,
+}: CreateRelaySubscribeFunctionArgs) {
+  let websocketClient: Client;
+
+  if (typeof WebSocket !== "undefined") {
+    websocketClient = createClient({
+      url,
+    });
+  }
+
+  const relaySubscribeFunction: SubscribeFunction = (operation, variables) => {
+    return Observable.create((sink) => {
+      if (!operation.text) {
+        throw new Error(
+          "Relay subscribe function called without any operation text"
+        );
+      }
+
+      return websocketClient.subscribe(
+        {
+          operationName: operation.name,
+          query: operation.text,
+          variables,
+        },
+        // @ts-expect-error types arent' lining up
+        sink
+      );
+    });
+  };
+
+  return relaySubscribeFunction;
+}

--- a/packages/shared/src/relay/utils.ts
+++ b/packages/shared/src/relay/utils.ts
@@ -1,0 +1,15 @@
+import { GraphQLSingularResponse } from "relay-runtime";
+
+export function isResponsePersistedQueryNotFound(
+  response: GraphQLSingularResponse
+) {
+  if ("errors" in response) {
+    const persistedQueryWasNotFound = response.errors?.some(
+      (error) => error.message === "PersistedQueryNotFound"
+    );
+
+    return persistedQueryWasNotFound;
+  }
+
+  return false;
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,3 +1,8 @@
+directive @defer(
+  label: String!
+  if: Boolean = true
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 # Use @goField(forceResolver: true) to lazily handle recursive or expensive fields that shouldn't be
 # resolved unless the caller asks for them
 directive @goField(

--- a/yarn.lock
+++ b/yarn.lock
@@ -22421,10 +22421,14 @@ __metadata:
     react: 18.1.0
     react-native: 0.70.5
     react-native-fast-image: ^8.6.3
+    react-native-fetch-api: ^3.0.0
+    react-native-polyfill-globals: ^3.1.0
     react-relay: ^14.1.0
     relay-compiler: ^14.1.0
     relay-runtime: ^14.1.0
+    text-encoding: ^0.7.0
     typescript: ^4.9.4
+    web-streams-polyfill: ^3.2.1
   languageName: unknown
   linkType: soft
 
@@ -23602,6 +23606,13 @@ __metadata:
   version: 3.0.0
   resolution: "p-cancelable@npm:3.0.0"
   checksum: 2b5ae34218f9c2cf7a7c18e5d9a726ef9b165ef07e6c959f6738371509e747334b5f78f3bcdeb03d8a12dcb978faf641fd87eb21486ed7d36fb823b8ddef3219
+  languageName: node
+  linkType: hard
+
+"p-defer@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "p-defer@npm:3.0.0"
+  checksum: ac3b0976a1c76b67cca1a34e00f7299b0cc230891f820749686aa84f8947326bbe0f8e3b7d9ca511578ee06f0c1a6e0ff68c8e9c325eac455f09d99f91697161
   languageName: node
   linkType: hard
 
@@ -25020,10 +25031,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-fetch-api@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "react-native-fetch-api@npm:3.0.0"
+  dependencies:
+    p-defer: ^3.0.0
+  checksum: f10f435060551c470711ba0b3663e3d49c7701aae84ea645d66992d756b13e923fb5762b324d3583d85c1c0def4138b9cc3f686bab1c1bc10d3ad82dc7175c99
+  languageName: node
+  linkType: hard
+
 "react-native-gradle-plugin@npm:^0.70.3":
   version: 0.70.3
   resolution: "react-native-gradle-plugin@npm:0.70.3"
   checksum: 04a3379842bcb4709ac6b37e093a3de59acd33b28b200885843b13908fac685a77ab81d732c34090c56e5c0eec971d578b227f302bd04fe7901e8792d434f41f
+  languageName: node
+  linkType: hard
+
+"react-native-polyfill-globals@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "react-native-polyfill-globals@npm:3.1.0"
+  peerDependencies:
+    base-64: "*"
+    react-native-fetch-api: "*"
+    react-native-get-random-values: "*"
+    react-native-url-polyfill: "*"
+    text-encoding: "*"
+    web-streams-polyfill: "*"
+  checksum: ff968f257a10c420c96fb1b5e838bf665f5312b9709ff23001fd57480a05991df6d0f8751a2f46250174f858dcc3ebfdaf5548c9f37b729d472d3152b99e3356
   languageName: node
   linkType: hard
 
@@ -28288,6 +28322,13 @@ __metadata:
   version: 1.0.2
   resolution: "text-encoding-utf-8@npm:1.0.2"
   checksum: ec4c15d50e738c5dba7327ad432ebf0725ec75d4d69c0bd55609254c5a3bc5341272d7003691084a0a73d60d981c8eb0e87603676fdb6f3fed60f4c9192309f9
+  languageName: node
+  linkType: hard
+
+"text-encoding@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "text-encoding@npm:0.7.0"
+  checksum: b6109a843fb1b8748b32e1ecd6df74d370f46c13ac136bcb6ca15db70209bb0b8ec1f296ebb4b0dd9961150e205dcc044b89f8cf7657f6faef78c7569a2a81bc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -26719,6 +26719,7 @@ __metadata:
     "@types/relay-runtime": ^14.1.7
     graphql: ^16.6.0
     graphql-ws: ^5.11.3
+    relay-compiler: ^14.1.0
     relay-runtime: ^14.1.0
     typescript: ^4.9.5
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -15994,6 +15994,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fetch-multipart-graphql@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "fetch-multipart-graphql@npm:3.1.1"
+  checksum: 7f99dca25743743bc625f5e0bcad0f7647af112953baab6941f80e3cf94789ac9b27723566fbaa642b7735e2bb531ce1f7de49742cb333fb5118479bfb016a42
+  languageName: node
+  linkType: hard
+
 "fetch-ponyfill@npm:^4.0.0":
   version: 4.1.0
   resolution: "fetch-ponyfill@npm:4.1.0"
@@ -26717,6 +26724,7 @@ __metadata:
   resolution: "shared@workspace:packages/shared"
   dependencies:
     "@types/relay-runtime": ^14.1.7
+    fetch-multipart-graphql: ^3.1.1
     graphql: ^16.6.0
     graphql-ws: ^5.11.3
     relay-compiler: ^14.1.0


### PR DESCRIPTION
The goal of this PR is to enable support for the `@defer` directive on mobile. 

- I've completely separated this new network layer from the web one to make sure web stays stable until we've figured this out.
- I've manually tested this about 1000x locally to make sure things work
- Automatic persisted queries still work.

### Polyfills / `fetch-multipart-graphql`
React Native does not support streaming responses out of the box. To get this to work I had to add a few polyfills. You can read more about that [here](https://github.com/acostalima/react-native-polyfill-globals).

The `fetch-multipart-graphql` library does a lot of the heavy lifting for us to actualy parse the streaming bytes of the response and turn them into streaming objects which we can use to send to Relay.

### Demo
It's really hard to see but if you look closely, `b_ez_man` should appear slightly after `robin` because I set it up such that the `Terence` component requests a bunch more data.

#### Example Code
```tsx
const QueryNode = graphql`
  query AppDeferredDataQuery {
    ...AppRobinFragment @defer
    ...AppTerenceFragment @defer
  }
`;

function DeferredData() {
  const query = useLazyLoadQuery<AppDeferredDataQuery>(QueryNode, {});

  return (
    <SafeAreaView>
      <Suspense fallback={<Text>Loading Robin...</Text>}>
        <RobinUser queryRef={query} />
      </Suspense>

      <Suspense fallback={<Text>Loading Robin...</Text>}>
        <TerenceUser queryRef={query} />
      </Suspense>
    </SafeAreaView>
  );
}
```

#### Video
https://user-images.githubusercontent.com/6754223/220417024-f954662a-376f-4650-84ac-fa6397e3695a.mov

