### PR TITLE
[GAL-3011] Render markdown on collection description

### DIFF
--- a/apps/mobile/src/components/Gallery/GalleryVirtualizedRow.tsx
+++ b/apps/mobile/src/components/Gallery/GalleryVirtualizedRow.tsx
@@ -8,7 +8,6 @@ import { Typography } from '~/components/Typography';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import unescape from '~/shared/utils/unescape';
 
-import { sanitizeMarkdown } from '../../utils/sanitizeMarkdown';
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
 
 type Props = {
@@ -42,7 +41,7 @@ export function GalleryVirtualizedRow({ item, isOnCollectionScreen }: Props) {
     };
 
     return (
-      <View className="flex flex-col bg-white dark:bg-black py-2 px-4">
+      <View className="flex flex-col bg-white dark:bg-black pt-2 pb-1 px-4">
         <GalleryTouchableOpacity onPress={handlePress}>
           <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
             {unescape(item.name || 'Untitled')}
@@ -55,16 +54,10 @@ export function GalleryVirtualizedRow({ item, isOnCollectionScreen }: Props) {
       return null;
     }
 
-    const firstLineOfCollectorsNote = sanitizeMarkdown(item.collectorsNote ?? '');
-
     return (
       <View className="flex flex-col bg-white dark:bg-black px-4">
-        <Typography
-          className="text-sm"
-          font={{ family: 'ABCDiatype', weight: 'Regular' }}
-          numberOfLines={1}
-        >
-          {firstLineOfCollectorsNote}
+        <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+          <Markdown>{item.collectorsNote}</Markdown>
         </Typography>
       </View>
     );


### PR DESCRIPTION
**Changes**
- Render markdown on collection description
- Fix spacing

**Demo**

**Before**
<img width="451" alt="CleanShot 2023-05-18 at 11 26 48@2x" src="https://github.com/gallery-so/gallery/assets/4480258/37fed7dc-78ca-4e19-950e-9110c56563e3">


**After**
<img width="485" alt="CleanShot 2023-05-18 at 11 25 51@2x" src="https://github.com/gallery-so/gallery/assets/4480258/b8019cef-8bd1-4a66-a180-4b6c8b777d53">
