### PR TITLE
Settings sidebar refactor, prep mobile sign-in

### DIFF
--- a/apps/web/pages/mobile.tsx
+++ b/apps/web/pages/mobile.tsx
@@ -1,0 +1,24 @@
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+import { StandardSidebar } from '~/contexts/globalLayout/GlobalSidebar/StandardSidebar';
+import GalleryRoute from '~/scenes/_Router/GalleryRoute';
+
+export default function Mobile() {
+  const query = useLazyLoadQuery(
+    graphql`
+      query mobileQuery {
+        ...StandardSidebarFragment
+      }
+    `,
+    {}
+  );
+  return (
+    <GalleryRoute
+      element={<>dope mobile landing page</>}
+      sidebar={<StandardSidebar queryRef={query} />}
+      navbar={false}
+      banner={false}
+      footer={false}
+    />
+  );
+}

--- a/apps/web/pages/mobile.tsx
+++ b/apps/web/pages/mobile.tsx
@@ -1,10 +1,11 @@
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 import { StandardSidebar } from '~/contexts/globalLayout/GlobalSidebar/StandardSidebar';
+import { mobileQuery } from '~/generated/mobileQuery.graphql';
 import GalleryRoute from '~/scenes/_Router/GalleryRoute';
 
 export default function Mobile() {
-  const query = useLazyLoadQuery(
+  const query = useLazyLoadQuery<mobileQuery>(
     graphql`
       query mobileQuery {
         ...StandardSidebarFragment
@@ -12,6 +13,7 @@ export default function Mobile() {
     `,
     {}
   );
+
   return (
     <GalleryRoute
       element={<>dope mobile landing page</>}

--- a/apps/web/src/components/ManageWallets/ManageWallets.tsx
+++ b/apps/web/src/components/ManageWallets/ManageWallets.tsx
@@ -3,7 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import { Button } from '~/components/core/Button/Button';
-import { VStack } from '~/components/core/Spacer/Stack';
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import ErrorText from '~/components/core/Text/ErrorText';
 import SettingsRowDescription from '~/components/Settings/SettingsRowDescription';
 import { useToastActions } from '~/contexts/toast/ToastContext';
@@ -121,7 +121,7 @@ function ManageWallets({
             chain={primaryWallet.chainAddress.chain}
           />
         )}
-        <VStack>
+        <VStack gap={8}>
           {nonPrimaryWallets.map((wallet) => (
             <ManageWalletsRow
               key={wallet.dbid}
@@ -136,15 +136,18 @@ function ManageWallets({
           ))}
         </VStack>
       </VStack>
-      <StyledButton onClick={handleSubmit} disabled={addWalletDisabled} variant="secondary">
-        Add another
-      </StyledButton>
+      <HStack justify="end">
+        <StyledButton onClick={handleSubmit} disabled={addWalletDisabled} variant="secondary">
+          Add new wallet
+        </StyledButton>
+      </HStack>
     </VStack>
   );
 }
 
 const StyledButton = styled(Button)`
   align-self: flex-start;
+  padding: 8px 12px;
 `;
 
 const StyledErrorText = styled(ErrorText)`

--- a/apps/web/src/components/ManageWallets/ManageWalletsRow.tsx
+++ b/apps/web/src/components/ManageWallets/ManageWalletsRow.tsx
@@ -114,7 +114,6 @@ export default ManageWalletsRow;
 
 const StyledWalletRow = styled.div`
   display: flex;
-  padding: 8px 0px;
   justify-content: space-between;
   flex-direction: row;
   align-items: center;

--- a/apps/web/src/components/Settings/ManageAccountsSection/ManageAccountsSection.tsx
+++ b/apps/web/src/components/Settings/ManageAccountsSection/ManageAccountsSection.tsx
@@ -1,0 +1,28 @@
+import { graphql, useFragment } from 'react-relay';
+
+import { VStack } from '~/components/core/Spacer/Stack';
+import { TitleDiatypeL } from '~/components/core/Text/Text';
+import ManageWallets from '~/components/ManageWallets/ManageWallets';
+import { ManageAccountsSectionFragment$key } from '~/generated/ManageAccountsSectionFragment.graphql';
+
+type Props = {
+  queryRef: ManageAccountsSectionFragment$key;
+};
+
+export default function ManageAccountsSection({ queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment ManageAccountsSectionFragment on Query {
+        ...ManageWalletsFragment
+      }
+    `,
+    queryRef
+  );
+
+  return (
+    <VStack>
+      <TitleDiatypeL>Manage Accounts</TitleDiatypeL>
+      <ManageWallets queryRef={query} />
+    </VStack>
+  );
+}

--- a/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
+++ b/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useMemo, useState } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import { Button } from '~/components/core/Button/Button';
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { TitleDiatypeL } from '~/components/core/Text/Text';
+import Toggle from '~/components/core/Toggle/Toggle';
+import EmailManager from '~/components/Email/EmailManager';
+import useUpdateEmailNotificationSettings from '~/components/Email/useUpdateEmailNotificationSettings';
+import { useToastActions } from '~/contexts/toast/ToastContext';
+import { ManageEmailSectionFragment$key } from '~/generated/ManageEmailSectionFragment.graphql';
+import { useReportError } from '~/shared/contexts/ErrorReportingContext';
+import colors from '~/shared/theme/colors';
+
+import SettingsRowDescription from '../SettingsRowDescription';
+
+type Props = {
+  queryRef: ManageEmailSectionFragment$key;
+};
+
+const DISABLED_TOGGLE_BY_EMAIL_STATUS = ['Unverified', 'Failed'];
+
+export default function ManageEmailSection({ queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment ManageEmailSectionFragment on Query {
+        viewer @required(action: THROW) {
+          ... on Viewer {
+            email @required(action: THROW) {
+              email
+              verificationStatus
+              emailNotificationSettings {
+                unsubscribedFromAll
+                unsubscribedFromNotifications
+              }
+            }
+          }
+        }
+
+        ...EmailManagerFragment
+      }
+    `,
+    queryRef
+  );
+
+  const userEmail = query?.viewer?.email?.email;
+
+  const updateEmailNotificationSettings = useUpdateEmailNotificationSettings();
+
+  const isEmailNotificationSubscribed =
+    !query?.viewer?.email?.emailNotificationSettings?.unsubscribedFromNotifications;
+
+  const [isEmailNotificationChecked, setIsEmailNotificationChecked] = useState<boolean>(
+    isEmailNotificationSubscribed
+  );
+  const { pushToast } = useToastActions();
+  const reportError = useReportError();
+
+  const isEmailUnsubscribedFromAll =
+    query?.viewer?.email?.emailNotificationSettings?.unsubscribedFromAll ?? false;
+
+  const [shouldDisplayAddEmailInput, setShouldDisplayAddEmailInput] = useState<boolean>(
+    Boolean(userEmail)
+  );
+
+  const [isPending, setIsPending] = useState(false);
+
+  const handleEmailNotificationChange = useCallback(
+    async (checked: boolean) => {
+      const unsubscribedFromNotifications = checked;
+      setIsEmailNotificationChecked(!checked);
+      setIsPending(true);
+      try {
+        const response = await updateEmailNotificationSettings(
+          unsubscribedFromNotifications,
+          isEmailUnsubscribedFromAll
+        );
+
+        if (
+          response.updateEmailNotificationSettings?.viewer?.email?.emailNotificationSettings
+            ?.unsubscribedFromNotifications
+        ) {
+          pushToast({
+            message:
+              'Settings successfully updated. You will no longer receive notification emails',
+          });
+          return;
+        }
+        pushToast({
+          message: 'Settings successfully updated. You will now receive notification emails',
+        });
+        return;
+      } catch (error) {
+        if (error instanceof Error) {
+          reportError('Failed to update email notification settings');
+        }
+        pushToast({
+          message: 'Unfortunately there was an error to update your notification settings',
+        });
+        // If its failed, revert the toggle state
+        setIsEmailNotificationChecked(checked);
+      } finally {
+        setIsPending(false);
+      }
+    },
+    [isEmailUnsubscribedFromAll, pushToast, reportError, updateEmailNotificationSettings]
+  );
+
+  const toggleEmailNotification = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      handleEmailNotificationChange(!event.target.checked);
+    },
+    [handleEmailNotificationChange]
+  );
+
+  const handleOpenEmailManager = useCallback(() => {
+    setShouldDisplayAddEmailInput(true);
+  }, []);
+
+  const handleCloseEmailManager = useCallback(() => {
+    if (!userEmail) {
+      setShouldDisplayAddEmailInput(false);
+    }
+  }, [userEmail]);
+
+  const isEmailUnverified = useMemo(() => {
+    return DISABLED_TOGGLE_BY_EMAIL_STATUS.includes(query?.viewer?.email?.verificationStatus ?? '');
+  }, [query]);
+
+  const isToggleChecked = useMemo(() => {
+    // if the user dont have an email or not verified, we want to toggle off
+    if (!userEmail || isEmailUnverified) {
+      return false;
+    }
+    setIsEmailNotificationChecked(isEmailNotificationSubscribed);
+    return isEmailNotificationChecked;
+  }, [isEmailNotificationChecked, isEmailNotificationSubscribed, isEmailUnverified, userEmail]);
+
+  return (
+    <VStack gap={16}>
+      <VStack>
+        <TitleDiatypeL>Email Notifications</TitleDiatypeL>
+        <HStack justify="space-between" align="center">
+          <SettingsRowDescription>
+            Receive weekly recaps about product updates, airdrop opportunities, and your most recent
+            gallery admirers.
+          </SettingsRowDescription>
+        </HStack>
+      </VStack>
+      <StyledButtonContainer gap={12}>
+        {shouldDisplayAddEmailInput ? (
+          <EmailManager queryRef={query} onClose={handleCloseEmailManager} />
+        ) : (
+          <StyledButton variant="secondary" onClick={handleOpenEmailManager}>
+            add email address
+          </StyledButton>
+        )}
+        <Divider />
+        <HStack justify="space-between" align="center">
+          <strong>
+            <SettingsRowDescription>Receive weekly recaps</SettingsRowDescription>
+          </strong>
+          <Toggle
+            checked={isToggleChecked}
+            isPending={isPending || isEmailUnverified}
+            onChange={toggleEmailNotification}
+          />
+        </HStack>
+      </StyledButtonContainer>
+    </VStack>
+  );
+}
+
+const StyledButtonContainer = styled(VStack)`
+  background-color: ${colors.faint};
+  padding: 12px;
+`;
+
+const StyledButton = styled(Button)`
+  padding: 8px 12px;
+`;
+
+const Divider = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: ${colors.porcelain};
+`;

--- a/apps/web/src/components/Settings/ManageTwitterSection/ManageTwitterSection.tsx
+++ b/apps/web/src/components/Settings/ManageTwitterSection/ManageTwitterSection.tsx
@@ -1,0 +1,28 @@
+import { graphql, useFragment } from 'react-relay';
+
+import { VStack } from '~/components/core/Spacer/Stack';
+import { TitleDiatypeL } from '~/components/core/Text/Text';
+import TwitterSetting from '~/components/Twitter/TwitterSetting';
+import { ManageTwitterSectionFragment$key } from '~/generated/ManageTwitterSectionFragment.graphql';
+
+type Props = {
+  queryRef: ManageTwitterSectionFragment$key;
+};
+
+export default function ManageTwitterSection({ queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment ManageTwitterSectionFragment on Query {
+        ...TwitterSettingFragment
+      }
+    `,
+    queryRef
+  );
+
+  return (
+    <VStack gap={16}>
+      <TitleDiatypeL>Connect Twitter</TitleDiatypeL>
+      <TwitterSetting queryRef={query} />
+    </VStack>
+  );
+}

--- a/apps/web/src/components/Settings/MembersClubSection/MembersClubSection.tsx
+++ b/apps/web/src/components/Settings/MembersClubSection/MembersClubSection.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import { graphql, useFragment } from 'react-relay';
+
+import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { BaseM, TitleDiatypeL } from '~/components/core/Text/Text';
+import { GALLERY_DISCORD } from '~/constants/urls';
+import { MembersClubSectionFragment$key } from '~/generated/MembersClubSectionFragment.graphql';
+import CircleCheckIcon from '~/icons/CircleCheckIcon';
+import colors from '~/shared/theme/colors';
+import { GALLERY_OS_ADDRESS } from '~/shared/utils/getOpenseaExternalUrl';
+
+import SettingsRowDescription from '../SettingsRowDescription';
+
+type Props = {
+  queryRef: MembersClubSectionFragment$key;
+};
+
+export default function MembersClubSection({ queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment MembersClubSectionFragment on Query {
+        viewer {
+          ... on Viewer {
+            user {
+              roles
+            }
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  const hasEarlyAccess = useMemo(() => {
+    return query.viewer?.user?.roles?.includes('EARLY_ACCESS');
+  }, [query]);
+
+  return (
+    <VStack>
+      <TitleDiatypeL>Members Club</TitleDiatypeL>
+      <HStack justify="space-between" align="center" gap={8}>
+        <SettingsRowDescription>
+          Unlock early access to features, a profile badge, and the members-only{' '}
+          <InteractiveLink href={GALLERY_DISCORD}>Discord channel</InteractiveLink> by holding a{' '}
+          <InteractiveLink
+            href={`https://opensea.io/collection/gallery-membership-cards?ref=${GALLERY_OS_ADDRESS}`}
+          >
+            Premium Gallery Membership Card
+          </InteractiveLink>{' '}
+          and verifying your email address.
+        </SettingsRowDescription>
+        <HStack align="center" gap={4} shrink={false}>
+          {hasEarlyAccess ? (
+            <>
+              <CircleCheckIcon />
+              <BaseM>Active</BaseM>
+            </>
+          ) : (
+            <BaseM color={colors.metal}>Inactive</BaseM>
+          )}
+        </HStack>
+      </HStack>
+    </VStack>
+  );
+}

--- a/apps/web/src/components/Settings/MobileAuthManagerSection/MobileAuthManagerSection.tsx
+++ b/apps/web/src/components/Settings/MobileAuthManagerSection/MobileAuthManagerSection.tsx
@@ -1,0 +1,23 @@
+import { Button } from '~/components/core/Button/Button';
+import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
+import { VStack } from '~/components/core/Spacer/Stack';
+import { TitleDiatypeL } from '~/components/core/Text/Text';
+
+import SettingsRowDescription from '../SettingsRowDescription';
+
+export default function MobileAuthManagerSection() {
+  return (
+    <VStack gap={16}>
+      <VStack>
+        <TitleDiatypeL>Pair with Mobile</TitleDiatypeL>
+        <SettingsRowDescription>
+          Use a QR Code to sign in to the Gallery mobile app.
+        </SettingsRowDescription>
+      </VStack>
+      <VStack justify="center" align="start" gap={8}>
+        <Button>View QR Code</Button>
+        <InteractiveLink to={{ pathname: '/mobile' }}>Learn more about the app</InteractiveLink>
+      </VStack>
+    </VStack>
+  );
+}

--- a/apps/web/src/components/Settings/Settings.tsx
+++ b/apps/web/src/components/Settings/Settings.tsx
@@ -1,62 +1,34 @@
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
 import { Button } from '~/components/core/Button/Button';
-import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM, TitleDiatypeL } from '~/components/core/Text/Text';
-import Toggle from '~/components/core/Toggle/Toggle';
-import EmailManager from '~/components/Email/EmailManager';
-import ManageWallets from '~/components/ManageWallets/ManageWallets';
-import TwitterSetting from '~/components/Twitter/TwitterSetting';
-import { GALLERY_DISCORD } from '~/constants/urls';
 import DrawerHeader from '~/contexts/globalLayout/GlobalSidebar/DrawerHeader';
-import { useToastActions } from '~/contexts/toast/ToastContext';
 import { SettingsFragment$key } from '~/generated/SettingsFragment.graphql';
 import { useLogout } from '~/hooks/useLogout';
-import CircleCheckIcon from '~/icons/CircleCheckIcon';
-import { useReportError } from '~/shared/contexts/ErrorReportingContext';
 import colors from '~/shared/theme/colors';
-import { GALLERY_OS_ADDRESS } from '~/shared/utils/getOpenseaExternalUrl';
 
-import useUpdateEmailNotificationSettings from '../Email/useUpdateEmailNotificationSettings';
-import SettingsRowDescription from './SettingsRowDescription';
+import ManageAuthSection from './ManageAccountsSection/ManageAccountsSection';
+import ManageEmailSection from './ManageEmailSection/ManageEmailSection';
+import ManageTwitterSection from './ManageTwitterSection/ManageTwitterSection';
+import MembersClubSection from './MembersClubSection/MembersClubSection';
+import MobileAuthManagerSection from './MobileAuthManagerSection/MobileAuthManagerSection';
 
 type Props = {
   queryRef: SettingsFragment$key;
-  newAddress?: string;
-  onEthAddWalletSuccess?: () => void;
-  onTezosAddWalletSuccess?: () => void;
 };
 
-const DISABLED_TOGGLE_BY_EMAIL_STATUS = ['Unverified', 'Failed'];
-
-function Settings({ newAddress, queryRef, onEthAddWalletSuccess, onTezosAddWalletSuccess }: Props) {
+function Settings({ queryRef }: Props) {
   const query = useFragment(
     graphql`
       fragment SettingsFragment on Query {
-        viewer @required(action: THROW) {
-          ... on Viewer {
-            email @required(action: THROW) {
-              email
-              verificationStatus
-              emailNotificationSettings {
-                unsubscribedFromAll
-                unsubscribedFromNotifications
-              }
-            }
-            user {
-              roles
-            }
-          }
-        }
-
-        ...EmailManagerFragment
-        ...ManageWalletsFragment
-        ...TwitterSettingFragment
+        ...ManageEmailSectionFragment
+        ...ManageAccountsSectionFragment
+        ...ManageTwitterSectionFragment
+        ...MembersClubSectionFragment
       }
     `,
     queryRef
@@ -73,102 +45,6 @@ function Settings({ newAddress, queryRef, onEthAddWalletSuccess, onTezosAddWalle
     }
   }, [pathname, replace, urlQuery]);
 
-  const updateEmailNotificationSettings = useUpdateEmailNotificationSettings();
-
-  const isEmailNotificationSubscribed =
-    !query?.viewer?.email?.emailNotificationSettings?.unsubscribedFromNotifications;
-
-  const [isEmailNotificationChecked, setIsEmailNotificationChecked] = useState<boolean>(
-    isEmailNotificationSubscribed
-  );
-  const { pushToast } = useToastActions();
-  const reportError = useReportError();
-
-  const isEmailUnsubscribedFromAll =
-    query?.viewer?.email?.emailNotificationSettings?.unsubscribedFromAll ?? false;
-
-  const userEmail = query?.viewer?.email?.email;
-  const [shouldDisplayAddEmailInput, setShouldDisplayAddEmailInput] = useState<boolean>(
-    Boolean(userEmail)
-  );
-
-  const [isPending, setIsPending] = useState(false);
-
-  const handleEmailNotificationChange = useCallback(
-    async (checked: boolean) => {
-      const unsubscribedFromNotifications = checked;
-      setIsEmailNotificationChecked(!checked);
-      setIsPending(true);
-      try {
-        const response = await updateEmailNotificationSettings(
-          unsubscribedFromNotifications,
-          isEmailUnsubscribedFromAll
-        );
-
-        if (
-          response.updateEmailNotificationSettings?.viewer?.email?.emailNotificationSettings
-            ?.unsubscribedFromNotifications
-        ) {
-          pushToast({
-            message:
-              'Settings successfully updated. You will no longer receive notification emails',
-          });
-          return;
-        }
-        pushToast({
-          message: 'Settings successfully updated. You will now receive notification emails',
-        });
-        return;
-      } catch (error) {
-        if (error instanceof Error) {
-          reportError('Failed to update email notification settings');
-        }
-        pushToast({
-          message: 'Unfortunately there was an error to update your notification settings',
-        });
-        // If its failed, revert the toggle state
-        setIsEmailNotificationChecked(checked);
-      } finally {
-        setIsPending(false);
-      }
-    },
-    [isEmailUnsubscribedFromAll, pushToast, reportError, updateEmailNotificationSettings]
-  );
-
-  const toggleEmailNotification = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      handleEmailNotificationChange(!event.target.checked);
-    },
-    [handleEmailNotificationChange]
-  );
-
-  const handleOpenEmailManager = useCallback(() => {
-    setShouldDisplayAddEmailInput(true);
-  }, []);
-
-  const handleCloseEmailManager = useCallback(() => {
-    if (!userEmail) {
-      setShouldDisplayAddEmailInput(false);
-    }
-  }, [userEmail]);
-
-  const isEmailUnverified = useMemo(() => {
-    return DISABLED_TOGGLE_BY_EMAIL_STATUS.includes(query?.viewer?.email?.verificationStatus ?? '');
-  }, [query]);
-
-  const isToggleChecked = useMemo(() => {
-    // if the user dont have an email or not verified, we want to toggle off
-    if (!userEmail || isEmailUnverified) {
-      return false;
-    }
-    setIsEmailNotificationChecked(isEmailNotificationSubscribed);
-    return isEmailNotificationChecked;
-  }, [isEmailNotificationChecked, isEmailNotificationSubscribed, isEmailUnverified, userEmail]);
-
-  const hasEarlyAccess = useMemo(() => {
-    return query.viewer?.user?.roles?.includes('EARLY_ACCESS');
-  }, [query]);
-
   const logout = useLogout();
 
   const handleSignOutClick = useCallback(() => {
@@ -181,87 +57,26 @@ function Settings({ newAddress, queryRef, onEthAddWalletSuccess, onTezosAddWalle
       <StyledContentWrapper>
         <StyledSettings gap={12}>
           <SettingsContents gap={24}>
-            <VStack gap={16}>
-              <VStack>
-                <TitleDiatypeL>Email notifications</TitleDiatypeL>
-                <HStack justify="space-between" align="center">
-                  <SettingsRowDescription>
-                    Receive weekly recaps about product updates, airdrop opportunities, and your
-                    most recent gallery admirers.
-                  </SettingsRowDescription>
-                </HStack>
-              </VStack>
-              <StyledButtonContainer gap={12}>
-                {shouldDisplayAddEmailInput ? (
-                  <EmailManager queryRef={query} onClose={handleCloseEmailManager} />
-                ) : (
-                  <StyledButton variant="secondary" onClick={handleOpenEmailManager}>
-                    add email address
-                  </StyledButton>
-                )}
-                <Divider />
-                <HStack justify="space-between" align="center">
-                  <strong>
-                    <SettingsRowDescription>Receive weekly recaps</SettingsRowDescription>
-                  </strong>
-                  <Toggle
-                    checked={isToggleChecked}
-                    isPending={isPending || isEmailUnverified}
-                    onChange={toggleEmailNotification}
-                  />
-                </HStack>
-              </StyledButtonContainer>
-            </VStack>
+            <ManageEmailSection queryRef={query} />
+
             <Divider />
-            <VStack gap={16}>
-              <TitleDiatypeL>Connect twitter</TitleDiatypeL>
-              <TwitterSetting queryRef={query} />
-            </VStack>
+
+            <ManageTwitterSection queryRef={query} />
+
             <Divider />
-            <VStack>
-              <TitleDiatypeL>Manage accounts</TitleDiatypeL>
-              <ManageWallets
-                queryRef={query}
-                newAddress={newAddress}
-                onTezosAddWalletSuccess={onTezosAddWalletSuccess}
-                onEthAddWalletSuccess={onEthAddWalletSuccess}
-              />
-            </VStack>
+
+            <ManageAuthSection queryRef={query} />
+
             <Divider />
-            <VStack>
-              <TitleDiatypeL>QR Code Sign In</TitleDiatypeL>
-              <SettingsRowDescription>
-                Use a QR Code to effortlessly sign in to the Gallery mobile app.
-              </SettingsRowDescription>
-            </VStack>
+
+            <MobileAuthManagerSection />
+
             <Divider />
-            <VStack>
-              <TitleDiatypeL>Members Club</TitleDiatypeL>
-              <HStack justify="space-between" align="center" gap={8}>
-                <SettingsRowDescription>
-                  Unlock early access to features, a profile badge, and the members-only{' '}
-                  <InteractiveLink href={GALLERY_DISCORD}>Discord channel</InteractiveLink> by
-                  holding a{' '}
-                  <InteractiveLink
-                    href={`https://opensea.io/collection/gallery-membership-cards?ref=${GALLERY_OS_ADDRESS}`}
-                  >
-                    Premium Gallery Membership Card
-                  </InteractiveLink>{' '}
-                  and verifying your email address.
-                </SettingsRowDescription>
-                <HStack align="center" gap={4} shrink={false}>
-                  {hasEarlyAccess ? (
-                    <>
-                      <CircleCheckIcon />
-                      <BaseM>Active</BaseM>
-                    </>
-                  ) : (
-                    <BaseM color={colors.metal}>Inactive</BaseM>
-                  )}
-                </HStack>
-              </HStack>
-            </VStack>
+
+            <MembersClubSection queryRef={query} />
+
             <Divider />
+
             <HStack justify="end">
               <StyledButton variant="warning" onClick={handleSignOutClick}>
                 Sign Out
@@ -289,11 +104,6 @@ const Divider = styled.div`
   width: 100%;
   height: 1px;
   background-color: ${colors.porcelain};
-`;
-
-const StyledButtonContainer = styled(VStack)`
-  background-color: ${colors.faint};
-  padding: 12px;
 `;
 
 const StyledButton = styled(Button)`

--- a/apps/web/src/components/Settings/Settings.tsx
+++ b/apps/web/src/components/Settings/Settings.tsx
@@ -180,7 +180,7 @@ function Settings({ newAddress, queryRef, onEthAddWalletSuccess, onTezosAddWalle
       <DrawerHeader headerText="Settings" />
       <StyledContentWrapper>
         <StyledSettings gap={12}>
-          <SettingsContents gap={32}>
+          <SettingsContents gap={24}>
             <VStack gap={16}>
               <VStack>
                 <TitleDiatypeL>Email notifications</TitleDiatypeL>
@@ -213,6 +213,21 @@ function Settings({ newAddress, queryRef, onEthAddWalletSuccess, onTezosAddWalle
               </StyledButtonContainer>
             </VStack>
             <Divider />
+            <VStack gap={16}>
+              <TitleDiatypeL>Connect twitter</TitleDiatypeL>
+              <TwitterSetting queryRef={query} />
+            </VStack>
+            <Divider />
+            <VStack>
+              <TitleDiatypeL>Manage accounts</TitleDiatypeL>
+              <ManageWallets
+                queryRef={query}
+                newAddress={newAddress}
+                onTezosAddWalletSuccess={onTezosAddWalletSuccess}
+                onEthAddWalletSuccess={onEthAddWalletSuccess}
+              />
+            </VStack>
+            <Divider />
             <VStack>
               <TitleDiatypeL>Members Club</TitleDiatypeL>
               <HStack justify="space-between" align="center" gap={8}>
@@ -240,21 +255,6 @@ function Settings({ newAddress, queryRef, onEthAddWalletSuccess, onTezosAddWalle
                   )}
                 </HStack>
               </HStack>
-            </VStack>
-            <Divider />
-            <VStack gap={16}>
-              <TitleDiatypeL>Connect twitter</TitleDiatypeL>
-              <TwitterSetting queryRef={query} />
-            </VStack>
-            <Divider />
-            <VStack>
-              <TitleDiatypeL>Manage accounts</TitleDiatypeL>
-              <ManageWallets
-                queryRef={query}
-                newAddress={newAddress}
-                onTezosAddWalletSuccess={onTezosAddWalletSuccess}
-                onEthAddWalletSuccess={onEthAddWalletSuccess}
-              />
             </VStack>
             <Divider />
             <HStack>

--- a/apps/web/src/components/Settings/Settings.tsx
+++ b/apps/web/src/components/Settings/Settings.tsx
@@ -10,6 +10,7 @@ import DrawerHeader from '~/contexts/globalLayout/GlobalSidebar/DrawerHeader';
 import { SettingsFragment$key } from '~/generated/SettingsFragment.graphql';
 import { useLogout } from '~/hooks/useLogout';
 import colors from '~/shared/theme/colors';
+import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
 import ManageAuthSection from './ManageAccountsSection/ManageAccountsSection';
 import ManageEmailSection from './ManageEmailSection/ManageEmailSection';
@@ -29,6 +30,8 @@ function Settings({ queryRef }: Props) {
         ...ManageAccountsSectionFragment
         ...ManageTwitterSectionFragment
         ...MembersClubSectionFragment
+
+        ...isFeatureEnabledFragment
       }
     `,
     queryRef
@@ -51,6 +54,8 @@ function Settings({ queryRef }: Props) {
     logout();
   }, [logout]);
 
+  const isMobileLoginEnabled = isFeatureEnabled(FeatureFlag.MOBILE_BETA, query);
+
   return (
     <>
       <DrawerHeader headerText="Settings" />
@@ -69,9 +74,12 @@ function Settings({ queryRef }: Props) {
 
             <Divider />
 
-            <MobileAuthManagerSection />
-
-            <Divider />
+            {isMobileLoginEnabled && (
+              <>
+                <MobileAuthManagerSection />
+                <Divider />
+              </>
+            )}
 
             <MembersClubSection queryRef={query} />
 

--- a/apps/web/src/components/Settings/Settings.tsx
+++ b/apps/web/src/components/Settings/Settings.tsx
@@ -229,21 +229,26 @@ function Settings({ newAddress, queryRef, onEthAddWalletSuccess, onTezosAddWalle
             </VStack>
             <Divider />
             <VStack>
+              <TitleDiatypeL>QR Code Sign In</TitleDiatypeL>
+              <SettingsRowDescription>
+                Use a QR Code to effortlessly sign in to the Gallery mobile app.
+              </SettingsRowDescription>
+            </VStack>
+            <Divider />
+            <VStack>
               <TitleDiatypeL>Members Club</TitleDiatypeL>
               <HStack justify="space-between" align="center" gap={8}>
-                <span>
-                  <SettingsRowDescription>
-                    Unlock early access to features, a profile badge, and the members-only{' '}
-                    <InteractiveLink href={GALLERY_DISCORD}>Discord channel</InteractiveLink> by
-                    holding a{' '}
-                    <InteractiveLink
-                      href={`https://opensea.io/collection/gallery-membership-cards?ref=${GALLERY_OS_ADDRESS}`}
-                    >
-                      Premium Gallery Membership Card
-                    </InteractiveLink>{' '}
-                    and verifying your email address.
-                  </SettingsRowDescription>
-                </span>
+                <SettingsRowDescription>
+                  Unlock early access to features, a profile badge, and the members-only{' '}
+                  <InteractiveLink href={GALLERY_DISCORD}>Discord channel</InteractiveLink> by
+                  holding a{' '}
+                  <InteractiveLink
+                    href={`https://opensea.io/collection/gallery-membership-cards?ref=${GALLERY_OS_ADDRESS}`}
+                  >
+                    Premium Gallery Membership Card
+                  </InteractiveLink>{' '}
+                  and verifying your email address.
+                </SettingsRowDescription>
                 <HStack align="center" gap={4} shrink={false}>
                   {hasEarlyAccess ? (
                     <>
@@ -257,7 +262,7 @@ function Settings({ newAddress, queryRef, onEthAddWalletSuccess, onTezosAddWalle
               </HStack>
             </VStack>
             <Divider />
-            <HStack>
+            <HStack justify="end">
               <StyledButton variant="warning" onClick={handleSignOutClick}>
                 Sign Out
               </StyledButton>

--- a/apps/web/src/components/Twitter/useOpenTwitterFollowingModal.tsx
+++ b/apps/web/src/components/Twitter/useOpenTwitterFollowingModal.tsx
@@ -4,7 +4,6 @@ import { graphql, useFragment } from 'react-relay';
 
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { useOpenTwitterFollowingModalFragment$key } from '~/generated/useOpenTwitterFollowingModalFragment.graphql';
-import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
 import TwitterFollowingModal from './TwitterFollowingModal';
 
@@ -34,7 +33,6 @@ export default function useOpenTwitterFollowingModal(
 
         ...TwitterFollowingModalFragment
         ...TwitterFollowingModalQueryFragment
-        ...isFeatureEnabledFragment
       }
     `,
     queryRef
@@ -50,12 +48,10 @@ export default function useOpenTwitterFollowingModal(
 
   const isTwitterModalOpen = useRef(false);
 
-  const isTwitterFollowingEnabled = isFeatureEnabled(FeatureFlag.TWITTER_FOLLOWING, query);
-
   const totalTwitterConnections = query.socialConnections?.pageInfo?.total ?? 0;
 
   useEffect(() => {
-    if (!isLoggedIn || !isTwitterFollowingEnabled || totalTwitterConnections === 0) {
+    if (!isLoggedIn || totalTwitterConnections === 0) {
       return;
     }
 
@@ -65,5 +61,5 @@ export default function useOpenTwitterFollowingModal(
         content: <TwitterFollowingModal queryRef={query} followingRef={query} />,
       });
     }
-  }, [isLoggedIn, isTwitterFollowingEnabled, query, showModal, totalTwitterConnections, twitter]);
+  }, [isLoggedIn, query, showModal, totalTwitterConnections, twitter]);
 }

--- a/apps/web/src/utils/graphql/isFeatureEnabled.tsx
+++ b/apps/web/src/utils/graphql/isFeatureEnabled.tsx
@@ -6,31 +6,25 @@ import { removeNullValues } from '~/shared/relay/removeNullValues';
 import isProduction from '~/utils/isProduction';
 
 export enum FeatureFlag {
-  TWITTER_FOLLOWING = 'TWITTER_FOLLOWING',
   MOBILE_BETA = 'MOBILE_BETA',
 }
 
 const PROD_FLAGS: Record<FeatureFlag, boolean> = {
-  TWITTER_FOLLOWING: true,
   MOBILE_BETA: false,
 };
 
 const DEV_FLAGS: Record<FeatureFlag, boolean> = {
-  TWITTER_FOLLOWING: true,
   MOBILE_BETA: true,
 };
 
 const ROLE_FLAGS: Record<Role, Record<FeatureFlag, boolean>> = {
   ADMIN: {
-    TWITTER_FOLLOWING: true,
     MOBILE_BETA: true,
   },
   BETA_TESTER: {
-    TWITTER_FOLLOWING: true,
     MOBILE_BETA: false,
   },
   EARLY_ACCESS: {
-    TWITTER_FOLLOWING: true,
     MOBILE_BETA: false,
   },
 };

--- a/apps/web/src/utils/graphql/isFeatureEnabled.tsx
+++ b/apps/web/src/utils/graphql/isFeatureEnabled.tsx
@@ -7,25 +7,31 @@ import isProduction from '~/utils/isProduction';
 
 export enum FeatureFlag {
   TWITTER_FOLLOWING = 'TWITTER_FOLLOWING',
+  MOBILE_BETA = 'MOBILE_BETA',
 }
 
 const PROD_FLAGS: Record<FeatureFlag, boolean> = {
   TWITTER_FOLLOWING: true,
+  MOBILE_BETA: false,
 };
 
 const DEV_FLAGS: Record<FeatureFlag, boolean> = {
   TWITTER_FOLLOWING: true,
+  MOBILE_BETA: true,
 };
 
 const ROLE_FLAGS: Record<Role, Record<FeatureFlag, boolean>> = {
   ADMIN: {
     TWITTER_FOLLOWING: true,
+    MOBILE_BETA: true,
   },
   BETA_TESTER: {
     TWITTER_FOLLOWING: true,
+    MOBILE_BETA: false,
   },
   EARLY_ACCESS: {
     TWITTER_FOLLOWING: true,
+    MOBILE_BETA: false,
   },
 };
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by openai -->

https://www.loom.com/looms/videos/eng-0cd39ddabd44498398778ac306f0ac43

### Summary by OpenAI

New Feature: Several new components were added to the web app, including `Mobile`, `ManageAccountsSection`, `ManageEmailSection`, `ManageTwitterSection`, `MembersClubSection`, and `MobileAuthManagerSection`. The `Settings` component underwent significant changes, including the removal of email notification settings and the addition of a mobile authentication manager section. Minor updates were made to other components.

> A web app sprouts new features,
> Mobile, Twitter, and more creatures.
> Manage wallets with ease,
> And join the club, if you please.
> With GraphQL and OpenSea,
> This PR is quite a spree!
<!-- end of auto-generated comment: release notes by openai -->
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- New Feature: Added components that use `react-relay` to fetch data and render a sidebar with a title and a list of wallets.
- Refactor: Refactored the settings sidebar and added a gap between non-primary wallets. Also, changed the text on a button and removed a padding style rule from a styled component.
- Significant Changes: Updated GraphQL queries and feature flags in the settings sidebar. Removed a call to `isFeatureEnabled` function and its corresponding fragment, as well as updating the condition in the `useEffect` hook.

> "New features and refactors galore,
> Settings sidebar now has much more.
> GraphQL queries and feature flags,
> All updated without any lags."
<!-- end of auto-generated comment: release notes by openai -->