### PR TITLE
[GAL-2813] Galleries page shouldn’t count hidden collections

### DIFF
--- a/apps/web/src/components/MultiGallery/Gallery.tsx
+++ b/apps/web/src/components/MultiGallery/Gallery.tsx
@@ -65,6 +65,7 @@ export default function Gallery({
         hidden @required(action: THROW)
         collections @required(action: THROW) {
           id
+          hidden
         }
         owner {
           id
@@ -127,6 +128,12 @@ export default function Gallery({
   const { name, collections, tokenPreviews, hidden, dbid } = gallery;
 
   const { pushToast } = useToastActions();
+
+  const totalCollections = useMemo(() => {
+    const visibleCollections = collections.filter((collection) => !collection?.hidden);
+
+    return visibleCollections.length;
+  }, [collections]);
 
   const reassignFeaturedGallery = useCallback(async () => {
     if (!isFeatured) return;
@@ -286,7 +293,7 @@ export default function Gallery({
                 <TitleContainer>
                   <StyledGalleryTitle tabIndex={1}>{name || 'Untitled'}</StyledGalleryTitle>
                   <BaseM>
-                    {collections.length} collection{collections.length === 1 ? '' : 's'}
+                    {totalCollections} collection{totalCollections === 1 ? '' : 's'}
                   </BaseM>
                 </TitleContainer>
               </StyledGalleryTitleWrapper>


### PR DESCRIPTION
Fix hidden collection count 

**Before**
![CleanShot 2023-04-12 at 11 37 50@2x](https://user-images.githubusercontent.com/4480258/231342804-e6c61510-829a-4bff-ae1d-f474d2238cf9.png)


**After**

<img width="1168" alt="CleanShot 2023-04-12 at 11 37 03@2x" src="https://user-images.githubusercontent.com/4480258/231342672-d4a3fe63-2d0f-4dd6-b04a-10af0b064438.png">
