### PR TITLE
[GAL-2492] [GAL-1150] Fix failed NFT on Feed

### DIFF
--- a/apps/web/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
+++ b/apps/web/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
@@ -86,8 +86,8 @@ function FeedEventNftPreviewWrapper({ tokenRef, maxWidth, maxHeight }: Props) {
 const StyledNftPreviewWrapper = styled.div<{ maxWidth: number; maxHeight: number }>`
   display: flex;
   width: 100%;
-
-  min-width: 150px;
+  max-height: ${({ maxHeight }) => maxHeight}px;
+  min-width: ${({ maxWidth }) => maxWidth ?? 150}px;
 
   ${StyledImageWithLoading}, ${StyledVideo} {
     max-height: calc((100vw - 64px) / 3);

--- a/apps/web/src/components/Feed/Socialize/Interactions.tsx
+++ b/apps/web/src/components/Feed/Socialize/Interactions.tsx
@@ -147,9 +147,11 @@ export function Interactions({ eventRef, queryRef, onPotentialLayoutShift }: Pro
 
       return (
         <VStack gap={8}>
-          {lastTwoComments.map((comment) => {
-            return <CommentLine key={comment.dbid} commentRef={comment} />;
-          })}
+          <VStack>
+            {lastTwoComments.map((comment) => {
+              return <CommentLine key={comment.dbid} commentRef={comment} />;
+            })}
+          </VStack>
 
           <RemainingAdmireCount remainingCount={remainingAdmiresAndComments} eventRef={event} />
         </VStack>

--- a/apps/web/src/components/NftFailureFallback/NftFailureFallback.tsx
+++ b/apps/web/src/components/NftFailureFallback/NftFailureFallback.tsx
@@ -17,13 +17,17 @@ type Props = {
 };
 
 export function NftFailureFallback({ onRetry, refreshing, size = 'medium' }: Props) {
-  const handleClick = useCallback(() => {
-    if (refreshing) {
-      return;
-    }
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      event.preventDefault();
+      if (refreshing) {
+        return;
+      }
 
-    onRetry?.();
-  }, [onRetry, refreshing]);
+      onRetry?.();
+    },
+    [onRetry, refreshing]
+  );
 
   const handleMouseDown = useCallback<MouseEventHandler>((event) => {
     // Have to do this to stop messing with Drag & Drop stuff


### PR DESCRIPTION
**Changes**

- Refresh button not clickable from feed & shouldn't redirect to collection page
- Broken NFT state looks too big on mobile feed



**Refresh button not clickable from feed**

**Before**

https://user-images.githubusercontent.com/4480258/225192756-20b3a4a3-a8b2-4d93-b2ae-07edddfaa225.mp4


**After**

https://user-images.githubusercontent.com/4480258/225192789-6d4a9e8d-7969-41b4-8edc-8f1d5e0c011d.mp4

**Broken NFT state looks too big on mobile feed**

**Before**

![CleanShot 2023-03-15 at 10 44 54](https://user-images.githubusercontent.com/4480258/225192345-651ce8e1-f57a-4388-9994-955d59465ffb.png)


**After**

![CleanShot 2023-03-15 at 10 44 14](https://user-images.githubusercontent.com/4480258/225192303-628ec728-5f84-4ac5-a883-9610abab2ccd.png)
