### PR TITLE
Add back nft detail modal w/o blocking feed page

### DIFF
--- a/apps/web/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
+++ b/apps/web/src/components/Feed/Events/CollectorsNoteAddedToTokenFeedEvent.tsx
@@ -93,7 +93,7 @@ export default function CollectorsNoteAddedToTokenFeedEvent({
       showModal({
         content: (
           <StyledNftDetailViewPopover>
-            <NftDetailView authenticatedUserOwnsAsset={false} queryRef={event.token} />
+            <NftDetailView authenticatedUserOwnsAsset={false} collectionTokenRef={event.token} />
           </StyledNftDetailViewPopover>
         ),
         isFullPage: true,

--- a/apps/web/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
+++ b/apps/web/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
@@ -1,20 +1,16 @@
-// import { useCallback } from 'react';
 import { Suspense, useCallback } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
 import FullPageLoader from '~/components/core/Loader/FullPageLoader';
-// import breakpoints from '~/components/core/breakpoints';
 import { StyledImageWithLoading } from '~/components/LoadingAsset/ImageWithLoading';
 import { StyledVideo } from '~/components/LoadingAsset/VideoWithLoading';
 import NftPreview from '~/components/NftPreview/NftPreview';
 import { useModalActions } from '~/contexts/modal/ModalContext';
-// import { useModalActions } from '~/contexts/modal/ModalContext';
 import ShimmerProvider from '~/contexts/shimmer/ShimmerContext';
 import { FeedEventNftPreviewWrapperFragment$key } from '~/generated/FeedEventNftPreviewWrapperFragment.graphql';
 import { LoadableNftDetailView } from '~/scenes/NftDetailPage/NftDetailView';
-// import NftDetailView from '~/scenes/NftDetailPage/NftDetailView';
 
 type Props = {
   tokenRef: FeedEventNftPreviewWrapperFragment$key;

--- a/apps/web/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
+++ b/apps/web/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
@@ -1,14 +1,19 @@
 // import { useCallback } from 'react';
+import { Suspense, useCallback } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
+import breakpoints from '~/components/core/breakpoints';
+import FullPageLoader from '~/components/core/Loader/FullPageLoader';
 // import breakpoints from '~/components/core/breakpoints';
 import { StyledImageWithLoading } from '~/components/LoadingAsset/ImageWithLoading';
 import { StyledVideo } from '~/components/LoadingAsset/VideoWithLoading';
 import NftPreview from '~/components/NftPreview/NftPreview';
+import { useModalActions } from '~/contexts/modal/ModalContext';
 // import { useModalActions } from '~/contexts/modal/ModalContext';
 import ShimmerProvider from '~/contexts/shimmer/ShimmerContext';
 import { FeedEventNftPreviewWrapperFragment$key } from '~/generated/FeedEventNftPreviewWrapperFragment.graphql';
+import { LoadableNftDetailView } from '~/scenes/NftDetailPage/NftDetailView';
 // import NftDetailView from '~/scenes/NftDetailPage/NftDetailView';
 
 type Props = {
@@ -29,25 +34,41 @@ function FeedEventNftPreviewWrapper({ tokenRef, maxWidth, maxHeight }: Props) {
   const token = useFragment(
     graphql`
       fragment FeedEventNftPreviewWrapperFragment on CollectionToken {
+        collection {
+          dbid
+        }
+        token {
+          dbid
+        }
+
         ...NftPreviewFragment
-        # ...NftDetailViewFragment
       }
     `,
     tokenRef
   );
 
-  // const { showModal } = useModalActions();
+  const { showModal } = useModalActions();
 
-  // const handleClick = useCallback(() => {
-  //   showModal({
-  //     content: (
-  //       <StyledNftDetailViewPopover>
-  //         <NftDetailView authenticatedUserOwnsAsset={false} queryRef={token} />
-  //       </StyledNftDetailViewPopover>
-  //     ),
-  //     isFullPage: true,
-  //   });
-  // }, [showModal, token]);
+  const handleClick = useCallback(() => {
+    if (!token.token || !token.collection) {
+      return;
+    }
+
+    showModal({
+      content: (
+        <StyledNftDetailViewPopover>
+          <Suspense fallback={<FullPageLoader />}>
+            <LoadableNftDetailView
+              tokenId={token.token.dbid}
+              collectionId={token.collection.dbid}
+              authenticatedUserOwnsAsset={false}
+            />
+          </Suspense>
+        </StyledNftDetailViewPopover>
+      ),
+      isFullPage: true,
+    });
+  }, [showModal, token]);
 
   return (
     <StyledNftPreviewWrapper
@@ -58,7 +79,7 @@ function FeedEventNftPreviewWrapper({ tokenRef, maxWidth, maxHeight }: Props) {
       <NftPreview
         tokenRef={token}
         previewSize={maxWidth}
-        // onClick={handleClick}
+        onClick={handleClick}
         disableLiverender
         isInFeedEvent
       />
@@ -79,15 +100,15 @@ const StyledNftPreviewWrapper = styled.div<{ maxWidth: number; maxHeight: number
   }
 `;
 
-// const StyledNftDetailViewPopover = styled.div`
-//   display: flex;
-//   justify-content: center;
-//   height: 100%;
-//   padding: 80px 0;
+const StyledNftDetailViewPopover = styled.div`
+  display: flex;
+  justify-content: center;
+  height: 100%;
+  padding: 80px 0;
 
-//   @media only screen and ${breakpoints.desktop} {
-//     padding: 0;
-//   }
-// `;
+  @media only screen and ${breakpoints.desktop} {
+    padding: 0;
+  }
+`;
 
 export default NftPreviewWithShimmer;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
@@ -32,7 +32,12 @@ function Fixture() {
     throw new Error('Yikes');
   }
 
-  return <NftDetailView authenticatedUserOwnsAsset={false} collectionTokenRef={query.collectionTokenById} />;
+  return (
+    <NftDetailView
+      authenticatedUserOwnsAsset={false}
+      collectionTokenRef={query.collectionTokenById}
+    />
+  );
 }
 
 const UnknownMediaResponse: NftDetailAssetTestQueryQuery = {

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
@@ -32,7 +32,7 @@ function Fixture() {
     throw new Error('Yikes');
   }
 
-  return <NftDetailView authenticatedUserOwnsAsset={false} queryRef={query.collectionTokenById} />;
+  return <NftDetailView authenticatedUserOwnsAsset={false} collectionTokenRef={query.collectionTokenById} />;
 }
 
 const UnknownMediaResponse: NftDetailAssetTestQueryQuery = {

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -206,7 +206,10 @@ function NftDetailPage({
       {prevNft && <NavigationHandle direction={Directions.LEFT} onClick={handlePrevPress} />}
       {mountedNfts.map(({ token, visibility }) => (
         <_DirectionalFade key={token.token.dbid} visibility={visibility}>
-          <NftDetailView collectionTokenRef={token} authenticatedUserOwnsAsset={authenticatedUserOwnsAsset} />
+          <NftDetailView
+            collectionTokenRef={token}
+            authenticatedUserOwnsAsset={authenticatedUserOwnsAsset}
+          />
         </_DirectionalFade>
       ))}
       {nextNft && <NavigationHandle direction={Directions.RIGHT} onClick={handleNextPress} />}

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -206,7 +206,7 @@ function NftDetailPage({
       {prevNft && <NavigationHandle direction={Directions.LEFT} onClick={handlePrevPress} />}
       {mountedNfts.map(({ token, visibility }) => (
         <_DirectionalFade key={token.token.dbid} visibility={visibility}>
-          <NftDetailView queryRef={token} authenticatedUserOwnsAsset={authenticatedUserOwnsAsset} />
+          <NftDetailView collectionTokenRef={token} authenticatedUserOwnsAsset={authenticatedUserOwnsAsset} />
         </_DirectionalFade>
       ))}
       {nextNft && <NavigationHandle direction={Directions.RIGHT} onClick={handleNextPress} />}


### PR DESCRIPTION
Instead of including the NftDetailView's data as a part of the main request, we just split it off into its own when the user clicks on the preview.