### PR TITLE
Dismiss announcement notifications when moving away from panel

### DIFF
--- a/apps/web/src/utils/graphql/experiences/useUpdateUserExperience.tsx
+++ b/apps/web/src/utils/graphql/experiences/useUpdateUserExperience.tsx
@@ -75,3 +75,24 @@ export default function useUpdateUserExperience() {
     [pushToast, updateUserExperience]
   );
 }
+
+// Optimistically marking experiences as dismissed is almost always the intent
+export function useOptimisticallyDismissExperience() {
+  const update = useUpdateUserExperience();
+
+  return useCallback(
+    (experienceKey: UserExperienceType) => {
+      update({
+        type: experienceKey,
+        experienced: true,
+        optimisticExperiencesList: [
+          {
+            type: experienceKey,
+            experienced: true,
+          },
+        ],
+      });
+    },
+    [update]
+  );
+}


### PR DESCRIPTION
Currently, the only way to dismiss an announcement – and get rid of the blue dot in the sidebar – is by actively clicking on the announcement and going to its CTA.

This may be annoying for new users who see a bunch of notifications especially as our announcements grow over time.

<img width="634" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/33ac6196-ce77-42b1-99f1-d66e59950a12">
