### PR TITLE
Fix Audio NFT Detail Page

### DIFF
--- a/apps/web/src/scenes/NftDetailPage/NftDetailAudio.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAudio.tsx
@@ -50,8 +50,8 @@ function NftDetailAudio({ tokenRef, onLoad }: Props) {
         controls
         loop
         controlsList="nodownload"
-        preload="none"
-        onLoad={onLoad}
+        preload="auto"
+        onLoadedData={onLoad}
         onError={handleError}
         src={token.media.contentRenderURL}
       />

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAudio.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAudio.tsx
@@ -7,7 +7,6 @@ import ImageWithLoading from '~/components/LoadingAsset/ImageWithLoading';
 import { NftDetailAudioFragment$key } from '~/generated/NftDetailAudioFragment.graphql';
 import { useThrowOnMediaFailure } from '~/hooks/useNftRetry';
 import { CouldNotRenderNftError } from '~/shared/errors/CouldNotRenderNftError';
-import noop from '~/utils/noop';
 
 type Props = {
   tokenRef: NftDetailAudioFragment$key;
@@ -45,13 +44,16 @@ function NftDetailAudio({ tokenRef, onLoad }: Props) {
   return (
     <StyledAudioContainer>
       {/* TODO(Terence): How do we want to handle onLoad / onError since this loads two things? */}
-      <ImageWithLoading onLoad={noop} src={token.media?.previewURLs.large} alt={token.name ?? ''} />
+      <ImageWithLoading
+        onLoad={onLoad}
+        src={token.media?.previewURLs.large}
+        alt={token.name ?? ''}
+      />
       <StyledAudio
         controls
         loop
         controlsList="nodownload"
-        preload="auto"
-        onLoadedData={onLoad}
+        preload="none"
         onError={handleError}
         src={token.media.contentRenderURL}
       />


### PR DESCRIPTION
Not sure when this stopped working but we're using `preload="none"` on the audio tag which tells the page it doesn't have to start loading the audio file. This means `onLoad` will never get called, which means the shimmer will never go away.

If we want `preload="none"`, then my changes are chill, I just use the image asset for the `onLoad` part. 