### PR TITLE
[GAL-3076] Fix search text color on theme switch

### DIFF
--- a/apps/mobile/src/components/Markdown.tsx
+++ b/apps/mobile/src/components/Markdown.tsx
@@ -27,6 +27,12 @@ const darkModeMarkdownStyles = {
   },
 };
 
+const lightModeMarkdownStyles = {
+  body: {
+    color: colors.offBlack,
+  },
+};
+
 type GalleryMarkdownProps = PropsWithChildren<{
   numberOfLines?: number;
   touchToExpand?: boolean;
@@ -49,6 +55,10 @@ export function Markdown({
 
     if (colorScheme === 'dark') {
       merge(mergedStyles, darkModeMarkdownStyles);
+    }
+
+    if (colorScheme === 'light') {
+      merge(mergedStyles, lightModeMarkdownStyles);
     }
 
     merge(mergedStyles, style);


### PR DESCRIPTION
**Changes**
- Fix markdown text didn't update on theme switcher (dark -> light)

**Demo**

**Before**

https://github.com/gallery-so/gallery/assets/4480258/c30f1eda-7f92-4a3a-b05e-fabbffd4527c


**After**

https://github.com/gallery-so/gallery/assets/4480258/ccb1bcc1-4f07-4355-b6d0-cedd1ea24b85

