### PR TITLE
[GAL-3170] Make usernames on admires + comments tappable

### DIFF
--- a/apps/mobile/src/components/Feed/Socialize/AdmireLine.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/AdmireLine.tsx
@@ -4,6 +4,7 @@ import { graphql, useFragment } from 'react-relay';
 
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { Typography } from '~/components/Typography';
+import { UsernameDisplay } from '~/components/UsernameDisplay';
 import { AdmireLineEventFragment$key } from '~/generated/AdmireLineEventFragment.graphql';
 import { AdmireLineFragment$key } from '~/generated/AdmireLineFragment.graphql';
 import { AdmireLineQueryFragment$key } from '~/generated/AdmireLineQueryFragment.graphql';
@@ -23,9 +24,10 @@ export function AdmireLine({ admireRef, eventRef, queryRef, totalAdmires }: Prop
       fragment AdmireLineFragment on Admire {
         dbid
 
-        admirer {
+        admirer @required(action: THROW) {
           dbid
           username
+          ...UsernameDisplayFragment
         }
       }
     `,
@@ -76,16 +78,12 @@ export function AdmireLine({ admireRef, eventRef, queryRef, totalAdmires }: Prop
   return (
     <View>
       <View className="flex flex-row">
-        {admire.admirer && (
-          <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-            {admirerName}{' '}
-          </Typography>
-        )}
+        <UsernameDisplay userRef={admire.admirer} text={admirerName} />
         {totalAdmires === 1 ? (
-          <Text className="text-xs dark:text-white">admired this</Text>
+          <Text className="text-xs dark:text-white"> admired this</Text>
         ) : (
           <View className="flex flex-row">
-            <Text className="text-xs dark:text-white">and </Text>
+            <Text className="text-xs dark:text-white"> and </Text>
 
             <GalleryTouchableOpacity
               onPress={handleOpen}

--- a/apps/mobile/src/components/Feed/Socialize/CommentLine.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentLine.tsx
@@ -1,7 +1,7 @@
 import { Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
-import { Typography } from '~/components/Typography';
+import { UsernameDisplay } from '~/components/UsernameDisplay';
 import { CommentLineFragment$key } from '~/generated/CommentLineFragment.graphql';
 
 type Props = {
@@ -13,8 +13,8 @@ export function CommentLine({ commentRef }: Props) {
     graphql`
       fragment CommentLineFragment on Comment {
         comment @required(action: THROW)
-        commenter {
-          username
+        commenter @required(action: THROW) {
+          ...UsernameDisplayFragment
         }
       }
     `,
@@ -22,10 +22,8 @@ export function CommentLine({ commentRef }: Props) {
   );
 
   return (
-    <View className="flex flex-row gap-1">
-      <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-        {comment.commenter?.username}
-      </Typography>
+    <View className="flex flex-row items-center gap-1">
+      <UsernameDisplay userRef={comment.commenter} />
       <Text className="text-xs dark:text-white flex-1">{comment.comment}</Text>
     </View>
   );

--- a/apps/mobile/src/components/Feed/Socialize/NotesModal/AdmireNote.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/NotesModal/AdmireNote.tsx
@@ -2,6 +2,7 @@ import { Text, View, ViewProps } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
 import { Typography } from '~/components/Typography';
+import { UsernameDisplay } from '~/components/UsernameDisplay';
 import { AdmireNoteFragment$key } from '~/generated/AdmireNoteFragment.graphql';
 import { getTimeSince } from '~/shared/utils/time';
 
@@ -19,8 +20,8 @@ export function AdmireNote({ admireRef, style }: Props) {
         __typename
 
         creationTime
-        admirer {
-          username
+        admirer @required(action: THROW) {
+          ...UsernameDisplayFragment
         }
       }
     `,
@@ -31,18 +32,10 @@ export function AdmireNote({ admireRef, style }: Props) {
     <View className="flex flex-row justify-between items-center px-4" style={style}>
       <View className="flex flex-row items-center space-x-2">
         <AdmireIcon active height={20} />
-        <Text>
-          <Typography
-            font={{
-              family: 'ABCDiatype',
-              weight: 'Bold',
-            }}
-            className="text-sm"
-          >
-            {admire.admirer?.username ?? null}
-          </Typography>{' '}
-          admired this
-        </Text>
+        <View className="flex flex-row items-center">
+          <UsernameDisplay userRef={admire.admirer} size="sm" />
+          <Text> admired this</Text>
+        </View>
       </View>
       <Typography className="text-metal text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
         {getTimeSince(admire.creationTime)}

--- a/apps/mobile/src/components/Feed/Socialize/NotesModal/CommentNote.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/NotesModal/CommentNote.tsx
@@ -2,6 +2,7 @@ import { Text, View, ViewProps } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
 import { Typography } from '~/components/Typography';
+import { UsernameDisplay } from '~/components/UsernameDisplay';
 import { CommentNoteFragment$key } from '~/generated/CommentNoteFragment.graphql';
 import { getTimeSince } from '~/shared/utils/time';
 
@@ -19,8 +20,8 @@ export function CommentNote({ commentRef, style }: Props) {
         comment
         creationTime
 
-        commenter {
-          username
+        commenter @required(action: THROW) {
+          ...UsernameDisplayFragment
         }
       }
     `,
@@ -29,18 +30,8 @@ export function CommentNote({ commentRef, style }: Props) {
 
   return (
     <View className="flex flex-row gap-1 justify-between items-center px-4" style={style}>
-      <Text className="dark:text-white flex-1">
-        <Typography
-          font={{
-            family: 'ABCDiatype',
-            weight: 'Bold',
-          }}
-          className="text-sm"
-        >
-          {comment.commenter?.username ?? null}
-        </Typography>{' '}
-        {comment.comment}
-      </Text>
+      <UsernameDisplay size="sm" userRef={comment.commenter} />
+      <Text className="dark:text-white flex-1">{comment.comment}</Text>
       <Typography className="text-metal text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
         {getTimeSince(comment.creationTime)}
       </Typography>

--- a/apps/mobile/src/components/UsernameDisplay.tsx
+++ b/apps/mobile/src/components/UsernameDisplay.tsx
@@ -37,8 +37,8 @@ export function UsernameDisplay({ userRef, style, size = 'xs', text }: Props) {
     <GalleryTouchableOpacity
       onPress={handlePress}
       style={style}
-      eventElementId={null}
-      eventName={null}
+      eventElementId="Username Interaction"
+      eventName="Username Interaction Clicked"
     >
       <Typography className={`text-${size}`} font={{ family: 'ABCDiatype', weight: 'Bold' }}>
         {text ? text : user.username}

--- a/apps/mobile/src/components/UsernameDisplay.tsx
+++ b/apps/mobile/src/components/UsernameDisplay.tsx
@@ -1,0 +1,48 @@
+import { useNavigation } from '@react-navigation/native';
+import { useCallback } from 'react';
+import { graphql, useFragment } from 'react-relay';
+
+import { UsernameDisplayFragment$key } from '~/generated/UsernameDisplayFragment.graphql';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
+
+import { GalleryTouchableOpacity, GalleryTouchableOpacityProps } from './GalleryTouchableOpacity';
+import { Typography } from './Typography';
+
+type Props = {
+  userRef: UsernameDisplayFragment$key;
+  style?: GalleryTouchableOpacityProps['style'];
+  size?: 'xs' | 'sm';
+  text?: string;
+};
+
+export function UsernameDisplay({ userRef, style, size = 'xs', text }: Props) {
+  const user = useFragment(
+    graphql`
+      fragment UsernameDisplayFragment on GalleryUser {
+        username
+      }
+    `,
+    userRef
+  );
+
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
+
+  const handlePress = useCallback(() => {
+    if (user.username) {
+      navigation.push('Profile', { username: user.username, hideBackButton: false });
+    }
+  }, [navigation, user.username]);
+
+  return (
+    <GalleryTouchableOpacity
+      onPress={handlePress}
+      style={style}
+      eventElementId={null}
+      eventName={null}
+    >
+      <Typography className={`text-${size}`} font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+        {text ? text : user.username}
+      </Typography>
+    </GalleryTouchableOpacity>
+  );
+}


### PR DESCRIPTION
**Changes**

1. Make the username in the feed clickable
2. Username in comment/admire in the Notes modal clickable

**Demo**

**Feed**
https://github.com/gallery-so/gallery/assets/4480258/0fde635f-16df-442f-9519-5108c4335ae6

**Notes Modal**
https://github.com/gallery-so/gallery/assets/4480258/f1d46104-7cb8-4998-aa52-88ef17bb5fcb



**Pending**
- [ ] The username in the notes modal not clickable because of react navigation