### PR TITLE
GAL-2507 temp fix for baseurl

### DIFF
--- a/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -144,7 +144,7 @@ function UserGalleryCollection({
             <StyledCollectorsTitle>{unescapedCollectionName}</StyledCollectorsTitle>
           </UnstyledLink>
           <StyledOptionsContainer gap={16}>
-            <StyledCopyToClipboard textToCopy={`${window?.origin}${collectionUrl}`}>
+            <StyledCopyToClipboard textToCopy={`${window?.location.origin}${collectionUrl}`}>
               <TextButton text="Share" onClick={handleShareClick} />
             </StyledCopyToClipboard>
             <SettingsDropdown iconVariant="default">

--- a/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -26,7 +26,6 @@ import { UserGalleryCollectionQueryFragment$key } from '~/generated/UserGalleryC
 import useUpdateCollectionInfo from '~/hooks/api/collections/useUpdateCollectionInfo';
 import { useLoggedInUserId } from '~/hooks/useLoggedInUserId';
 import useResizeObserver from '~/hooks/useResizeObserver';
-import { baseUrl } from '~/utils/baseUrl';
 import unescape from '~/utils/unescape';
 
 type Props = {

--- a/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -144,7 +144,7 @@ function UserGalleryCollection({
             <StyledCollectorsTitle>{unescapedCollectionName}</StyledCollectorsTitle>
           </UnstyledLink>
           <StyledOptionsContainer gap={16}>
-            <StyledCopyToClipboard textToCopy={`${baseUrl}${collectionUrl}`}>
+            <StyledCopyToClipboard textToCopy={`${window?.origin}${collectionUrl}`}>
               <TextButton text="Share" onClick={handleShareClick} />
             </StyledCopyToClipboard>
             <SettingsDropdown iconVariant="default">

--- a/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -26,6 +26,7 @@ import { UserGalleryCollectionQueryFragment$key } from '~/generated/UserGalleryC
 import useUpdateCollectionInfo from '~/hooks/api/collections/useUpdateCollectionInfo';
 import { useLoggedInUserId } from '~/hooks/useLoggedInUserId';
 import useResizeObserver from '~/hooks/useResizeObserver';
+import { getBaseUrl } from '~/utils/baseUrl';
 import unescape from '~/utils/unescape';
 
 type Props = {
@@ -143,7 +144,7 @@ function UserGalleryCollection({
             <StyledCollectorsTitle>{unescapedCollectionName}</StyledCollectorsTitle>
           </UnstyledLink>
           <StyledOptionsContainer gap={16}>
-            <StyledCopyToClipboard textToCopy={`${window?.location.origin}${collectionUrl}`}>
+            <StyledCopyToClipboard textToCopy={`${getBaseUrl()}${collectionUrl}`}>
               <TextButton text="Share" onClick={handleShareClick} />
             </StyledCopyToClipboard>
             <SettingsDropdown iconVariant="default">

--- a/apps/web/src/utils/baseUrl.ts
+++ b/apps/web/src/utils/baseUrl.ts
@@ -1,16 +1,14 @@
-const getBaseUrl = () => {
-  // If we're inside the Vercel environment
-  switch (process.env.NEXT_PUBLIC_VERCEL_ENV) {
-    case 'production':
-      return 'https://gallery.so';
-    case 'development':
-      return `https://gallery-dev.vercel.app`;
-    case 'preview':
-      return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
+export function getBaseUrl(): string {
+  const environment = process.env.NEXT_PUBLIC_VERCEL_ENV;
+
+  if (environment === 'production') {
+    return 'https://gallery.so';
+  } else if (environment === 'development') {
+    return `https://gallery-dev.vercel.app`;
+  } else if (environment === 'preview') {
+    return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
   }
 
   // Otherwise, we're probably running locally?
   return 'http://localhost:3000';
-};
-
-export const baseUrl = getBaseUrl();
+}


### PR DESCRIPTION
## Description
`baseUrl` isn't working as expected on prod, and causes the link copied by the Share button to have localhost instead of gallery.so

getting the baseurl from the next env vars didn't seem to be working as expected on deployed environments, so this is a temp solution to use window.origin until we figure out why