### PR TITLE
Handle missing collection on NftDetail screen more gracefully

### DIFF
--- a/apps/mobile/src/components/NftPreview/NftPreview.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreview.tsx
@@ -71,12 +71,10 @@ function NftPreviewInner({
 
   const navigation = useNavigation<MainTabStackNavigatorProp>();
   const handlePress = useCallback(() => {
-    if (collectionToken.collection?.dbid) {
-      navigation.push('NftDetail', {
-        tokenId: token.dbid,
-        collectionId: collectionToken.collection.dbid,
-      });
-    }
+    navigation.push('NftDetail', {
+      tokenId: token.dbid,
+      collectionId: collectionToken.collection?.dbid ?? null,
+    });
   }, [collectionToken.collection?.dbid, navigation, token.dbid]);
 
   const handleLoad = useCallback(

--- a/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
@@ -83,20 +83,16 @@ export function NftPreviewContextMenuPopup({
   const handleMenuItemPress = useCallback<OnPressMenuItemEvent>(
     (event) => {
       if (event.nativeEvent.actionKey === 'view-details') {
-        if (collectionToken.collection?.dbid) {
-          navigation.navigate('NftDetail', {
-            tokenId: token.dbid,
-            collectionId: collectionToken.collection.dbid,
-          });
-        }
+        navigation.navigate('NftDetail', {
+          tokenId: token.dbid,
+          collectionId: collectionToken?.collection?.dbid ?? null,
+        });
       } else if (event.nativeEvent.actionKey === 'share') {
         shareToken(token, collectionToken.collection ?? null);
       } else if (event.nativeEvent.actionKey === 'view-gallery') {
-        if (collectionToken.collection?.gallery?.dbid) {
-          navigation.push('Gallery', {
-            galleryId: collectionToken.collection.gallery.dbid,
-          });
-        }
+        navigation.push('Gallery', {
+          galleryId: collectionToken.collection?.gallery?.dbid ?? 'not-found',
+        });
       }
     },
     [collectionToken.collection, navigation, token]

--- a/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
@@ -40,7 +40,10 @@ export function NftPreviewContextMenuPopup({
           gallery {
             dbid
           }
+
+          ...shareTokenCollectionFragment
         }
+
         token @required(action: THROW) {
           dbid
           name
@@ -56,9 +59,9 @@ export function NftPreviewContextMenuPopup({
               }
             }
           }
-        }
 
-        ...shareTokenFragment
+          ...shareTokenFragment
+        }
       }
     `,
     collectionTokenRef
@@ -87,7 +90,7 @@ export function NftPreviewContextMenuPopup({
           });
         }
       } else if (event.nativeEvent.actionKey === 'share') {
-        shareToken(collectionToken);
+        shareToken(token, collectionToken.collection ?? null);
       } else if (event.nativeEvent.actionKey === 'view-gallery') {
         if (collectionToken.collection?.gallery?.dbid) {
           navigation.push('Gallery', {
@@ -96,7 +99,7 @@ export function NftPreviewContextMenuPopup({
         }
       }
     },
-    [collectionToken, navigation, token.dbid]
+    [collectionToken.collection, navigation, token]
   );
 
   const track = useTrack();

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -14,7 +14,7 @@ export type MainTabStackNavigatorParamList = {
   Profile: { username: string; hideBackButton?: boolean };
   NftDetail: {
     tokenId: string;
-    collectionId: string;
+    collectionId: string | null;
   };
   Gallery: { galleryId: string };
   Collection: { collectionId: string };

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailAsset/NftDetailAsset.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailAsset/NftDetailAsset.tsx
@@ -17,53 +17,49 @@ import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlFo
 type ImageState = { kind: 'loading' } | { kind: 'loaded'; dimensions: Dimensions | null };
 
 type NftDetailProps = {
-  collectionTokenRef: NftDetailAssetFragment$key;
+  tokenRef: NftDetailAssetFragment$key;
   style?: ViewProps['style'];
 };
 
-export function NftDetailAsset({ collectionTokenRef, style }: NftDetailProps) {
-  const collectionToken = useFragment(
+export function NftDetailAsset({ tokenRef, style }: NftDetailProps) {
+  const token = useFragment(
     graphql`
-      fragment NftDetailAssetFragment on CollectionToken {
-        token @required(action: THROW) {
-          media {
+      fragment NftDetailAssetFragment on Token {
+        media {
+          __typename
+
+          ... on InvalidMedia {
             __typename
-
-            ... on InvalidMedia {
-              __typename
-            }
-
-            ... on AudioMedia {
-              __typename
-            }
-
-            ... on GIFMedia {
-              __typename
-            }
-            ... on ImageMedia {
-              __typename
-            }
-
-            ... on HtmlMedia {
-              contentRenderURL
-            }
-
-            ... on VideoMedia {
-              __typename
-              contentRenderURLs {
-                large
-              }
-            }
           }
 
-          ...getVideoOrImageUrlForNftPreviewFragment
+          ... on AudioMedia {
+            __typename
+          }
+
+          ... on GIFMedia {
+            __typename
+          }
+          ... on ImageMedia {
+            __typename
+          }
+
+          ... on HtmlMedia {
+            contentRenderURL
+          }
+
+          ... on VideoMedia {
+            __typename
+            contentRenderURLs {
+              large
+            }
+          }
         }
+
+        ...getVideoOrImageUrlForNftPreviewFragment
       }
     `,
-    collectionTokenRef
+    tokenRef
   );
-
-  const { token } = collectionToken;
 
   const windowDimensions = useWindowDimensions();
 
@@ -83,7 +79,7 @@ export function NftDetailAsset({ collectionTokenRef, style }: NftDetailProps) {
   const finalAssetDimensions = useMemo((): Dimensions => {
     if (viewDimensions && imageState.kind === 'loaded' && imageState.dimensions) {
       // Give the piece a little bit of breathing room. This might be an issue
-      // if we evers upport landscape view (turning your phone horizontally).
+      // if we ever support landscape view (turning your phone horizontally).
       const MAX_HEIGHT = windowDimensions.height - 400;
 
       // Width is the width of the parent view (the screen - some padding)

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
@@ -62,7 +62,10 @@ export function NftDetailScreenInner() {
         }
       }
     `,
-    { tokenId: route.params.tokenId, collectionId: route.params.collectionId }
+    {
+      tokenId: route.params.tokenId,
+      collectionId: route.params.collectionId ?? 'definitely-not-a-collection',
+    }
     // Use one of these if you want to test with a specific NFT
     // POAP
     // { tokenId: '2Hu1U34d5UpXWDoVNOkMtguCEpk' }

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
@@ -35,26 +35,30 @@ export function NftDetailScreenInner() {
       query NftDetailScreenInnerQuery($tokenId: DBID!, $collectionId: DBID!) {
         collectionTokenById(tokenId: $tokenId, collectionId: $collectionId) {
           ... on CollectionToken {
+            collection {
+              ...shareTokenCollectionFragment
+            }
+          }
+        }
+
+        tokenById(id: $tokenId) {
+          ... on Token {
             __typename
+            name
+            chain
+            tokenId
+            description
 
-            token @required(action: THROW) {
-              __typename
+            contract {
               name
-              chain
-              tokenId
-              description
-
-              contract {
-                name
-                badgeURL
-              }
-
-              ...NftAdditionalDetailsFragment
+              badgeURL
             }
 
-            ...shareTokenFragment
+            ...NftAdditionalDetailsFragment
             ...NftDetailAssetFragment
           }
+
+          ...shareTokenFragment
         }
       }
     `,
@@ -74,13 +78,11 @@ export function NftDetailScreenInner() {
     // { tokenId: '2O1TnqK7sbhbdlAeQwLFkxo8T9i' }
   );
 
-  const collectionToken = query.collectionTokenById;
+  const token = query.tokenById;
 
-  if (collectionToken?.__typename !== 'CollectionToken') {
-    throw new Error('Invalid token');
+  if (token?.__typename !== 'Token') {
+    throw new Error("We couldn't find that token. Something went wrong and we're looking into it.");
   }
-
-  const token = collectionToken.token;
 
   const [showAdditionalDetails, setShowAdditionalDetails] = useState(false);
 
@@ -89,8 +91,8 @@ export function NftDetailScreenInner() {
   }, []);
 
   const handleShare = useCallback(() => {
-    shareToken(collectionToken);
-  }, [collectionToken]);
+    shareToken(token, query.collectionTokenById?.collection ?? null);
+  }, [query.collectionTokenById, token]);
 
   return (
     <ScrollView>
@@ -106,7 +108,7 @@ export function NftDetailScreenInner() {
             />
           </View>
 
-          <NftDetailAsset collectionTokenRef={collectionToken} />
+          <NftDetailAsset tokenRef={token} />
         </View>
 
         <View className="flex flex-col space-y-4">

--- a/apps/mobile/src/utils/shareToken.ts
+++ b/apps/mobile/src/utils/shareToken.ts
@@ -1,32 +1,37 @@
 import { Share } from 'react-native';
 import { graphql, readInlineData } from 'relay-runtime';
 
+import { shareTokenCollectionFragment$key } from '~/generated/shareTokenCollectionFragment.graphql';
 import { shareTokenFragment$key } from '~/generated/shareTokenFragment.graphql';
 
-export async function shareToken(collectionTokenRef: shareTokenFragment$key) {
-  const collectionToken = readInlineData(
+export async function shareToken(
+  tokenRef: shareTokenFragment$key,
+  collectionRef: shareTokenCollectionFragment$key | null
+) {
+  const collection = readInlineData(
     graphql`
-      fragment shareTokenFragment on CollectionToken @inline {
-        collection {
-          dbid
-        }
-        token {
-          dbid
-          owner {
-            username
-          }
+      fragment shareTokenCollectionFragment on Collection @inline {
+        dbid
+      }
+    `,
+    collectionRef
+  );
+
+  const token = readInlineData(
+    graphql`
+      fragment shareTokenFragment on Token @inline {
+        dbid
+        owner {
+          username
         }
       }
     `,
-    collectionTokenRef
+    tokenRef
   );
 
-  if (
-    collectionToken.token?.owner?.username &&
-    collectionToken.collection &&
-    collectionToken.token
-  ) {
-    const url = `https://gallery.so/${collectionToken.token.owner.username}/${collectionToken.collection?.dbid}/${collectionToken.token?.dbid}`;
+  // TODO(Terence) We need to handle the case where we're missing a collectionId
+  if (token.owner?.username && collection?.dbid) {
+    const url = `https://gallery.so/${token.owner.username}/${collection?.dbid}/${token.dbid}`;
 
     Share.share({ url });
   }


### PR DESCRIPTION
Okay back story

- The web nft detail page requires the collection id since we let you slide between pieces in a collection.
- Since we have a share button on mobile that links to the web version, I thought it would make sense to thread down a `CollectionToken` type and not allow navigation if there wasn't a collection id.
- Sometimes, a feed event token's collection no longer exists, which means we couldn't navigate to the nft detail screen as it required a `collectionId`

Now we just optionally require a collectionId, and the Share button just doesn't work if there's not a collection associated w/ the token.

Tested by setting the resolver on the backend to always return `nil` for the collection and observed that the nft detail and popup menu still work as expected.