### PR TITLE
Remove done footer from settings and make Search closable when clicking the icon

### DIFF
--- a/apps/web/src/components/Settings/Settings.tsx
+++ b/apps/web/src/components/Settings/Settings.tsx
@@ -15,7 +15,6 @@ import ManageWallets from '~/components/ManageWallets/ManageWallets';
 import TwitterSetting from '~/components/Twitter/TwitterSetting';
 import { GALLERY_DISCORD } from '~/constants/urls';
 import DrawerHeader from '~/contexts/globalLayout/GlobalSidebar/DrawerHeader';
-import { useDrawerActions } from '~/contexts/globalLayout/GlobalSidebar/SidebarDrawerContext';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { SettingsFragment$key } from '~/generated/SettingsFragment.graphql';
 import { useLogout } from '~/hooks/useLogout';
@@ -176,16 +175,9 @@ function Settings({ newAddress, queryRef, onEthAddWalletSuccess, onTezosAddWalle
     logout();
   }, [logout]);
 
-  const { hideDrawer } = useDrawerActions();
-
-  const handleDoneClick = useCallback(() => {
-    hideDrawer();
-  }, [hideDrawer]);
-
   return (
     <>
       <DrawerHeader headerText="Settings" />
-
       <StyledContentWrapper>
         <StyledSettings gap={12}>
           <SettingsContents gap={32}>
@@ -273,9 +265,6 @@ function Settings({ newAddress, queryRef, onEthAddWalletSuccess, onTezosAddWalle
           </SettingsContents>
         </StyledSettings>
       </StyledContentWrapper>
-      <StyledFooter align="center" justify="flex-end">
-        <DoneButton onClick={handleDoneClick}>Done</DoneButton>
-      </StyledFooter>
     </>
   );
 }
@@ -311,19 +300,6 @@ const StyledContentWrapper = styled.div`
   overflow-x: hidden;
   overscroll-behavior: contain;
   height: 100%;
-`;
-
-const DoneButton = styled(Button)`
-  align-self: flex-end;
-`;
-
-const StyledFooter = styled(HStack)`
-  width: 100%;
-  background-color: ${colors.offWhite};
-  position: absolute;
-  display: flex;
-  bottom: 0;
-  padding: 12px 16px;
 `;
 
 export default Settings;

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
@@ -145,12 +145,11 @@ export function StandardSidebar({ queryRef }: Props) {
   }, [hideDrawer, track]);
 
   const handleSearchClick = useCallback(() => {
-    hideDrawer();
     track('Sidebar Search Click');
     showDrawer({
       content: <Search />,
     });
-  }, [hideDrawer, showDrawer, track]);
+  }, [showDrawer, track]);
 
   const isMobile = useIsMobileOrMobileLargeWindowWidth();
 


### PR DESCRIPTION
## Description

- Remove "Done" footer from Settings sidebar drawer


- fix Search icon button so that clicking it when Search is open, closes the drawer



before: (settings)
<img width="620" alt="Screen Shot 2023-03-16 at 13 42 16" src="https://user-images.githubusercontent.com/80802871/225516525-fd9a16ab-d6e9-459a-a7c4-0f8e059285ae.png">


after: (settings)
<img width="695" alt="Screen Shot 2023-03-16 at 13 42 02" src="https://user-images.githubusercontent.com/80802871/225516535-19e9856b-d0bb-43c8-be9b-4f8023afcfaf.png">

