### PR TITLE
Disable APQ on mobile

### DIFF
--- a/apps/mobile/moon.yml
+++ b/apps/mobile/moon.yml
@@ -11,7 +11,7 @@ fileGroups:
 
 tasks:
   relay-watch:
-    command: relay-compiler --project mobile --repersist --watch ../../relay.config.js
+    command: relay-compiler --project mobile --watch relay.config.js
     local: true
 
   relay-codegen:

--- a/packages/shared/src/relay/deferNetwork.ts
+++ b/packages/shared/src/relay/deferNetwork.ts
@@ -31,6 +31,7 @@ type FlattenedDeferResponse = {
   data: ReadonlyArray<GraphQLSingularResponse>;
   isLast: boolean;
 };
+
 function flattenDeferResponse(responses: DeferResponse[]): FlattenedDeferResponse {
   const formatted: ReadonlyArray<GraphQLSingularResponse> = responses.flatMap((part) => {
     if ('incremental' in part) {
@@ -41,6 +42,11 @@ function flattenDeferResponse(responses: DeferResponse[]): FlattenedDeferRespons
   });
 
   const anyOfTheResponsesAreTheLast = responses.some((response) => {
+    // This query is not deferred and should finish immediately.
+    if (!response.hasOwnProperty('hasNext')) {
+      return true;
+    }
+
     if ('hasNext' in response) {
       return !response.hasNext;
     }
@@ -73,6 +79,7 @@ const fetchWithJustHash: InternalFetchFunction = async (
     credentials: 'include',
     body: JSON.stringify({
       operationName: request.name,
+      query: request.text,
       extensions: {
         persistedQuery: {
           version: 1,

--- a/relay.config.js
+++ b/relay.config.js
@@ -1,51 +1,52 @@
-const fs = require("fs");
-const path = require("path");
+const fs = require('fs');
+const path = require('path');
 
 function generateConfig(projectDir) {
-  const generatedDirectory = path.join(projectDir, "__generated__", "relay");
-  const persistedQueriesFile = path.join(projectDir, "persisted_queries.json");
+  const generatedDirectory = path.join(projectDir, '__generated__', 'relay');
+  const persistedQueriesFile = path.join(projectDir, 'persisted_queries.json');
 
   // Automatically touch the generated directory
   fs.mkdirSync(path.resolve(__dirname, generatedDirectory), {
     recursive: true,
   });
+
   // Automatically touch the persisted_queries file
-  fs.writeFileSync(
-    path.resolve(__dirname, persistedQueriesFile),
-    "{}",
-    "utf-8"
-  );
+  fs.writeFileSync(path.resolve(__dirname, persistedQueriesFile), '{}', 'utf-8');
 
   return {
-    schema: "schema.graphql",
-    language: "typescript",
+    schema: 'schema.graphql',
+    language: 'typescript',
     output: generatedDirectory,
 
     customScalarTypes: {
-      Email: "string",
-      Address: "string",
-      DBID: "string",
+      Email: 'string',
+      Address: 'string',
+      DBID: 'string',
     },
 
-    persist: {
-      file: "persisted_queries.json",
-      algorithm: "SHA256", // this can be one of MD5, SHA256, SHA1
-    },
+    persist:
+      // Disable APQ for mobile
+      projectDir === 'apps/mobile'
+        ? undefined
+        : {
+            file: path.resolve(__dirname, persistedQueriesFile),
+            algorithm: 'SHA256', // this can be one of MD5, SHA256, SHA1
+          },
   };
 }
 
 module.exports = {
   root: __dirname,
   sources: {
-    "apps/web": "web",
-    "apps/mobile": "mobile",
+    'apps/web': 'web',
+    'apps/mobile': 'mobile',
 
     // This means web, mobile, and the shared package can use fragments from the shared package.
-    "packages/shared": ["web", "mobile", "shared"],
+    'packages/shared': ['web', 'mobile', 'shared'],
   },
   projects: {
-    web: generateConfig("apps/web"),
-    mobile: generateConfig("apps/mobile"),
-    shared: generateConfig("packages/shared"),
+    web: generateConfig('apps/web'),
+    mobile: generateConfig('apps/mobile'),
+    shared: generateConfig('packages/shared'),
   },
 };


### PR DESCRIPTION
It seems like the Metro bundler is not doing a good job of reloading the `persisted_queries.json` file and causes a bunch of annoying errors while development. For now, we'll just disable it.