### PR TITLE
Fix Load Infinite Loop

### DIFF
--- a/apps/mobile/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -6,6 +6,7 @@ import { graphql } from 'relay-runtime';
 
 import { UserFollowedUsersFeedEventFragment$key } from '~/generated/UserFollowedUsersFeedEventFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
+import { getTimeSince } from '~/shared/utils/time';
 
 import { Typography } from '../../Typography';
 
@@ -20,6 +21,8 @@ export function UserFollowedUsersFeedEvent({
     graphql`
       fragment UserFollowedUsersFeedEventFragment on UserFollowedUsersFeedEventData {
         __typename
+        eventTime
+
         owner {
           username
         }
@@ -50,16 +53,33 @@ export function UserFollowedUsersFeedEvent({
   }, [followeeUsername, navigation]);
 
   return (
-    <View className="flex flex-row space-x-1">
-      <TouchableOpacity onPress={handleFollowerPress}>
-        <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }}>{followerUsername}</Typography>
-      </TouchableOpacity>
+    <View className="flex flex-row justify-between items-center px-3">
+      <View className="flex flex-row space-x-1">
+        <TouchableOpacity onPress={handleFollowerPress}>
+          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+            {followerUsername}
+          </Typography>
+        </TouchableOpacity>
 
-      <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }}>followed</Typography>
+        <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+          followed
+        </Typography>
 
-      <TouchableOpacity onPress={handleFolloweePress}>
-        <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }}>{followeeUsername}</Typography>
-      </TouchableOpacity>
+        <TouchableOpacity onPress={handleFolloweePress}>
+          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+            {followeeUsername}
+          </Typography>
+        </TouchableOpacity>
+      </View>
+
+      <View>
+        <Typography
+          className="text-metal text-xs"
+          font={{ family: 'ABCDiatype', weight: 'Regular' }}
+        >
+          {getTimeSince(eventData.eventTime)}
+        </Typography>
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -18,6 +18,12 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
   const event = useFragment(
     graphql`
       fragment FeedEventSocializeSectionFragment on FeedEvent {
+        eventData {
+          ... on UserFollowedUsersFeedEventData {
+            __typename
+          }
+        }
+
         ...InteractionsFragment
         ...AdmireButtonFragment
         ...CommentButtonFragment
@@ -36,6 +42,10 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
     `,
     queryRef
   );
+
+  if (event.eventData?.__typename === 'UserFollowedUsersFeedEventData') {
+    return <View className="pb-6" />;
+  }
 
   return (
     <View className="flex flex-row px-3 justify-between pb-8 pt-5">

--- a/apps/mobile/src/components/Feed/createVirtualizedFeedEventItems.ts
+++ b/apps/mobile/src/components/Feed/createVirtualizedFeedEventItems.ts
@@ -68,6 +68,8 @@ export function createVirtualizedFeedEventItems({
           caption
 
           eventData {
+            __typename
+
             ... on GalleryUpdatedFeedEventData {
               __typename
               subEventDatas {

--- a/apps/mobile/src/screens/HomeScreen/LatestScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen/LatestScreen.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useEffect, useMemo } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef } from 'react';
 import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/NotesModal/NotesList';
@@ -43,10 +43,12 @@ function LatestScreenInner({ queryRef }: LatestScreenInnerProps) {
     queryRef
   );
 
+  const firstMountRef = useRef(true);
   useEffect(() => {
-    if (hasPrevious && !isLoadingPrevious) {
+    if (firstMountRef.current && hasPrevious) {
       loadPrevious(PER_PAGE - INITIAL_COUNT);
     }
+    firstMountRef.current = false;
   }, [hasPrevious, isLoadingPrevious, loadPrevious]);
 
   const handleLoadMore = useCallback(() => {

--- a/apps/mobile/src/screens/HomeScreen/TrendingScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen/TrendingScreen.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useEffect, useMemo } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef } from 'react';
 import { graphql, useFragment, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/NotesModal/NotesList';
@@ -77,10 +77,13 @@ function TrendingScreenInner({ queryRef }: TrendingScreenInnerProps) {
     query
   );
 
+  const firstMountRef = useRef(true);
   useEffect(() => {
-    if (trendingFeed.hasPrevious) {
+    if (firstMountRef.current && trendingFeed.hasPrevious) {
       trendingFeed.loadPrevious(PER_PAGE - INITIAL_COUNT);
     }
+
+    firstMountRef.current = false;
   }, [trendingFeed]);
 
   const handleLoadMore = useCallback(() => {

--- a/apps/mobile/src/screens/HomeScreen/TrendingScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen/TrendingScreen.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useEffect, useMemo, useRef } from 'react';
+import { Suspense, useCallback, useMemo } from 'react';
 import { graphql, useFragment, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/NotesModal/NotesList';
@@ -18,7 +18,6 @@ type TrendingScreenInnerProps = {
 };
 
 const PER_PAGE = 20;
-const INITIAL_COUNT = 3;
 
 function TrendingScreenInner({ queryRef }: TrendingScreenInnerProps) {
   const query = useFragment(
@@ -77,15 +76,6 @@ function TrendingScreenInner({ queryRef }: TrendingScreenInnerProps) {
     query
   );
 
-  const firstMountRef = useRef(true);
-  useEffect(() => {
-    if (firstMountRef.current && trendingFeed.hasPrevious) {
-      trendingFeed.loadPrevious(PER_PAGE - INITIAL_COUNT);
-    }
-
-    firstMountRef.current = false;
-  }, [trendingFeed]);
-
   const handleLoadMore = useCallback(() => {
     if (trendingFeed.isLoadingPrevious || globalFeed.isLoadingPrevious) {
       return;
@@ -133,7 +123,7 @@ export function TrendingScreen() {
       }
     `,
     {
-      trendingFeedCount: INITIAL_COUNT,
+      trendingFeedCount: PER_PAGE,
       interactionsFirst: NOTES_PER_PAGE,
     }
   );


### PR DESCRIPTION
Putting the load more in an effect was really dumb without any extra safe guards. This fixes it by making sure we only load more on first mount.

I also removed this optimization from the trending screen since that isn't as critical for first load and will likely have worse performance since we're updating the list items more than once.

I also fixed a bug where we were only rendering GalleryUpdated events, now we actually render follow events so I had to make those presentable as well.