### PR TITLE
Some more feed polish GAL-2795 GAL-2794

### DIFF
--- a/apps/mobile/src/components/Feed/EventTokenGrid.tsx
+++ b/apps/mobile/src/components/Feed/EventTokenGrid.tsx
@@ -60,7 +60,7 @@ export function EventTokenGrid({
                 priority={imagePriority}
                 resizeMode={ResizeMode.COVER}
                 collectionTokenRef={firstToken}
-                tokenUrl={firstToken.urls.small}
+                tokenUrl={firstToken.urls.medium}
               />
             </View>
             <View className="h-full w-1/2">
@@ -68,7 +68,7 @@ export function EventTokenGrid({
                 priority={imagePriority}
                 resizeMode={ResizeMode.COVER}
                 collectionTokenRef={secondToken}
-                tokenUrl={secondToken.urls.small}
+                tokenUrl={secondToken.urls.medium}
               />
             </View>
           </View>
@@ -79,7 +79,7 @@ export function EventTokenGrid({
                 priority={imagePriority}
                 resizeMode={ResizeMode.COVER}
                 collectionTokenRef={thirdToken}
-                tokenUrl={thirdToken.urls.small}
+                tokenUrl={thirdToken.urls.medium}
               />
             </View>
             <View className="h-full w-1/2">
@@ -87,7 +87,7 @@ export function EventTokenGrid({
                 priority={imagePriority}
                 resizeMode={ResizeMode.COVER}
                 collectionTokenRef={fourthToken}
-                tokenUrl={fourthToken.urls.small}
+                tokenUrl={fourthToken.urls.medium}
               />
             </View>
           </View>
@@ -101,7 +101,7 @@ export function EventTokenGrid({
               priority={imagePriority}
               resizeMode={ResizeMode.COVER}
               collectionTokenRef={firstToken}
-              tokenUrl={firstToken.urls.medium}
+              tokenUrl={firstToken.urls.large}
             />
           </View>
           <View className="h-full w-1/2">
@@ -109,7 +109,7 @@ export function EventTokenGrid({
               priority={imagePriority}
               resizeMode={ResizeMode.COVER}
               collectionTokenRef={secondToken}
-              tokenUrl={secondToken.urls.medium}
+              tokenUrl={secondToken.urls.large}
             />
           </View>
         </View>

--- a/apps/mobile/src/components/Feed/EventTokenGrid.tsx
+++ b/apps/mobile/src/components/Feed/EventTokenGrid.tsx
@@ -51,9 +51,17 @@ export function EventTokenGrid({
 
     const [firstToken, secondToken, thirdToken, fourthToken] = tokensWithMedia;
 
+    const fullHeight = dimensions.width;
+    const fullWidth = dimensions.width;
+    const halfHeight = dimensions.width / 2;
+
     if (firstToken && secondToken && thirdToken && fourthToken) {
       return (
-        <View className="flex h-full w-full flex-col space-y-[2]">
+        <View
+          className="flex flex-1 flex-col space-y-[2]"
+          // We use min height here since it's possible that the
+          style={{ minHeight: fullHeight, width: fullWidth }}
+        >
           <View className="flex h-1/2 w-full flex-row space-x-[2]">
             <View className="h-full w-1/2">
               <NftPreview
@@ -95,7 +103,11 @@ export function EventTokenGrid({
       );
     } else if (firstToken && secondToken) {
       return (
-        <View className="flex w-full flex-row space-x-[2]">
+        <View
+          className="flex flex-row space-x-[2]"
+          // We use min height here since it's possible that the
+          style={{ minHeight: halfHeight, width: fullWidth }}
+        >
           <View className="h-full w-1/2">
             <NftPreview
               priority={imagePriority}
@@ -116,7 +128,12 @@ export function EventTokenGrid({
       );
     } else if (firstToken) {
       return (
-        <View className="h-full w-full">
+        <View
+          style={{
+            minHeight: fullHeight,
+            minWidth: fullWidth,
+          }}
+        >
           <NftPreview
             resizeMode={preserveAspectRatio ? ResizeMode.CONTAIN : ResizeMode.COVER}
             priority={imagePriority}
@@ -128,13 +145,10 @@ export function EventTokenGrid({
     } else {
       throw new Error('Tried to render EventTokenGrid without any tokens');
     }
-  }, [imagePriority, preserveAspectRatio, collectionTokens]);
+  }, [collectionTokens, dimensions.width, imagePriority, preserveAspectRatio]);
 
   return (
-    <View
-      className="flex flex-1 flex-row"
-      style={{ width: dimensions.width, maxHeight: dimensions.height, height: dimensions.width }}
-    >
+    <View className="flex flex-1 flex-col" style={{ width: dimensions.width }}>
       {inner}
     </View>
   );

--- a/apps/mobile/src/components/Feed/EventTokenGrid.tsx
+++ b/apps/mobile/src/components/Feed/EventTokenGrid.tsx
@@ -132,7 +132,7 @@ export function EventTokenGrid({
 
   return (
     <View
-      className="flex flex-row"
+      className="flex flex-1 flex-row"
       style={{ width: dimensions.width, maxHeight: dimensions.height, height: dimensions.width }}
     >
       {inner}

--- a/apps/mobile/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -59,7 +59,7 @@ export function CollectionCreatedFeedEvent({
         <FeedListCollectorsNote collectorsNote={eventData.collection.collectorsNote} />
       )}
 
-      <View className="flex flex-grow justify-center">
+      <View className="flex flex-grow">
         <EventTokenGrid
           imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
           allowPreserveAspectRatio={allowPreserveAspectRatio}

--- a/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
@@ -60,7 +60,7 @@ export function CollectionUpdatedFeedEvent({
         <FeedListCollectorsNote collectorsNote={eventData.newCollectorsNote} />
       )}
 
-      <View className="flex flex-grow justify-center">
+      <View className="flex flex-grow">
         <EventTokenGrid
           imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
           allowPreserveAspectRatio={allowPreserveAspectRatio}

--- a/apps/mobile/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -60,7 +60,7 @@ export function CollectorsNoteAddedToCollectionFeedEvent({
         <FeedListCollectorsNote collectorsNote={eventData.newCollectorsNote} />
       )}
 
-      <View className="flex flex-grow justify-center">
+      <View className="flex flex-grow">
         <EventTokenGrid
           imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
           allowPreserveAspectRatio={allowPreserveAspectRatio}

--- a/apps/mobile/src/components/Feed/Events/GalleryUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/GalleryUpdatedFeedEvent.tsx
@@ -62,6 +62,7 @@ export function GalleryUpdatedFeedEvent({ eventDataRef, eventId }: GalleryUpdate
     <View className="flex flex-col space-y-3">
       <ScrollView
         horizontal
+        directionalLockEnabled
         pagingEnabled
         snapToInterval={width}
         onScroll={handleScroll}

--- a/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -53,7 +53,7 @@ export function TokensAddedToCollectionFeedEvent({
         </Typography>
       </FeedEventCarouselCellHeader>
 
-      <View className="flex flex-grow justify-center">
+      <View className="flex flex-grow">
         <EventTokenGrid
           imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
           allowPreserveAspectRatio={allowPreserveAspectRatio}

--- a/apps/mobile/src/components/Feed/FeedListCollectorsNote.tsx
+++ b/apps/mobile/src/components/Feed/FeedListCollectorsNote.tsx
@@ -11,7 +11,7 @@ export function FeedListCollectorsNote({ collectorsNote }: Props) {
     <View className="flex flex-row space-x-2 px-3 py-2">
       <View className="bg-porcelain h-full w-0.5" />
       <View>
-        <Markdown numberOfLines={3}>{collectorsNote}</Markdown>
+        <Markdown numberOfLines={2}>{collectorsNote}</Markdown>
       </View>
     </View>
   );

--- a/apps/mobile/src/components/Markdown.tsx
+++ b/apps/mobile/src/components/Markdown.tsx
@@ -24,10 +24,16 @@ const markdownStyles = StyleSheet.create({
 
 type GalleryMarkdownProps = PropsWithChildren<{
   numberOfLines?: number;
+  touchToExpand?: boolean;
   style?: StyleProp<unknown>;
 }>;
 
-export function Markdown({ children, numberOfLines, style }: GalleryMarkdownProps) {
+export function Markdown({
+  children,
+  touchToExpand = false,
+  numberOfLines,
+  style,
+}: GalleryMarkdownProps) {
   const [showAll, setShowAll] = useState(false);
 
   const mergedStyles = useMemo(() => {
@@ -57,7 +63,10 @@ export function Markdown({ children, numberOfLines, style }: GalleryMarkdownProp
   }, []);
 
   return (
-    <TouchableOpacity onPress={handlePress} disabled={numberOfLines === undefined}>
+    <TouchableOpacity
+      onPress={handlePress}
+      disabled={numberOfLines === undefined || !touchToExpand}
+    >
       <MarkdownDisplay
         markdownit={MarkdownIt({ typographer: true, linkify: true })}
         rules={rules}

--- a/apps/mobile/src/components/NftPreview/NftPreview.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreview.tsx
@@ -1,11 +1,12 @@
 import { useNavigation } from '@react-navigation/native';
 import { ResizeMode } from 'expo-av';
 import { useCallback, useState } from 'react';
-import { TouchableWithoutFeedback, View } from 'react-native';
+import { Pressable, TouchableWithoutFeedback, View } from 'react-native';
 import { Priority } from 'react-native-fast-image';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
+import { noop } from 'swr/_internal';
 
 import { NftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
 import { NftPreviewContextMenuPopup } from '~/components/NftPreview/NftPreviewContextMenuPopup';
@@ -69,7 +70,8 @@ function NftPreviewInner({ collectionTokenRef, tokenUrl, resizeMode, priority }:
       collectionTokenRef={collectionToken}
       imageDimensions={imageState.kind === 'loaded' ? imageState.dimensions : null}
     >
-      <TouchableWithoutFeedback onPress={handlePress}>
+      {/* https://github.com/dominicstop/react-native-ios-context-menu/issues/9#issuecomment-1047058781 */}
+      <Pressable delayLongPress={100} onPress={handlePress} onLongPress={() => {}}>
         <View className="relative h-full w-full">
           <NftPreviewAsset
             tokenUrl={tokenUrl}
@@ -85,7 +87,7 @@ function NftPreviewInner({ collectionTokenRef, tokenUrl, resizeMode, priority }:
             </View>
           ) : null}
         </View>
-      </TouchableWithoutFeedback>
+      </Pressable>
     </NftPreviewContextMenuPopup>
   );
 }

--- a/apps/mobile/src/components/NftPreview/NftPreview.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreview.tsx
@@ -1,12 +1,11 @@
 import { useNavigation } from '@react-navigation/native';
 import { ResizeMode } from 'expo-av';
 import { useCallback, useState } from 'react';
-import { Pressable, TouchableWithoutFeedback, View } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { Priority } from 'react-native-fast-image';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
-import { noop } from 'swr/_internal';
 
 import { NftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
 import { NftPreviewContextMenuPopup } from '~/components/NftPreview/NftPreviewContextMenuPopup';

--- a/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
@@ -146,10 +146,10 @@ export function NftPreviewContextMenuPopup({
                 </View>
               )}
             </View>
-            <View className="flex flex-col space-y-2 p-4">
+            <View className="flex flex-col space-y-2 py-4">
               {token.name && (
                 <Typography
-                  className="text-2xl"
+                  className="px-4 text-2xl"
                   font={{ family: 'GTAlpina', weight: 'Light', italic: true }}
                 >
                   {token.name}
@@ -158,7 +158,7 @@ export function NftPreviewContextMenuPopup({
 
               {token.contract?.name && (
                 <Typography
-                  className="text-shadow text-sm"
+                  className="text-shadow px-4 text-sm"
                   font={{ family: 'ABCDiatype', weight: 'Regular' }}
                 >
                   {token.contract.name}

--- a/apps/mobile/src/screens/HomeScreen/LatestScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen/LatestScreen.tsx
@@ -47,8 +47,10 @@ function LatestScreenInner({ queryRef }: LatestScreenInnerProps) {
   }, [hasPrevious, loadPrevious]);
 
   const handleLoadMore = useCallback(() => {
-    loadPrevious(PER_PAGE);
-  }, [loadPrevious]);
+    if (hasPrevious) {
+      loadPrevious(PER_PAGE);
+    }
+  }, [hasPrevious, loadPrevious]);
 
   const events = useMemo(() => {
     return removeNullValues(query.globalFeed?.edges?.map((it) => it?.node)).reverse();


### PR DESCRIPTION
- Make sure images in carousel fill the height of other slides
- Make height a little bit more predictable based on the layout mode we're in (2x2, 1x2, 1x1)
- Use higher quality images as requested by @Robinnnnn 
- Fix where we were trying to load more even if we reached the end of the feed
- Lock the scroll direction to horizontal so you can't move your finger up or down while scrolling between slides in a carousel
- Lower # of lines in Markdown to 2 on the feed
- Disable expandable markdown for now
- Fix crash GAL-2795
- Fix text clipping GAL-2794

There's a quirk with clamping line count w/ markdown. I think we could solve this but it would involve a lot of AST traversal / modification. Native isn't as cool as web on this front, you can only line clamp a single text element. When the markdown has multiple elements (text, link, etc) the line clamping doesn't work as well. You may get more lines than you specified.

https://user-images.githubusercontent.com/6754223/230660116-9cf4c4f6-9b93-4fd9-8138-0339d4d8ae61.mp4
