### PR TITLE
Switch to Moon for parallel dev processes

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -40,7 +40,6 @@
     "@types/relay-runtime": "^14.1.6",
     "babel-plugin-relay": "^14.1.0",
     "babel-plugin-tsconfig-paths-module-resolver": "^1.0.4",
-    "concurrently": "^7.6.0",
     "eas-cli": "^3.7.2",
     "relay-compiler": "^14.1.0",
     "tailwindcss": "^3.2.7"

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -36,9 +36,9 @@ tasks:
   dev:
     command: noop
     deps:
-      - "~:next-dev-server"
-      - "~:relay-watch"
-      - "~:graphql-codegen-watch"
+      - '~:next-dev-server'
+      - '~:relay-watch'
+      - '~:graphql-codegen-watch'
 
   start:
     command: next start

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -29,13 +29,16 @@ tasks:
       - --key 9d633f22-7630-4a11-9cf4-ff9809332564
       - --configFile cypress.config.ts
 
+  next-dev-server:
+    command: next dev
+    local: true
+
   dev:
-    command:
-      - concurrently
-      - -n Next,Relay-Compiler,GraphQL-Codegen
-      - yarn next dev
-      - node_modules/.bin/moon run web:relay-watch
-      - node_modules/.bin/moon run web:graphql-codegen-watch
+    command: noop
+    deps:
+      - "~:next-dev-server"
+      - "~:relay-watch"
+      - "~:graphql-codegen-watch"
 
   start:
     command: next start

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,7 +36,6 @@
     "@types/relay-runtime": "^14.1.6",
     "@types/styled-components": "5.1.9",
     "@types/uuid": "^8.3.4",
-    "concurrently": "^7.0.0",
     "cypress": "^10.7.0",
     "eslint-config-next": "^13.1.6",
     "graphql": "^16.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12330,26 +12330,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concurrently@npm:^7.0.0, concurrently@npm:^7.6.0":
-  version: 7.6.0
-  resolution: "concurrently@npm:7.6.0"
-  dependencies:
-    chalk: ^4.1.0
-    date-fns: ^2.29.1
-    lodash: ^4.17.21
-    rxjs: ^7.0.0
-    shell-quote: ^1.7.3
-    spawn-command: ^0.0.2-1
-    supports-color: ^8.1.0
-    tree-kill: ^1.2.2
-    yargs: ^17.3.1
-  bin:
-    conc: dist/bin/concurrently.js
-    concurrently: dist/bin/concurrently.js
-  checksum: f705c9a7960f1b16559ca64958043faeeef6385c0bf30a03d1375e15ab2d96dba4f8166f1bbbb1c85e8da35ca0ce3c353875d71dff2aa132b2357bb533b3332e
-  languageName: node
-  linkType: hard
-
 "connect-history-api-fallback@npm:^2.0.0":
   version: 2.0.0
   resolution: "connect-history-api-fallback@npm:2.0.0"
@@ -13055,7 +13035,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^2.29.1, date-fns@npm:^2.29.3":
+"date-fns@npm:^2.29.3":
   version: 2.29.3
   resolution: "date-fns@npm:2.29.3"
   checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
@@ -23185,7 +23165,6 @@ __metadata:
     "@types/relay-runtime": ^14.1.6
     babel-plugin-relay: ^14.1.0
     babel-plugin-tsconfig-paths-module-resolver: ^1.0.4
-    concurrently: ^7.6.0
     eas-cli: ^3.7.2
     expo: ~48.0.4
     expo-av: ~13.2.1
@@ -27357,7 +27336,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.0.0, rxjs@npm:^7.5.1, rxjs@npm:^7.5.5, rxjs@npm:^7.8.0":
+"rxjs@npm:^7.5.1, rxjs@npm:^7.5.5, rxjs@npm:^7.8.0":
   version: 7.8.0
   resolution: "rxjs@npm:7.8.0"
   dependencies:
@@ -28296,13 +28275,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"spawn-command@npm:^0.0.2-1":
-  version: 0.0.2
-  resolution: "spawn-command@npm:0.0.2"
-  checksum: e35c5d28177b4d461d33c88cc11f6f3a5079e2b132c11e1746453bbb7a0c0b8a634f07541a2a234fa4758239d88203b758def509161b651e81958894c0b4b64b
-  languageName: node
-  linkType: hard
-
 "spawn-wrap@npm:^2.0.0":
   version: 2.0.0
   resolution: "spawn-wrap@npm:2.0.0"
@@ -29055,7 +29027,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.0.0, supports-color@npm:^8.1.0, supports-color@npm:^8.1.1":
+"supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -29791,15 +29763,6 @@ __metadata:
   version: 0.6.7
   resolution: "traverse@npm:0.6.7"
   checksum: 21018085ab72f717991597e12e2b52446962ed59df591502e4d7e1a709bc0a989f7c3d451aa7d882666ad0634f1546d696c5edecda1f2fc228777df7bb529a1e
-  languageName: node
-  linkType: hard
-
-"tree-kill@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "tree-kill@npm:1.2.2"
-  bin:
-    tree-kill: cli.js
-  checksum: 49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
   languageName: node
   linkType: hard
 
@@ -31664,7 +31627,6 @@ __metadata:
     "@web3-react/walletconnect-connector": ^6.1.9
     "@web3-react/walletlink-connector": 6.1.9
     bufferutil: ^4.0.5
-    concurrently: ^7.0.0
     cypress: ^10.7.0
     date-fns: ^2.29.3
     eslint-config-next: ^13.1.6


### PR DESCRIPTION
We were using `concurrently` to run our dev processes in parallel before. I only just recently found out that we can leverage Moon to do this. Mobile was already switched in another PR

This will fix the bugs we had with multiple processes trying to touch the `tsconfig.json` at once.