### PR TITLE
[GAL-2981] remove revealHeaderOnScroll since it causes scrolling issues

### DIFF
--- a/apps/mobile/src/components/ProfileView/ProfileView.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileView.tsx
@@ -134,7 +134,6 @@ export function ProfileView({ userRef, queryRef, shouldShowBackButton }: Profile
 
       <GalleryTokenDimensionCacheProvider>
         <Tabs.Container
-          revealHeaderOnScroll
           ref={containerRef}
           pagerProps={{ scrollEnabled: false }}
           containerStyle={{


### PR DESCRIPTION
I think there's some bugs in the library we're using with the `revealHeaderOnScroll` prop. For now I've disabled it.