### PR TITLE
enable analytics events for non authed users

### DIFF
--- a/apps/web/src/contexts/analytics/AnalyticsContext.tsx
+++ b/apps/web/src/contexts/analytics/AnalyticsContext.tsx
@@ -85,7 +85,7 @@ const AnalyticsProvider = memo(({ children }: Props) => {
       .then((query) => {
         const userId = query?.viewer?.user?.dbid;
 
-        // don't track unauthenticated users
+        // don't identify unauthenticated users
         if (!userId) {
           return;
         }
@@ -105,11 +105,6 @@ const AnalyticsProvider = memo(({ children }: Props) => {
         .toPromise()
         .then((query) => {
           const userId = query?.viewer?.user?.dbid;
-
-          // don't track unauthenticated users
-          if (!userId) {
-            return;
-          }
 
           _track(eventName, eventProps, userId);
         });


### PR DESCRIPTION
This PR enables analytics for non authed users. This is feasible because of changes to the Mixpanel pricing plans.