### PR TITLE
Feed Perf: Give first slide images higher download priority

### DIFF
--- a/apps/mobile/src/components/Feed/CollectionCreatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/CollectionCreatedFeedEvent.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { View } from 'react-native';
+import FastImage from 'react-native-fast-image';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -12,11 +13,13 @@ import { FeedEventCarouselCellHeader } from './FeedEventCarouselCellHeader';
 import { FeedListCollectorsNote } from './FeedListCollectorsNote';
 
 type CollectionCreatedFeedEventProps = {
+  isFirstSlide: boolean;
   allowPreserveAspectRatio: boolean;
   collectionUpdatedFeedEventDataRef: CollectionCreatedFeedEventFragment$key;
 };
 
 export function CollectionCreatedFeedEvent({
+  isFirstSlide,
   allowPreserveAspectRatio,
   collectionUpdatedFeedEventDataRef,
 }: CollectionCreatedFeedEventProps) {
@@ -58,7 +61,11 @@ export function CollectionCreatedFeedEvent({
         <FeedListCollectorsNote collectorsNote={eventData.collection.collectorsNote} />
       )}
 
-      <EventTokenGrid allowPreserveAspectRatio={allowPreserveAspectRatio} tokenRefs={tokens} />
+      <EventTokenGrid
+        imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
+        allowPreserveAspectRatio={allowPreserveAspectRatio}
+        tokenRefs={tokens}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/CollectionUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/CollectionUpdatedFeedEvent.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { View } from 'react-native';
+import FastImage from 'react-native-fast-image';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -12,11 +13,13 @@ import { FeedEventCarouselCellHeader } from './FeedEventCarouselCellHeader';
 import { FeedListCollectorsNote } from './FeedListCollectorsNote';
 
 type CollectionUpdatedFeedEventProps = {
+  isFirstSlide: boolean;
   allowPreserveAspectRatio: boolean;
   collectionUpdatedFeedEventDataRef: CollectionUpdatedFeedEventFragment$key;
 };
 
 export function CollectionUpdatedFeedEvent({
+  isFirstSlide,
   allowPreserveAspectRatio,
   collectionUpdatedFeedEventDataRef,
 }: CollectionUpdatedFeedEventProps) {
@@ -59,7 +62,11 @@ export function CollectionUpdatedFeedEvent({
         <FeedListCollectorsNote collectorsNote={eventData.newCollectorsNote} />
       )}
 
-      <EventTokenGrid allowPreserveAspectRatio={allowPreserveAspectRatio} tokenRefs={tokens} />
+      <EventTokenGrid
+        imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
+        allowPreserveAspectRatio={allowPreserveAspectRatio}
+        tokenRefs={tokens}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { View } from 'react-native';
+import FastImage from 'react-native-fast-image';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -12,11 +13,13 @@ import { FeedEventCarouselCellHeader } from './FeedEventCarouselCellHeader';
 import { FeedListCollectorsNote } from './FeedListCollectorsNote';
 
 type CollectorsNoteAddedToCollectionFeedEventProps = {
+  isFirstSlide: boolean;
   allowPreserveAspectRatio: boolean;
   collectionUpdatedFeedEventDataRef: CollectorsNoteAddedToCollectionFeedEventFragment$key;
 };
 
 export function CollectorsNoteAddedToCollectionFeedEvent({
+  isFirstSlide,
   allowPreserveAspectRatio,
   collectionUpdatedFeedEventDataRef,
 }: CollectorsNoteAddedToCollectionFeedEventProps) {
@@ -61,7 +64,11 @@ export function CollectorsNoteAddedToCollectionFeedEvent({
         <FeedListCollectorsNote collectorsNote={eventData.newCollectorsNote} />
       )}
 
-      <EventTokenGrid allowPreserveAspectRatio={allowPreserveAspectRatio} tokenRefs={tokens} />
+      <EventTokenGrid
+        imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
+        allowPreserveAspectRatio={allowPreserveAspectRatio}
+        tokenRefs={tokens}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/EventTokenGrid.tsx
+++ b/apps/mobile/src/components/Feed/EventTokenGrid.tsx
@@ -1,6 +1,7 @@
 import { ResizeMode } from 'expo-av';
 import { useMemo } from 'react';
 import { useWindowDimensions, View } from 'react-native';
+import { Priority } from 'react-native-fast-image';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -9,11 +10,16 @@ import { EventTokenGridFragment$key } from '~/generated/EventTokenGridFragment.g
 import { NftPreview } from '../NftPreview';
 
 type EventTokenGridProps = {
+  imagePriority: Priority;
   allowPreserveAspectRatio: boolean;
   tokenRefs: EventTokenGridFragment$key;
 };
 
-export function EventTokenGrid({ tokenRefs, allowPreserveAspectRatio }: EventTokenGridProps) {
+export function EventTokenGrid({
+  tokenRefs,
+  allowPreserveAspectRatio,
+  imagePriority,
+}: EventTokenGridProps) {
   const tokens = useFragment(
     graphql`
       fragment EventTokenGridFragment on Token @relay(plural: true) {
@@ -37,19 +43,35 @@ export function EventTokenGrid({ tokenRefs, allowPreserveAspectRatio }: EventTok
         <View className="flex h-full w-full flex-col space-y-[2]">
           <View className="flex h-1/2 w-full flex-row space-x-[2]">
             <View className="h-full w-1/2">
-              <NftPreview resizeMode={ResizeMode.COVER} tokenRef={firstToken} />
+              <NftPreview
+                priority={imagePriority}
+                resizeMode={ResizeMode.COVER}
+                tokenRef={firstToken}
+              />
             </View>
             <View className="h-full w-1/2">
-              <NftPreview resizeMode={ResizeMode.COVER} tokenRef={secondToken} />
+              <NftPreview
+                priority={imagePriority}
+                resizeMode={ResizeMode.COVER}
+                tokenRef={secondToken}
+              />
             </View>
           </View>
 
           <View className="flex h-1/2 w-full flex-row space-x-[2]">
             <View className="h-full w-1/2">
-              <NftPreview resizeMode={ResizeMode.COVER} tokenRef={thirdToken} />
+              <NftPreview
+                priority={imagePriority}
+                resizeMode={ResizeMode.COVER}
+                tokenRef={thirdToken}
+              />
             </View>
             <View className="h-full w-1/2">
-              <NftPreview resizeMode={ResizeMode.COVER} tokenRef={fourthToken} />
+              <NftPreview
+                priority={imagePriority}
+                resizeMode={ResizeMode.COVER}
+                tokenRef={fourthToken}
+              />
             </View>
           </View>
         </View>
@@ -58,10 +80,18 @@ export function EventTokenGrid({ tokenRefs, allowPreserveAspectRatio }: EventTok
       return (
         <View className="flex w-full flex-row space-x-[2]">
           <View className="h-full w-1/2">
-            <NftPreview resizeMode={ResizeMode.COVER} tokenRef={firstToken} />
+            <NftPreview
+              priority={imagePriority}
+              resizeMode={ResizeMode.COVER}
+              tokenRef={firstToken}
+            />
           </View>
           <View className="h-full w-1/2">
-            <NftPreview resizeMode={ResizeMode.COVER} tokenRef={secondToken} />
+            <NftPreview
+              priority={imagePriority}
+              resizeMode={ResizeMode.COVER}
+              tokenRef={secondToken}
+            />
           </View>
         </View>
       );
@@ -69,13 +99,14 @@ export function EventTokenGrid({ tokenRefs, allowPreserveAspectRatio }: EventTok
       return (
         <NftPreview
           resizeMode={preserveAspectRatio ? ResizeMode.CONTAIN : ResizeMode.COVER}
+          priority={imagePriority}
           tokenRef={firstToken}
         />
       );
     } else {
       throw new Error('Tried to render EventTokenGrid without any tokens');
     }
-  }, [preserveAspectRatio, tokens]);
+  }, [imagePriority, preserveAspectRatio, tokens]);
 
   return (
     <View

--- a/apps/mobile/src/components/Feed/FeedListItem.tsx
+++ b/apps/mobile/src/components/Feed/FeedListItem.tsx
@@ -31,5 +31,5 @@ export function FeedListItem({ eventDataRef }: FeedListItemProps) {
     return <GalleryUpdatedFeedEvent eventDataRef={eventData} />;
   }
 
-  return <NonRecursiveFeedListItem eventCount={1} eventDataRef={eventData} />;
+  return <NonRecursiveFeedListItem slideIndex={0} eventCount={1} eventDataRef={eventData} />;
 }

--- a/apps/mobile/src/components/Feed/GalleryUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/GalleryUpdatedFeedEvent.tsx
@@ -57,8 +57,14 @@ export function GalleryUpdatedFeedEvent({ eventDataRef }: GalleryUpdatedFeedEven
   );
 
   const renderItem = useCallback<ListRenderItem<(typeof subEvents)[number]>>(
-    ({ item }) => {
-      return <NonRecursiveFeedListItem eventCount={subEvents.length} eventDataRef={item} />;
+    ({ item, index }) => {
+      return (
+        <NonRecursiveFeedListItem
+          slideIndex={index}
+          eventCount={subEvents.length}
+          eventDataRef={item}
+        />
+      );
     },
     [subEvents.length]
   );

--- a/apps/mobile/src/components/Feed/NonRecursiveFeedListItem.tsx
+++ b/apps/mobile/src/components/Feed/NonRecursiveFeedListItem.tsx
@@ -11,6 +11,7 @@ import { CollectorsNoteAddedToCollectionFeedEvent } from './CollectorsNoteAddedT
 import { TokensAddedToCollectionFeedEvent } from './TokensAddedToCollectionFeedEvent';
 
 type NonRecursiveFeedListItemProps = {
+  slideIndex: number;
   eventCount: number;
   eventDataRef: NonRecursiveFeedListItemFragment$key;
 };
@@ -18,6 +19,7 @@ type NonRecursiveFeedListItemProps = {
 export function NonRecursiveFeedListItem({
   eventDataRef,
   eventCount,
+  slideIndex,
 }: NonRecursiveFeedListItemProps) {
   const eventData = useFragment(
     graphql`
@@ -57,6 +59,7 @@ export function NonRecursiveFeedListItem({
       case 'CollectorsNoteAddedToCollectionFeedEventData':
         return (
           <CollectorsNoteAddedToCollectionFeedEvent
+            isFirstSlide={slideIndex === 0}
             allowPreserveAspectRatio={allowPreserveAspectRatio}
             collectionUpdatedFeedEventDataRef={eventData}
           />
@@ -64,6 +67,7 @@ export function NonRecursiveFeedListItem({
       case 'CollectionUpdatedFeedEventData':
         return (
           <CollectionUpdatedFeedEvent
+            isFirstSlide={slideIndex === 0}
             allowPreserveAspectRatio={allowPreserveAspectRatio}
             collectionUpdatedFeedEventDataRef={eventData}
           />
@@ -71,6 +75,7 @@ export function NonRecursiveFeedListItem({
       case 'CollectionCreatedFeedEventData':
         return (
           <CollectionCreatedFeedEvent
+            isFirstSlide={slideIndex === 0}
             allowPreserveAspectRatio={allowPreserveAspectRatio}
             collectionUpdatedFeedEventDataRef={eventData}
           />
@@ -78,6 +83,7 @@ export function NonRecursiveFeedListItem({
       case 'TokensAddedToCollectionFeedEventData':
         return (
           <TokensAddedToCollectionFeedEvent
+            isFirstSlide={slideIndex === 0}
             allowPreserveAspectRatio={allowPreserveAspectRatio}
             collectionUpdatedFeedEventDataRef={eventData}
           />
@@ -85,7 +91,7 @@ export function NonRecursiveFeedListItem({
       default:
         return null;
     }
-  }, [eventCount, eventData]);
+  }, [eventCount, eventData, slideIndex]);
 
   return <View style={{ width }}>{inner}</View>;
 }

--- a/apps/mobile/src/components/Feed/TokensAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/TokensAddedToCollectionFeedEvent.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { View } from 'react-native';
+import FastImage from 'react-native-fast-image';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -11,11 +12,13 @@ import { EventTokenGrid } from './EventTokenGrid';
 import { FeedEventCarouselCellHeader } from './FeedEventCarouselCellHeader';
 
 type TokensAddedToCollectionFeedEventProps = {
+  isFirstSlide: boolean;
   allowPreserveAspectRatio: boolean;
   collectionUpdatedFeedEventDataRef: TokensAddedToCollectionFeedEventFragment$key;
 };
 
 export function TokensAddedToCollectionFeedEvent({
+  isFirstSlide,
   allowPreserveAspectRatio,
   collectionUpdatedFeedEventDataRef,
 }: TokensAddedToCollectionFeedEventProps) {
@@ -52,7 +55,11 @@ export function TokensAddedToCollectionFeedEvent({
         </Typography>
       </FeedEventCarouselCellHeader>
 
-      <EventTokenGrid allowPreserveAspectRatio={allowPreserveAspectRatio} tokenRefs={tokens} />
+      <EventTokenGrid
+        imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
+        allowPreserveAspectRatio={allowPreserveAspectRatio}
+        tokenRefs={tokens}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/components/NftPreview.tsx
+++ b/apps/mobile/src/components/NftPreview.tsx
@@ -1,5 +1,5 @@
 import { ResizeMode, Video } from 'expo-av';
-import FastImage from 'react-native-fast-image';
+import FastImage, { Priority } from 'react-native-fast-image';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -11,11 +11,12 @@ import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlFo
 import { SvgWebView } from './SvgWebView';
 
 type NftPreviewProps = {
+  priority?: Priority;
   tokenRef: NftPreviewFragment$key;
   resizeMode: ResizeMode;
 };
 
-function NftPreviewInner({ tokenRef, resizeMode }: NftPreviewProps) {
+function NftPreviewInner({ tokenRef, resizeMode, priority }: NftPreviewProps) {
   const token = useFragment(
     graphql`
       fragment NftPreviewFragment on Token {
@@ -66,15 +67,16 @@ function NftPreviewInner({ tokenRef, resizeMode }: NftPreviewProps) {
       source={{
         headers: { Accepts: 'image/avif;image/png' },
         uri: tokenUrl,
+        priority,
       }}
     />
   );
 }
 
-export function NftPreview({ tokenRef, resizeMode }: NftPreviewProps) {
+export function NftPreview({ tokenRef, resizeMode, priority }: NftPreviewProps) {
   return (
     <ReportingErrorBoundary fallback={null}>
-      <NftPreviewInner tokenRef={tokenRef} resizeMode={resizeMode} />
+      <NftPreviewInner tokenRef={tokenRef} resizeMode={resizeMode} priority={priority} />
     </ReportingErrorBoundary>
   );
 }


### PR DESCRIPTION
We just want to make sure that images that are actually showing as you scroll have a higher download priority than other content.