### PR TITLE
fix broken virtualization on feed

### DIFF
--- a/apps/web/src/components/Feed/FeedList.tsx
+++ b/apps/web/src/components/Feed/FeedList.tsx
@@ -171,8 +171,10 @@ export default function FeedList({
       {({ height, scrollTop, registerChild }) => (
         <AutoSizer disableHeight>
           {({ width }) => (
+            // calling registerChild resets the scroll position which fixes an issue where upon remounting this list, virtualization didn't work
+            // https://github.com/bvaughn/react-virtualized/issues/1324
             // @ts-expect-error shitty react-virtualized types
-            <div ref={registerChild}>
+            <div ref={(el) => registerChild(el)}>
               <List
                 className="FeedList"
                 ref={virtualizedListRef}


### PR DESCRIPTION
This PR attempts to fix an issue with the feed where returning to the feed list after it had been mounted before (ie navigating from Trending -> Latest -> Trending) results in virtualization being broken, with extra whitespace and rows not being rendered.

Before
https://user-images.githubusercontent.com/80802871/230043529-c90f3c1b-a025-4bb9-a2e3-2aa8802c1523.mp4

After
https://user-images.githubusercontent.com/80802871/230043551-731a8bcf-0d84-481a-89a9-c2c3ad23dd81.mp4



