### PR TITLE
fix notifications dot for lhn

### DIFF
--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
@@ -216,6 +216,7 @@ export function StandardSidebar({ queryRef }: Props) {
               onClick={handleNotificationsClick}
               icon={<BellIcon />}
               isActive={activeDrawerType === Notifications}
+              showUnreadDot={notificationCount > 0}
             />
             <SidebarIcon
               tooltipLabel="Settings"


### PR DESCRIPTION
## Description
The notifications unread dot wasn't appearing, even when there were unread notifications.

Just needed to pass the unread prop into the icon component.


https://user-images.githubusercontent.com/80802871/223298045-faf045e2-fabd-4e24-bbec-c0adaf048390.mp4

