### PR TITLE
add follow button to hover card even if signed out

### DIFF
--- a/apps/web/src/components/HoverCard/HoverCard.tsx
+++ b/apps/web/src/components/HoverCard/HoverCard.tsx
@@ -103,7 +103,7 @@ export function HoverCard({ preloadedQuery }: HoverCardProps) {
           </HStack>
         </StyledUsernameAndBadge>
 
-        {isLoggedIn && !isOwnProfile && (
+        {!isOwnProfile && (
           <StyledFollowButtonWrapper>
             <FollowButton userRef={user} queryRef={query} source="user hover card" />
           </StyledFollowButtonWrapper>


### PR DESCRIPTION
## description
title says it all

clicking the follow button if signed out will open the sign in modal, as usual

<img width="694" alt="Screenshot 2023-03-25 at 8 34 08" src="https://user-images.githubusercontent.com/80802871/227661593-02e2b5bd-89a5-4b8b-97be-9091712b74e2.png">
