### PR TITLE
Misc Mobile Fixes

### DIFF
--- a/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
@@ -57,13 +57,13 @@ export function CollectionUpdatedFeedEvent({
   return (
     <View className="flex flex-1 flex-col">
       <FeedEventCarouselCellHeader>
-        <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+        <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
           Made a change to
         </Typography>
         <TouchableOpacity className="flex-1" onPress={handleCollectionNamePress}>
           <Typography
             numberOfLines={1}
-            className="text-xs"
+            className="text-sm"
             font={{ family: 'ABCDiatype', weight: 'Bold' }}
           >
             {eventData.collection?.name || 'Untitled'}

--- a/apps/mobile/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -57,13 +57,13 @@ export function CollectorsNoteAddedToCollectionFeedEvent({
   return (
     <View className="flex flex-1 flex-col">
       <FeedEventCarouselCellHeader>
-        <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+        <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
           Added a collector's note to
         </Typography>
         <TouchableOpacity className="flex-1" onPress={handleCollectionNamePress}>
           <Typography
             numberOfLines={1}
-            className="text-xs"
+            className="text-sm"
             font={{ family: 'ABCDiatype', weight: 'Bold' }}
           >
             {eventData.collection?.name || 'Untitled'}

--- a/apps/mobile/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -58,7 +58,7 @@ export function CollectorsNoteAddedToCollectionFeedEvent({
     <View className="flex flex-1 flex-col">
       <FeedEventCarouselCellHeader>
         <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-          Added a colloctors note to
+          Added a collector's note to
         </Typography>
         <TouchableOpacity className="flex-1" onPress={handleCollectionNamePress}>
           <Typography

--- a/apps/mobile/src/components/ProfileView/ProfileTabBar.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileTabBar.tsx
@@ -29,7 +29,7 @@ function TabItem({ activeRoute, counter = 0, route, onRouteChange }: TabItemProp
         font={{ family: 'ABCDiatype', weight: 'Medium' }}
       >
         {route}
-        {counter > 0 && <Text> {counter}</Text>}
+        {counter > 0 && <Text className="text-xs"> {counter}</Text>}
       </Typography>
     </TouchableOpacity>
   );

--- a/apps/mobile/src/navigation/MainTabNavigator/MainTabNavigator.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/MainTabNavigator.tsx
@@ -70,10 +70,10 @@ export function MainTabNavigator() {
         backgroundColor: colorScheme === 'dark' ? colors.black : colors.white,
       }}
     >
-      <Tab.Screen name="AccountTab" component={AccountScreen} />
       <Tab.Screen name="HomeTab" component={HomeScreen} />
       <Tab.Screen name="SearchTab" component={SearchScreen} />
       <Tab.Screen name="NotificationsTab" component={NotificationsScreen} />
+      <Tab.Screen name="AccountTab" component={AccountScreen} />
     </Tab.Navigator>
   );
 }


### PR DESCRIPTION
## Description
- reorder main tabs 
- reduce gallery+follower count font size
- fix typo in collectors note feed event + adjust size ("colloctors" -> "collector's")

New order of tabs
Home, Search, Notifications, Profile. this order was agreed upon in slack a few days back
![Screenshot 2023-05-11 at 19 54 35](https://github.com/gallery-so/gallery/assets/80802871/b68c802f-b859-454f-816e-f86c5cbacf67)


Before (gallery+follower count font size)
![Screenshot 2023-05-11 at 19 55 08](https://github.com/gallery-so/gallery/assets/80802871/b4bfdef2-729b-4b37-a1d5-17684fa47fcc)

After (gallery+follower count font size)
![Screenshot 2023-05-11 at 19 55 01](https://github.com/gallery-so/gallery/assets/80802871/73bdb085-f682-455f-9c6a-c1bcf1082934)

