### PR TITLE
upgrade moon

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
-    "@moonrepo/cli": "^0.23.4",
+    "@moonrepo/cli": "^1.3.1",
     "@types/markdown-it": "^12.2.3",
     "@types/react-native": "^0.71.1",
     "babel-plugin-relay": "^14.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "@gallery-so/visitor-plugin-common": "^0.0.2",
     "@graphql-codegen/cli": "^2.11.6",
     "@graphql-codegen/typescript": "^2.7.3",
-    "@moonrepo/cli": "^0.23.4",
+    "@moonrepo/cli": "^1.3.1",
     "@next/bundle-analyzer": "^13.0.4",
     "@svgr/webpack": "^5.5.0",
     "@synthetixio/synpress": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@wagmi/core@0.7.9": "patch:@wagmi/core@npm%3A0.7.9#./.yarn/patches/@wagmi-core-npm-0.7.9-fde5e7dcba.patch"
   },
   "devDependencies": {
-    "@moonrepo/cli": "^0.25.0",
+    "@moonrepo/cli": "^1.3.1",
     "@types/react-relay": "^14.1.3",
     "@types/relay-runtime": "^14.1.8",
     "@typescript-eslint/eslint-plugin": "^5.44.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4421,17 +4421,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@moonrepo/cli@npm:^0.23.4":
-  version: 0.23.4
-  resolution: "@moonrepo/cli@npm:0.23.4"
+"@moonrepo/cli@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@moonrepo/cli@npm:1.3.1"
   dependencies:
-    "@moonrepo/core-linux-arm64-gnu": ^0.23.4
-    "@moonrepo/core-linux-arm64-musl": ^0.23.4
-    "@moonrepo/core-linux-x64-gnu": ^0.23.4
-    "@moonrepo/core-linux-x64-musl": ^0.23.4
-    "@moonrepo/core-macos-arm64": ^0.23.4
-    "@moonrepo/core-macos-x64": ^0.23.4
-    "@moonrepo/core-windows-x64-msvc": ^0.23.4
+    "@moonrepo/core-linux-arm64-gnu": ^1.3.1
+    "@moonrepo/core-linux-arm64-musl": ^1.3.1
+    "@moonrepo/core-linux-x64-gnu": ^1.3.1
+    "@moonrepo/core-linux-x64-musl": ^1.3.1
+    "@moonrepo/core-macos-arm64": ^1.3.1
+    "@moonrepo/core-macos-x64": ^1.3.1
+    "@moonrepo/core-windows-x64-msvc": ^1.3.1
     detect-libc: ^2.0.1
   dependenciesMeta:
     "@moonrepo/core-linux-arm64-gnu":
@@ -4450,137 +4450,55 @@ __metadata:
       optional: true
   bin:
     moon: moon
-  checksum: c238236fed264ab87d10a14f13172a6cf03358c079a42158fb6185d28569dba2da529bf39311212a36dabf37f13d4b88ed98c6fecaa8d776e5520247f7f9fa42
+  checksum: 60c2c0199bd7c2e5317132057849c1e31be3fe38adfeeae7ac267f8e78f30878bf70be0e6f9dce50d59a0843bb578066d93ac7873bb7ecbf82755318bf6e5369
   languageName: node
   linkType: hard
 
-"@moonrepo/cli@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "@moonrepo/cli@npm:0.25.0"
-  dependencies:
-    "@moonrepo/core-linux-arm64-gnu": ^0.25.0
-    "@moonrepo/core-linux-arm64-musl": ^0.25.0
-    "@moonrepo/core-linux-x64-gnu": ^0.25.0
-    "@moonrepo/core-linux-x64-musl": ^0.25.0
-    "@moonrepo/core-macos-arm64": ^0.25.0
-    "@moonrepo/core-macos-x64": ^0.25.0
-    "@moonrepo/core-windows-x64-msvc": ^0.25.0
-    detect-libc: ^2.0.1
-  dependenciesMeta:
-    "@moonrepo/core-linux-arm64-gnu":
-      optional: true
-    "@moonrepo/core-linux-arm64-musl":
-      optional: true
-    "@moonrepo/core-linux-x64-gnu":
-      optional: true
-    "@moonrepo/core-linux-x64-musl":
-      optional: true
-    "@moonrepo/core-macos-arm64":
-      optional: true
-    "@moonrepo/core-macos-x64":
-      optional: true
-    "@moonrepo/core-windows-x64-msvc":
-      optional: true
-  bin:
-    moon: moon
-  checksum: 7c12010a891e34fe1bd886ab9ec7c45a5a84730bf02377e38af3207b769664a0ac6ca6f4093ebaca9faed78f952c8caf652eb3c9d78e554b1c845ab6b3cff28e
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-linux-arm64-gnu@npm:^0.23.4":
-  version: 0.23.4
-  resolution: "@moonrepo/core-linux-arm64-gnu@npm:0.23.4"
+"@moonrepo/core-linux-arm64-gnu@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@moonrepo/core-linux-arm64-gnu@npm:1.3.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@moonrepo/core-linux-arm64-gnu@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "@moonrepo/core-linux-arm64-gnu@npm:0.25.0"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-linux-arm64-musl@npm:^0.23.4":
-  version: 0.23.4
-  resolution: "@moonrepo/core-linux-arm64-musl@npm:0.23.4"
+"@moonrepo/core-linux-arm64-musl@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@moonrepo/core-linux-arm64-musl@npm:1.3.1"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@moonrepo/core-linux-arm64-musl@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "@moonrepo/core-linux-arm64-musl@npm:0.25.0"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-linux-x64-gnu@npm:^0.23.4":
-  version: 0.23.4
-  resolution: "@moonrepo/core-linux-x64-gnu@npm:0.23.4"
+"@moonrepo/core-linux-x64-gnu@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@moonrepo/core-linux-x64-gnu@npm:1.3.1"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@moonrepo/core-linux-x64-gnu@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "@moonrepo/core-linux-x64-gnu@npm:0.25.0"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-linux-x64-musl@npm:^0.23.4":
-  version: 0.23.4
-  resolution: "@moonrepo/core-linux-x64-musl@npm:0.23.4"
+"@moonrepo/core-linux-x64-musl@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@moonrepo/core-linux-x64-musl@npm:1.3.1"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@moonrepo/core-linux-x64-musl@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "@moonrepo/core-linux-x64-musl@npm:0.25.0"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-macos-arm64@npm:^0.23.4":
-  version: 0.23.4
-  resolution: "@moonrepo/core-macos-arm64@npm:0.23.4"
+"@moonrepo/core-macos-arm64@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@moonrepo/core-macos-arm64@npm:1.3.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@moonrepo/core-macos-arm64@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "@moonrepo/core-macos-arm64@npm:0.25.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-macos-x64@npm:^0.23.4":
-  version: 0.23.4
-  resolution: "@moonrepo/core-macos-x64@npm:0.23.4"
+"@moonrepo/core-macos-x64@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@moonrepo/core-macos-x64@npm:1.3.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@moonrepo/core-macos-x64@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "@moonrepo/core-macos-x64@npm:0.25.0"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-windows-x64-msvc@npm:^0.23.4":
-  version: 0.23.4
-  resolution: "@moonrepo/core-windows-x64-msvc@npm:0.23.4"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@moonrepo/core-windows-x64-msvc@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "@moonrepo/core-windows-x64-msvc@npm:0.25.0"
+"@moonrepo/core-windows-x64-msvc@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@moonrepo/core-windows-x64-msvc@npm:1.3.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -17634,7 +17552,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "gallery-monorepo@workspace:."
   dependencies:
-    "@moonrepo/cli": ^0.25.0
+    "@moonrepo/cli": ^1.3.1
     "@types/react-relay": ^14.1.3
     "@types/relay-runtime": ^14.1.8
     "@typescript-eslint/eslint-plugin": ^5.44.0
@@ -23551,7 +23469,7 @@ __metadata:
     "@aveq-research/localforage-asyncstorage-driver": ^3.0.1
     "@babel/core": ^7.12.9
     "@magic-sdk/react-native-expo": ^16.0.0
-    "@moonrepo/cli": ^0.23.4
+    "@moonrepo/cli": ^1.3.1
     "@react-native-async-storage/async-storage": 1.17.11
     "@react-native-masked-view/masked-view": ^0.2.8
     "@react-navigation/material-top-tabs": ^6.6.0
@@ -32114,7 +32032,7 @@ __metadata:
     "@gallery-so/visitor-plugin-common": ^0.0.2
     "@graphql-codegen/cli": ^2.11.6
     "@graphql-codegen/typescript": ^2.7.3
-    "@moonrepo/cli": ^0.23.4
+    "@moonrepo/cli": ^1.3.1
     "@next/bundle-analyzer": ^13.0.4
     "@rainbow-me/rainbowkit": ^0.8.0
     "@sentry/nextjs": ^7.23.0


### PR DESCRIPTION
stable release! you can read the release notes here https://github.com/moonrepo/moon/releases/tag/v1.0.0

there have been a few releases since 1.0.0, and we're on the latest, but I figured I'd post the 1.0.0 release.