### PR TITLE
[GAL-2957] Show back buttons when screen is loading

### DIFF
--- a/apps/mobile/src/components/BackButton.tsx
+++ b/apps/mobile/src/components/BackButton.tsx
@@ -1,0 +1,11 @@
+import { useNavigation } from '@react-navigation/native';
+
+import { IconContainer } from '~/components/IconContainer';
+
+import { BackIcon } from '../icons/BackIcon';
+
+export function BackButton() {
+  const navigation = useNavigation();
+
+  return <IconContainer icon={<BackIcon />} onPress={navigation.goBack} />;
+}

--- a/apps/mobile/src/components/ProfileView/GalleryProfileNavBar.tsx
+++ b/apps/mobile/src/components/ProfileView/GalleryProfileNavBar.tsx
@@ -12,7 +12,6 @@ import { GalleryProfileNavBarQueryFragment$key } from '~/generated/GalleryProfil
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
 
-import { BackIcon } from '../../icons/BackIcon';
 import { QRCodeIcon } from '../../icons/QRCodeIcon';
 import { ShareIcon } from '../../icons/ShareIcon';
 import { FeedbackButton } from '../FeedbackButton';

--- a/apps/mobile/src/components/ProfileView/GalleryProfileNavBar.tsx
+++ b/apps/mobile/src/components/ProfileView/GalleryProfileNavBar.tsx
@@ -4,6 +4,7 @@ import { Share, View, ViewProps } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
+import { BackButton } from '~/components/BackButton';
 import { FollowButton } from '~/components/FollowButton';
 import { IconContainer } from '~/components/IconContainer';
 import { GalleryProfileNavBarFragment$key } from '~/generated/GalleryProfileNavBarFragment.graphql';
@@ -97,11 +98,7 @@ export function GalleryProfileNavBar({
   return (
     <View style={style} className="flex flex-row justify-between bg-white dark:bg-black">
       {isLoggedInUser && !shouldShowBackButton && <FeedbackButton />}
-      {shouldShowBackButton ? (
-        <IconContainer icon={<BackIcon />} onPress={navigation.goBack} />
-      ) : (
-        <View />
-      )}
+      {shouldShowBackButton ? <BackButton /> : <View />}
 
       <View className="flex flex-row items-center space-x-2">
         {isLoggedInUser && <IconContainer icon={<QRCodeIcon />} onPress={handleQrCode} />}
@@ -109,6 +106,24 @@ export function GalleryProfileNavBar({
 
         {!isLoggedInUser && <FollowButton queryRef={query} userRef={user} />}
       </View>
+    </View>
+  );
+}
+
+type GalleryProfileNavbarFallbackProps = {
+  style?: ViewProps['style'];
+  shouldShowBackButton: boolean;
+};
+
+export function GalleryProfileNavbarFallback({
+  style,
+  shouldShowBackButton,
+}: GalleryProfileNavbarFallbackProps) {
+  return (
+    <View style={style} className="flex flex-row justify-between bg-white dark:bg-black">
+      {shouldShowBackButton ? <BackButton /> : <FeedbackButton />}
+
+      <View className="flex flex-row items-center space-x-2"></View>
     </View>
   );
 }

--- a/apps/mobile/src/components/ProfileView/ProfileView.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileView.tsx
@@ -1,15 +1,10 @@
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useColorScheme, View } from 'react-native';
 import { CollapsibleRef, Tabs } from 'react-native-collapsible-tab-view';
-import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import { GallerySkeleton } from '~/components/GallerySkeleton';
-import {
-  GalleryProfileNavBar,
-  GalleryProfileNavbarFallback,
-} from '~/components/ProfileView/GalleryProfileNavBar';
+import { GalleryProfileNavBar } from '~/components/ProfileView/GalleryProfileNavBar';
 import { ProfileViewHeader } from '~/components/ProfileView/ProfileViewHeader';
 import { ProfileViewActivityTab } from '~/components/ProfileView/Tabs/ProfileViewActivityTab';
 import { ProfileViewFeaturedTab } from '~/components/ProfileView/Tabs/ProfileViewFeaturedTab';
@@ -187,7 +182,7 @@ export function ProfileViewUsername({ queryRef }: ProfileViewUsernameProps) {
       className="bg-white dark:bg-black text-center text-2xl tracking-tighter"
       font={{ family: 'GTAlpina', weight: 'StandardLight' }}
     >
-      {query.userByUsername.username}
+      {query.userByUsername?.username}
     </Typography>
   );
 }

--- a/apps/mobile/src/components/ProfileView/ProfileViewFallback.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewFallback.tsx
@@ -2,6 +2,7 @@ import { View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 
 import { GallerySkeleton } from '~/components/GallerySkeleton';
+import { GalleryProfileNavbarFallback } from '~/components/ProfileView/GalleryProfileNavBar';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 
 export function ProfileViewFallback() {
@@ -9,17 +10,12 @@ export function ProfileViewFallback() {
 
   return (
     <View className="flex-1 bg-white dark:bg-black px-4" style={{ paddingTop: top }}>
+      <GalleryProfileNavbarFallback shouldShowBackButton={true} />
+
       <GallerySkeleton>
         <SkeletonPlaceholder.Item flexDirection="column" width="100%">
-          <SkeletonPlaceholder.Item flexDirection="row" justifyContent="flex-end">
-            <SkeletonPlaceholder.Item flexDirection="row" gap={4}>
-              <SkeletonPlaceholder.Item height={28} width={28} />
-              <SkeletonPlaceholder.Item height={28} width={28} />
-            </SkeletonPlaceholder.Item>
-          </SkeletonPlaceholder.Item>
-
-          <SkeletonPlaceholder.Item marginVertical={16} flexDirection="row" justifyContent="center">
-            <SkeletonPlaceholder.Item width={100} height={20} />
+          <SkeletonPlaceholder.Item marginBottom={16} flexDirection="row" justifyContent="center">
+            <SkeletonPlaceholder.Item width={100} height={32} />
           </SkeletonPlaceholder.Item>
 
           <SkeletonPlaceholder.Item flexDirection="column" gap={4}>

--- a/apps/mobile/src/components/ProfileView/ProfileViewHeader.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewHeader.tsx
@@ -16,33 +16,44 @@ type Props = {
   selectedRoute: string;
   onRouteChange: (value: string) => void;
 
-  userRef: ProfileViewHeaderFragment$key;
+  queryRef: ProfileViewHeaderFragment$key;
 };
 
-export function ProfileViewHeader({ userRef, selectedRoute, onRouteChange }: Props) {
-  const user = useFragment(
+export function ProfileViewHeader({ queryRef, selectedRoute, onRouteChange }: Props) {
+  const query = useFragment(
     graphql`
-      fragment ProfileViewHeaderFragment on GalleryUser {
-        bio
-
-        galleries {
-          __typename
-          hidden
-        }
-        followers {
-          __typename
-        }
-
-        socialAccounts {
-          twitter {
+      fragment ProfileViewHeaderFragment on Query {
+        userByUsername(username: $username) {
+          ... on GalleryUser {
             __typename
-            username
+            bio
+
+            galleries {
+              __typename
+              hidden
+            }
+            followers {
+              __typename
+            }
+
+            socialAccounts {
+              twitter {
+                __typename
+                username
+              }
+            }
           }
         }
       }
     `,
-    userRef
+    queryRef
   );
+
+  const user = query?.userByUsername;
+
+  if (user?.__typename !== 'GalleryUser') {
+    throw new Error(`Unable to fetch the current user`);
+  }
 
   const handleTwitterPress = useCallback(() => {
     if (user.socialAccounts?.twitter?.username) {

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewFeaturedTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewFeaturedTab.tsx
@@ -14,29 +14,33 @@ import { useListContentStyle } from '~/components/ProfileView/Tabs/useListConten
 import { ProfileViewFeaturedTabFragment$key } from '~/generated/ProfileViewFeaturedTabFragment.graphql';
 
 type ProfileViewFeaturedTabProps = {
-  userRef: ProfileViewFeaturedTabFragment$key;
+  queryRef: ProfileViewFeaturedTabFragment$key;
 };
 
-export function ProfileViewFeaturedTab({ userRef }: ProfileViewFeaturedTabProps) {
-  const user = useFragment(
+export function ProfileViewFeaturedTab({ queryRef }: ProfileViewFeaturedTabProps) {
+  const query = useFragment(
     graphql`
-      fragment ProfileViewFeaturedTabFragment on GalleryUser {
-        __typename
+      fragment ProfileViewFeaturedTabFragment on Query {
+        userByUsername(username: $username) {
+          ... on GalleryUser {
+            featuredGallery {
+              ...createVirtualizedGalleryRows
 
-        featuredGallery {
-          ...createVirtualizedGalleryRows
-
-          # This is so we have the cache prefilled for their full gallery page / collection page
-          # eslint-disable-next-line relay/must-colocate-fragment-spreads
-          ...GalleryScreenGalleryFragment @defer
+              # This is so we have the cache prefilled for their full gallery page / collection page
+              # eslint-disable-next-line relay/must-colocate-fragment-spreads
+              ...GalleryScreenGalleryFragment @defer
+            }
+          }
         }
       }
     `,
-    userRef
+    queryRef
   );
 
-  if (!user.featuredGallery) {
-    throw new Error('Yikes');
+  const user = query.userByUsername;
+
+  if (!user?.featuredGallery) {
+    throw new Error('TODO');
   }
 
   const { items, stickyIndices } = createVirtualizedGalleryRows({

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewGalleriesTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewGalleriesTab.tsx
@@ -18,39 +18,43 @@ type ListItem = {
 };
 
 type ProfileViewGalleriesTabProps = {
-  userRef: ProfileViewGalleriesTabFragment$key;
+  queryRef: ProfileViewGalleriesTabFragment$key;
 };
 
-export function ProfileViewGalleriesTab({ userRef }: ProfileViewGalleriesTabProps) {
-  const galleryUser = useFragment(
+export function ProfileViewGalleriesTab({ queryRef }: ProfileViewGalleriesTabProps) {
+  const query = useFragment(
     graphql`
-      fragment ProfileViewGalleriesTabFragment on GalleryUser {
-        __typename
+      fragment ProfileViewGalleriesTabFragment on Query {
+        userByUsername(username: $username) {
+          ... on GalleryUser {
+            featuredGallery {
+              dbid
+            }
 
-        featuredGallery {
-          dbid
-        }
+            galleries {
+              dbid
 
-        galleries {
-          dbid
-
-          ...GalleryPreviewCardFragment
+              ...GalleryPreviewCardFragment
+            }
+          }
         }
       }
     `,
-    userRef
+    queryRef
   );
 
+  const user = query.userByUsername;
+
   const items = useMemo<ListItem[]>(() => {
-    return removeNullValues(galleryUser.galleries).map((gallery): ListItem => {
+    return removeNullValues(user?.galleries).map((gallery): ListItem => {
       return {
         kind: 'gallery',
 
         gallery,
-        isFeatured: galleryUser.featuredGallery?.dbid === gallery.dbid,
+        isFeatured: user?.featuredGallery?.dbid === gallery.dbid,
       };
     });
-  }, [galleryUser.featuredGallery?.dbid, galleryUser.galleries]);
+  }, [user?.featuredGallery?.dbid, user?.galleries]);
 
   const renderItem = useCallback<ListRenderItem<ListItem>>(({ item }) => {
     return (

--- a/apps/mobile/src/screens/CollectionScreen/CollectionScreenFallback.tsx
+++ b/apps/mobile/src/screens/CollectionScreen/CollectionScreenFallback.tsx
@@ -2,6 +2,7 @@ import { View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 
 import { GallerySkeleton } from '~/components/GallerySkeleton';
+import { GalleryProfileNavbarFallback } from '~/components/ProfileView/GalleryProfileNavBar';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 
 export function CollectionScreenFallback() {
@@ -9,9 +10,11 @@ export function CollectionScreenFallback() {
 
   return (
     <View className="flex-1 bg-white dark:bg-black px-4" style={{ paddingTop: top }}>
+      <GalleryProfileNavbarFallback shouldShowBackButton />
+
       <GallerySkeleton>
         <SkeletonPlaceholder.Item>
-          <SkeletonPlaceholder.Item width="100%" height={28} marginBottom={8} />
+          <SkeletonPlaceholder.Item marginTop={16} width="100%" height={28} marginBottom={8} />
           <SkeletonPlaceholder.Item width="80%" height={28} marginBottom={16} />
 
           <SkeletonPlaceholder.Item width="20%" height={20} marginBottom={8} />

--- a/apps/mobile/src/screens/FeedEventScreen.tsx
+++ b/apps/mobile/src/screens/FeedEventScreen.tsx
@@ -1,4 +1,5 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
+import { Suspense } from 'react';
 import { View } from 'react-native';
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
 
@@ -12,7 +13,7 @@ import { MainTabStackNavigatorParamList } from '~/navigation/types';
 
 import { useRefreshHandle } from '../hooks/useRefreshHandle';
 
-export function FeedEventScreen() {
+function FeedEventScreenInner() {
   const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'FeedEvent'>>();
   const wrapperQuery = useLazyLoadQuery<FeedEventScreenQuery>(
     graphql`
@@ -51,24 +52,32 @@ export function FeedEventScreen() {
 
   if (query.feedEventById?.__typename === 'FeedEvent') {
     return (
-      <View className="flex-1 bg-white dark:bg-black">
-        <SafeAreaViewWithPadding className="flex-1">
-          <View className="px-3 pb-6">
-            <BackButton />
-          </View>
-
-          <FeedList
-            queryRef={query}
-            isLoadingMore={false}
-            onLoadMore={() => {}}
-            onRefresh={handleRefresh}
-            isRefreshing={isRefreshing}
-            feedEventRefs={[query.feedEventById]}
-          />
-        </SafeAreaViewWithPadding>
-      </View>
+      <FeedList
+        queryRef={query}
+        isLoadingMore={false}
+        onLoadMore={() => {}}
+        onRefresh={handleRefresh}
+        isRefreshing={isRefreshing}
+        feedEventRefs={[query.feedEventById]}
+      />
     );
   }
 
   return null;
+}
+
+export function FeedEventScreen() {
+  return (
+    <View className="flex-1 bg-white dark:bg-black">
+      <SafeAreaViewWithPadding className="flex-1">
+        <View className="px-3 pb-6">
+          <BackButton />
+        </View>
+
+        <Suspense fallback={null}>
+          <FeedEventScreenInner />
+        </Suspense>
+      </SafeAreaViewWithPadding>
+    </View>
+  );
 }

--- a/apps/mobile/src/screens/FeedEventScreen.tsx
+++ b/apps/mobile/src/screens/FeedEventScreen.tsx
@@ -1,9 +1,9 @@
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { View } from 'react-native';
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
 
+import { BackButton } from '~/components/BackButton';
 import { FeedList } from '~/components/Feed/FeedList';
-import { IconContainer } from '~/components/IconContainer';
 import { SafeAreaViewWithPadding } from '~/components/SafeAreaViewWithPadding';
 import { FeedEventRefetchableFragmentQuery } from '~/generated/FeedEventRefetchableFragmentQuery.graphql';
 import { FeedEventScreenFragment$key } from '~/generated/FeedEventScreenFragment.graphql';
@@ -11,7 +11,6 @@ import { FeedEventScreenQuery } from '~/generated/FeedEventScreenQuery.graphql';
 import { MainTabStackNavigatorParamList } from '~/navigation/types';
 
 import { useRefreshHandle } from '../hooks/useRefreshHandle';
-import { BackIcon } from '../icons/BackIcon';
 
 export function FeedEventScreen() {
   const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'FeedEvent'>>();
@@ -50,13 +49,12 @@ export function FeedEventScreen() {
 
   const { isRefreshing, handleRefresh } = useRefreshHandle(refetch);
 
-  const navigation = useNavigation();
   if (query.feedEventById?.__typename === 'FeedEvent') {
     return (
       <View className="flex-1 bg-white dark:bg-black">
         <SafeAreaViewWithPadding className="flex-1">
           <View className="px-3 pb-6">
-            <IconContainer icon={<BackIcon />} onPress={navigation.goBack} />
+            <BackButton />
           </View>
 
           <FeedList

--- a/apps/mobile/src/screens/GalleryScreen/GalleryScreenFallback.tsx
+++ b/apps/mobile/src/screens/GalleryScreen/GalleryScreenFallback.tsx
@@ -2,6 +2,7 @@ import { View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 
 import { GallerySkeleton } from '~/components/GallerySkeleton';
+import { GalleryProfileNavbarFallback } from '~/components/ProfileView/GalleryProfileNavBar';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 
 export function GalleryScreenFallback() {
@@ -9,9 +10,11 @@ export function GalleryScreenFallback() {
 
   return (
     <View className="flex-1 bg-white dark:bg-black px-4" style={{ paddingTop: top }}>
+      <GalleryProfileNavbarFallback shouldShowBackButton />
+
       <GallerySkeleton>
         <SkeletonPlaceholder.Item>
-          <SkeletonPlaceholder.Item width="100%" height={28} marginBottom={8} />
+          <SkeletonPlaceholder.Item marginTop={16} width="100%" height={28} marginBottom={8} />
           <SkeletonPlaceholder.Item width="80%" height={28} marginBottom={16} />
 
           <SkeletonPlaceholder.Item width="20%" height={20} marginBottom={8} />

--- a/apps/mobile/src/screens/NftDetailScreen/LoadingNftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/LoadingNftDetailScreenInner.tsx
@@ -1,17 +1,14 @@
-import { useNavigation } from '@react-navigation/native';
 import { View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
-import { BackIcon } from 'src/icons/BackIcon';
 
+import { BackButton } from '~/components/BackButton';
 import { GallerySkeleton } from '~/components/GallerySkeleton';
-import { IconContainer } from '~/components/IconContainer';
 
 export function LoadingNftDetailScreenInner() {
-  const navigation = useNavigation();
   return (
     <View className="flex flex-col space-y-3 px-4">
       <View className="flex flex-row justify-between">
-        <IconContainer icon={<BackIcon />} onPress={navigation.goBack} />
+        <BackButton />
       </View>
       <View>
         <GallerySkeleton>

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
@@ -5,6 +5,7 @@ import FastImage from 'react-native-fast-image';
 import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
+import { BackButton } from '~/components/BackButton';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { Pill } from '~/components/Pill';
 import { NftDetailScreenInnerQuery } from '~/generated/NftDetailScreenInnerQuery.graphql';
@@ -14,7 +15,6 @@ import { IconContainer } from '../../components/IconContainer';
 import { InteractiveLink } from '../../components/InteractiveLink';
 import { Markdown } from '../../components/Markdown';
 import { Typography } from '../../components/Typography';
-import { BackIcon } from '../../icons/BackIcon';
 import { PoapIcon } from '../../icons/PoapIcon';
 import { ShareIcon } from '../../icons/ShareIcon';
 import { shareToken } from '../../utils/shareToken';
@@ -98,7 +98,7 @@ export function NftDetailScreenInner() {
       <View className="flex flex-col space-y-8 px-4 pb-4">
         <View className="flex flex-col space-y-3">
           <View className="flex flex-row justify-between">
-            <IconContainer icon={<BackIcon />} onPress={navigation.goBack} />
+            <BackButton />
             <IconContainer icon={<ShareIcon />} onPress={handleShare} />
           </View>
 

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
@@ -1,4 +1,4 @@
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { useCallback, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
@@ -28,7 +28,6 @@ const markdownStyles = StyleSheet.create({
 });
 
 export function NftDetailScreenInner() {
-  const navigation = useNavigation();
   const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'NftDetail'>>();
 
   const query = useLazyLoadQuery<NftDetailScreenInnerQuery>(

--- a/apps/mobile/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -1,5 +1,5 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
-import { Suspense, useMemo } from 'react';
+import { Suspense } from 'react';
 import { RefreshControl, ScrollView, View } from 'react-native';
 import { useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
@@ -8,7 +8,6 @@ import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/NotesModal/NotesList
 import { ProfileView } from '~/components/ProfileView/ProfileView';
 import { ProfileViewFallback } from '~/components/ProfileView/ProfileViewFallback';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
-import { Typography } from '~/components/Typography';
 import { ProfileScreenQuery } from '~/generated/ProfileScreenQuery.graphql';
 import { ProfileScreenRefetchableFragment$key } from '~/generated/ProfileScreenRefetchableFragment.graphql';
 import { ProfileScreenRefetchableFragmentQuery } from '~/generated/ProfileScreenRefetchableFragmentQuery.graphql';

--- a/apps/mobile/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -36,7 +36,7 @@ function ProfileScreenInner() {
       feedLast: 24,
       interactionsFirst: NOTES_PER_PAGE,
     },
-    { fetchPolicy: 'network-only' }
+    { fetchPolicy: 'store-or-network', UNSTABLE_renderPolicy: 'partial' }
   );
 
   const [query, refetch] = useRefetchableFragment<
@@ -46,20 +46,6 @@ function ProfileScreenInner() {
     graphql`
       fragment ProfileScreenRefetchableFragment on Query
       @refetchable(queryName: "ProfileScreenRefetchableFragmentQuery") {
-        userByUsername(username: $username) {
-          ... on GalleryUser {
-            ...ProfileViewFragment
-          }
-
-          ... on ErrUserNotFound {
-            __typename
-          }
-
-          ... on Error {
-            __typename
-          }
-        }
-
         ...ProfileViewQueryFragment
       }
     `,
@@ -69,29 +55,17 @@ function ProfileScreenInner() {
   const { top } = useSafeAreaPadding();
   const { isRefreshing, handleRefresh } = useRefreshHandle(refetch);
 
-  const inner = useMemo(() => {
-    if (query.userByUsername?.__typename === 'GalleryUser') {
-      return (
-        <View style={{ flex: 1, paddingTop: top }}>
-          <ScrollView
-            showsVerticalScrollIndicator={false}
-            contentContainerStyle={{ flex: 1 }}
-            refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
-          >
-            <ProfileView
-              queryRef={query}
-              userRef={query.userByUsername}
-              shouldShowBackButton={!route.params.hideBackButton}
-            />
-          </ScrollView>
-        </View>
-      );
-    } else {
-      return <Typography font={{ family: 'ABCDiatype', weight: 'Regular' }}>Not found</Typography>;
-    }
-  }, [handleRefresh, isRefreshing, query, route.params.hideBackButton, top]);
-
-  return inner;
+  return (
+    <View style={{ flex: 1, paddingTop: top }}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ flex: 1 }}
+        refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
+      >
+        <ProfileView queryRef={query} shouldShowBackButton={!route.params.hideBackButton} />
+      </ScrollView>
+    </View>
+  );
 }
 
 export function ProfileScreen() {


### PR DESCRIPTION
Watch this video first https://www.loom.com/share/2eaa9312162345b9b508e9b5777d2ed9 

## Demos
| Profile | Gallery |
|--------|--------|
| <video src="https://github.com/gallery-so/gallery/assets/6754223/f685ac47-70f0-42c2-9673-f9abbf68abca" /> | <video src="https://github.com/gallery-so/gallery/assets/6754223/5b76b0bb-85d2-41a4-ac9a-ed9a5af4c233" /> | 


| Collection | Feed Event |
|--------|--------|
| <video src="https://github.com/gallery-so/gallery/assets/6754223/4c540c2a-0cd8-4c3f-9d04-83c014b9dac8" /> | <video src="https://github.com/gallery-so/gallery/assets/6754223/0c51b104-403e-4456-9824-a4ec418e797f" /> | 



## Addressing the main problem

- I updated all of the fallbacks to have a back button in them when appropriate.

## Long Term

- How do we achieve super granular loading states? 
  - Make components closer to the leaves suspend instead of components closer to the screen level


- What causes a fragment not to suspend?
  - If the only thing it selects are fragment spreads
  - If all of the data it selects is already in the cache
    - This will actually serve as a helpful tool by making top level queries like `userByUsername` resolve instantly since a user with that username should already be in the cache.


- How can I avoid selecting data at the screen level
  - Push your query ref down to the leaves if possible.