### PR TITLE
add special msg for community page for disabled contracts

### DIFF
--- a/apps/web/pages/community/[contractAddress]/index.tsx
+++ b/apps/web/pages/community/[contractAddress]/index.tsx
@@ -14,7 +14,6 @@ import { MetaTagProps } from '~/pages/_app';
 import GalleryRedirect from '~/scenes/_Router/GalleryRedirect';
 import GalleryRoute from '~/scenes/_Router/GalleryRoute';
 import CommunityPageScene from '~/scenes/CommunityPage/CommunityPage';
-import { DISABLED_CONTRACTS } from '~/utils/getCommunityUrlForToken';
 
 type CommunityPageProps = MetaTagProps & {
   contractAddress: string;
@@ -53,10 +52,6 @@ export default function CommunityPage({ contractAddress }: CommunityPageProps) {
 
   if (!contractAddress) {
     // Something went horribly wrong
-    return <GalleryRedirect to={{ pathname: '/' }} />;
-  }
-
-  if (DISABLED_CONTRACTS.includes(contractAddress)) {
     return <GalleryRedirect to={{ pathname: '/' }} />;
   }
 

--- a/apps/web/src/scenes/CommunityPage/CommunityPageDisabled.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageDisabled.tsx
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
+import { VStack } from '~/components/core/Spacer/Stack';
+import { BaseM, TitleDiatypeM } from '~/components/core/Text/Text';
+import { GALLERY_DISCORD, GALLERY_TWITTER } from '~/constants/urls';
+
+type Props = {
+  name: string;
+};
+
+export default function CommunityPageDisabled({ name }: Props) {
+  return (
+    <StyledDisabledSection align="center" justify="center" gap={16}>
+      <TitleDiatypeM>Coming Soon</TitleDiatypeM>
+
+      <BaseM>
+        We are working to enable community pages for individual projects under the {name} contract.
+      </BaseM>
+      <BaseM>
+        Be the first to know when it's available by joining us on{' '}
+        <InteractiveLink href={GALLERY_DISCORD}>Discord</InteractiveLink> or{' '}
+        <InteractiveLink href={GALLERY_TWITTER}>Twitter</InteractiveLink>.
+      </BaseM>
+      <BaseM>
+        <InteractiveLink to={{ pathname: '/trending' }}>Back to home</InteractiveLink>
+      </BaseM>
+    </StyledDisabledSection>
+  );
+}
+
+const StyledDisabledSection = styled(VStack)`
+  margin-top: 20vh; // position a bit higher than the center
+
+  text-align: center;
+`;

--- a/apps/web/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -19,8 +19,10 @@ import MemberListPageProvider from '~/contexts/memberListPage/MemberListPageCont
 import { CommunityPageViewFragment$key } from '~/generated/CommunityPageViewFragment.graphql';
 import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import formatUrl from '~/utils/formatUrl';
+import { DISABLED_CONTRACTS } from '~/utils/getCommunityUrlForToken';
 import { getExternalAddressLink, truncateAddress } from '~/utils/wallet';
 
+import CommunityPageDisabled from './CommunityPageDisabled';
 import LayoutToggleButton from './LayoutToggleButton';
 
 type Props = {
@@ -49,17 +51,21 @@ export default function CommunityPageView({ communityRef }: Props) {
   const { name, description, contractAddress, badgeURL } = community;
   const isMobile = useIsMobileWindowWidth();
 
-  const [layout, setLayout] = useState<DisplayLayout>(DisplayLayout.GRID);
-  const isGrid = useMemo(() => layout === DisplayLayout.GRID, [layout]);
-
   if (!contractAddress) {
     throw new Error('CommunityPageView: contractAddress not found on community');
   }
 
-  const isArtGobbler = useMemo(
+  const isGridEnabled = useMemo(
     () => GRID_ENABLED_COMMUNITY_ADDRESSES.includes(contractAddress.address || ''),
     [contractAddress.address]
   );
+  const [layout, setLayout] = useState<DisplayLayout>(DisplayLayout.GRID);
+  const showGrid = useMemo(
+    () => isGridEnabled && layout === DisplayLayout.GRID,
+    [isGridEnabled, layout]
+  );
+
+  const isCommunityPageDisabled = DISABLED_CONTRACTS.includes(contractAddress.address ?? '');
 
   // whether "Show More" has been clicked or not
   const [showExpandedDescription, setShowExpandedDescription] = useState(false);
@@ -123,14 +129,16 @@ export default function CommunityPageView({ communityRef }: Props) {
             )}
           </StyledHeader>
 
-          {isArtGobbler && (
+          {isGridEnabled && (
             <StyledLayoutToggleButtonContainer>
               <LayoutToggleButton layout={layout} setLayout={setLayout} />
             </StyledLayoutToggleButtonContainer>
           )}
         </HStack>
 
-        {isGrid && isArtGobbler ? (
+        {isCommunityPageDisabled ? (
+          <CommunityPageDisabled name={name ?? ''} />
+        ) : showGrid ? (
           <StyledGridViewContainer gap={24}>
             <StyledBreakLine />
             <StyledListWrapper>

--- a/apps/web/src/utils/getCommunityUrlForToken.ts
+++ b/apps/web/src/utils/getCommunityUrlForToken.ts
@@ -6,6 +6,8 @@ import { getCommunityUrlForTokenFragment$key } from '~/generated/getCommunityUrl
 
 export const DISABLED_CONTRACTS = [
   '0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270', // Art Blocks
+  '0x059edd72cd353df5106d2b9cc5ab83a52287ac3a', // Art Blocks
+  '0x99a9b7c1116f9ceeb1652de04d5969cce509b069', // Art Blocks
   '0x495f947276749ce646f68ac8c248420045cb7b5e', // OS
   '0xf6793da657495ffeff9ee6350824910abc21356c', // Rarible
   '0x3b3ee1931dc30c1957379fac9aba94d1c48a5405', // Foundation


### PR DESCRIPTION
We currently automatically redirect home from the community page if the contract is in the disabled list.
We disable umbrella contracts since we don't support sub collections yet.


Since we're surfacing the community page in more places now, the redirect leads to a poor+confusing experience. instead of disabling the page entirely, we'll show a message informing the user the page isn't available yet.


![Screen Shot 2023-03-17 at 14 00 17](https://user-images.githubusercontent.com/80802871/225816892-6b548bd3-0e96-4a01-a466-bbc6f21109ad.png)
![Screen Shot 2023-03-17 at 14 00 22](https://user-images.githubusercontent.com/80802871/225816895-2e27ca40-ad51-4142-b65f-437a746a1d2c.png)
