### PR TITLE
Fix flaky ordering of sections

### DIFF
--- a/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionListItem.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionListItem.tsx
@@ -154,6 +154,9 @@ export function CollectionListItem({ collectionId, queryRef }: CollectionListIte
 
 const CollectionTitleText = styled(TitleXS)<{ italicize: boolean; isHidden: boolean }>`
   text-transform: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 
   ${({ isHidden }) =>
     isHidden

--- a/apps/web/src/components/NftGallery/NftGallery.tsx
+++ b/apps/web/src/components/NftGallery/NftGallery.tsx
@@ -35,8 +35,9 @@ function NftGallery({ collectionRef, mobileLayout }: Props) {
 
   const parsedCollection = useMemo(() => {
     if (!collection.tokens || !collection.layout) {
-      return {};
+      return [];
     }
+
     return parseCollectionLayoutGraphql(
       removeNullValues(collection.tokens),
       collection.layout,
@@ -46,10 +47,10 @@ function NftGallery({ collectionRef, mobileLayout }: Props) {
 
   return (
     <StyledCollectionTokens>
-      {Object.entries(parsedCollection).map(([sectionId, section]) => {
+      {parsedCollection.map((section) => {
         return (
           <StyledSection
-            key={sectionId}
+            key={section.id}
             columns={section.columns}
             mobileLayout={mobileLayout}
             // we used this option for figure31's gallery. in the future, if we want

--- a/apps/web/src/utils/collectionLayout.test.ts
+++ b/apps/web/src/utils/collectionLayout.test.ts
@@ -75,9 +75,7 @@ describe('parseCollectionLayout', () => {
     const collection = parseCollectionLayout(tokens, collectionLayout);
 
     expect(Object.keys(collection).length).toEqual(3);
-    Object.keys(collection).forEach((sectionId, index) => {
-      const section = collection[sectionId];
-
+    collection.forEach((section, index) => {
       expect(section?.columns).toEqual(collectionLayout.sectionLayout[index]?.columns);
       expect(section?.items.length).toEqual(expectedItemLengths[index]);
     });

--- a/apps/web/src/utils/collectionLayout.ts
+++ b/apps/web/src/utils/collectionLayout.ts
@@ -14,10 +14,11 @@ type WhitespaceBlock = {
 };
 
 type Section<T> = {
+  id: string;
   items: ReadonlyArray<T | WhitespaceBlock>;
   columns: number;
 };
-type CollectionWithLayout<T> = Record<string, Section<T>>;
+type CollectionWithLayout<T> = Array<Section<T>>;
 
 export function parseCollectionLayoutGraphql<T>(
   tokens: T[],
@@ -63,7 +64,7 @@ export function parseCollectionLayout<T>(
   ignoreWhitespace = false
 ): CollectionWithLayout<T> {
   if (tokens.length === 0) {
-    return { [generate12DigitId()]: { items: [], columns: DEFAULT_COLUMNS } };
+    return [{ id: generate12DigitId(), items: [], columns: DEFAULT_COLUMNS }];
   }
 
   const parsedCollection = collectionLayout.sections.reduce(
@@ -82,13 +83,16 @@ export function parseCollectionLayout<T>(
         );
       }
       const sectionId = generate12DigitId();
-      allSections[sectionId] = {
+
+      allSections.push({
+        id: sectionId,
         items: section,
         columns: collectionLayout.sectionLayout[index]?.columns ?? 1,
-      };
+      });
+
       return allSections;
     },
-    {}
+    []
   );
 
   return parsedCollection;


### PR DESCRIPTION
HAHAHAHAHHAHAHAHAHHA

Okay, so we were using a map to store the parsed collection layout (not sure why). As it turns out, when we iterate over this using `Object.entries`, the key order in which we inserted into the object is not always preserved. See [thread here](https://stackoverflow.com/questions/5525795/does-javascript-guarantee-object-property-order).

I switched the parsing function to just return a list since we have no use case for the map

Also fixed some text wrapping