### PR TITLE
[GAL-2816] Disable animations on tab navigators

### DIFF
--- a/apps/mobile/src/navigation/FeedTabNavigator/FeedTabNavigator.tsx
+++ b/apps/mobile/src/navigation/FeedTabNavigator/FeedTabNavigator.tsx
@@ -19,7 +19,7 @@ export function FeedTabNavigator() {
       tabBarPosition="top"
       initialRouteName="Latest"
       tabBar={TabBar}
-      screenOptions={{ lazy: true }}
+      screenOptions={{ lazy: true, swipeEnabled: false, animationEnabled: false }}
       sceneContainerStyle={{
         backgroundColor: colorScheme === 'dark' ? colors.black : colors.white,
       }}

--- a/apps/mobile/src/navigation/MainTabNavigator/MainTabNavigator.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/MainTabNavigator.tsx
@@ -65,7 +65,7 @@ export function MainTabNavigator() {
       tabBarPosition="bottom"
       initialRouteName="HomeTab"
       tabBar={TabBar}
-      screenOptions={{ swipeEnabled: false }}
+      screenOptions={{ swipeEnabled: false, animationEnabled: false }}
       sceneContainerStyle={{
         backgroundColor: colorScheme === 'dark' ? colors.black : colors.white,
       }}


### PR DESCRIPTION
This bug is ruining us https://github.com/satya164/react-native-tab-view/issues/1181

Disabling animations feels better and solves the problem described in GAL-2816.