### PR TITLE
Clear token error after sync

### DIFF
--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
@@ -134,7 +134,7 @@ function SidebarNftIcon({
         // If the token was failing before, we need to make sure
         // that it's error state gets cleared on the chance
         // that it just got loaded.
-        clearTokenFailureState(token.dbid);
+        clearTokenFailureState([token.dbid]);
 
         timeoutId = setTimeout(refreshToken, POLLING_INTERVAL_MS);
       }
@@ -143,7 +143,7 @@ function SidebarNftIcon({
 
       return () => clearTimeout(timeoutId);
     },
-    [relayEnvironment, token.dbid, token.media?.__typename]
+    [clearTokenFailureState, relayEnvironment, token.dbid, token.media?.__typename]
   );
 
   if (token.media?.__typename === 'SyncingMedia') {

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
@@ -11,6 +11,7 @@ import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFa
 import { SIDEBAR_ICON_DIMENSIONS } from '~/constants/sidebar';
 import { useCollectionEditorContext } from '~/contexts/collectionEditor/CollectionEditorContext';
 import { useReportError } from '~/contexts/errorReporting/ErrorReportingContext';
+import { useNftErrorContext } from '~/contexts/NftErrorContext';
 import { ContentIsLoadedEvent } from '~/contexts/shimmer/ShimmerContext';
 import { CouldNotRenderNftError } from '~/errors/CouldNotRenderNftError';
 import { SidebarNftIconFragment$key } from '~/generated/SidebarNftIconFragment.graphql';
@@ -107,6 +108,7 @@ function SidebarNftIcon({
   );
 
   const relayEnvironment = useRelayEnvironment();
+  const { clearTokenFailureState } = useNftErrorContext();
   useEffect(
     function pollTokenWhileStillSyncing() {
       const POLLING_INTERVAL_MS = 5000;
@@ -128,6 +130,11 @@ function SidebarNftIcon({
           `,
           { id: token.dbid }
         ).toPromise();
+
+        // If the token was failing before, we need to make sure
+        // that it's error state gets cleared on the chance
+        // that it just got loaded.
+        clearTokenFailureState(token.dbid);
 
         timeoutId = setTimeout(refreshToken, POLLING_INTERVAL_MS);
       }

--- a/apps/web/src/contexts/NftErrorContext.tsx
+++ b/apps/web/src/contexts/NftErrorContext.tsx
@@ -31,7 +31,7 @@ type NftErrorContextType = {
 
   markTokenAsLoaded: (tokenId: string) => void;
   refreshToken: (tokenId: string) => Promise<void>;
-  clearTokenFailureState: (tokenId: string) => void;
+  clearTokenFailureState: (tokenIds: string[]) => void;
   handleNftError: (tokenId: string, error: Error) => void;
 };
 
@@ -140,15 +140,14 @@ export function NftErrorProvider({ children }: PropsWithChildren) {
     [FragmentResource, reportError, tokens]
   );
 
-  const clearTokenFailureState = useCallback((tokenId: string) => {
-    setTokens((previous) => {
-      const next = { ...previous };
-
-      delete next[tokenId];
-
-      return next;
-    });
-  }, []);
+  const clearTokenFailureState = useCallback(
+    (tokenIds: string[]) => {
+      for (const tokenId of tokenIds) {
+        retryToken(tokenId);
+      }
+    },
+    [retryToken]
+  );
 
   const [refresh] = usePromisifiedMutation<NftErrorContextRetryMutation>(graphql`
     mutation NftErrorContextRetryMutation($tokenId: DBID!) {
@@ -232,7 +231,7 @@ export function NftErrorProvider({ children }: PropsWithChildren) {
       markTokenAsLoaded,
       clearTokenFailureState,
     };
-  }, [handleNftError, markTokenAsLoaded, refreshToken, tokens]);
+  }, [clearTokenFailureState, handleNftError, markTokenAsLoaded, refreshToken, tokens]);
 
   return <NftErrorContext.Provider value={value}>{children}</NftErrorContext.Provider>;
 }

--- a/apps/web/src/contexts/NftErrorContext.tsx
+++ b/apps/web/src/contexts/NftErrorContext.tsx
@@ -30,8 +30,9 @@ type NftErrorContextType = {
   tokens: TokenErrorMap;
 
   markTokenAsLoaded: (tokenId: string) => void;
-  handleNftError: (tokenId: string, error: Error) => void;
   refreshToken: (tokenId: string) => Promise<void>;
+  clearTokenFailureState: (tokenId: string) => void;
+  handleNftError: (tokenId: string, error: Error) => void;
 };
 
 const NftErrorContext = createContext<NftErrorContextType | undefined>(undefined);
@@ -139,6 +140,16 @@ export function NftErrorProvider({ children }: PropsWithChildren) {
     [FragmentResource, reportError, tokens]
   );
 
+  const clearTokenFailureState = useCallback((tokenId: string) => {
+    setTokens((previous) => {
+      const next = { ...previous };
+
+      delete next[tokenId];
+
+      return next;
+    });
+  }, []);
+
   const [refresh] = usePromisifiedMutation<NftErrorContextRetryMutation>(graphql`
     mutation NftErrorContextRetryMutation($tokenId: DBID!) {
       refreshToken(tokenId: $tokenId) {
@@ -216,9 +227,10 @@ export function NftErrorProvider({ children }: PropsWithChildren) {
     return {
       tokens,
 
-      markTokenAsLoaded,
       refreshToken,
       handleNftError,
+      markTokenAsLoaded,
+      clearTokenFailureState,
     };
   }, [handleNftError, markTokenAsLoaded, refreshToken, tokens]);
 

--- a/apps/web/src/hooks/api/tokens/useSyncTokens.ts
+++ b/apps/web/src/hooks/api/tokens/useSyncTokens.ts
@@ -1,12 +1,15 @@
 import { useCallback, useMemo } from 'react';
 import { graphql } from 'relay-runtime';
 
+import { useNftErrorContext } from '~/contexts/NftErrorContext';
 import { useSyncTokensContext } from '~/contexts/SyncTokensLockContext';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { Chain, useSyncTokensMutation } from '~/generated/useSyncTokensMutation.graphql';
 import { usePromisifiedMutation } from '~/hooks/usePromisifiedMutation';
+import { removeNullValues } from '~/utils/removeNullValues';
 
 export default function useSyncTokens() {
+  const { clearTokenFailureState } = useNftErrorContext();
   const { isLocked, lock } = useSyncTokensContext();
 
   const [syncTokens] = usePromisifiedMutation<useSyncTokensMutation>(
@@ -63,6 +66,14 @@ export default function useSyncTokens() {
 
         if (response.syncTokens?.__typename !== 'SyncTokensPayload') {
           showFailure();
+        } else {
+          const tokenIds = removeNullValues(
+            response.syncTokens.viewer?.user?.tokens?.map((token) => {
+              return token?.dbid;
+            })
+          );
+
+          clearTokenFailureState(tokenIds);
         }
       } catch (error) {
         showFailure();
@@ -70,7 +81,7 @@ export default function useSyncTokens() {
         unlock();
       }
     },
-    [isLocked, lock, pushToast, syncTokens]
+    [clearTokenFailureState, isLocked, lock, pushToast, syncTokens]
   );
 
   return useMemo(() => {

--- a/apps/web/src/hooks/api/tokens/useSyncTokens.ts
+++ b/apps/web/src/hooks/api/tokens/useSyncTokens.ts
@@ -22,6 +22,14 @@ export default function useSyncTokens() {
               # This should be sufficient to capture all the things
               # we want to refresh. Don't @me when this fails.
               ...CollectionEditorViewerFragment
+
+              ... on Viewer {
+                user {
+                  tokens {
+                    dbid
+                  }
+                }
+              }
             }
           }
           ... on ErrNotAuthorized {


### PR DESCRIPTION
The `NftErrorContext` state is stale after a sync / refresh. This ensures that the state gets reset after a failure.