### PR TITLE
Show bio instead of collection # in Explore page user cards

### DIFF
--- a/apps/web/src/components/Explore/ExploreUserCard.tsx
+++ b/apps/web/src/components/Explore/ExploreUserCard.tsx
@@ -8,6 +8,7 @@ import { ExploreUserCardFragment$key } from '~/generated/ExploreUserCardFragment
 import { useLoggedInUserId } from '~/hooks/useLoggedInUserId';
 import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
+import unescape from '~/utils/unescape';
 
 import Badge from '../Badge/Badge';
 import breakpoints from '../core/breakpoints';
@@ -63,6 +64,10 @@ export default function ExploreUserCard({ userRef, queryRef }: Props) {
     throw new Error('No user available to showcase ExploreUserCard');
   }
 
+  const { bio } = user;
+
+  const unescapedBio = useMemo(() => (bio ? unescape(bio) : ''), [bio]);
+
   const userGalleries = useMemo(() => {
     return user.galleries ?? [];
   }, [user.galleries]);
@@ -90,11 +95,11 @@ export default function ExploreUserCard({ userRef, queryRef }: Props) {
   const isMobile = useIsMobileWindowWidth();
 
   const bioFirstLine = useMemo(() => {
-    if (!user.bio) {
+    if (!unescapedBio) {
       return '';
     }
-    return user.bio.split('\n')[0] ?? '';
-  }, [user.bio]);
+    return unescapedBio.split('\n')[0] ?? '';
+  }, [unescapedBio]);
 
   return (
     // @ts-expect-error This is the future next/link version

--- a/apps/web/src/components/Explore/ExploreUserCard.tsx
+++ b/apps/web/src/components/Explore/ExploreUserCard.tsx
@@ -6,12 +6,14 @@ import styled from 'styled-components';
 import { ExploreUserCardFollowFragment$key } from '~/generated/ExploreUserCardFollowFragment.graphql';
 import { ExploreUserCardFragment$key } from '~/generated/ExploreUserCardFragment.graphql';
 import { useLoggedInUserId } from '~/hooks/useLoggedInUserId';
+import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import { pluralize } from '~/utils/string';
 
 import Badge from '../Badge/Badge';
 import breakpoints from '../core/breakpoints';
 import colors from '../core/colors';
+import Markdown from '../core/Markdown/Markdown';
 import { HStack, VStack } from '../core/Spacer/Stack';
 import { BaseM, TitleM } from '../core/Text/Text';
 import FollowButton from '../Follow/FollowButton';
@@ -32,6 +34,7 @@ export default function ExploreUserCard({ userRef, queryRef }: Props) {
           imageURL
           ...BadgeFragment
         }
+        bio
         galleries {
           collections {
             id
@@ -98,6 +101,8 @@ export default function ExploreUserCard({ userRef, queryRef }: Props) {
     return badges;
   }, [user.badges]);
 
+  const isMobile = useIsMobileWindowWidth();
+
   return (
     // @ts-expect-error This is the future next/link version
     <StyledExploreUserCard legacyBehavior={false} href={`/${user.username}`}>
@@ -109,24 +114,33 @@ export default function ExploreUserCard({ userRef, queryRef }: Props) {
         </TokenPreviewContainer>
         <UserDetailsContainer>
           <UserDetailsText>
-            <HStack gap={4} align="center">
-              <Username>
-                <strong>{user.username}</strong>
-              </Username>
-              <HStack align="center" gap={0}>
-                {userBadges.map((badge) => (
-                  <Badge key={badge.name} badgeRef={badge} />
-                ))}
+            <HStack gap={4} align="center" justify="space-between">
+              <HStack>
+                <Username>
+                  <strong>{user.username}</strong>
+                </Username>
+                <HStack align="center" gap={0}>
+                  {userBadges.map((badge) => (
+                    <Badge key={badge.name} badgeRef={badge} />
+                  ))}
+                </HStack>
               </HStack>
+              {!isMobile && !isOwnProfile && (
+                <StyledFollowButton
+                  userRef={user}
+                  queryRef={query}
+                  source="Explore Page user card"
+                />
+              )}
             </HStack>
-            <BaseM>
-              {collectionCount} {pluralize(collectionCount, 'collection')}
-            </BaseM>
+            <StyledUserBio>
+              <Markdown text={user.bio ?? ''} />
+            </StyledUserBio>
           </UserDetailsText>
-          {!isOwnProfile && (
-            <StyledFollowButton userRef={user} queryRef={query} source="Explore Page user card" />
-          )}
         </UserDetailsContainer>
+        {isMobile && !isOwnProfile && (
+          <StyledFollowButton userRef={user} queryRef={query} source="Explore Page user card" />
+        )}
       </StyledContent>
     </StyledExploreUserCard>
   );
@@ -151,12 +165,14 @@ const StyledExploreUserCard = styled(Link)`
 
 const StyledContent = styled(VStack)`
   height: 100%;
+  width: 100%;
 `;
 
 const UserDetailsContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 8px;
+  width: 100%;
 
   @media only screen and ${breakpoints.desktop} {
     flex-direction: row;
@@ -167,6 +183,19 @@ const UserDetailsContainer = styled.div`
 
 const UserDetailsText = styled(VStack)`
   overflow: hidden;
+  width: 100%;
+`;
+
+const StyledUserBio = styled(BaseM)`
+  height: 20px;
+  overflow: hidden;
+
+  display: block;
+  -webkit-line-clamp: 1;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+
+  line-clamp: 1;
 `;
 
 const TokenPreviewContainer = styled.div`

--- a/apps/web/src/components/Explore/ExploreUserCard.tsx
+++ b/apps/web/src/components/Explore/ExploreUserCard.tsx
@@ -8,7 +8,6 @@ import { ExploreUserCardFragment$key } from '~/generated/ExploreUserCardFragment
 import { useLoggedInUserId } from '~/hooks/useLoggedInUserId';
 import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
-import { pluralize } from '~/utils/string';
 
 import Badge from '../Badge/Badge';
 import breakpoints from '../core/breakpoints';
@@ -36,9 +35,6 @@ export default function ExploreUserCard({ userRef, queryRef }: Props) {
         }
         bio
         galleries {
-          collections {
-            id
-          }
           tokenPreviews {
             large
           }
@@ -79,16 +75,6 @@ export default function ExploreUserCard({ userRef, queryRef }: Props) {
     return gallery?.tokenPreviews?.slice(0, 2) ?? [];
   }, [userGalleries]);
 
-  const collectionCount = useMemo(() => {
-    return userGalleries.reduce((sum, gallery) => {
-      if (gallery === null || gallery.hidden || !gallery.collections) {
-        return sum;
-      }
-
-      return sum + gallery.collections.length;
-    }, 0);
-  }, [userGalleries]);
-
   const userBadges = useMemo(() => {
     const badges = [];
 
@@ -102,6 +88,13 @@ export default function ExploreUserCard({ userRef, queryRef }: Props) {
   }, [user.badges]);
 
   const isMobile = useIsMobileWindowWidth();
+
+  const bioFirstLine = useMemo(() => {
+    if (!user.bio) {
+      return '';
+    }
+    return user.bio.split('\n')[0] ?? '';
+  }, [user.bio]);
 
   return (
     // @ts-expect-error This is the future next/link version
@@ -134,7 +127,7 @@ export default function ExploreUserCard({ userRef, queryRef }: Props) {
               )}
             </HStack>
             <StyledUserBio>
-              <Markdown text={user.bio ?? ''} />
+              <Markdown text={bioFirstLine} />
             </StyledUserBio>
           </UserDetailsText>
         </UserDetailsContainer>
@@ -187,15 +180,12 @@ const UserDetailsText = styled(VStack)`
 `;
 
 const StyledUserBio = styled(BaseM)`
-  height: 20px;
-  overflow: hidden;
+  height: 20px; // ensure consistent height even if bio is not present
 
-  display: block;
+  line-clamp: 1;
   -webkit-line-clamp: 1;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-
-  line-clamp: 1;
 `;
 
 const TokenPreviewContainer = styled.div`


### PR DESCRIPTION
## Description

Changes are based on discussion around replacing collection # with bio on Explore page user cards.

Bio is truncated to one line to visually balance cards with and without bios.


before
![Screen Shot 2023-03-09 at 12 08 19](https://user-images.githubusercontent.com/80802871/223906409-1e55b2da-2834-4018-857f-d1e171fb6044.png)



after

![Screen Shot 2023-03-08 at 19 31 54](https://user-images.githubusercontent.com/80802871/223906390-8e442508-805c-434e-8f4c-7816c98bb0f4.png)
