### PR TITLE
Improve admire icon visibility for active states + dark mode

### DIFF
--- a/apps/mobile/src/components/Feed/Socialize/AdmireButton.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/AdmireButton.tsx
@@ -257,6 +257,7 @@ export function AdmireButton({ eventRef, queryRef, style }: Props) {
   return (
     <TouchableOpacity
       onPress={hasViewerAdmiredEvent ? handleRemoveAdmire : handleAdmire}
+      className="flex justify-center align-center w-[32] h-[32] pt-[2] "
       style={style}
     >
       <AdmireIcon active={hasViewerAdmiredEvent} />

--- a/apps/mobile/src/components/Feed/Socialize/AdmireIcon.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/AdmireIcon.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import { useColorScheme } from 'react-native';
-import Svg, { Path, SvgProps } from 'react-native-svg';
+import Svg, { G, Path, SvgProps } from 'react-native-svg';
+
+import colors from '~/shared/theme/colors';
 
 type Props = {
   active?: boolean;
@@ -8,34 +10,50 @@ type Props = {
   height?: number;
 } & SvgProps;
 
-export function AdmireIcon({ active = false, style, height = 18, ...props }: Props) {
+export function AdmireIcon({ active = false, style, height = 28, ...props }: Props) {
   const colorScheme = useColorScheme();
 
-  const originalHeight = 18;
+  const originalHeight = 24;
   const scale = height / originalHeight;
+  const width = height;
 
-  const iconColor = useMemo(() => {
+  // unofficial lighter shade of hyperBlue for better visibility on dark mode
+  const lightActiveBlue = '#0E60FF';
+  const blueToDisplay = useMemo(
+    () => (colorScheme === 'dark' ? lightActiveBlue : colors.hyperBlue),
+    [colorScheme]
+  );
+
+  const strokeColor = useMemo(() => {
     if (active) {
-      return 'text-activeBlue';
+      return blueToDisplay;
     }
 
-    return colorScheme === 'dark' ? 'text-white' : 'text-offBlack';
-  }, [active, colorScheme]);
+    return colorScheme === 'dark' ? colors.white : colors.offBlack;
+  }, [active, blueToDisplay, colorScheme]);
+
+  const fillColor = useMemo(() => {
+    return blueToDisplay;
+  }, [blueToDisplay]);
 
   return (
     <Svg
-      width={19 * scale}
+      width={width}
       height={height}
-      fill="none"
+      fill={active ? fillColor : 'none'}
       {...props}
       style={style}
-      className={iconColor}
+      stroke={strokeColor}
+      viewBox={`0 0 ${width} ${height}`}
     >
-      <Path
-        stroke="currentColor"
-        d="M9 5a5 5 0 0 1 5 5M14 10a5 5 0 0 1 5-5M19 5a5 5 0 0 1-5-5M14 0a5 5 0 0 1-5 5M0 14a4 4 0 0 1 4 4M4 18a4 4 0 0 1 4-4M8 14a4 4 0 0 1-4-4M4 10a4 4 0 0 1-4 4M3 1v5M.5 3.5h5M15 13v5M12.5 15.5h5"
-        transform={`scale(${scale})`}
-      />
+      <G transform={`scale(${scale})`}>
+        <Path d="M15.5355 6.53553C16.3546 5.71645 16.8602 4.64245 16.975 3.5H17.025C17.1398 4.64245 17.6454 5.71645 18.4645 6.53553C19.2835 7.35462 20.3576 7.86017 21.5 7.97495V8.02505C20.3576 8.13983 19.2835 8.64538 18.4645 9.46447C17.6454 10.2835 17.1398 11.3576 17.025 12.5H16.975C16.8602 11.3576 16.3546 10.2835 15.5355 9.46447C14.7165 8.64538 13.6424 8.13983 12.5 8.02505V7.97495C13.6424 7.86017 14.7165 7.35462 15.5355 6.53553Z" />
+        <Path d="M5.82843 15.8284C6.45974 15.1971 6.85823 14.3765 6.96864 13.5H7.03136C7.14177 14.3765 7.54026 15.1971 8.17157 15.8284C8.80289 16.4597 9.6235 16.8582 10.5 16.9686V17.0314C9.6235 17.1418 8.80289 17.5403 8.17157 18.1716C7.54026 18.8029 7.14177 19.6235 7.03136 20.5H6.96864C6.85823 19.6235 6.45974 18.8029 5.82843 18.1716C5.19711 17.5403 4.3765 17.1418 3.5 17.0314V16.9686C4.3765 16.8582 5.19711 16.4597 5.82843 15.8284Z" />
+        <Path d="M6 4V9" />
+        <Path d="M3.5 6.5H8.5" />
+        <Path d="M18 16V21" />
+        <Path d="M15.5 18.5H20.5" />
+      </G>
     </Svg>
   );
 }

--- a/apps/mobile/src/components/Feed/Socialize/CommentButton.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentButton.tsx
@@ -61,11 +61,13 @@ export function CommentButton({ eventRef, queryRef, style, onClick }: Props) {
 
   return (
     <>
-      <View className="flex flex-row space-x-4" style={style}>
-        <TouchableOpacity onPress={toggleCommentBox}>
-          <CommentIcon />
-        </TouchableOpacity>
-      </View>
+      <TouchableOpacity
+        onPress={toggleCommentBox}
+        className="flex justify-center items-center w-[32] h-[32] pt-1 "
+        style={style}
+      >
+        <CommentIcon className="h-[20]" />
+      </TouchableOpacity>
       <GalleryBottomSheetModal
         index={0}
         ref={bottomSheetRef}

--- a/apps/mobile/src/components/Feed/Socialize/CommentIcon.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentIcon.tsx
@@ -8,7 +8,7 @@ export function CommentIcon(props: SvgProps) {
   const colorScheme = useColorScheme();
 
   return (
-    <Svg width={20} height={20} fill="none" {...props}>
+    <Svg width={22} height={22} fill="none" {...props} viewBox="0 0 20 20">
       <Path
         stroke={colorScheme === 'dark' ? colors.white : colors.offBlack}
         d="M1 14V1h18v13h-9l-5 4v-4H1Z"

--- a/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -49,11 +49,11 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
 
   return (
     <View className="flex flex-row px-3 justify-between pb-8 pt-5">
-      <View className="flex-1 pr-4">
+      <View className="flex-1 pr-4 pt-1">
         <Interactions eventRef={event} queryRef={query} />
       </View>
 
-      <View className="flex flex-row space-x-4">
+      <View className="flex flex-row space-x-1">
         <AdmireButton eventRef={event} queryRef={query} />
         <CommentButton eventRef={event} queryRef={query} onClick={onCommentPress} />
       </View>


### PR DESCRIPTION
## Description
Improve admire icon visibility for active states + dark mode

- when active, fill in the icon with same color as stroke
- on dark mode, use a lighter shade of hyper blue that is more visible.
- increase admire and comment icon sizes as well as touchable area padding, for easier tapping.


### Before

Light Mode
Inactive
![Screenshot 2023-05-11 at 19 47 44](https://github.com/gallery-so/gallery/assets/80802871/e535b1ac-f828-4798-a35b-961938161ebc)


Active
![Screenshot 2023-05-11 at 19 47 51](https://github.com/gallery-so/gallery/assets/80802871/3ffcdd7a-87ee-4535-925d-e1022d530a40)


Notes list
![Screenshot 2023-05-11 at 19 48 03](https://github.com/gallery-so/gallery/assets/80802871/fbe1cc34-7907-4231-a3fa-01db2962674a)



Dark Mode
Inactive
![Screenshot 2023-05-11 at 19 48 26](https://github.com/gallery-so/gallery/assets/80802871/2a8036a6-4a50-4925-bb44-6b7790e4a318)

Active
![Screenshot 2023-05-11 at 19 48 35](https://github.com/gallery-so/gallery/assets/80802871/09da0a1e-4bea-4349-9da1-cb719f93495a)

Notes list
![Screenshot 2023-05-11 at 19 48 31](https://github.com/gallery-so/gallery/assets/80802871/7d78612b-b04f-403b-b051-6256a2456e42)

### After
Inactive
![Screenshot 2023-05-11 at 19 49 36](https://github.com/gallery-so/gallery/assets/80802871/1648548a-1297-48f8-9254-e52bdd618a91)


Active
![Screenshot 2023-05-11 at 19 49 42](https://github.com/gallery-so/gallery/assets/80802871/a4305790-c211-42e5-ae16-384f1cf374c1)


Notes list
![Screenshot 2023-05-11 at 19 49 48](https://github.com/gallery-so/gallery/assets/80802871/51c4cdb6-d637-4d2d-9f10-e5c3831686bf)


Dark Mode
Inactive
![Screenshot 2023-05-11 at 19 51 24](https://github.com/gallery-so/gallery/assets/80802871/0293d8cd-b8a7-4a1e-b6da-d52e2e261d56)

Active
![Screenshot 2023-05-11 at 19 50 32](https://github.com/gallery-so/gallery/assets/80802871/068483f0-04b6-48a1-9bf0-a2c70861c6d0)

Notes list
![Screenshot 2023-05-11 at 19 50 58](https://github.com/gallery-so/gallery/assets/80802871/c8b681b8-638b-481d-af66-f3b4570b70a7)

