### PR TITLE
[GAL-3046] Update feed copy for empty gallery/collection name

### DIFF
--- a/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
@@ -67,7 +67,7 @@ export function CollectionUpdatedFeedEvent({
             className="text-sm"
             font={{ family: 'ABCDiatype', weight: 'Bold' }}
           >
-            {eventData.collection?.name || 'Untitled'}
+            {eventData.collection?.name || 'their collection'}
           </Typography>
         </GalleryTouchableOpacity>
       </FeedEventCarouselCellHeader>

--- a/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -72,7 +72,7 @@ export function TokensAddedToCollectionFeedEvent({
             className="text-sm"
             font={{ family: 'ABCDiatype', weight: 'Bold' }}
           >
-            {eventData.collection?.name || 'Untitled'}
+            {eventData.collection?.name || 'their collection'}
           </Typography>
         </GalleryTouchableOpacity>
       </FeedEventCarouselCellHeader>

--- a/apps/mobile/src/components/Feed/FeedListSectionHeader.tsx
+++ b/apps/mobile/src/components/Feed/FeedListSectionHeader.tsx
@@ -73,7 +73,7 @@ export function FeedListSectionHeader({ feedEventRef }: FeedListSectionHeaderPro
 
         <GalleryTouchableOpacity onPress={handleGalleryNamePress}>
           <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-            {feedEvent.eventData.gallery?.name || 'Untitled'}
+            {feedEvent.eventData.gallery?.name || 'their gallery'}
           </Typography>
         </GalleryTouchableOpacity>
       </View>


### PR DESCRIPTION
**Changes**
- change default name for empty gallery/collection name

**Demo**

**Empty gallery name**
<img width="494" alt="CleanShot 2023-05-18 at 12 46 04@2x" src="https://github.com/gallery-so/gallery/assets/4480258/2d94c703-58c1-4b1e-8c9b-78ef9d322638">


**Empty collection name**
<img width="454" alt="CleanShot 2023-05-18 at 12 40 06@2x" src="https://github.com/gallery-so/gallery/assets/4480258/bb49a3f3-560a-4699-84ff-399a605b0fc9">
