### PR TITLE
Left Hand Nav - mobile improvements + fixes

### DIFF
--- a/apps/web/src/components/ManageWallets/ManageWalletsRow.tsx
+++ b/apps/web/src/components/ManageWallets/ManageWalletsRow.tsx
@@ -134,7 +134,11 @@ const Icon = styled.img`
 `;
 
 const StyledButton = styled(Button)`
-  padding: 8px 12px;
+  padding: 8px;
+
+  @media only screen and ${breakpoints.mobileLarge} {
+    padding: 8px 12px;
+  }
 `;
 
 const StyledButtonContainer = styled.div`
@@ -142,6 +146,4 @@ const StyledButtonContainer = styled.div`
   flex-direction: row;
 
   gap: 4px;
-  @media only screen and ${breakpoints.tablet} {
-  }
 `;

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/AnimatedSidebarDrawer.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/AnimatedSidebarDrawer.tsx
@@ -72,15 +72,18 @@ export default function AnimatedSidebarDrawer({ content }: Props) {
 }
 
 const StyledMotion = styled(motion.div)`
-  height: 100vh;
+  height: 100%;
   min-height: 0;
+  display: flex;
+  // flex: 1; and min-height: 0 on the child, StyledDrawer, prevents the drawer content from stretching this container beyond the viewable area
+  flex: 1;
 `;
 
 const StyledDrawer = styled(VStack)`
   background-color: ${colors.offWhite};
   width: 100%;
-  height: 100%;
   position: relative;
+  min-height: 0;
 
   @media only screen and ${breakpoints.tablet} {
     height: 100vh;

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/GlobalSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/GlobalSidebar.tsx
@@ -22,8 +22,10 @@ export default function GlobalSidebar({ content }: GlobalSidebarProps) {
     return null;
   }
 
+  const isDrawerOpen = Boolean(drawerState.activeDrawer);
+
   return (
-    <StyledGlobalSidebar>
+    <StyledGlobalSidebar isDrawerOpen={isDrawerOpen}>
       <StyledGlobalSidebarContent>{content}</StyledGlobalSidebarContent>
       <AnimatePresence>
         {drawerState.activeDrawer && (
@@ -34,13 +36,16 @@ export default function GlobalSidebar({ content }: GlobalSidebarProps) {
   );
 }
 
-const StyledGlobalSidebar = styled.div`
+const StyledGlobalSidebar = styled.div<{ isDrawerOpen: boolean }>`
   position: fixed;
   bottom: 0;
-  max-height: 100vh;
   width: 100vw;
   display: flex;
   flex-direction: column-reverse;
+
+  // this allows the drawer content height to adjust to changing mobile view area height, when the url bar changes height.
+  // height should be 100% only when drawer is open because otherwise it will cover the entire screen when drawer is closed
+  ${({ isDrawerOpen }) => isDrawerOpen && `height: 100%;`}
 
   z-index: 2;
 

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/SidebarDrawerContext.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/SidebarDrawerContext.tsx
@@ -61,7 +61,9 @@ function SidebarDrawerProvider({ children }: Props): ReactElement {
   useEffect(() => {
     if (isMobile) {
       const isDrawerOpen = drawerState.activeDrawer !== null;
+
       document.body.style.overflow = isDrawerOpen ? 'hidden' : 'unset';
+      document.body.style.position = isDrawerOpen ? 'fixed' : 'unset';
     }
   }, [drawerState.activeDrawer, isMobile]);
 

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/SidebarDrawerContext.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/SidebarDrawerContext.tsx
@@ -4,9 +4,12 @@ import {
   ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
+
+import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 
 export type DrawerType = 'Notifications' | 'Settings';
 
@@ -50,6 +53,17 @@ type Props = { children: ReactNode };
 
 function SidebarDrawerProvider({ children }: Props): ReactElement {
   const [drawerState, setDrawerState] = useState<DrawerState>({ activeDrawer: null });
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
+
+  /**
+   * EFFECT: Prevent main body from being scrollable on mobile when drawer is open. On desktop we allow users to scroll the main body while the drawer is open.
+   */
+  useEffect(() => {
+    if (isMobile) {
+      const isDrawerOpen = drawerState.activeDrawer !== null;
+      document.body.style.overflow = isDrawerOpen ? 'hidden' : 'unset';
+    }
+  }, [drawerState.activeDrawer, isMobile]);
 
   const showDrawer = useCallback((props: ActiveDrawer) => {
     setDrawerState((previous) => {

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/SidebarDrawerContext.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/SidebarDrawerContext.tsx
@@ -63,7 +63,6 @@ function SidebarDrawerProvider({ children }: Props): ReactElement {
       const isDrawerOpen = drawerState.activeDrawer !== null;
 
       document.body.style.overflow = isDrawerOpen ? 'hidden' : 'unset';
-      document.body.style.position = isDrawerOpen ? 'fixed' : 'unset';
     }
   }, [drawerState.activeDrawer, isMobile]);
 


### PR DESCRIPTION
## Description

This PR fixes issues with the Left Hand Nav on mobile devices.

## issues fixed:


### Fix busted nav layout/heights on mobile (it was working on browser mobile view but not on actual mobile device)
Before
![Screen Shot 2023-03-04 at 15 57 42](https://user-images.githubusercontent.com/80802871/222881469-dc8d347c-c32d-492c-845e-b70176725e10.png)

After (url bar expanded)
![Screen Shot 2023-03-04 at 15 43 28](https://user-images.githubusercontent.com/80802871/222881479-26893be0-a019-4171-b7b2-873c56b72678.png)

After (url bar minimized)
![Screen Shot 2023-03-04 at 15 43 36](https://user-images.githubusercontent.com/80802871/222881491-7a685374-ae1f-45ca-a8a4-dbff189b911a.png)
View Notifications screen (shows height is ok when the drawer content is less than view height)
![Screen Shot 2023-03-04 at 15 43 43](https://user-images.githubusercontent.com/80802871/222881506-602ff762-1e3d-4926-87fd-e0b732cacb6d.png)



### On mobile, fix drawer to screen when it's open and prevent any scroll behavior

The `overscroll-behavior: contain;` property on the drawer content prevents scroll if the drawer was scrollable, but has no effect if the content is not scrollable. for example the header and footer areas of the drawer, or if the drawer content is not tall. This led to unpleasant scroll behavior, causing seemingly random scrolling (and elastic scrolling on iOS) depending on where you happened to touch.
Added `overflow:hidden` to `body` if drawer is open. This provides a small improvement in preventing unnecessary scroll. It's not perfect since you can still trigger the elastic scrolling and change in url bar height, but there doesn't seem to be an ideal fix atm.

Before
https://user-images.githubusercontent.com/80802871/222882239-9dd74f62-4dac-4139-8dac-f25e906f0e2c.mp4

After
https://user-images.githubusercontent.com/80802871/222884310-07dbe757-baf1-41df-a99e-7ea3ff58a796.mp4



###  Make wallet button fit better on small mobile screens
Before
![Screen Shot 2023-03-04 at 16 07 08](https://user-images.githubusercontent.com/80802871/222881459-73ec43a2-0b62-4410-9d0b-a6da371860fe.png)

After
![Screen Shot 2023-03-04 at 16 06 34](https://user-images.githubusercontent.com/80802871/222881461-8a8b83f6-e1e0-4122-b12f-1ab0657333d7.png)
