### PR TITLE
Handle fallback on NFT Detail screen

### DIFF
--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailAsset/NftDetailAsset.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailAsset/NftDetailAsset.tsx
@@ -157,7 +157,7 @@ export function NftDetailAsset({ collectionTokenRef, style }: NftDetailProps) {
     throw new CouldNotRenderNftError('NftDetailAsset', 'Unsupported media type', {
       typename: token.media?.__typename,
     });
-  }, [finalAssetDimensions, handleLoad, token.media]);
+  }, [finalAssetDimensions, handleLoad, token]);
 
   return (
     <View


### PR DESCRIPTION
Since we're making the decision to use imgix urls for the NftDetail screen, we can just re-use the existing code we have to handle fallbacks.