### PR TITLE
fix memento image size

### DIFF
--- a/apps/web/src/scenes/MintPages/MementosPage.tsx
+++ b/apps/web/src/scenes/MintPages/MementosPage.tsx
@@ -66,7 +66,7 @@ export default function MementosPage() {
       </StyledBackLink>
       <StyledWrapper>
         <StyledImageContainer>
-          <Image src={pathToImage} alt="splash-image" width={500} />
+          <StyledImage src={pathToImage} alt="splash-image" />
         </StyledImageContainer>
         <StyledContent>
           <HStack align="center" gap={4}>
@@ -187,6 +187,11 @@ const StyledImageContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+`;
+
+const StyledImage = styled(Image)`
+  width: 100%;
+  height: 100%;
 `;
 
 const StyledWrapper = styled.div`

--- a/apps/web/src/scenes/MintPages/MementosPage.tsx
+++ b/apps/web/src/scenes/MintPages/MementosPage.tsx
@@ -66,7 +66,7 @@ export default function MementosPage() {
       </StyledBackLink>
       <StyledWrapper>
         <StyledImageContainer>
-          <Image src={pathToImage} alt="splash-image" />
+          <Image src={pathToImage} alt="splash-image" width={500} />
         </StyledImageContainer>
         <StyledContent>
           <HStack align="center" gap={4}>


### PR DESCRIPTION
## description
memento image on the mint page was busted 


before:
![Screen Shot 2023-02-28 at 13 41 40](https://user-images.githubusercontent.com/80802871/221757708-04e25e5e-5142-4f1f-ad6a-5a7b83d43496.png)



after:

![Screen Shot 2023-02-28 at 13 54 34](https://user-images.githubusercontent.com/80802871/221757720-93f2aa3e-1351-4db1-bddc-345957010eeb.png)
![Screen Shot 2023-02-28 at 13 54 41](https://user-images.githubusercontent.com/80802871/221757730-4e2a18f9-31ca-4468-84e3-e3ed2af1ce80.png)

