### PR TITLE
fix nav shift

### DIFF
--- a/apps/web/src/contexts/modal/ModalContext.tsx
+++ b/apps/web/src/contexts/modal/ModalContext.tsx
@@ -210,7 +210,6 @@ function ModalProvider({ children }: Props) {
        * Leaving the code in tho in case scrollbar issue comes back
        */
       globalNavbar.style.transform = modalShowing ? 'translateX(0px)' : 'unset';
-      globalNavbar.style.width = modalShowing ? `calc(100vw - ${currentScrollbarWidth}px)` : '100%';
     }
   }, [modals.length]);
 


### PR DESCRIPTION
## Description
This PR fixes an issue where after clicking Sign In, the contents of the global nav shifted right.

Before
![CleanShot 2023-03-08 at 20 31 18](https://user-images.githubusercontent.com/80802871/223702566-a826b86f-8571-47ae-9266-6a947d6cd503.png)

After
desktop

https://user-images.githubusercontent.com/80802871/223702897-ff5b8bca-ab4c-4839-8ca9-65387ef85a05.mp4



mobile
![Screen Shot 2023-03-08 at 20 29 50](https://user-images.githubusercontent.com/80802871/223702622-0273f864-6861-4d9d-a1bd-52ce2eaa63c4.png)



The fix removes a line of code that is related to the banner width, so attaching a screenshot confirming that the banner still looks good post-change
![CleanShot 2023-03-08 at 19 48 06](https://user-images.githubusercontent.com/80802871/223702712-e5705561-f8e1-4b85-891f-f1239470eaf4.png)

