### PR TITLE
Use fallbackMedia as a fallback

### DIFF
--- a/apps/web/graphql.config.js
+++ b/apps/web/graphql.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  schema: ['schema.graphql', './relay-extensions.graphql'],
-  documents: '{src,pages}/**/*.{ts,tsx}',
-};

--- a/apps/web/src/components/GalleryEditor/CollectionEditor/SortableStagedNft.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionEditor/SortableStagedNft.tsx
@@ -86,7 +86,11 @@ function SortableStagedNft({ tokenRef, size, mini }: Props) {
         tokenId={token.dbid}
         fallback={
           <FallbackContainer ref={setNodeRef} size={size} {...attributes} {...listeners}>
-            <NftFailureFallback onRetry={refreshMetadata} refreshing={refreshingMetadata} />
+            <NftFailureFallback
+              tokenId={token.dbid}
+              onRetry={refreshMetadata}
+              refreshing={refreshingMetadata}
+            />
           </FallbackContainer>
         }
         onError={handleNftError}

--- a/apps/web/src/components/GalleryEditor/CollectionEditor/StagedItemDragging.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionEditor/StagedItemDragging.tsx
@@ -64,7 +64,7 @@ function StagedNftImageDraggingWrapper({ tokenRef, size }: StagedNftImageDraggin
     <NftFailureBoundary
       key={retryKey}
       tokenId={token.dbid}
-      fallback={<NftFailureFallback refreshing={false} onRetry={noop} />}
+      fallback={<NftFailureFallback tokenId={token.dbid} refreshing={false} onRetry={noop} />}
       onError={handleNftError}
     >
       <StagedNftImageDragging onLoad={handleNftLoaded} tokenRef={token} size={size} />

--- a/apps/web/src/components/GalleryEditor/CollectionEditor/StagedNftImageDragging.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionEditor/StagedNftImageDragging.tsx
@@ -3,25 +3,71 @@ import { graphql, useFragment } from 'react-relay';
 import styled, { keyframes } from 'styled-components';
 
 import { StagedNftImageDraggingFragment$key } from '~/generated/StagedNftImageDraggingFragment.graphql';
+import { StagedNftImageDraggingWithoutFallbackFragment$key } from '~/generated/StagedNftImageDraggingWithoutFallbackFragment.graphql';
 import { useImageFailureCheck } from '~/hooks/useImageFailureCheck';
 import useMouseUp from '~/hooks/useMouseUp';
 import { useThrowOnMediaFailure } from '~/hooks/useNftRetry';
 import { useReportError } from '~/shared/contexts/ErrorReportingContext';
 import { CouldNotRenderNftError } from '~/shared/errors/CouldNotRenderNftError';
+import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
 import colors from '~/shared/theme/colors';
 import { getBackgroundColorOverrideForContract } from '~/utils/token';
 
-type Props = {
+type StagedNftImageDraggingProps = {
   tokenRef: StagedNftImageDraggingFragment$key;
   onLoad: () => void;
   size: number;
 };
 
-function StagedNftImageDragging({ tokenRef, size, onLoad }: Props) {
+function StagedNftImageDragging({ tokenRef, onLoad, size }: StagedNftImageDraggingProps) {
   const token = useFragment(
     graphql`
       fragment StagedNftImageDraggingFragment on Token {
+        media {
+          ... on Media {
+            fallbackMedia {
+              mediaURL
+            }
+          }
+        }
+
+        ...StagedNftImageDraggingWithoutFallbackFragment
+      }
+    `,
+    tokenRef
+  );
+
+  return (
+    <ReportingErrorBoundary
+      fallback={
+        <RawStagedNftImageDragging
+          onLoad={onLoad}
+          size={size}
+          url={token.media?.fallbackMedia?.mediaURL}
+          type="image"
+        />
+      }
+    >
+      <StagedNftImageDraggingWithoutFallback tokenRef={token} onLoad={onLoad} size={size} />
+    </ReportingErrorBoundary>
+  );
+}
+
+type StagedNftImageDraggingWithoutFallbackProps = {
+  tokenRef: StagedNftImageDraggingWithoutFallbackFragment$key;
+  onLoad: () => void;
+  size: number;
+};
+
+function StagedNftImageDraggingWithoutFallback({
+  tokenRef,
+  size,
+  onLoad,
+}: StagedNftImageDraggingWithoutFallbackProps) {
+  const token = useFragment(
+    graphql`
+      fragment StagedNftImageDraggingWithoutFallbackFragment on Token {
         contract {
           contractAddress {
             address
@@ -33,11 +79,6 @@ function StagedNftImageDragging({ tokenRef, size, onLoad }: Props) {
     tokenRef
   );
 
-  const isMouseUp = useMouseUp();
-
-  // slightly enlarge the image when dragging
-  const zoomedSize = useMemo(() => size * 1.02, [size]);
-
   const reportError = useReportError();
   const result = getVideoOrImageUrlForNftPreview({
     tokenRef: token,
@@ -48,25 +89,60 @@ function StagedNftImageDragging({ tokenRef, size, onLoad }: Props) {
   const backgroundColorOverride = getBackgroundColorOverrideForContract(contractAddress);
 
   if (result?.urls.large) {
-    return result?.type === 'video' ? (
-      <StagedNftImageDraggingVideo
-        zoomedSize={zoomedSize}
-        isMouseUp={isMouseUp}
-        url={result.urls.large}
+    return (
+      <RawStagedNftImageDragging
+        size={size}
         onLoad={onLoad}
-      />
-    ) : (
-      <StagedNftImageDraggingImage
-        zoomedSize={zoomedSize}
-        isMouseUp={isMouseUp}
+        type={result.type}
+        url={result.urls.large}
         backgroundColorOverride={backgroundColorOverride}
-        url={result.urls.large}
-        onLoad={onLoad}
       />
     );
   } else {
     throw new CouldNotRenderNftError('StagedNftImageDragging', 'Nft did not have a large url');
   }
+}
+
+type RawStagedNftImageDraggingProps = {
+  size: number;
+  type: 'image' | 'video';
+  url: string | null | undefined;
+  onLoad: () => void;
+  backgroundColorOverride?: string;
+};
+
+function RawStagedNftImageDragging({
+  url,
+  type,
+  size,
+  onLoad,
+  backgroundColorOverride,
+}: RawStagedNftImageDraggingProps) {
+  if (!url) {
+    throw new CouldNotRenderNftError('RawStagedNftImageDragging', 'Nft did not have a url');
+  }
+
+  const isMouseUp = useMouseUp();
+
+  // slightly enlarge the image when dragging
+  const zoomedSize = useMemo(() => size * 1.02, [size]);
+
+  return type === 'video' ? (
+    <StagedNftImageDraggingVideo
+      zoomedSize={zoomedSize}
+      isMouseUp={isMouseUp}
+      url={url}
+      onLoad={onLoad}
+    />
+  ) : (
+    <StagedNftImageDraggingImage
+      zoomedSize={zoomedSize}
+      isMouseUp={isMouseUp}
+      backgroundColorOverride={backgroundColorOverride ?? ''}
+      url={url}
+      onLoad={onLoad}
+    />
+  );
 }
 
 type StagedNftImageDraggingVideoProps = {
@@ -118,7 +194,7 @@ function StagedNftImageDraggingImage({
 }
 
 const grow = keyframes`
-  from {height: 280px; width 280px};
+  from {height: 280px; width: 280px}
   to {height: 284px; width: 284px}
 `;
 
@@ -149,7 +225,7 @@ const StyledDraggingImage = styled.div<{
   isMouseUp: boolean;
   size: number;
 }>`
-  background-image: ${({ srcUrl }) => `url(${srcUrl})`}};
+  background-image: ${({ srcUrl }) => `url(${srcUrl})`};
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
@@ -7,7 +7,6 @@ import { BODY_FONT_FAMILY } from '~/components/core/Text/Text';
 import transitions from '~/components/core/transitions';
 import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
-import { RawNftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
 import { SIDEBAR_ICON_DIMENSIONS } from '~/constants/sidebar';
 import { useCollectionEditorContext } from '~/contexts/collectionEditor/CollectionEditorContext';
 import { useNftErrorContext } from '~/contexts/NftErrorContext';
@@ -185,7 +184,7 @@ function SidebarNftIcon({
           />
         </StyledSidebarNftIcon>
       }
-      // onError={handleError}
+      onError={handleError}
     >
       <ReportingErrorBoundary
         fallback={

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
@@ -7,6 +7,7 @@ import { BODY_FONT_FAMILY } from '~/components/core/Text/Text';
 import transitions from '~/components/core/transitions';
 import { NftFailureBoundary } from '~/components/NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
+import { RawNftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
 import { SIDEBAR_ICON_DIMENSIONS } from '~/constants/sidebar';
 import { useCollectionEditorContext } from '~/contexts/collectionEditor/CollectionEditorContext';
 import { useNftErrorContext } from '~/contexts/NftErrorContext';
@@ -17,6 +18,7 @@ import { SidebarNftIconPreviewAssetNew$key } from '~/generated/SidebarNftIconPre
 import { useNftRetry, useThrowOnMediaFailure } from '~/hooks/useNftRetry';
 import { useReportError } from '~/shared/contexts/ErrorReportingContext';
 import { CouldNotRenderNftError } from '~/shared/errors/CouldNotRenderNftError';
+import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
 import colors from '~/shared/theme/colors';
 import { getBackgroundColorOverrideForContract } from '~/utils/token';
@@ -42,6 +44,12 @@ function SidebarNftIcon({
           }
         }
         media {
+          ... on Media {
+            fallbackMedia {
+              mediaURL
+            }
+          }
+
           ... on SyncingMedia {
             __typename
           }
@@ -171,21 +179,33 @@ function SidebarNftIcon({
         <StyledSidebarNftIcon backgroundColorOverride={backgroundColorOverride}>
           <NftFailureFallback
             size="tiny"
+            tokenId={token.dbid}
             onRetry={refreshMetadata}
             refreshing={refreshingMetadata}
           />
         </StyledSidebarNftIcon>
       }
-      onError={handleError}
+      // onError={handleError}
     >
-      <StyledSidebarNftIcon backgroundColorOverride={backgroundColorOverride}>
-        <SidebarPreviewAsset
-          tokenRef={token}
-          onLoad={handleLoad}
-          isSelected={isSelected ?? false}
-        />
-        <StyledOutline onClick={handleClick} isSelected={isSelected} />
-      </StyledSidebarNftIcon>
+      <ReportingErrorBoundary
+        fallback={
+          <RawSidebarPreviewAsset
+            onLoad={handleLoad}
+            type="image"
+            isSelected={isSelected ?? false}
+            src={token.media?.fallbackMedia?.mediaURL}
+          />
+        }
+      >
+        <StyledSidebarNftIcon backgroundColorOverride={backgroundColorOverride}>
+          <SidebarPreviewAsset
+            tokenRef={token}
+            onLoad={handleLoad}
+            isSelected={isSelected ?? false}
+          />
+          <StyledOutline onClick={handleClick} isSelected={isSelected} />
+        </StyledSidebarNftIcon>
+      </ReportingErrorBoundary>
     </NftFailureBoundary>
   );
 }
@@ -210,6 +230,42 @@ const LoadingText = styled.span`
 
   color: ${colors.metal};
 `;
+
+function RawSidebarPreviewAsset({
+  type,
+  isSelected,
+  src,
+  onLoad,
+}: {
+  type: 'video' | 'image';
+  isSelected: boolean;
+  src: string | null | undefined;
+  onLoad: () => void;
+  alt?: string | null;
+}) {
+  if (!src) {
+    throw new CouldNotRenderNftError('SidebarNftIcon', 'missing src');
+  }
+
+  const { handleError } = useThrowOnMediaFailure('SidebarPreviewAsset');
+
+  // Some OpenSea assets don't have an image url,
+  // so render a freeze-frame of the video instead
+  if (type === 'video')
+    return (
+      <StyledVideo onLoadedData={onLoad} onError={handleError} isSelected={isSelected} src={src} />
+    );
+
+  return (
+    <StyledImage
+      isSelected={isSelected}
+      src={src}
+      alt="token"
+      onLoad={onLoad}
+      onError={handleError}
+    />
+  );
+}
 
 type SidebarPreviewAssetProps = {
   tokenRef: SidebarNftIconPreviewAssetNew$key;
@@ -237,27 +293,12 @@ function SidebarPreviewAsset({ tokenRef, onLoad, isSelected }: SidebarPreviewAss
     throw new CouldNotRenderNftError('SidebarNftIcon', 'could not find small image url');
   }
 
-  const { handleError } = useThrowOnMediaFailure('SidebarPreviewAsset');
-
-  // Some OpenSea assets don't have an image url,
-  // so render a freeze-frame of the video instead
-  if (previewUrlSet?.type === 'video')
-    return (
-      <StyledVideo
-        onLoadedData={onLoad}
-        onError={handleError}
-        isSelected={isSelected}
-        src={previewUrlSet.urls.small}
-      />
-    );
-
   return (
-    <StyledImage
+    <RawSidebarPreviewAsset
+      type={previewUrlSet.type}
       isSelected={isSelected}
       src={previewUrlSet.urls.small}
-      alt="token"
       onLoad={onLoad}
-      onError={handleError}
     />
   );
 }

--- a/apps/web/src/components/NftFailureFallback/NftFailureFallback.tsx
+++ b/apps/web/src/components/NftFailureFallback/NftFailureFallback.tsx
@@ -12,11 +12,12 @@ type Size = 'tiny' | 'medium';
 
 type Props = {
   size?: Size;
+  tokenId: string;
   onRetry: () => void;
   refreshing: boolean;
 };
 
-export function NftFailureFallback({ onRetry, refreshing, size = 'medium' }: Props) {
+export function NftFailureFallback({ tokenId, onRetry, refreshing, size = 'medium' }: Props) {
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       event.preventDefault();
@@ -57,7 +58,7 @@ export function NftFailureFallback({ onRetry, refreshing, size = 'medium' }: Pro
 
   return (
     <AspectRatioWrapper>
-      <Wrapper gap={spaceY} align="center" justify="center">
+      <Wrapper data-tokenid={tokenId} gap={spaceY} align="center" justify="center">
         {refreshing ? (
           <Label size={size}>Loading...</Label>
         ) : (

--- a/apps/web/src/components/NftPreview/NftPreview.tsx
+++ b/apps/web/src/components/NftPreview/NftPreview.tsx
@@ -15,12 +15,13 @@ import LinkToNftDetailView from '~/scenes/NftDetailPage/LinkToNftDetailView';
 import NftDetailAnimation from '~/scenes/NftDetailPage/NftDetailAnimation';
 import NftDetailGif from '~/scenes/NftDetailPage/NftDetailGif';
 import NftDetailVideo from '~/scenes/NftDetailPage/NftDetailVideo';
+import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
 import { isFirefox } from '~/utils/browser';
 import isSvg from '~/utils/isSvg';
 import { getBackgroundColorOverrideForContract } from '~/utils/token';
 
-import NftPreviewAsset from './NftPreviewAsset';
+import NftPreviewAsset, { RawNftPreviewAsset } from './NftPreviewAsset';
 import NftPreviewLabel from './NftPreviewLabel';
 
 type Props = {
@@ -43,6 +44,13 @@ const nftPreviewTokenFragment = graphql`
       }
     }
     media {
+      ... on Media {
+        __typename
+        fallbackMedia {
+          mediaURL
+        }
+      }
+
       ... on VideoMedia {
         __typename
         ...NftDetailVideoFragment
@@ -50,6 +58,7 @@ const nftPreviewTokenFragment = graphql`
       ... on GIFMedia {
         __typename
       }
+
       ... on HtmlMedia {
         __typename
       }
@@ -204,7 +213,17 @@ function NftPreview({
           This will inherit the `as` URL from the parent component. */}
         <StyledA onClick={handleClick}>
           <StyledNftPreview backgroundColorOverride={backgroundColorOverride} fullWidth={fullWidth}>
-            {PreviewAsset}
+            <ReportingErrorBoundary
+              fallback={
+                <RawNftPreviewAsset
+                  src={token.media?.fallbackMedia?.mediaURL}
+                  onLoad={handleNftLoaded}
+                />
+              }
+            >
+              {PreviewAsset}
+            </ReportingErrorBoundary>
+
             {isMobileOrLargeMobile ? null : (
               <StyledNftFooter>
                 <StyledNftLabel tokenRef={token} />

--- a/apps/web/src/components/NftPreview/NftPreview.tsx
+++ b/apps/web/src/components/NftPreview/NftPreview.tsx
@@ -199,7 +199,11 @@ function NftPreview({
       tokenId={token.dbid}
       fallback={
         <NftFailureWrapper>
-          <NftFailureFallback refreshing={refreshingMetadata} onRetry={refreshMetadata} />
+          <NftFailureFallback
+            tokenId={token.dbid}
+            refreshing={refreshingMetadata}
+            onRetry={refreshMetadata}
+          />
         </NftFailureWrapper>
       }
       onError={handleNftError}
@@ -211,7 +215,7 @@ function NftPreview({
       >
         {/* NextJS <Link> tags don't come with an anchor tag by default, so we're adding one here.
           This will inherit the `as` URL from the parent component. */}
-        <StyledA data-tokenId={token.dbid} onClick={handleClick}>
+        <StyledA data-tokenid={token.dbid} onClick={handleClick}>
           <StyledNftPreview backgroundColorOverride={backgroundColorOverride} fullWidth={fullWidth}>
             <ReportingErrorBoundary
               fallback={

--- a/apps/web/src/components/NftPreview/NftPreview.tsx
+++ b/apps/web/src/components/NftPreview/NftPreview.tsx
@@ -211,7 +211,7 @@ function NftPreview({
       >
         {/* NextJS <Link> tags don't come with an anchor tag by default, so we're adding one here.
           This will inherit the `as` URL from the parent component. */}
-        <StyledA onClick={handleClick}>
+        <StyledA data-tokenId={token.dbid} onClick={handleClick}>
           <StyledNftPreview backgroundColorOverride={backgroundColorOverride} fullWidth={fullWidth}>
             <ReportingErrorBoundary
               fallback={

--- a/apps/web/src/components/NftPreview/NftPreviewAsset.tsx
+++ b/apps/web/src/components/NftPreview/NftPreviewAsset.tsx
@@ -83,6 +83,22 @@ function NftPreviewAsset({ tokenRef, size, onLoad }: Props) {
 
   const { url: src } = resizedNft;
 
+  return <RawNftPreviewAsset src={src} onLoad={onLoad} alt={token.name} />;
+}
+
+export function RawNftPreviewAsset({
+  src,
+  onLoad,
+  alt,
+}: {
+  alt?: string | undefined | null;
+  src: string | null | undefined;
+  onLoad: () => void;
+}) {
+  if (!src) {
+    throw new CouldNotRenderNftError('RawNftPreviewAsset', 'Missing src');
+  }
+
   // TODO: this is a hack to handle videos that are returned by OS as images.
   // i.e., assets that do not have animation_urls, and whose image_urls all contain
   // links to videos. we should be able to remove this hack once we're off of OS.
@@ -91,12 +107,7 @@ function NftPreviewAsset({ tokenRef, size, onLoad }: Props) {
   }
 
   return (
-    <ImageWithLoading
-      onLoad={onLoad}
-      src={src}
-      heightType="maxHeightScreen"
-      alt={token.name ?? ''}
-    />
+    <ImageWithLoading onLoad={onLoad} src={src} heightType="maxHeightScreen" alt={alt ?? ''} />
   );
 }
 

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
@@ -64,6 +64,7 @@ const UnknownMediaResponse: NftDetailAssetTestQueryQuery = {
       collectorsNote: 'Test Collectors Note',
       media: {
         __typename: 'UnknownMedia',
+        fallbackMedia: null,
         contentRenderURL: 'bad url here',
       },
       contract: {
@@ -97,6 +98,7 @@ const RetryImageMediaResponse: NftErrorContextRetryMutationMutation = {
       chain: Chain.Ethereum,
       media: {
         __typename: 'ImageMedia',
+        fallbackMedia: null,
         contentRenderURL: 'bad url here',
         previewURLs: {
           small: 'http://someimage.com',

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -221,6 +221,7 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
 
   return (
     <StyledAssetContainer
+      data-tokenId={token.dbid}
       footerHeight={GLOBAL_FOOTER_HEIGHT}
       shouldEnforceSquareAspectRatio={shouldEnforceSquareAspectRatio}
       hasExtraPaddingForNote={hasExtraPaddingForNote}

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -221,7 +221,7 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
 
   return (
     <StyledAssetContainer
-      data-tokenId={token.dbid}
+      data-tokenid={token.dbid}
       footerHeight={GLOBAL_FOOTER_HEIGHT}
       shouldEnforceSquareAspectRatio={shouldEnforceSquareAspectRatio}
       hasExtraPaddingForNote={hasExtraPaddingForNote}

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -49,7 +49,13 @@ export function NftDetailAssetComponent({ tokenRef, onLoad }: NftDetailAssetComp
 
   return (
     <ReportingErrorBoundary
-      fallback={<NftDetailImage onLoad={onLoad} imageUrl={token.media?.fallbackMedia?.mediaURL} />}
+      fallback={
+        <NftDetailImage
+          alt={null}
+          onLoad={onLoad}
+          imageUrl={token.media?.fallbackMedia?.mediaURL}
+        />
+      }
     >
       <NftDetailAssetComponentWithouFallback tokenRef={token} onLoad={onLoad} />
     </ReportingErrorBoundary>
@@ -68,6 +74,8 @@ function NftDetailAssetComponentWithouFallback({
   const token = useFragment(
     graphql`
       fragment NftDetailAssetComponentWithoutFallbackFragment on Token {
+        name
+
         media @required(action: THROW) {
           ... on VideoMedia {
             __typename
@@ -132,6 +140,7 @@ function NftDetailAssetComponentWithouFallback({
 
       return (
         <NftDetailImage
+          alt={token.name}
           onLoad={onLoad}
           imageUrl={imageMedia.contentRenderURL}
           onClick={() => {
@@ -231,7 +240,13 @@ function NftDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
         key={retryKey}
         tokenId={token.dbid}
         onError={handleNftError}
-        fallback={<NftFailureFallback onRetry={refreshMetadata} refreshing={refreshingMetadata} />}
+        fallback={
+          <NftFailureFallback
+            tokenId={token.dbid}
+            onRetry={refreshMetadata}
+            refreshing={refreshingMetadata}
+          />
+        }
       >
         <NftDetailAssetComponent onLoad={handleNftLoaded} tokenRef={token} />
       </NftFailureBoundary>

--- a/apps/web/src/scenes/NftDetailPage/NftDetailImage.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailImage.tsx
@@ -10,12 +10,13 @@ import { graphqlGetResizedNftImageUrlWithFallback } from '~/utils/token';
 import { StyledVideo } from './NftDetailVideo';
 
 type Props = {
+  alt: string | null | undefined;
   imageUrl: string | null | undefined;
   onClick?: () => void;
   onLoad: () => void;
 };
 
-function NftDetailImage({ imageUrl, onClick = noop, onLoad }: Props) {
+function NftDetailImage({ alt, imageUrl, onClick = noop, onLoad }: Props) {
   const breakpoint = useBreakpoint();
   const { handleError } = useThrowOnMediaFailure('NftDetailImage');
 
@@ -49,6 +50,7 @@ function NftDetailImage({ imageUrl, onClick = noop, onLoad }: Props) {
 
   return (
     <ImageWithLoading
+      alt={alt ?? ''}
       src={url}
       heightType={breakpoint === size.desktop ? 'maxHeightMinScreen' : undefined}
       onClick={onClick}

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
@@ -61,7 +61,7 @@ function TokenDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
 
   return (
     <StyledAssetContainer
-      data-tokenId={token.dbid}
+      data-tokenid={token.dbid}
       footerHeight={GLOBAL_FOOTER_HEIGHT}
       shouldEnforceSquareAspectRatio={shouldEnforceSquareAspectRatio}
       hasExtraPaddingForNote={hasExtraPaddingForNote}

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
@@ -61,6 +61,7 @@ function TokenDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
 
   return (
     <StyledAssetContainer
+      data-tokenId={token.dbid}
       footerHeight={GLOBAL_FOOTER_HEIGHT}
       shouldEnforceSquareAspectRatio={shouldEnforceSquareAspectRatio}
       hasExtraPaddingForNote={hasExtraPaddingForNote}

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
@@ -71,7 +71,13 @@ function TokenDetailAsset({ tokenRef, hasExtraPaddingForNote }: Props) {
         key={retryKey}
         tokenId={token.dbid}
         onError={handleNftError}
-        fallback={<NftFailureFallback onRetry={refreshMetadata} refreshing={refreshingMetadata} />}
+        fallback={
+          <NftFailureFallback
+            tokenId={token.dbid}
+            onRetry={refreshMetadata}
+            refreshing={refreshingMetadata}
+          />
+        }
       >
         <NftDetailAssetComponent onLoad={handleNftLoaded} tokenRef={token} />
       </NftFailureBoundary>

--- a/graphql.config.yml
+++ b/graphql.config.yml
@@ -1,1 +1,2 @@
 schema: schema.graphql
+documents: '**/*.graphql'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6754223/236076671-934decca-0a50-4cdf-a45c-3bf886a57b17.png)

### Follow Up
- Right now the backend only gives us the fallback media if the backend thinks the optimistic media is broken. I though the whole point of this was to handle cases the backend is unable to realize is broken. I had to change this backend logic locally to test this out.
- tokenPreviews on a Gallery or GalleryUser should use the fallback media, but I can't do anything about it since I only have access to the `TokenPreview`

### Testing Video
Throughout the video, you'll see that the green token is being rendered. This is the fallback media provided by the backend. 

**In the gallery token preview part, you'll see a broken image. Re-read the follow up section of this PR to see why that is**

https://user-images.githubusercontent.com/6754223/236078349-659344ee-cbc3-4301-aa24-5c84ddf82cf8.mov


## Architecture

We now have two layers of Error Boundaries for rendering an asset.

1. **New**. This is the first error boundary to get hit if a token fails to load. If we fail, we'll render a fallback version of the relevant component with the fallback media as the URL.
2. The old one, sitting right above the new error boundary, if the fallback also fails (or the fallback does not exist), we'll trigger this boundary, which shows the fallback as you know it today.

### Small Changes
I added `data-tokenid` attributes to the following components so you can quickly grab it by inspecting the element. 
- NftPreview
- NftFailureFallback
- NftDetailAsset
- TokenDetailAsset


### Notes

I kept some notes while working on this to make sure we covered every plae 

```
- SidebarNftIcon
    - Takes a token ref
    - Video / Image
- StagedNftImage
    - Takes a token ref
    - Video / Image
- StagedNftImageDragging
    - Takes a token ref
    - Video / Image
- SortableStagedNft
    - Takes a tokenRef
    - Video / Image
- NftPreview
    - Takes a tokenRef
    - Forwards to one of the following
        - NftPreviewAsset
        - NftDetailVideo
        - NftDetailGif
        - NftDetailAnimation
    - Supports live display
- TokenDetailAsset
    - Straight to NftDetailAssetComponent (Underlying for NftDetail)
- NftDetailAsset
    - Yah
```

