### PR TITLE
[GAL-3089] Clear Notification Count

### DIFF
--- a/apps/mobile/src/components/Notification/NotificationList.tsx
+++ b/apps/mobile/src/components/Notification/NotificationList.tsx
@@ -36,9 +36,7 @@ export function NotificationList({ queryRef }: Props) {
         viewer {
           ... on Viewer {
             id
-            user {
-              dbid
-            }
+
             notifications(last: $notificationsLast, before: $notificationsBefore)
               @connection(key: "NotificationsFragment_notifications") {
               edges {
@@ -85,12 +83,8 @@ export function NotificationList({ queryRef }: Props) {
   // if user go outside of notifications screen, clear notifications
   useFocusEffect(
     useCallback(() => {
-      return () => {
-        if (query.viewer?.user?.dbid && query.viewer.id) {
-          clearNotifications();
-        }
-      };
-    }, [clearNotifications, query.viewer?.id, query.viewer?.user?.dbid])
+      clearNotifications();
+    }, [clearNotifications])
   );
 
   if (nonNullNotifications.length === 0) {

--- a/apps/mobile/src/components/Notification/NotificationList.tsx
+++ b/apps/mobile/src/components/Notification/NotificationList.tsx
@@ -2,12 +2,12 @@ import { useFocusEffect } from '@react-navigation/native';
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 import { useCallback, useMemo } from 'react';
 import { RefreshControl, View } from 'react-native';
-import { ConnectionHandler, graphql, usePaginationFragment } from 'react-relay';
+import { graphql, usePaginationFragment } from 'react-relay';
 
 import { NotificationFragment$key } from '~/generated/NotificationFragment.graphql';
 import { NotificationListFragment$key } from '~/generated/NotificationListFragment.graphql';
-import { useClearNotifications } from '~/shared/relay/useClearNotifications';
 
+import { useMobileClearNotifications } from '../../hooks/useMobileClearNotifications';
 import { useRefreshHandle } from '../../hooks/useRefreshHandle';
 import { Typography } from '../Typography';
 import { NOTIFICATIONS_PER_PAGE } from './constants';
@@ -55,7 +55,7 @@ export function NotificationList({ queryRef }: Props) {
     queryRef
   );
 
-  const clearNotification = useClearNotifications();
+  const clearNotifications = useMobileClearNotifications();
   const { isRefreshing, handleRefresh } = useRefreshHandle(refetch);
 
   const nonNullNotifications = useMemo(() => {
@@ -87,19 +87,10 @@ export function NotificationList({ queryRef }: Props) {
     useCallback(() => {
       return () => {
         if (query.viewer?.user?.dbid && query.viewer.id) {
-          clearNotification(query.viewer.user.dbid, [
-            ConnectionHandler.getConnectionID(
-              query.viewer?.id,
-              'TabBarMainTabNavigator_notifications'
-            ),
-            ConnectionHandler.getConnectionID(
-              query.viewer?.id,
-              'NotificationsFragment_notifications'
-            ),
-          ]);
+          clearNotifications();
         }
       };
-    }, [clearNotification, query.viewer?.id, query.viewer?.user?.dbid])
+    }, [clearNotifications, query.viewer?.id, query.viewer?.user?.dbid])
   );
 
   if (nonNullNotifications.length === 0) {

--- a/apps/mobile/src/components/Notification/NotificationRegistrar.tsx
+++ b/apps/mobile/src/components/Notification/NotificationRegistrar.tsx
@@ -6,8 +6,11 @@ import { useRelayEnvironment } from 'react-relay';
 import { registerNotificationToken } from '~/components/Notification/registerNotificationToken';
 import { RootStackNavigatorProp } from '~/navigation/types';
 
+import { useMobileClearNotifications } from '../../hooks/useMobileClearNotifications';
+
 export function NotificationRegistrar() {
   const relayEnvironment = useRelayEnvironment();
+  const clearNotifications = useMobileClearNotifications();
 
   useEffect(() => {
     registerNotificationToken({ shouldPrompt: false, relayEnvironment });
@@ -16,6 +19,8 @@ export function NotificationRegistrar() {
   const navigation = useNavigation<RootStackNavigatorProp>();
   useEffect(() => {
     const cleanup = Notifications.addNotificationResponseReceivedListener(() => {
+      clearNotifications();
+
       navigation.navigate('MainTabs', {
         screen: 'NotificationsTab',
         params: { screen: 'Notifications', params: { fetchKey: Math.random().toString() } },
@@ -23,7 +28,7 @@ export function NotificationRegistrar() {
     });
 
     return () => cleanup.remove();
-  }, [navigation]);
+  }, [clearNotifications, navigation]);
 
   return null;
 }

--- a/apps/mobile/src/hooks/useMobileClearNotifications.ts
+++ b/apps/mobile/src/hooks/useMobileClearNotifications.ts
@@ -1,0 +1,39 @@
+import { dismissAllNotificationsAsync } from 'expo-notifications';
+import { useCallback } from 'react';
+import { ConnectionHandler, fetchQuery, graphql, useRelayEnvironment } from 'react-relay';
+
+import { useMobileClearNotificationsQuery } from '~/generated/useMobileClearNotificationsQuery.graphql';
+import { clearNotifications } from '~/shared/relay/useClearNotifications';
+
+export function useMobileClearNotifications() {
+  const environment = useRelayEnvironment();
+  return useCallback(async () => {
+    dismissAllNotificationsAsync();
+
+    const query = await fetchQuery<useMobileClearNotificationsQuery>(
+      environment,
+      graphql`
+        query useMobileClearNotificationsQuery {
+          viewer {
+            ... on Viewer {
+              id
+
+              user {
+                dbid
+              }
+            }
+          }
+        }
+      `,
+      {},
+      { fetchPolicy: 'store-or-network' }
+    ).toPromise();
+
+    if (query?.viewer?.id && query.viewer?.user?.dbid) {
+      await clearNotifications(environment, query.viewer.user.dbid, [
+        ConnectionHandler.getConnectionID(query.viewer.id, 'TabBarMainTabNavigator_notifications'),
+        ConnectionHandler.getConnectionID(query.viewer.id, 'NotificationsFragment_notifications'),
+      ]);
+    }
+  }, [environment]);
+}

--- a/apps/mobile/src/hooks/useMobileClearNotifications.ts
+++ b/apps/mobile/src/hooks/useMobileClearNotifications.ts
@@ -1,4 +1,4 @@
-import { dismissAllNotificationsAsync } from 'expo-notifications';
+import { setBadgeCountAsync } from 'expo-notifications';
 import { useCallback } from 'react';
 import { ConnectionHandler, fetchQuery, graphql, useRelayEnvironment } from 'react-relay';
 
@@ -8,7 +8,7 @@ import { clearNotifications } from '~/shared/relay/useClearNotifications';
 export function useMobileClearNotifications() {
   const environment = useRelayEnvironment();
   return useCallback(async () => {
-    dismissAllNotificationsAsync();
+    setBadgeCountAsync(0);
 
     const query = await fetchQuery<useMobileClearNotificationsQuery>(
       environment,


### PR DESCRIPTION
- I updated `useClearNotifications` to expose the underlying `clearNotifications` function so we could re-use it on mobile w/o relying on the hook.
  - Now mobile has a `useMobileClearNotifications` which does what web does, but also calls `setBadgeCount(0)`
- I also updated the `NotificationList` to clear your notifications right away since that seems more like what the user would expect.

https://github.com/gallery-so/gallery/assets/6754223/85a4d8ed-468e-4e5c-baca-753d7c9d2864

