### PR TITLE
show address on community page

### DIFF
--- a/apps/web/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -120,7 +120,7 @@ export default function CommunityPageView({ communityRef }: Props) {
                 </StyledDescriptionWrapper>
               )}
             </VStack>
-            {externalAddressLink && externalAddressLink && (
+            {externalAddressLink && (
               <StyledAddressContainer>
                 <TitleXS>Contract Address</TitleXS>
                 <InteractiveLink href={externalAddressLink}>

--- a/apps/web/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -9,15 +9,17 @@ import breakpoints from '~/components/core/breakpoints';
 import TextButton from '~/components/core/Button/TextButton';
 import colors from '~/components/core/colors';
 import { DisplayLayout } from '~/components/core/enums';
+import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import Markdown from '~/components/core/Markdown/Markdown';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM, TitleL } from '~/components/core/Text/Text';
+import { BaseM, TitleL, TitleXS } from '~/components/core/Text/Text';
 import MemberListFilter from '~/components/TokenHolderList/TokenHolderListFilter';
 import { GRID_ENABLED_COMMUNITY_ADDRESSES } from '~/constants/community';
 import MemberListPageProvider from '~/contexts/memberListPage/MemberListPageContext';
 import { CommunityPageViewFragment$key } from '~/generated/CommunityPageViewFragment.graphql';
 import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import formatUrl from '~/utils/formatUrl';
+import { truncateAddress } from '~/utils/wallet';
 
 import LayoutToggleButton from './LayoutToggleButton';
 
@@ -32,6 +34,7 @@ export default function CommunityPageView({ communityRef }: Props) {
         name
         description
         badgeURL
+        chain
         contractAddress {
           address
         }
@@ -76,28 +79,54 @@ export default function CommunityPageView({ communityRef }: Props) {
 
   const formattedDescription = formatUrl(description || '');
 
+  const externalAddressLink = useMemo(() => {
+    if (!contractAddress?.address) {
+      return null;
+    }
+
+    if (community.chain === 'Ethereum') {
+      return `https://etherscan.io/address/${contractAddress.address}`;
+    } else if (community.chain === 'Tezos') {
+      return `https://tzkt.io/${contractAddress.address}`;
+    }
+    return null;
+  }, [community.chain, contractAddress?.address]);
+
   return (
     <MemberListPageProvider>
       <StyledCommunityPageContainer>
         <HStack>
-          <StyledHeader>
-            <HStack gap={12} align="center">
-              <TitleL>{name}</TitleL>
-              {badgeURL && <StyledBadge src={badgeURL} />}
-            </HStack>
+          <StyledHeader gap={24}>
+            <VStack>
+              <HStack gap={12} align="center">
+                <TitleL>{name}</TitleL>
+                {badgeURL && <StyledBadge src={badgeURL} />}
+              </HStack>
 
-            {description && (
-              <StyledDescriptionWrapper gap={8}>
-                <StyledBaseM showExpandedDescription={showExpandedDescription} ref={descriptionRef}>
-                  <Markdown text={formattedDescription} />
-                </StyledBaseM>
-                {isLineClampEnabled && (
-                  <TextButton
-                    text={showExpandedDescription ? 'Show less' : 'Show More'}
-                    onClick={handleShowMoreClick}
-                  />
-                )}
-              </StyledDescriptionWrapper>
+              {description && (
+                <StyledDescriptionWrapper gap={8}>
+                  <StyledBaseM
+                    showExpandedDescription={showExpandedDescription}
+                    ref={descriptionRef}
+                  >
+                    <Markdown text={formattedDescription} />
+                  </StyledBaseM>
+                  {isLineClampEnabled && (
+                    <TextButton
+                      text={showExpandedDescription ? 'Show less' : 'Show More'}
+                      onClick={handleShowMoreClick}
+                    />
+                  )}
+                </StyledDescriptionWrapper>
+              )}
+            </VStack>
+            {externalAddressLink && externalAddressLink && (
+              <StyledAddressContainer>
+                <TitleXS>Contract Address</TitleXS>
+                <InteractiveLink href={externalAddressLink}>
+                  {truncateAddress(contractAddress?.address ?? '')}
+                </InteractiveLink>
+              </StyledAddressContainer>
             )}
           </StyledHeader>
 
@@ -156,8 +185,12 @@ const StyledListWrapper = styled.div`
   width: 100%;
 `;
 
-const StyledHeader = styled.div`
+const StyledHeader = styled(VStack)`
   width: 100%;
+`;
+
+const StyledAddressContainer = styled(VStack)`
+  width: fit-content;
 `;
 
 const StyledLayoutToggleButtonContainer = styled.div`


### PR DESCRIPTION
## Description
This PR adds the contract address to the community page so that it's easier for the user to verify that the community page they're viewing is for the contract they expect.



For now, we show the address and link to the appropriate explorer (etherscan / tzkt) depending on chain. We won't show a link for POAP since Poap's website uses an event ID instead of contract name/address, so we can add that as a follow up.

Ethereum: (with description)
![Screen Shot 2023-03-14 at 17 40 46](https://user-images.githubusercontent.com/80802871/224945370-8cb4a7cd-d0da-4e58-a734-e000005d3a38.png)

Tezos: (without description)
![Screen Shot 2023-03-14 at 17 40 42](https://user-images.githubusercontent.com/80802871/224945473-737b65ba-8669-4b1c-a08a-6f5e8390b343.png)

POAP
don't show anything
![Screen Shot 2023-03-14 at 17 40 40](https://user-images.githubusercontent.com/80802871/224945534-c1caa4f6-5623-46a7-9760-ea91492275c7.png)

Looks good on mobile
![Screen Shot 2023-03-14 at 17 40 57](https://user-images.githubusercontent.com/80802871/224945619-6fac681e-15e6-41b0-87a7-3504b1d0ac51.png)
