### PR TITLE
fix mint button dimensions for safari

### DIFF
--- a/apps/web/src/scenes/MintPages/MementosPage.tsx
+++ b/apps/web/src/scenes/MintPages/MementosPage.tsx
@@ -228,12 +228,14 @@ const StyledUl = styled.ul`
 
 const StyledCallToAction = styled.div<{ hasEnded?: boolean }>`
   text-align: center;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 12px;
 
   @media (max-width: ${contentSize.desktop}px) {
     grid-template-columns: ${({ hasEnded }) => (hasEnded ? '1fr' : 'repeat(2, minmax(0, 1fr))')};
     align-items: center;
+    display: grid;
     text-align: ${({ hasEnded }) => (hasEnded ? 'center' : 'left')};
     position: fixed;
     z-index: 30;


### PR DESCRIPTION
## Description

Fixes a small visual issue with the Mementos Mint button where the button was hyuge on Safari

Before
<img width="1051" alt="Screen Shot 2023-02-24 at 16 02 31" src="https://user-images.githubusercontent.com/80802871/221113894-8693af4b-5114-40e1-a8ef-d5a12e857c3e.png">


After
<img width="1042" alt="Screen Shot 2023-02-24 at 16 01 15" src="https://user-images.githubusercontent.com/80802871/221113919-dc6cd46f-0c42-4ef5-bb0a-701d46ce95c6.png">


Regression check on mobile ✅
<img width="389" alt="Screen Shot 2023-02-24 at 16 01 18" src="https://user-images.githubusercontent.com/80802871/221113964-05743d0f-20f6-4062-b03a-930cf2f1be6d.png">
