### PR TITLE
Silence unnecessary gallery update errors

### DIFF
--- a/apps/web/src/components/GalleryEditor/GalleryEditorContext.tsx
+++ b/apps/web/src/components/GalleryEditor/GalleryEditorContext.tsx
@@ -492,10 +492,13 @@ export function GalleryEditorProvider({
         setEditSessionID(uuid());
         setHasSaved(false);
       } catch (error) {
-        pushToast({
-          autoClose: false,
-          message: "Something went wrong while publishing your gallery. We're looking into it.",
-        });
+        // TODO: silencing the error toast until we can get a more granular response from the server;
+        //       right now this is being presented on successful updates where the change does not produce
+        //       a feed event
+        // pushToast({
+        //   autoClose: false,
+        //   message: "Something went wrong while publishing your gallery. We're looking into it.",
+        // });
 
         if (error instanceof Error) {
           reportError(error, { tags: { galleryId } });
@@ -511,7 +514,7 @@ export function GalleryEditorProvider({
         }
       }
     },
-    [editSessionID, publish, pushToast, query.galleryById.dbid, reportError, track]
+    [editSessionID, publish, query.galleryById.dbid, reportError, track]
   );
 
   const [initialName, setInitialName] = useState(name);


### PR DESCRIPTION
currently, users encounter this error if they simply rearrange pieces within their gallery, i.e. perform an action that does not produce a feed event. this is a confusing experience given that **_the gallery update itself is successful_**, and the error is unnecessarily and incorrectly displayed.

this PR silences the error for now to reduce confusion; we can update this once the server returns a more granular error type, or doesn't return an error at all.

<img width="552" alt="image" src="https://user-images.githubusercontent.com/12162433/230282748-102efffb-8e49-4699-bed3-03fe2035b4c3.png">

suggested improvements:
1. don't return an error to the client if a gallery update is successful but feed event creation fails
2. if a user rearranges their pieces within a collection, a feed event _should_ be created, such as type `TokensRearrangedWithinCollection`
3. or, we could simply display a `gallery updated` event with the initial tokens within the gallery