### PR TITLE
Scroll to top when navigating to current route

### DIFF
--- a/apps/mobile/src/components/Feed/FeedList.tsx
+++ b/apps/mobile/src/components/Feed/FeedList.tsx
@@ -103,8 +103,9 @@ export function FeedList({ feedEventRefs, isLoadingMore, onLoadMore }: FeedListP
     return indices;
   }, [items]);
 
-  const ref = useRef(null);
+  const ref = useRef<FlashList<FeedListItem> | null>(null);
 
+  // @ts-expect-error - useScrollToTop is not typed correctly for FlashList
   useScrollToTop(ref);
 
   const renderItem = useCallback<ListRenderItem<FeedListItem>>(

--- a/apps/mobile/src/components/Feed/FeedList.tsx
+++ b/apps/mobile/src/components/Feed/FeedList.tsx
@@ -1,5 +1,6 @@
+import { useScrollToTop } from '@react-navigation/native';
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
@@ -102,6 +103,10 @@ export function FeedList({ feedEventRefs, isLoadingMore, onLoadMore }: FeedListP
     return indices;
   }, [items]);
 
+  const ref = useRef(null);
+
+  useScrollToTop(ref);
+
   const renderItem = useCallback<ListRenderItem<FeedListItem>>(
     ({ item }) => {
       const markFailure = () => markEventAsFailure(item.event.dbid);
@@ -141,6 +146,7 @@ export function FeedList({ feedEventRefs, isLoadingMore, onLoadMore }: FeedListP
 
   return (
     <FlashList
+      ref={ref}
       data={items}
       onScroll={handleScroll}
       estimatedItemSize={300}

--- a/apps/mobile/src/navigation/FeedTabNavigator/TabBar.tsx
+++ b/apps/mobile/src/navigation/FeedTabNavigator/TabBar.tsx
@@ -1,10 +1,9 @@
 import { MaterialTopTabBarProps } from '@react-navigation/material-top-tabs';
-import { useNavigation } from '@react-navigation/native';
 import { NavigationRoute } from '@sentry/react-native/dist/js/tracing/reactnavigation';
 import { useCallback } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 
-import { FeedTabNavigatorParamList, FeedTabNavigatorProp } from '~/navigation/types';
+import { FeedTabNavigatorParamList } from '~/navigation/types';
 
 import { Typography } from '../../components/Typography';
 

--- a/apps/mobile/src/navigation/MainTabNavigator/TabBar.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/TabBar.tsx
@@ -1,5 +1,5 @@
 import { MaterialTopTabBarProps } from '@react-navigation/material-top-tabs';
-import { useNavigation } from '@react-navigation/native';
+import { NavigationRoute } from '@sentry/react-native/dist/js/tracing/reactnavigation';
 import { ReactNode, useCallback } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -7,42 +7,43 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AccountIcon } from '~/navigation/MainTabNavigator/AccountIcon';
 import { GLogo } from '~/navigation/MainTabNavigator/GLogo';
 import { NotificationsIcon } from '~/navigation/MainTabNavigator/NotificationsIcon';
-import { MainTabNavigatorParamList, MainTabNavigatorProp } from '~/navigation/types';
+import { MainTabNavigatorParamList } from '~/navigation/types';
 
 type TabItemProps = {
-  activeRoute: keyof MainTabNavigatorParamList;
-  route: keyof MainTabNavigatorParamList;
   icon: ReactNode;
+  route: NavigationRoute;
+  activeRoute: keyof MainTabNavigatorParamList;
+  navigation: MaterialTopTabBarProps['navigation'];
 };
 
-function TabItem({ route, icon, activeRoute }: TabItemProps) {
-  const navigation = useNavigation<MainTabNavigatorProp>();
-
-  const isFocused = activeRoute === route;
+function TabItem({ navigation, route, icon, activeRoute }: TabItemProps) {
+  const isFocused = activeRoute === route.name;
 
   const onPress = useCallback(() => {
-    if (!isFocused) {
-      if (route === 'Home') {
-        navigation.navigate(route, { screen: 'Trending' });
-      } else {
-        navigation.navigate(route);
-      }
+    const event = navigation.emit({
+      type: 'tabPress',
+      target: route.key,
+      canPreventDefault: true,
+    });
+
+    if (!isFocused && !event.defaultPrevented) {
+      navigation.navigate(route.name);
     }
   }, [isFocused, navigation, route]);
 
   return (
     <TouchableOpacity
-      className={`px-8 ${isFocused ? 'opacity-100' : 'opacity-25'}`}
+      onPress={onPress}
       accessibilityRole="button"
       accessibilityState={isFocused ? { selected: true } : {}}
-      onPress={onPress}
+      className={`px-8 ${isFocused ? 'opacity-100' : 'opacity-25'}`}
     >
       {icon}
     </TouchableOpacity>
   );
 }
 
-export function TabBar({ state }: MaterialTopTabBarProps) {
+export function TabBar({ state, navigation }: MaterialTopTabBarProps) {
   const { bottom } = useSafeAreaInsets();
 
   const activeRoute = state.routeNames[state.index] as keyof MainTabNavigatorParamList;
@@ -57,9 +58,26 @@ export function TabBar({ state }: MaterialTopTabBarProps) {
       }
       className="bg-offWhite flex flex-row items-center justify-center"
     >
-      <TabItem activeRoute={activeRoute} route="Account" icon={<AccountIcon />} />
-      <TabItem activeRoute={activeRoute} route="Home" icon={<GLogo />} />
-      <TabItem activeRoute={activeRoute} route="Notifications" icon={<NotificationsIcon />} />
+      {state.routes.map((route) => {
+        let icon = null;
+        if (route.name === 'Account') {
+          icon = <AccountIcon />;
+        } else if (route.name === 'Home') {
+          icon = <GLogo />;
+        } else if (route.name === 'Notifications') {
+          icon = <NotificationsIcon />;
+        }
+
+        return (
+          <TabItem
+            icon={icon}
+            route={route}
+            key={route.key}
+            navigation={navigation}
+            activeRoute={activeRoute}
+          />
+        );
+      })}
     </View>
   );
 }


### PR DESCRIPTION
Users expect to scroll to the top of the primary scrollable view if they press the tab item of the current route. Had to update a few things so we emit the right events to react navigation when we press a tab item, but all is good and works.