### PR TITLE
[GAL-2619] [GAL-2620] fix paste link bugs

### DIFF
--- a/apps/web/src/components/core/Markdown/Link.tsx
+++ b/apps/web/src/components/core/Markdown/Link.tsx
@@ -22,16 +22,16 @@ export default function Bold({
 
     const selectedText = textArea.value.substring(start, end);
 
-    // If the user clicks an empty link, remove the [](https://)
-    if (textArea.value.substring(start - 1, end + 11) === '[](https://)') {
+    // If the user clicks an empty link, remove the [](url)
+    if (textArea.value.substring(start - 1, end + 11) === '[](url)') {
       const newText =
         textArea.value.substring(0, start - 1) +
         textArea.value.substring(end + 11, textArea.value.length);
       setValueAndTriggerOnChange(textArea, newText, [start - 1, start - 1]);
       return;
     }
-    // If user is at the end of (https://), they probably just clicked the link button.
-    // Removing the [text](https://) would be difficult because [text] can be any number of chars. For now, just return
+    // If user is at the end of (url), they probably just clicked the link button.
+    // Removing the [text](url) would be difficult because [text] can be any number of chars. For now, just return
     if (textArea.value.substring(start - 1, end + 1) == '/)') {
       return;
     }
@@ -39,18 +39,18 @@ export default function Bold({
       // If the user has selected text, add a link around it
       const newText =
         textArea.value.substring(0, start) +
-        `[${selectedText}](https://)` +
+        `[${selectedText}](url)` +
         textArea.value.substring(end);
       setValueAndTriggerOnChange(textArea, newText, [
         start + 11 + selectedText.length,
         start + 11 + selectedText.length,
-      ]); // Link [0, 4] -> [Link](https://) (end)
+      ]); // Link [0, 4] -> [Link](url) (end)
       return;
     }
     if (!selectedText) {
       // If there is no selected text, just add a link where the cursor is and place the cursor in middle
       const newText =
-        textArea.value.substring(0, start) + '[](https://)' + textArea.value.substring(end);
+        textArea.value.substring(0, start) + '[](url)' + textArea.value.substring(end);
       setValueAndTriggerOnChange(textArea, newText, [start + 1, start + 1]); // [0, 0] -> []() ([1, 1])
       return;
     }

--- a/apps/web/src/components/core/Markdown/MarkdownShortcuts.test.tsx
+++ b/apps/web/src/components/core/Markdown/MarkdownShortcuts.test.tsx
@@ -90,7 +90,7 @@ describe('MarkdownShortcuts', () => {
       fireEvent.click(linkIcon);
     }
 
-    const message = screen.getByDisplayValue('[](https://)');
+    const message = screen.getByDisplayValue('[](url)');
     expect(message).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Description
This PR fixes 2 bugs with the markdown text editor - specifically the link functionality.

**Bug 1: Pasting a link into the text editor deletes text that follows** [GAL-2619](https://linear.app/galleryso/issue/GAL-2619/pasting-a-link-into-the-text-editor-deletes-text-that-follows)

before

https://user-images.githubusercontent.com/80802871/225652221-660789bc-4ecf-4010-a9cd-456f03c840df.mp4


after

https://user-images.githubusercontent.com/80802871/225652264-859de658-d464-4b22-a555-ca30ac7b2637.mp4





**Bug 2: Pasting a link into the url portion of the markdown format** []() adds more markdown [GAL-2620](https://linear.app/galleryso/issue/GAL-2620/pasting-a-link-into-the-url-portion-of-the-markdown-format-[]-adds)


before

https://user-images.githubusercontent.com/80802871/225652335-3d8d5266-7804-427f-8a40-b09fbbcd65a0.mp4



after

https://user-images.githubusercontent.com/80802871/225652417-c7dd948d-5630-4e44-890d-dd2d3faa5020.mp4






**Improvement:**

I also changed the placeholder text when you add a markdown link from ()[https://] to ()[url] .
you can double click and select `url` to replace the text, which you can't with `https://`, making the value easier to replace.

`url` is also equally explicit to the user that that's where the url should go, so we shouldn't sacrifice any communication from this change