### PR TITLE
Enable nfts with fallback media to be added to collections

### DIFF
--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
@@ -188,12 +188,15 @@ function SidebarNftIcon({
     >
       <ReportingErrorBoundary
         fallback={
-          <RawSidebarPreviewAsset
-            onLoad={handleLoad}
-            type="image"
-            isSelected={isSelected ?? false}
-            src={token.media?.fallbackMedia?.mediaURL}
-          />
+          <StyledSidebarNftIcon>
+            <RawSidebarPreviewAsset
+              onLoad={handleLoad}
+              type="image"
+              isSelected={isSelected ?? false}
+              src={token.media?.fallbackMedia?.mediaURL}
+            />
+            <StyledOutline onClick={handleClick} isSelected={isSelected} />
+          </StyledSidebarNftIcon>
         }
       >
         <StyledSidebarNftIcon backgroundColorOverride={backgroundColorOverride}>

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
@@ -188,7 +188,7 @@ function SidebarNftIcon({
     >
       <ReportingErrorBoundary
         fallback={
-          <StyledSidebarNftIcon>
+          <StyledSidebarNftIcon backgroundColorOverride={backgroundColorOverride}>
             <RawSidebarPreviewAsset
               onLoad={handleLoad}
               type="image"


### PR DESCRIPTION
## Description

This PR allows NFTs with fallback media to be added to collections. Currently they can't be clicked in the sidebar, which is confusing to the user.

A user reported they couldn't add certain NFTs from the sidebar to their collection, and it was because those were displaying fallback media without the onClick handler.


Haven't thought deeply about the implications of this for different types of fallback media as listed in #1519 so will only merge after ok from terence/eng team


Before

https://user-images.githubusercontent.com/80802871/236385298-d1a3ef01-2387-421b-aab4-daf7fe148c10.mp4




After

https://user-images.githubusercontent.com/80802871/236385310-39c0323a-fae7-4af0-936b-2c21b52a352a.mp4

