### PR TITLE
Switch to Relay's supported preloaded query pattern to fix dedupes.

### DIFF
--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -98,16 +98,6 @@ const App: FC<AppProps> = (props) => {
     if (isProduction()) welcomeDoormat();
   }, []);
 
-  // const { query } = useRouter();
-
-  // // Kick off queries that would waterfall
-  // let pagePreloadedQuery: PreloadedQuery<any> | null;
-  // if (typeof window !== 'undefined') {
-  //   pagePreloadedQuery = Component.preloadQuery?.({ relayEnvironment, query });
-  //   GlobalLayoutContextProvider.preloadQuery?.({ relayEnvironment, query });
-  //   AuthProvider.preloadQuery?.({ relayEnvironment, query });
-  // }
-
   return (
     <>
       <Head>

--- a/apps/web/pages/latest/index.tsx
+++ b/apps/web/pages/latest/index.tsx
@@ -1,4 +1,4 @@
-import { graphql, useLazyLoadQuery } from 'react-relay';
+import { graphql, loadQuery, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 
 import { ITEMS_PER_PAGE, MAX_PIECES_DISPLAYED_PER_FEED_EVENT } from '~/components/Feed/constants';
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/NotesModal/NotesModal';
@@ -7,28 +7,28 @@ import { StandardSidebar } from '~/contexts/globalLayout/GlobalSidebar/StandardS
 import { latestQuery } from '~/generated/latestQuery.graphql';
 import GalleryRoute from '~/scenes/_Router/GalleryRoute';
 import { LatestHomePage } from '~/scenes/Home/Latest/LatestHomePage';
+import { PreloadQueryArgs } from '~/types/PageComponentPreloadQuery';
 
-export default function Latest() {
-  const query = useLazyLoadQuery<latestQuery>(
-    graphql`
-      query latestQuery(
-        $latestBefore: String
-        $latestLast: Int!
-        $interactionsFirst: Int!
-        $interactionsAfter: String
-        $visibleTokensPerFeedEvent: Int!
-      ) {
-        ...LatestHomePageFragment
-        ...HomeNavbarFragment
-        ...StandardSidebarFragment
-      }
-    `,
-    {
-      latestLast: ITEMS_PER_PAGE,
-      visibleTokensPerFeedEvent: MAX_PIECES_DISPLAYED_PER_FEED_EVENT,
-      interactionsFirst: NOTES_PER_PAGE,
-    }
-  );
+const latestQueryNode = graphql`
+  query latestQuery(
+    $latestBefore: String
+    $latestLast: Int!
+    $interactionsFirst: Int!
+    $interactionsAfter: String
+    $visibleTokensPerFeedEvent: Int!
+  ) {
+    ...LatestHomePageFragment
+    ...HomeNavbarFragment
+    ...StandardSidebarFragment
+  }
+`;
+
+type Props = {
+  preloadedQuery: PreloadedQuery<latestQuery>;
+};
+
+export default function Latest({ preloadedQuery }: Props) {
+  const query = usePreloadedQuery<latestQuery>(latestQueryNode, preloadedQuery);
 
   return (
     <GalleryRoute
@@ -38,3 +38,16 @@ export default function Latest() {
     />
   );
 }
+
+Latest.preloadQuery = ({ relayEnvironment }: PreloadQueryArgs) => {
+  return loadQuery(
+    relayEnvironment,
+    latestQueryNode,
+    {
+      latestLast: ITEMS_PER_PAGE,
+      visibleTokensPerFeedEvent: MAX_PIECES_DISPLAYED_PER_FEED_EVENT,
+      interactionsFirst: NOTES_PER_PAGE,
+    },
+    { fetchPolicy: 'store-or-network' }
+  );
+};

--- a/apps/web/pages/trending.tsx
+++ b/apps/web/pages/trending.tsx
@@ -1,5 +1,4 @@
-import { graphql, useLazyLoadQuery } from 'react-relay';
-import { fetchQuery } from 'relay-runtime';
+import { graphql, loadQuery, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 
 import { ITEMS_PER_PAGE, MAX_PIECES_DISPLAYED_PER_FEED_EVENT } from '~/components/Feed/constants';
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/NotesModal/NotesModal';
@@ -10,7 +9,7 @@ import GalleryRoute from '~/scenes/_Router/GalleryRoute';
 import TrendingHomePage from '~/scenes/Home/TrendingHomePage';
 import { PreloadQueryArgs } from '~/types/PageComponentPreloadQuery';
 
-const activityPageQueryNode = graphql`
+const trendingPageQueryNode = graphql`
   query trendingPageQuery(
     $interactionsFirst: Int!
     $interactionsAfter: String
@@ -26,13 +25,12 @@ const activityPageQueryNode = graphql`
   }
 `;
 
-export default function Trending() {
-  const query = useLazyLoadQuery<trendingPageQuery>(activityPageQueryNode, {
-    interactionsFirst: NOTES_PER_PAGE,
-    globalLast: ITEMS_PER_PAGE,
-    trendingLast: ITEMS_PER_PAGE,
-    visibleTokensPerFeedEvent: MAX_PIECES_DISPLAYED_PER_FEED_EVENT,
-  });
+type Props = {
+  preloadedQuery: PreloadedQuery<trendingPageQuery>;
+};
+
+export default function Trending({ preloadedQuery }: Props) {
+  const query = usePreloadedQuery(trendingPageQueryNode, preloadedQuery);
 
   return (
     <GalleryRoute
@@ -44,9 +42,9 @@ export default function Trending() {
 }
 
 Trending.preloadQuery = ({ relayEnvironment }: PreloadQueryArgs) => {
-  fetchQuery<trendingPageQuery>(
+  return loadQuery<trendingPageQuery>(
     relayEnvironment,
-    activityPageQueryNode,
+    trendingPageQueryNode,
     {
       interactionsFirst: NOTES_PER_PAGE,
       globalLast: ITEMS_PER_PAGE,
@@ -54,7 +52,7 @@ Trending.preloadQuery = ({ relayEnvironment }: PreloadQueryArgs) => {
       visibleTokensPerFeedEvent: MAX_PIECES_DISPLAYED_PER_FEED_EVENT,
     },
     { fetchPolicy: 'store-or-network' }
-  ).toPromise();
+  );
 };
 
 /**

--- a/apps/web/src/components/Notifications/notifications/SomeoneViewedYourGallery.test.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneViewedYourGallery.test.tsx
@@ -3,10 +3,9 @@ import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
 import { SomeoneViewedYourGallery } from '~/components/Notifications/notifications/SomeoneViewedYourGallery';
-import AppProvider from '~/contexts/AppProvider';
-import { createEmptyRelayEnvironment } from '~/contexts/relay/RelayProvider';
 import { SomeoneViewedYourGalleryTestQuery } from '~/generated/SomeoneViewedYourGalleryTestQuery.graphql';
 import { SomeoneViewedYourGalleryTestQueryQuery } from '~/tests/__generated__/graphql-codegen/operations';
+import { MockAppProvider } from '~/tests/graphql/MockAppProvider';
 import { mockGraphqlQuery } from '~/tests/graphql/mockGraphqlQuery';
 import { mockProviderQueries } from '~/tests/graphql/mockProviderQueries';
 import noop from '~/utils/noop';
@@ -93,11 +92,10 @@ async function assertSituation(args: MockResponseArgs, expectedText: string) {
 
   mockGraphqlQuery('SomeoneViewedYourGalleryTestQuery', response);
 
-  const relayEnvironment = createEmptyRelayEnvironment();
   const { findByTestId } = render(
-    <AppProvider relayEnvironment={relayEnvironment}>
+    <MockAppProvider>
       <Fixture />
-    </AppProvider>
+    </MockAppProvider>
   );
 
   const element = await findByTestId('SomeoneViewedYourGallery');

--- a/apps/web/src/contexts/AppProvider.tsx
+++ b/apps/web/src/contexts/AppProvider.tsx
@@ -1,9 +1,11 @@
-import { Environment, RelayEnvironmentProvider } from 'react-relay';
+import { Environment, PreloadedQuery, RelayEnvironmentProvider } from 'react-relay';
 
 import Debugger from '~/components/Debugger/Debugger';
 import { GalleryNavigationProvider } from '~/contexts/navigation/GalleryNavigationProvider';
 import { NftErrorProvider } from '~/contexts/NftErrorContext';
 import { SyncTokensLockProvider } from '~/contexts/SyncTokensLockContext';
+import { AuthContextFetchUserQuery } from '~/generated/AuthContextFetchUserQuery.graphql';
+import { GlobalLayoutContextQuery } from '~/generated/GlobalLayoutContextQuery.graphql';
 import isProduction from '~/utils/isProduction';
 
 import AnalyticsProvider from './analytics/AnalyticsContext';
@@ -19,16 +21,23 @@ import ToastProvider from './toast/ToastContext';
 type Props = {
   children: React.ReactNode;
   relayEnvironment: Environment;
+  authProviderPreloadedQuery: PreloadedQuery<AuthContextFetchUserQuery>;
+  globalLayoutContextPreloadedQuery: PreloadedQuery<GlobalLayoutContextQuery>;
 };
 
 const isProd = isProduction();
 
-export default function AppProvider({ children, relayEnvironment }: Props) {
+export default function AppProvider({
+  children,
+  relayEnvironment,
+  authProviderPreloadedQuery,
+  globalLayoutContextPreloadedQuery,
+}: Props) {
   return (
     <Boundary>
       <ToastProvider>
         <RelayEnvironmentProvider environment={relayEnvironment}>
-          <AuthProvider>
+          <AuthProvider preloadedQuery={authProviderPreloadedQuery}>
             <AnalyticsProvider>
               <WebErrorReportingProvider>
                 <SwrProvider>
@@ -37,7 +46,9 @@ export default function AppProvider({ children, relayEnvironment }: Props) {
                       <ModalProvider>
                         <SidebarDrawerProvider>
                           <SyncTokensLockProvider>
-                            <GlobalLayoutContextProvider>
+                            <GlobalLayoutContextProvider
+                              preloadedQuery={globalLayoutContextPreloadedQuery}
+                            >
                               {isProd ? null : <Debugger />}
                               {children}
                             </GlobalLayoutContextProvider>

--- a/apps/web/src/contexts/globalLayout/GlobalLayoutContext.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalLayoutContext.tsx
@@ -13,8 +13,8 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useFragment, useLazyLoadQuery } from 'react-relay';
-import { fetchQuery, graphql } from 'relay-runtime';
+import { loadQuery, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
+import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
@@ -72,7 +72,7 @@ export const useGlobalLayoutActions = (): GlobalLayoutActions => {
   return context;
 };
 
-type Props = { children: ReactNode };
+type Props = { children: ReactNode; preloadedQuery: PreloadedQuery<GlobalLayoutContextQuery> };
 
 // the action that triggered the fade animation
 type FadeTriggerType = 'route' | 'scroll' | 'hover';
@@ -85,10 +85,11 @@ const GlobalLayoutContextQueryNode = graphql`
   }
 `;
 
-const GlobalLayoutContextProvider = memo(({ children }: Props) => {
-  const query = useLazyLoadQuery<GlobalLayoutContextQuery>(GlobalLayoutContextQueryNode, {
-    collectionIds: FEATURED_COLLECTION_IDS,
-  });
+const GlobalLayoutContextProvider = memo(({ children, preloadedQuery }: Props) => {
+  const query = usePreloadedQuery<GlobalLayoutContextQuery>(
+    GlobalLayoutContextQueryNode,
+    preloadedQuery
+  );
 
   // whether the global banner is visible
   const [isBannerVisible, setIsBannerVisible] = useState(false);
@@ -315,14 +316,14 @@ const StyledGlobalSidebarMotion = styled(motion.div)`
 `;
 
 GlobalLayoutContextProvider.preloadQuery = ({ relayEnvironment }: PreloadQueryArgs) => {
-  fetchQuery<GlobalLayoutContextQuery>(
+  return loadQuery<GlobalLayoutContextQuery>(
     relayEnvironment,
     GlobalLayoutContextQueryNode,
     {
       collectionIds: FEATURED_COLLECTION_IDS,
     },
     { fetchPolicy: 'store-or-network' }
-  ).toPromise();
+  );
 };
 
 GlobalLayoutContextProvider.displayName = 'GlobalLayoutContextProvider';

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
@@ -1,8 +1,6 @@
 import { fireEvent, render } from '@testing-library/react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
-import AppProvider from '~/contexts/AppProvider';
-import { createEmptyRelayEnvironment } from '~/contexts/relay/RelayProvider';
 import { NftDetailAssetTestQuery } from '~/generated/NftDetailAssetTestQuery.graphql';
 import NftDetailView from '~/scenes/NftDetailPage/NftDetailView';
 import {
@@ -10,6 +8,7 @@ import {
   NftDetailAssetTestQueryQuery,
   NftErrorContextRetryMutationMutation,
 } from '~/tests/__generated__/graphql-codegen/operations';
+import { MockAppProvider } from '~/tests/graphql/MockAppProvider';
 import { mockGraphqlQuery } from '~/tests/graphql/mockGraphqlQuery';
 import { mockProviderQueries } from '~/tests/graphql/mockProviderQueries';
 
@@ -129,11 +128,10 @@ describe('NftDetailAsset', () => {
     // Mock the retry for when they hit the button
     mockGraphqlQuery('NftErrorContextRetryMutation', RetryImageMediaResponse);
 
-    const relayEnvironment = createEmptyRelayEnvironment();
     const { findByText, findByTestId, findByAltText } = render(
-      <AppProvider relayEnvironment={relayEnvironment}>
+      <MockAppProvider>
         <Fixture />
-      </AppProvider>
+      </MockAppProvider>
     );
 
     // Ensure we see the fallback UI since we have bad media

--- a/apps/web/src/types/PageComponentPreloadQuery.ts
+++ b/apps/web/src/types/PageComponentPreloadQuery.ts
@@ -1,9 +1,10 @@
 import { ParsedUrlQuery } from 'querystring';
-import { Environment } from 'react-relay';
+import { Environment, PreloadedQuery } from 'react-relay';
+import { OperationType } from 'relay-runtime';
 
 export type PreloadQueryArgs = {
   query: ParsedUrlQuery;
   relayEnvironment: Environment;
 };
 
-export type PreloadQueryFn = (args: PreloadQueryArgs) => void;
+export type PreloadQueryFn<T extends OperationType> = (args: PreloadQueryArgs) => PreloadedQuery<T>;

--- a/apps/web/tests/graphql/MockAppProvider.tsx
+++ b/apps/web/tests/graphql/MockAppProvider.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from 'next/router';
+import { PropsWithChildren, useState } from 'react';
+
+import AuthProvider from '~/contexts/auth/AuthContext';
+
+import AppProvider from '../../src/contexts/AppProvider';
+import GlobalLayoutContextProvider from '../../src/contexts/globalLayout/GlobalLayoutContext';
+import { createRelayEnvironmentFromRecords } from '../../src/contexts/relay/RelayProvider';
+
+export function MockAppProvider({ children }: PropsWithChildren) {
+  const [relayEnvironment] = useState(() => createRelayEnvironmentFromRecords({}));
+  const { query } = useRouter();
+
+  const authProviderPreloadedQuery = AuthProvider.preloadQuery?.({ relayEnvironment, query });
+  const globalLayoutContextPreloadedQuery = GlobalLayoutContextProvider.preloadQuery?.({
+    relayEnvironment,
+    query,
+  });
+
+  if (!authProviderPreloadedQuery || !globalLayoutContextPreloadedQuery) {
+    throw new Error('Preloaded Queries were not returned from preloadQuery function');
+  }
+
+  return (
+    <AppProvider
+      relayEnvironment={relayEnvironment}
+      authProviderPreloadedQuery={authProviderPreloadedQuery}
+      globalLayoutContextPreloadedQuery={globalLayoutContextPreloadedQuery}
+    >
+      {children}
+    </AppProvider>
+  );
+}

--- a/apps/web/tests/graphql/MockAppProvider.tsx
+++ b/apps/web/tests/graphql/MockAppProvider.tsx
@@ -1,11 +1,10 @@
 import { useRouter } from 'next/router';
 import { PropsWithChildren, useState } from 'react';
 
+import AppProvider from '~/contexts/AppProvider';
 import AuthProvider from '~/contexts/auth/AuthContext';
-
-import AppProvider from '../../src/contexts/AppProvider';
-import GlobalLayoutContextProvider from '../../src/contexts/globalLayout/GlobalLayoutContext';
-import { createRelayEnvironmentFromRecords } from '../../src/contexts/relay/RelayProvider';
+import GlobalLayoutContextProvider from '~/contexts/globalLayout/GlobalLayoutContext';
+import { createRelayEnvironmentFromRecords } from '~/contexts/relay/RelayProvider';
 
 export function MockAppProvider({ children }: PropsWithChildren) {
   const [relayEnvironment] = useState(() => createRelayEnvironmentFromRecords({}));

--- a/apps/web/tests/graphql/mockAuthContextQuery.ts
+++ b/apps/web/tests/graphql/mockAuthContextQuery.ts
@@ -1,0 +1,23 @@
+import { AuthContextFetchUserQueryQuery } from '~/tests/__generated__/graphql-codegen/operations';
+
+import { GALLERY_USER_DBID, GALLERY_USER_ID, GALLERY_VIEWER_ID } from '../constants';
+import { mockGraphqlQuery } from './mockGraphqlQuery';
+
+export function mockAuthContextQuery() {
+  const response: AuthContextFetchUserQueryQuery = {
+    __typename: 'Query',
+    viewer: {
+      __typename: 'Viewer',
+      id: GALLERY_VIEWER_ID,
+      user: {
+        __typename: 'GalleryUser',
+        id: GALLERY_USER_ID,
+        dbid: GALLERY_USER_DBID,
+        username: 'Test Gallery User',
+        wallets: [],
+      },
+    },
+  };
+
+  return mockGraphqlQuery('AuthContextFetchUserQuery', response);
+}

--- a/apps/web/tests/graphql/mockProviderQueries.ts
+++ b/apps/web/tests/graphql/mockProviderQueries.ts
@@ -1,3 +1,4 @@
+import { mockAuthContextQuery } from '~/tests/graphql/mockAuthContextQuery';
 import { mockErrorReportingContextQuery } from '~/tests/graphql/mockErrorReportingContextQuery';
 
 import { mockDebuggerQuery } from './mockDebuggerQuery';
@@ -6,5 +7,6 @@ import { mockGlobalLayoutQuery } from './mockGlobalLayoutQuery';
 export function mockProviderQueries() {
   mockDebuggerQuery();
   mockGlobalLayoutQuery();
+  mockAuthContextQuery();
   mockErrorReportingContextQuery();
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,78 +6,30 @@
     "emitDeclarationOnly": false,
     "noEmit": true,
     "paths": {
-      "~/abis/*": [
-        "src/abis/*"
-      ],
-      "~/assets/*": [
-        "src/assets/*"
-      ],
-      "~/components/*": [
-        "src/components/*"
-      ],
-      "~/connectors/*": [
-        "src/connectors/*"
-      ],
-      "~/constants/*": [
-        "src/constants/*"
-      ],
-      "~/contexts/*": [
-        "src/contexts/*"
-      ],
-      "~/errors/*": [
-        "src/errors/*"
-      ],
-      "~/frames/*": [
-        "../../packages/frames-dls/src/*"
-      ],
-      "~/generated/*": [
-        "__generated__/relay/*",
-        "__generated__/graphql-codegen/*"
-      ],
-      "~/hooks/*": [
-        "src/hooks/*"
-      ],
-      "~/icons/*": [
-        "src/icons/*"
-      ],
-      "~/mocks/*": [
-        "src/mocks/*"
-      ],
-      "~/pages/*": [
-        "pages/*"
-      ],
-      "~/scenes/*": [
-        "src/scenes/*"
-      ],
-      "~/shared/*": [
-        "../../packages/shared/src/*"
-      ],
-      "~/snapshots/*": [
-        "src/snapshots/*"
-      ],
-      "~/tests/*": [
-        "tests/*"
-      ],
-      "~/types/*": [
-        "src/types/*"
-      ],
-      "~/utils/*": [
-        "src/utils/*"
-      ]
+      "~/abis/*": ["src/abis/*"],
+      "~/assets/*": ["src/assets/*"],
+      "~/components/*": ["src/components/*"],
+      "~/connectors/*": ["src/connectors/*"],
+      "~/constants/*": ["src/constants/*"],
+      "~/contexts/*": ["src/contexts/*"],
+      "~/errors/*": ["src/errors/*"],
+      "~/frames/*": ["../../packages/frames-dls/src/*"],
+      "~/generated/*": ["__generated__/relay/*", "__generated__/graphql-codegen/*"],
+      "~/hooks/*": ["src/hooks/*"],
+      "~/icons/*": ["src/icons/*"],
+      "~/mocks/*": ["src/mocks/*"],
+      "~/pages/*": ["pages/*"],
+      "~/scenes/*": ["src/scenes/*"],
+      "~/shared/*": ["../../packages/shared/src/*"],
+      "~/snapshots/*": ["src/snapshots/*"],
+      "~/tests/*": ["tests/*"],
+      "~/types/*": ["src/types/*"],
+      "~/utils/*": ["src/utils/*"]
     },
     "outDir": "../../.moon/cache/types/apps/web",
     "incremental": true
   },
-  "include": [
-    "src",
-    "scripts",
-    "pages",
-    "next-env.d.ts",
-    "app.d.ts",
-    "__generated__"
-  ],
+  "include": ["tests", "src", "scripts", "pages", "next-env.d.ts", "app.d.ts", "__generated__"],
   "references": [],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react": "^18.0.0",
     "@taquito/taquito": "^14.0.0",
     "react": "18.2.0",
+    "relay-runtime": "14.1.0",
     "typescript": "^4.9.4",
     "@expo/prebuild-config": "6.0.0",
     "@expo/config-plugins": "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -26992,29 +26992,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"relay-runtime@npm:12.0.0":
-  version: 12.0.0
-  resolution: "relay-runtime@npm:12.0.0"
-  dependencies:
-    "@babel/runtime": ^7.0.0
-    fbjs: ^3.0.0
-    invariant: ^2.2.4
-  checksum: 51cdc8a5e04188982452ae4e7c6ac7d6375ee769130d24ce8e8f9cdd45aa7e11ecd68670f56e30dcee1b4974585e88ecce19e69a9868b80cda0db7678c3b8f0a
-  languageName: node
-  linkType: hard
-
-"relay-runtime@npm:13.2.0":
-  version: 13.2.0
-  resolution: "relay-runtime@npm:13.2.0"
-  dependencies:
-    "@babel/runtime": ^7.0.0
-    fbjs: ^3.0.2
-    invariant: ^2.2.4
-  checksum: 4e03d5d3fabb12bd2e5f29da4e4664336af4077b215893e5e6cf4256e4b8f56a6ad1693b75465f1f6118bc682456714404e3f0fcdd51b5b6433a2ddd63ba8160
-  languageName: node
-  linkType: hard
-
-"relay-runtime@npm:14.1.0, relay-runtime@npm:^14.1.0":
+"relay-runtime@npm:14.1.0":
   version: 14.1.0
   resolution: "relay-runtime@npm:14.1.0"
   dependencies:


### PR DESCRIPTION
I haven't quite figured out what was causing the duplicate queries to happen earlier but this definitely fixes it.

Preloaded Queries are Relay's solution to the problem we had before with waterfalls. I'm pretty sure my original solution was relying on a race condition to work. With Preloaded Queries, we'll definitely never run into this problem again.

The code behind this is quite annoying (it's the same as what we were doing before). I want to callout that all of this nonsense should get better with the new Next.js app directory stuff.

### What is a preloaded query?
1. Start loading query
2. Get reference to this preloaded query
3. Pass that reference to the page  / component that needs it
4. That component now does `usePreloadedQuery`.

No room for race conditions here, very transparently passing around a reference to an in flight query.