### PR TITLE
Some Feed Carousel Polish

### DIFF
--- a/apps/mobile/src/components/Feed/EventTokenGrid.tsx
+++ b/apps/mobile/src/components/Feed/EventTokenGrid.tsx
@@ -132,7 +132,7 @@ export function EventTokenGrid({
 
   return (
     <View
-      className="flex flex-row flex-wrap"
+      className="flex flex-row"
       style={{ width: dimensions.width, maxHeight: dimensions.height, height: dimensions.width }}
     >
       {inner}

--- a/apps/mobile/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -44,7 +44,7 @@ export function CollectionCreatedFeedEvent({
   }, [eventData.newTokens]);
 
   return (
-    <View className="flex flex-col">
+    <View className="flex flex-1">
       <FeedEventCarouselCellHeader>
         <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
           Created a new collection
@@ -59,11 +59,13 @@ export function CollectionCreatedFeedEvent({
         <FeedListCollectorsNote collectorsNote={eventData.collection.collectorsNote} />
       )}
 
-      <EventTokenGrid
-        imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
-        allowPreserveAspectRatio={allowPreserveAspectRatio}
-        collectionTokenRefs={tokens}
-      />
+      <View className="flex flex-grow justify-center">
+        <EventTokenGrid
+          imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
+          allowPreserveAspectRatio={allowPreserveAspectRatio}
+          collectionTokenRefs={tokens}
+        />
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
@@ -45,7 +45,7 @@ export function CollectionUpdatedFeedEvent({
   }, [eventData.newTokens]);
 
   return (
-    <View className="flex flex-col">
+    <View className="flex flex-1 flex-col">
       <FeedEventCarouselCellHeader>
         <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
           Made a change to
@@ -60,11 +60,13 @@ export function CollectionUpdatedFeedEvent({
         <FeedListCollectorsNote collectorsNote={eventData.newCollectorsNote} />
       )}
 
-      <EventTokenGrid
-        imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
-        allowPreserveAspectRatio={allowPreserveAspectRatio}
-        collectionTokenRefs={tokens}
-      />
+      <View className="flex flex-grow justify-center">
+        <EventTokenGrid
+          imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
+          allowPreserveAspectRatio={allowPreserveAspectRatio}
+          collectionTokenRefs={tokens}
+        />
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -45,7 +45,7 @@ export function CollectorsNoteAddedToCollectionFeedEvent({
   }, [eventData.collection?.tokens]);
 
   return (
-    <View className="flex flex-col">
+    <View className="flex flex-1 flex-col">
       <FeedEventCarouselCellHeader>
         <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
           Added a colloctors note to
@@ -60,11 +60,13 @@ export function CollectorsNoteAddedToCollectionFeedEvent({
         <FeedListCollectorsNote collectorsNote={eventData.newCollectorsNote} />
       )}
 
-      <EventTokenGrid
-        imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
-        allowPreserveAspectRatio={allowPreserveAspectRatio}
-        collectionTokenRefs={tokens}
-      />
+      <View className="flex flex-grow justify-center">
+        <EventTokenGrid
+          imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
+          allowPreserveAspectRatio={allowPreserveAspectRatio}
+          collectionTokenRefs={tokens}
+        />
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/Events/GalleryUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/GalleryUpdatedFeedEvent.tsx
@@ -27,7 +27,6 @@ export function GalleryUpdatedFeedEvent({ eventDataRef, eventId }: GalleryUpdate
       fragment GalleryUpdatedFeedEventFragment on GalleryUpdatedFeedEventData {
         subEventDatas @required(action: THROW) {
           __typename
-          eventTime
           ...NonRecursiveFeedListItemFragment
         }
       }
@@ -74,15 +73,13 @@ export function GalleryUpdatedFeedEvent({ eventDataRef, eventId }: GalleryUpdate
       >
         {subEvents.map((subEvent, index) => {
           return (
-            <View className="flex-1">
-              <NonRecursiveFeedListItem
-                key={index}
-                eventId={eventId}
-                slideIndex={index}
-                eventCount={subEvents.length}
-                eventDataRef={subEvent}
-              />
-            </View>
+            <NonRecursiveFeedListItem
+              key={index}
+              eventId={eventId}
+              slideIndex={index}
+              eventCount={subEvents.length}
+              eventDataRef={subEvent}
+            />
           );
         })}
       </ScrollView>

--- a/apps/mobile/src/components/Feed/Events/GalleryUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/GalleryUpdatedFeedEvent.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
 import {
-  FlatList,
-  ListRenderItem,
   NativeScrollEvent,
   NativeSyntheticEvent,
+  ScrollView,
   StyleProp,
   useWindowDimensions,
   View,
@@ -28,6 +27,7 @@ export function GalleryUpdatedFeedEvent({ eventDataRef, eventId }: GalleryUpdate
       fragment GalleryUpdatedFeedEventFragment on GalleryUpdatedFeedEventData {
         subEventDatas @required(action: THROW) {
           __typename
+          eventTime
           ...NonRecursiveFeedListItemFragment
         }
       }
@@ -57,39 +57,35 @@ export function GalleryUpdatedFeedEvent({ eventDataRef, eventId }: GalleryUpdate
     [subEvents?.length, width]
   );
 
-  const renderItem = useCallback<ListRenderItem<(typeof subEvents)[number]>>(
-    ({ item, index }) => {
-      return (
-        <NonRecursiveFeedListItem
-          eventId={eventId}
-          slideIndex={index}
-          eventCount={subEvents.length}
-          eventDataRef={item}
-        />
-      );
-    },
-    [eventId, subEvents.length]
-  );
-
   const isPaginated = subEvents.length > 1;
 
   return (
     <View className="flex flex-col space-y-3">
-      {/* We're using a FlatList here instead of a FlashList due to issues */}
-      {/* with the FlashList clipping heights of views. Not sure why. */}
-      <FlatList
+      <ScrollView
         horizontal
-        data={subEvents}
         pagingEnabled
         snapToInterval={width}
         onScroll={handleScroll}
-        renderItem={renderItem}
         decelerationRate="fast"
         snapToAlignment="center"
         scrollEventThrottle={200}
         scrollEnabled={isPaginated}
         showsHorizontalScrollIndicator={false}
-      />
+      >
+        {subEvents.map((subEvent, index) => {
+          return (
+            <View className="flex-1">
+              <NonRecursiveFeedListItem
+                key={index}
+                eventId={eventId}
+                slideIndex={index}
+                eventCount={subEvents.length}
+                eventDataRef={subEvent}
+              />
+            </View>
+          );
+        })}
+      </ScrollView>
 
       {isPaginated && (
         <View className="flex w-full flex-row justify-center">

--- a/apps/mobile/src/components/Feed/Events/NonRecursiveFeedListItem.tsx
+++ b/apps/mobile/src/components/Feed/Events/NonRecursiveFeedListItem.tsx
@@ -104,5 +104,9 @@ export function NonRecursiveFeedListItem({
     }
   }, [eventCount, eventData, eventId, slideIndex]);
 
-  return <View style={{ width }}>{inner}</View>;
+  return (
+    <View className="flex-1" style={{ width }}>
+      {inner}
+    </View>
+  );
 }

--- a/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -42,7 +42,7 @@ export function TokensAddedToCollectionFeedEvent({
   }, [eventData.newTokens]);
 
   return (
-    <View className="flex flex-col">
+    <View className="flex flex-1 flex-col">
       <FeedEventCarouselCellHeader>
         <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
           Added new tokens to
@@ -53,11 +53,13 @@ export function TokensAddedToCollectionFeedEvent({
         </Typography>
       </FeedEventCarouselCellHeader>
 
-      <EventTokenGrid
-        imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
-        allowPreserveAspectRatio={allowPreserveAspectRatio}
-        collectionTokenRefs={tokens}
-      />
+      <View className="flex flex-grow justify-center">
+        <EventTokenGrid
+          imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
+          allowPreserveAspectRatio={allowPreserveAspectRatio}
+          collectionTokenRefs={tokens}
+        />
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/FeedListCollectorsNote.tsx
+++ b/apps/mobile/src/components/Feed/FeedListCollectorsNote.tsx
@@ -11,7 +11,7 @@ export function FeedListCollectorsNote({ collectorsNote }: Props) {
     <View className="flex flex-row space-x-2 px-3 py-2">
       <View className="bg-porcelain h-full w-0.5" />
       <View>
-        <Markdown>{collectorsNote}</Markdown>
+        <Markdown numberOfLines={3}>{collectorsNote}</Markdown>
       </View>
     </View>
   );

--- a/apps/mobile/src/components/Markdown.tsx
+++ b/apps/mobile/src/components/Markdown.tsx
@@ -1,6 +1,10 @@
-import { PropsWithChildren, useMemo } from 'react';
-import { StyleProp, StyleSheet } from 'react-native';
-import MarkdownDisplay, { MarkdownIt, MarkdownProps } from 'react-native-markdown-display';
+import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
+import { StyleProp, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import MarkdownDisplay, {
+  MarkdownIt,
+  MarkdownProps,
+  RenderRules,
+} from 'react-native-markdown-display';
 import NamedStyles = StyleSheet.NamedStyles;
 
 const markdownStyles = StyleSheet.create({
@@ -19,20 +23,48 @@ const markdownStyles = StyleSheet.create({
 });
 
 type GalleryMarkdownProps = PropsWithChildren<{
+  numberOfLines?: number;
   style?: StyleProp<unknown>;
 }>;
 
-export function Markdown({ children, style }: GalleryMarkdownProps) {
+export function Markdown({ children, numberOfLines, style }: GalleryMarkdownProps) {
+  const [showAll, setShowAll] = useState(false);
+
   const mergedStyles = useMemo(() => {
     return StyleSheet.flatten([markdownStyles, style]) as NamedStyles<MarkdownProps>;
   }, [style]);
 
+  const rules = useMemo<RenderRules>(() => {
+    const rules: RenderRules = {};
+
+    if (numberOfLines) {
+      rules.textgroup = (node, children, parent, styles) => (
+        <Text
+          key={node.key}
+          style={styles.textgroup}
+          numberOfLines={showAll ? undefined : numberOfLines}
+        >
+          {children}
+        </Text>
+      );
+    }
+
+    return rules;
+  }, [numberOfLines, showAll]);
+
+  const handlePress = useCallback(() => {
+    setShowAll((previous) => !previous);
+  }, []);
+
   return (
-    <MarkdownDisplay
-      markdownit={MarkdownIt({ typographer: true, linkify: true })}
-      style={mergedStyles}
-    >
-      {children}
-    </MarkdownDisplay>
+    <TouchableOpacity onPress={handlePress} disabled={numberOfLines === undefined}>
+      <MarkdownDisplay
+        markdownit={MarkdownIt({ typographer: true, linkify: true })}
+        rules={rules}
+        style={mergedStyles}
+      >
+        {children}
+      </MarkdownDisplay>
+    </TouchableOpacity>
   );
 }


### PR DESCRIPTION
- Make sure each slide is a consistent height
  - We can't use a virtualized list for the carousel if we want to do this since the height of the carousel has to be max(...allSlides)
  - This is fine since there aren't many slides per feed event
  - Center images if there is extra height
- Implement line clamp for the `Markdown` component. This is a little weird, but it turned out great. Basically we have to override the underlying text component for the `textgroup` rule. **I also made it expandable with a tap. Watch the video to see**.

| Before | After |
|--------|--------|
| <video src="https://user-images.githubusercontent.com/6754223/230481985-24596a4e-bdb2-49a2-a785-f35561bf2218.mp4" /> | <video src="https://user-images.githubusercontent.com/6754223/230481999-7ee6ad4a-64f8-43eb-a4d9-abac13871485.mp4" /> | 
