### PR TITLE
sort changelog results by date

### DIFF
--- a/apps/web/pages/changelog.tsx
+++ b/apps/web/pages/changelog.tsx
@@ -11,7 +11,7 @@ export default function Changelog({ document }: Props) {
 }
 
 export const getServerSideProps = async () => {
-  const content = await fetchSanityContent('changelog');
+  const content = await fetchSanityContent('*[ _type == "changelog" ] | order(date desc)');
 
   return {
     props: {

--- a/apps/web/src/utils/sanity.ts
+++ b/apps/web/src/utils/sanity.ts
@@ -7,9 +7,9 @@ export const getSanityUrl = (query: string) => {
   return `https://${sanityProjectId}.api.sanity.io/v1/data/query/production?query=${query}`;
 };
 
-export const fetchSanityContent = async (contentType: string) => {
-  const query = encodeURIComponent(`*[ _type == "${contentType}" ]`);
-  const url = getSanityUrl(query);
+export const fetchSanityContent = async (query: string) => {
+  const encodedQuery = encodeURIComponent(query);
+  const url = getSanityUrl(encodedQuery);
   const response = await fetch(url).then((res) => res.json());
 
   return response.result;


### PR DESCRIPTION
This PR updates the Sanity CMS query for the changelog page to retrieve documents sorted by date. 
This way we can insert docs in any order and they are presented chronologically.