### PR TITLE
Show shared communities on user hover card

### DIFF
--- a/apps/web/src/components/HoverCard/HoverCard.tsx
+++ b/apps/web/src/components/HoverCard/HoverCard.tsx
@@ -11,7 +11,7 @@ import { BaseM, TitleM } from '~/components/core/Text/Text';
 import FollowButton from '~/components/Follow/FollowButton';
 import { HoverCardQuery } from '~/generated/HoverCardQuery.graphql';
 import { useLoggedInUserId } from '~/hooks/useLoggedInUserId';
-import UserSharedInfo from '~/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfo';
+import UserSharedCommunities from '~/scenes/UserGalleryPage/UserSharedInfo/UserSharedCommunities';
 import { ErrorWithSentryMetadata } from '~/shared/errors/ErrorWithSentryMetadata';
 import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 
@@ -24,8 +24,6 @@ export const HoverCardQueryNode = graphql`
     $userId: DBID!
     $sharedCommunitiesFirst: Int
     $sharedCommunitiesAfter: String
-    $sharedFollowersFirst: Int
-    $sharedFollowersAfter: String
   ) {
     userById(id: $userId) @required(action: THROW) {
       ... on GalleryUser {
@@ -39,7 +37,7 @@ export const HoverCardQueryNode = graphql`
           ...BadgeFragment
         }
         ...FollowButtonUserFragment
-        ...UserSharedInfoFragment
+        ...UserSharedCommunitiesFragment
       }
     }
 
@@ -110,7 +108,7 @@ export function HoverCard({ preloadedQuery }: HoverCardProps) {
           </BaseM>
         </StyledCardDescription>
       )}
-      {isLoggedIn && !isOwnProfile && <UserSharedInfo userRef={user} showFollowers={false} />}
+      {isLoggedIn && !isOwnProfile && <UserSharedCommunities queryRef={user} />}
     </>
   );
 }

--- a/apps/web/src/components/HoverCard/HoverCard.tsx
+++ b/apps/web/src/components/HoverCard/HoverCard.tsx
@@ -82,7 +82,6 @@ export function HoverCard({ preloadedQuery }: HoverCardProps) {
   return (
     <>
       <StyledCardHeader align="center" gap={4}>
-        {/* <HStack align="center" gap={4}> */}
         <StyledUsernameAndBadge align="center" gap={4}>
           <StyledCardUsername>{displayName}</StyledCardUsername>
 

--- a/apps/web/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -27,8 +27,12 @@ import {
 import { HoverCard, HoverCardQueryNode } from '~/components/HoverCard/HoverCard';
 import { HoverCardOnUsernameFragment$key } from '~/generated/HoverCardOnUsernameFragment.graphql';
 import { HoverCardQuery } from '~/generated/HoverCardQuery.graphql';
+import { COMMUNITIES_PER_PAGE } from '~/scenes/UserGalleryPage/UserSharedInfo/UserSharedCommunities';
+import { FOLLOWERS_PER_PAGE } from '~/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList';
 import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 import noop from '~/utils/noop';
+
+import breakpoints, { pageGutter } from '../core/breakpoints';
 
 const HOVER_POPUP_DELAY = 100;
 
@@ -81,7 +85,11 @@ export default function HoverCardOnUsername({ children, userRef, onClick = noop 
 
   useEffect(() => {
     if (isHovering) {
-      preloadHoverCardQuery({ userId: user.dbid });
+      preloadHoverCardQuery({
+        userId: user.dbid,
+        sharedCommunitiesFirst: COMMUNITIES_PER_PAGE,
+        sharedFollowersFirst: FOLLOWERS_PER_PAGE,
+      });
     }
   }, [preloadHoverCardQuery, user.dbid, isHovering]);
 
@@ -102,34 +110,32 @@ export default function HoverCardOnUsername({ children, userRef, onClick = noop 
       <AnimatePresence>
         {isHovering && preloadedHoverCardQuery && (
           <FloatingFocusManager context={context} modal={false}>
-            <Link href={userProfileLink}>
-              <StyledCardWrapper
-                className="Popover"
-                aria-labelledby={headingId}
-                // Floating UI Props
-                ref={floating}
-                style={{
-                  position: strategy,
-                  top: y ?? 0,
-                  left: x ?? 0,
-                }}
-                {...getFloatingProps()}
-                // Framer Motion Props
-                transition={{
-                  duration: ANIMATED_COMPONENT_TRANSITION_S,
-                  ease: rawTransitions.cubicValues,
-                }}
-                initial={{ opacity: 0, y: 0 }}
-                animate={{ opacity: 1, y: ANIMATED_COMPONENT_TRANSLATION_PIXELS_SMALL }}
-                exit={{ opacity: 0, y: 0 }}
-              >
-                <StyledCardContainer>
-                  <Suspense fallback={null}>
-                    <HoverCard preloadedQuery={preloadedHoverCardQuery} />
-                  </Suspense>
-                </StyledCardContainer>
-              </StyledCardWrapper>
-            </Link>
+            <StyledCardWrapper
+              className="Popover"
+              aria-labelledby={headingId}
+              // Floating UI Props
+              ref={floating}
+              style={{
+                position: strategy,
+                top: y ?? 0,
+                left: x ?? 0,
+              }}
+              {...getFloatingProps()}
+              // Framer Motion Props
+              transition={{
+                duration: ANIMATED_COMPONENT_TRANSITION_S,
+                ease: rawTransitions.cubicValues,
+              }}
+              initial={{ opacity: 0, y: 0 }}
+              animate={{ opacity: 1, y: ANIMATED_COMPONENT_TRANSLATION_PIXELS_SMALL }}
+              exit={{ opacity: 0, y: 0 }}
+            >
+              <StyledCardContainer>
+                <Suspense fallback={null}>
+                  <HoverCard preloadedQuery={preloadedHoverCardQuery} />
+                </Suspense>
+              </StyledCardContainer>
+            </StyledCardWrapper>
           </FloatingFocusManager>
         )}
       </AnimatePresence>
@@ -141,9 +147,14 @@ const StyledCardContainer = styled.div`
   border: 1px solid ${colors.offBlack};
   padding: 16px;
   width: 375px;
+  max-width: calc(100vw - ${pageGutter.mobile * 2}px);
   display: grid;
   gap: 8px;
   background-color: ${colors.white};
+
+  @media only screen and ${breakpoints.desktop} {
+    max-width: initial;
+  }
 `;
 
 const StyledLink = styled(Link)`
@@ -161,7 +172,7 @@ const StyledCardWrapper = styled(motion.div)`
 const StyledContainer = styled.span`
   position: relative;
   display: inline-grid;
-  cursor: pointer;
+  cursor: initial;
 `;
 
 const StyledLinkContainer = styled.div`

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedCommunities.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedCommunities.tsx
@@ -118,18 +118,12 @@ export default function UserSharedCommunities({ queryRef }: Props) {
   }
 
   return (
-    <StyledSharedCommunities>
+    <div>
       <StyledBaseS>Also holds&nbsp;</StyledBaseS>
       {content}
-    </StyledSharedCommunities>
+    </div>
   );
 }
-
-const StyledSharedCommunities = styled.div`
-  p {
-    display: inline-block; // allow for line breaks
-  }
-`;
 
 const StyledInteractiveLink = styled(InteractiveLink)`
   font-size: 12px;

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedCommunities.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedCommunities.tsx
@@ -3,7 +3,6 @@ import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
-import { HStack } from '~/components/core/Spacer/Stack';
 import { BaseS } from '~/components/core/Text/Text';
 import { useTrack } from '~/contexts/analytics/AnalyticsContext';
 import { useModalActions } from '~/contexts/modal/ModalContext';
@@ -119,16 +118,21 @@ export default function UserSharedCommunities({ queryRef }: Props) {
   }
 
   return (
-    <HStack align="center" wrap="wrap">
+    <StyledSharedCommunities>
       <StyledBaseS>Also holds&nbsp;</StyledBaseS>
       {content}
-    </HStack>
+    </StyledSharedCommunities>
   );
 }
 
+const StyledSharedCommunities = styled.div`
+  p {
+    display: inline-block; // allow for line breaks
+  }
+`;
+
 const StyledInteractiveLink = styled(InteractiveLink)`
   font-size: 12px;
-  white-space: nowrap;
 `;
 
 const StyledBaseS = styled(BaseS)`

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedFollowers.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedFollowers.tsx
@@ -3,7 +3,6 @@ import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
-import { HStack } from '~/components/core/Spacer/Stack';
 import { BaseS } from '~/components/core/Text/Text';
 import { useTrack } from '~/contexts/analytics/AnalyticsContext';
 import { useModalActions } from '~/contexts/modal/ModalContext';
@@ -111,16 +110,15 @@ export default function UserSharedFollowers({ queryRef }: Props) {
   }
 
   return (
-    <HStack align="center" wrap="wrap">
+    <div>
       <StyledBaseS>Followed by&nbsp;</StyledBaseS>
       {content}
-    </HStack>
+    </div>
   );
 }
 
 const StyledInteractiveLink = styled(InteractiveLink)`
   font-size: 12px;
-  white-space: nowrap;
 `;
 
 const StyledBaseS = styled(BaseS)`

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfo.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfo.tsx
@@ -9,10 +9,9 @@ import UserSharedFollowers from './UserSharedFollowers';
 
 type Props = {
   userRef: UserSharedInfoFragment$key;
-  showFollowers?: boolean;
 };
 
-export default function UserSharedInfo({ userRef, showFollowers = true }: Props) {
+export default function UserSharedInfo({ userRef }: Props) {
   const query = useFragment(
     graphql`
       fragment UserSharedInfoFragment on GalleryUser {
@@ -27,7 +26,7 @@ export default function UserSharedInfo({ userRef, showFollowers = true }: Props)
   return (
     <StyledUserSharedInfo>
       <UserSharedCommunities queryRef={query} />
-      {showFollowers && <UserSharedFollowers queryRef={query} />}
+      <UserSharedFollowers queryRef={query} />
     </StyledUserSharedInfo>
   );
 }

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfo.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfo.tsx
@@ -9,9 +9,10 @@ import UserSharedFollowers from './UserSharedFollowers';
 
 type Props = {
   userRef: UserSharedInfoFragment$key;
+  showFollowers?: boolean;
 };
 
-export default function UserSharedInfo({ userRef }: Props) {
+export default function UserSharedInfo({ userRef, showFollowers = true }: Props) {
   const query = useFragment(
     graphql`
       fragment UserSharedInfoFragment on GalleryUser {
@@ -26,7 +27,7 @@ export default function UserSharedInfo({ userRef }: Props) {
   return (
     <StyledUserSharedInfo>
       <UserSharedCommunities queryRef={query} />
-      <UserSharedFollowers queryRef={query} />
+      {showFollowers && <UserSharedFollowers queryRef={query} />}
     </StyledUserSharedInfo>
   );
 }

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfo.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfo.tsx
@@ -31,4 +31,8 @@ export default function UserSharedInfo({ userRef }: Props) {
   );
 }
 
-const StyledUserSharedInfo = styled(VStack)``;
+const StyledUserSharedInfo = styled(VStack)`
+  p {
+    display: inline-block; // allow for line breaks
+  }
+`;


### PR DESCRIPTION
## Description

This PR adds shared communities ("Also owns xyz") to the user hover cards on the feed.
It also removes the Collection Count from the card as well to reduce text, and removes the wrapping Link so that only clicking the username navigates to the bio instead of the whole card.

Before
![Screenshot 2023-03-24 at 20 33 35](https://user-images.githubusercontent.com/80802871/227510755-aedb78d1-39e0-4362-8505-10632e65a7bb.png)

After
![Screenshot 2023-03-24 at 20 54 50](https://user-images.githubusercontent.com/80802871/227515263-bc5880c0-28ce-412f-afb4-8f9343ff5e71.png)




The text wraps if it's longer than the card max width.

![Screenshot 2023-03-24 at 20 55 00](https://user-images.githubusercontent.com/80802871/227515283-cbf855a0-1a77-4219-b859-90dafe79f9ff.png)



there are a few other small improvements as well:

- **let username take up as much space as possible:**
before
![Screenshot 2023-03-24 at 20 23 58](https://user-images.githubusercontent.com/80802871/227508905-06cdca7c-d2ab-4f4a-a522-e46fb39baa6d.png)

after
![Screenshot 2023-03-24 at 20 56 44](https://user-images.githubusercontent.com/80802871/227515319-57f2fd17-01aa-4c88-82cc-6653fca2be79.png)




- **fit card on screen on mobile**
Before:
![Screenshot 2023-03-24 at 20 24 47](https://user-images.githubusercontent.com/80802871/227509089-1950a20f-b764-4832-9232-a3b271082f1a.png)


After
![Screenshot 2023-03-24 at 20 57 07](https://user-images.githubusercontent.com/80802871/227515352-333ea7d9-992e-418e-af5e-778eb8e79da2.png)
