### PR TITLE
mobile style polish

### DIFF
--- a/apps/mobile/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -47,10 +47,10 @@ export function CollectionCreatedFeedEvent({
     <View className="flex flex-1">
       <FeedEventCarouselCellHeader>
         <Text numberOfLines={1}>
-          <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
             Created a new collection
           </Typography>{' '}
-          <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
             {eventData.collection?.name ?? 'Untitled'}
           </Typography>
         </Text>

--- a/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -45,10 +45,10 @@ export function TokensAddedToCollectionFeedEvent({
     <View className="flex flex-1 flex-col">
       <FeedEventCarouselCellHeader>
         <Text numberOfLines={1}>
-          <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
             Added new tokens to
           </Typography>{' '}
-          <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
             {eventData.collection?.name ?? 'Untitled'}
           </Typography>
         </Text>

--- a/apps/mobile/src/components/Feed/FeedListCaption.tsx
+++ b/apps/mobile/src/components/Feed/FeedListCaption.tsx
@@ -1,3 +1,4 @@
+import { View } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -24,11 +25,13 @@ export function FeedListCaption({ feedEventRef }: FeedListCaptionProps) {
   }
 
   return (
-    <Typography
-      className="px-4 text-center text-2xl"
-      font={{ family: 'GTAlpina', weight: 'Light', italic: true }}
-    >
-      {feedEvent.caption}
-    </Typography>
+    <View className="ml-[12px] h-[28px] border-porcelain dark:border-shadow border-l-2">
+      <Typography
+        className="  px-2  text-base tracking-tight"
+        font={{ family: 'GTAlpina', weight: 'Light', italic: true }}
+      >
+        {feedEvent.caption}
+      </Typography>
+    </View>
   );
 }

--- a/apps/mobile/src/components/Feed/FeedListSectionHeader.tsx
+++ b/apps/mobile/src/components/Feed/FeedListSectionHeader.tsx
@@ -40,22 +40,22 @@ export function FeedListSectionHeader({ feedEventRef }: FeedListSectionHeaderPro
     return (
       <View className="flex flex-row items-center justify-between bg-white dark:bg-black px-3 py-2">
         <View className="flex flex-row space-x-1">
-          <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
             {feedEvent.eventData.owner?.username}
           </Typography>
 
-          <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
             updated
           </Typography>
 
-          <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
             {feedEvent.eventData.gallery?.name || 'Untitled'}
           </Typography>
         </View>
 
         <View>
           <Typography
-            className="text-metal text-xxs"
+            className="text-metal text-xs"
             font={{ family: 'ABCDiatype', weight: 'Regular' }}
           >
             {getTimeSince(feedEvent.eventData.eventTime)}

--- a/apps/mobile/src/components/FollowButton.tsx
+++ b/apps/mobile/src/components/FollowButton.tsx
@@ -16,9 +16,10 @@ type Props = {
   userRef: FollowButtonUserFragment$key;
   className?: string;
   source?: string; // where the FollowButton is being used, for analytics
+  width?: 'fixed' | 'grow';
 };
 
-export function FollowButton({ queryRef, userRef, style }: Props) {
+export function FollowButton({ queryRef, userRef, style, width = 'fixed' }: Props) {
   const loggedInUserQuery = useFragment(
     graphql`
       fragment FollowButtonQueryFragment on Query {
@@ -82,18 +83,18 @@ export function FollowButton({ queryRef, userRef, style }: Props) {
       return null;
     } else if (isFollowing) {
       return (
-        <FollowChip variant="unfollow" onPress={handleUnfollowPress}>
+        <FollowChip variant="unfollow" onPress={handleUnfollowPress} width={width}>
           Following
         </FollowChip>
       );
     } else {
       return (
-        <FollowChip variant="follow" onPress={handleFollowPress}>
+        <FollowChip variant="follow" onPress={handleFollowPress} width={width}>
           Follow
         </FollowChip>
       );
     }
-  }, [handleFollowPress, handleUnfollowPress, isSelf, isFollowing]);
+  }, [isSelf, isFollowing, handleUnfollowPress, width, handleFollowPress]);
 
   return <View style={style}>{followChip}</View>;
 }
@@ -102,17 +103,21 @@ function FollowChip({
   children,
   variant,
   onPress,
+  width,
 }: PropsWithChildren<{
   variant: 'follow' | 'unfollow';
   onPress: TouchableOpacityProps['onPress'];
+  width?: 'fixed' | 'grow';
 }>) {
   return (
     <TouchableOpacity
       onPress={onPress}
-      className={clsx('flex h-6 w-20 items-center justify-center rounded-sm px-2 bg-black', {
+      className={clsx('flex h-6  items-center justify-center rounded-sm px-2 bg-black', {
         'border border-black dark:border-shadow': variant === 'follow',
         'bg-porcelain dark:bg-graphite border border-porcelain dark:border-graphite':
           variant === 'unfollow',
+        'w-20': width === 'fixed',
+        'w-auto': width === 'grow',
       })}
     >
       <Typography

--- a/apps/mobile/src/components/FollowButton.tsx
+++ b/apps/mobile/src/components/FollowButton.tsx
@@ -109,14 +109,15 @@ function FollowChip({
   return (
     <TouchableOpacity
       onPress={onPress}
-      className={clsx('flex h-6 w-20 items-center justify-center rounded-sm px-2', {
-        'bg-black dark:bg-white': variant === 'follow',
-        'bg-white dark:bg-black border border-faint dark:border-graphite': variant === 'unfollow',
+      className={clsx('flex h-6 w-20 items-center justify-center rounded-sm px-2 bg-black', {
+        'border border-black dark:border-shadow': variant === 'follow',
+        'bg-porcelain dark:bg-graphite border border-porcelain dark:border-graphite':
+          variant === 'unfollow',
       })}
     >
       <Typography
         className={clsx('text-sm', {
-          'text-white dark:text-black': variant === 'follow',
+          'text-white ': variant === 'follow',
           'text-black dark:text-white': variant === 'unfollow',
         })}
         font={{ family: 'ABCDiatype', weight: 'Bold' }}

--- a/apps/mobile/src/components/Pill.tsx
+++ b/apps/mobile/src/components/Pill.tsx
@@ -5,7 +5,10 @@ type Props = PropsWithChildren<{ className?: string; style?: ViewProps['style'] 
 
 export function Pill({ children, style }: Props) {
   return (
-    <View style={style} className="border-porcelain rounded-full border py-1 px-3">
+    <View
+      style={style}
+      className="border-porcelain dark:border-shadow rounded-full border py-1 px-3"
+    >
       {children}
     </View>
   );

--- a/apps/mobile/src/components/ProfileView/ProfileView.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileView.tsx
@@ -351,7 +351,7 @@ export function ProfileView({ userRef, queryRef }: ProfileViewProps) {
           </View>
         </View>
         <Typography
-          className="bg-white dark:bg-black text-center text-2xl"
+          className="bg-white dark:bg-black text-center text-2xl tracking-tighter"
           font={{ family: 'GTAlpina', weight: 'StandardLight' }}
         >
           {user.username}

--- a/apps/mobile/src/components/Trending/TrendingUserCard.tsx
+++ b/apps/mobile/src/components/Trending/TrendingUserCard.tsx
@@ -113,7 +113,7 @@ export function TrendingUserCard({ style, userRef, queryRef }: Props) {
         </View>
       </View>
 
-      <FollowButton queryRef={query} userRef={user} />
+      <FollowButton queryRef={query} userRef={user} width="grow" />
     </View>
   );
 }


### PR DESCRIPTION
## Description

Miscellaneous design polish items

- add width prop to FollowButton to so it can be fixed or grow  (follow button expands to fit parent on Explore page user cards)
- fixed FollowButton dark mode styling
- increased feed event text to 14px for better readability and consistency with other screens
- dimmed Twitter pill border on dark mode
- updated feed caption styling to match design




Screenshots

FollowButton
Before
![Screenshot 2023-05-01 at 20 55 02](https://user-images.githubusercontent.com/80802871/235448473-30dcf151-dbe4-4a3b-998d-a25e34317fda.png)
After
![Screenshot 2023-05-01 at 20 55 49](https://user-images.githubusercontent.com/80802871/235448480-c558729d-ec09-4035-82d4-08e335defcff.png)



Caption 
Before
![Screenshot 2023-05-01 at 20 54 51](https://user-images.githubusercontent.com/80802871/235448507-a44b7410-87d0-4282-b7d1-4d92be140ef5.png)

AFter
![Screenshot 2023-05-01 at 20 53 55](https://user-images.githubusercontent.com/80802871/235448522-006068e9-a7cd-43da-85e1-68ba8a05ff1b.png)



Feed font
Before
![Screenshot 2023-05-01 at 20 57 05](https://user-images.githubusercontent.com/80802871/235448598-e0c3d017-e57f-49de-9e14-b100099426d6.png)

After
![Screenshot 2023-05-01 at 20 53 37](https://user-images.githubusercontent.com/80802871/235448587-679bb903-d795-4314-8b64-ddb01b60e0b4.png)


Twitter pill
before
![Screenshot 2023-05-01 at 20 54 46](https://user-images.githubusercontent.com/80802871/235448628-856077c9-3fe2-4f5a-88d0-8381b0d181c8.png)



After
![Screenshot 2023-05-01 at 20 54 35](https://user-images.githubusercontent.com/80802871/235448651-ae83645b-81e6-453c-801e-632bbc12b342.png)
