### PR TITLE
Fix bug w/ login having stale data

### DIFF
--- a/apps/mobile/src/screens/AccountScreen.tsx
+++ b/apps/mobile/src/screens/AccountScreen.tsx
@@ -34,6 +34,9 @@ function AccountScreenInner() {
     {
       feedLast: 24,
       interactionsFirst: NOTES_PER_PAGE,
+    },
+    {
+      fetchPolicy: 'network-only',
     }
   );
 

--- a/apps/mobile/src/screens/Login/EnterEmailScreen.tsx
+++ b/apps/mobile/src/screens/Login/EnterEmailScreen.tsx
@@ -91,6 +91,7 @@ export function EnterEmailScreen() {
             )}
 
             <FadedInput
+              autoFocus
               placeholder="Email"
               keyboardType="email-address"
               autoCorrect={false}

--- a/apps/mobile/src/screens/NotificationsScreen.tsx
+++ b/apps/mobile/src/screens/NotificationsScreen.tsx
@@ -19,7 +19,8 @@ export function NotificationsScreen() {
     {
       notificationsLast: NOTIFICATIONS_PER_PAGE,
       notificationsBefore: null,
-    }
+    },
+    { fetchPolicy: 'network-only' }
   );
 
   const { top } = useSafeAreaInsets();


### PR DESCRIPTION
Relay being too smart here. It knows there's a `null` viewer in the store from the first load (since we're not logged in). After we log in, it's like "Right the viewer is null so let's use that until the network request has actually finished". 

We DO NOT want that to happen. We want full network only for the top level screens that use viewer data.