### PR TITLE
[GAL-2934] Reuse thumbnail image for NftDetail 

### DIFF
--- a/apps/mobile/src/components/NftPreview/NftPreview.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreview.tsx
@@ -91,6 +91,7 @@ function NftPreviewInner({
 
   return (
     <NftPreviewContextMenuPopup
+      cachedPreviewAssetUrl={tokenUrl}
       fallbackTokenUrl={tokenUrl}
       collectionTokenRef={collectionToken}
       imageDimensions={imageState.kind === 'loaded' ? imageState.dimensions : null}

--- a/apps/mobile/src/components/NftPreview/NftPreview.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreview.tsx
@@ -74,8 +74,9 @@ function NftPreviewInner({
     navigation.push('NftDetail', {
       tokenId: token.dbid,
       collectionId: collectionToken.collection?.dbid ?? null,
+      cachedPreviewAssetUrl: tokenUrl,
     });
-  }, [collectionToken.collection?.dbid, navigation, token.dbid]);
+  }, [collectionToken.collection?.dbid, navigation, token.dbid, tokenUrl]);
 
   const handleLoad = useCallback(
     (dimensions: Dimensions | null) => {

--- a/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
@@ -23,14 +23,17 @@ import { shareToken } from '../../utils/shareToken';
 type NftPreviewContextMenuPopupProps = PropsWithChildren<{
   fallbackTokenUrl?: string;
   imageDimensions: Dimensions | null;
+  cachedPreviewAssetUrl: string | null;
   collectionTokenRef: NftPreviewContextMenuPopupFragment$key;
 }>;
 
 export function NftPreviewContextMenuPopup({
+  children,
+
   imageDimensions,
   fallbackTokenUrl,
   collectionTokenRef,
-  children,
+  cachedPreviewAssetUrl,
 }: NftPreviewContextMenuPopupProps) {
   const collectionToken = useFragment(
     graphql`
@@ -84,6 +87,8 @@ export function NftPreviewContextMenuPopup({
     (event) => {
       if (event.nativeEvent.actionKey === 'view-details') {
         navigation.navigate('NftDetail', {
+          cachedPreviewAssetUrl,
+
           tokenId: token.dbid,
           collectionId: collectionToken?.collection?.dbid ?? null,
         });
@@ -95,7 +100,7 @@ export function NftPreviewContextMenuPopup({
         });
       }
     },
-    [collectionToken.collection, navigation, token]
+    [cachedPreviewAssetUrl, collectionToken.collection, navigation, token]
   );
 
   const track = useTrack();

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -15,6 +15,7 @@ export type MainTabStackNavigatorParamList = {
   NftDetail: {
     tokenId: string;
     collectionId: string | null;
+    cachedPreviewAssetUrl: string | null;
   };
   Gallery: { galleryId: string };
   Collection: { collectionId: string };

--- a/apps/mobile/src/screens/NftDetailScreen/LoadingNftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/LoadingNftDetailScreenInner.tsx
@@ -1,19 +1,26 @@
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { View } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 
 import { BackButton } from '~/components/BackButton';
 import { GallerySkeleton } from '~/components/GallerySkeleton';
+import { MainTabStackNavigatorParamList } from '~/navigation/types';
+import { NftDetailAssetCacheSwapper } from '~/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetCacheSwapper';
 
 export function LoadingNftDetailScreenInner() {
+  const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'NftDetail'>>();
+
   return (
     <View className="flex flex-col space-y-3 px-4">
       <View className="flex flex-row justify-between">
         <BackButton />
       </View>
+
+      <NftDetailAssetCacheSwapper cachedPreviewAssetUrl={route.params?.cachedPreviewAssetUrl} />
+
       <View>
         <GallerySkeleton>
           <SkeletonPlaceholder.Item flexDirection="column" gap={16}>
-            <SkeletonPlaceholder.Item width="100%" aspectRatio="1" />
             <SkeletonPlaceholder.Item flexDirection="column" gap={8} height="100%">
               <SkeletonPlaceholder.Item width="60%" height={36} />
               <SkeletonPlaceholder.Item width="80%" height={20} />

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailAsset/NftDetailAsset.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailAsset/NftDetailAsset.tsx
@@ -1,20 +1,19 @@
-import { useCallback, useMemo, useState } from 'react';
-import { LayoutChangeEvent, useWindowDimensions, View, ViewProps } from 'react-native';
+import { useCallback, useContext, useMemo } from 'react';
+import { View, ViewProps } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
 import { GallerySkeleton } from '~/components/GallerySkeleton';
 import { NftDetailAssetFragment$key } from '~/generated/NftDetailAssetFragment.graphql';
-import { fitDimensionsToContainerContain } from '~/screens/NftDetailScreen/NftDetailAsset/fitDimensionToContainer';
+import { NftDetailAssetCacheSwapperContext } from '~/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetCacheSwapper';
 import { NftDetailAssetHtml } from '~/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetHtml';
 import { NftDetailAssetImage } from '~/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetImage';
 import { NftDetailAssetVideo } from '~/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetVideo';
 import { Dimensions } from '~/screens/NftDetailScreen/NftDetailAsset/types';
+import { useNftDetailAssetSizer } from '~/screens/NftDetailScreen/NftDetailAsset/useNftDetailAssetSizer';
 import { CouldNotRenderNftError } from '~/shared/errors/CouldNotRenderNftError';
 import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
-
-type ImageState = { kind: 'loading' } | { kind: 'loaded'; dimensions: Dimensions | null };
 
 type NftDetailProps = {
   tokenRef: NftDetailAssetFragment$key;
@@ -61,44 +60,17 @@ export function NftDetailAsset({ tokenRef, style }: NftDetailProps) {
     tokenRef
   );
 
-  const windowDimensions = useWindowDimensions();
+  const assetSizer = useNftDetailAssetSizer();
 
-  const [imageState, setImageState] = useState<ImageState>({ kind: 'loading' });
-  const [viewDimensions, setViewDimensions] = useState<Dimensions | null>(null);
+  const cachedAssetSwapperContext = useContext(NftDetailAssetCacheSwapperContext);
+  const handleLoad = useCallback(
+    (dimensions?: Dimensions | null) => {
+      cachedAssetSwapperContext?.markDetailAssetAsLoaded();
 
-  const handleViewLayout = useCallback((event: LayoutChangeEvent) => {
-    const { width, height } = event.nativeEvent.layout;
-
-    setViewDimensions({ width, height });
-  }, []);
-
-  const handleLoad = useCallback((dimensions?: Dimensions | null) => {
-    setImageState({ kind: 'loaded', dimensions: dimensions ?? null });
-  }, []);
-
-  const finalAssetDimensions = useMemo((): Dimensions => {
-    if (viewDimensions && imageState.kind === 'loaded' && imageState.dimensions) {
-      // Give the piece a little bit of breathing room. This might be an issue
-      // if we ever support landscape view (turning your phone horizontally).
-      const MAX_HEIGHT = windowDimensions.height - 400;
-
-      // Width is the width of the parent view (the screen - some padding)
-      // Height is the max height for the image
-      //
-      // This will fit the image to the screen appropriately.
-      const containerDimensions: Dimensions = { width: viewDimensions.width, height: MAX_HEIGHT };
-
-      return fitDimensionsToContainerContain({
-        container: containerDimensions,
-        source: imageState.dimensions,
-      });
-    }
-
-    // This is a fallback for when we don't have the image dimensions yet.
-    // The user will never see the image in this state since it will be covered
-    // by a loading skeleton UI anyway.
-    return { width: 300, height: 300 };
-  }, [imageState, viewDimensions, windowDimensions.height]);
+      assetSizer.handleLoad(dimensions);
+    },
+    [assetSizer, cachedAssetSwapperContext]
+  );
 
   const inner = useMemo(() => {
     if (
@@ -120,7 +92,7 @@ export function NftDetailAsset({ tokenRef, style }: NftDetailProps) {
         <NftDetailAssetImage
           onLoad={handleLoad}
           imageUrl={imageUrl}
-          outputDimensions={finalAssetDimensions}
+          outputDimensions={assetSizer.finalAssetDimensions}
         />
       );
     } else if (token.media?.__typename === 'VideoMedia') {
@@ -134,7 +106,7 @@ export function NftDetailAsset({ tokenRef, style }: NftDetailProps) {
         <NftDetailAssetVideo
           onLoad={handleLoad}
           videoUrl={videoUrl}
-          outputDimensions={finalAssetDimensions}
+          outputDimensions={assetSizer.finalAssetDimensions}
         />
       );
     } else if (token.media?.__typename === 'HtmlMedia') {
@@ -153,23 +125,23 @@ export function NftDetailAsset({ tokenRef, style }: NftDetailProps) {
     throw new CouldNotRenderNftError('NftDetailAsset', 'Unsupported media type', {
       typename: token.media?.__typename,
     });
-  }, [finalAssetDimensions, handleLoad, token]);
+  }, [assetSizer.finalAssetDimensions, handleLoad, token]);
 
   return (
     <View
       style={style}
       className="relative flex flex-row justify-center"
-      onLayout={handleViewLayout}
+      onLayout={assetSizer.handleViewLayout}
     >
       {inner}
 
       {/* Show a skeleton placeholder over the image while it's loading */}
-      {imageState.kind === 'loading' && (
+      {assetSizer.imageState.kind === 'loading' && (
         <View className="absolute">
           <GallerySkeleton>
             <SkeletonPlaceholder.Item
-              width={viewDimensions?.width}
-              height={viewDimensions?.height}
+              width={assetSizer.viewDimensions?.width}
+              height={assetSizer.viewDimensions?.height}
             />
           </GallerySkeleton>
         </View>

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetCacheSwapper.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetCacheSwapper.tsx
@@ -1,0 +1,72 @@
+import { ResizeMode } from 'expo-av';
+import { createContext, PropsWithChildren, useCallback, useMemo, useState } from 'react';
+import { View, ViewProps } from 'react-native';
+
+import { NftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
+import { useNftDetailAssetSizer } from '~/screens/NftDetailScreen/NftDetailAsset/useNftDetailAssetSizer';
+
+type NftDetailAssetCacheSwapperContextType = {
+  markDetailAssetAsLoaded: () => void;
+};
+
+export const NftDetailAssetCacheSwapperContext = createContext<
+  NftDetailAssetCacheSwapperContextType | undefined
+>(undefined);
+
+type Props = PropsWithChildren<{
+  style?: ViewProps['style'];
+  cachedPreviewAssetUrl: string | null;
+}>;
+
+/**
+ * This component is used to swap out the cached asset for the real asset once it's loaded.
+ * The end goal is to ensure the user sees an image immediately if they just navigated
+ * from a screen that had the cached asset.
+ */
+export function NftDetailAssetCacheSwapper({ children, style, cachedPreviewAssetUrl }: Props) {
+  const [loaded, setLoaded] = useState(false);
+  const assetSizer = useNftDetailAssetSizer();
+
+  const markDetailAssetAsLoaded = useCallback(() => {
+    setLoaded(true);
+  }, []);
+
+  const contextValue = useMemo((): NftDetailAssetCacheSwapperContextType => {
+    return {
+      markDetailAssetAsLoaded,
+    };
+  }, [markDetailAssetAsLoaded]);
+
+  if (!cachedPreviewAssetUrl) {
+    return <>{children}</>;
+  }
+
+  return (
+    <View style={[style, { position: 'relative' }]}>
+      <View
+        onLayout={assetSizer.handleViewLayout}
+        style={[assetSizer.finalAssetDimensions, { width: '100%' }]}
+      >
+        <NftPreviewAsset
+          onLoad={assetSizer.handleLoad}
+          tokenUrl={cachedPreviewAssetUrl}
+          resizeMode={ResizeMode.CONTAIN}
+        />
+      </View>
+
+      <NftDetailAssetCacheSwapperContext.Provider value={contextValue}>
+        <View
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            zIndex: loaded ? 1 : -1,
+          }}
+        >
+          {children}
+        </View>
+      </NftDetailAssetCacheSwapperContext.Provider>
+    </View>
+  );
+}

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailAsset/useNftDetailAssetSizer.ts
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailAsset/useNftDetailAssetSizer.ts
@@ -1,0 +1,56 @@
+import { useCallback, useMemo, useState } from 'react';
+import { LayoutChangeEvent, useWindowDimensions } from 'react-native';
+
+import { fitDimensionsToContainerContain } from '~/screens/NftDetailScreen/NftDetailAsset/fitDimensionToContainer';
+import { Dimensions } from '~/screens/NftDetailScreen/NftDetailAsset/types';
+
+type ImageState = { kind: 'loading' } | { kind: 'loaded'; dimensions: Dimensions | null };
+
+export function useNftDetailAssetSizer() {
+  const windowDimensions = useWindowDimensions();
+
+  const [imageState, setImageState] = useState<ImageState>({ kind: 'loading' });
+  const [viewDimensions, setViewDimensions] = useState<Dimensions | null>(null);
+
+  const handleViewLayout = useCallback((event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+
+    setViewDimensions({ width, height });
+  }, []);
+
+  const handleLoad = useCallback((dimensions?: Dimensions | null) => {
+    setImageState({ kind: 'loaded', dimensions: dimensions ?? null });
+  }, []);
+
+  const finalAssetDimensions = useMemo((): Dimensions => {
+    if (viewDimensions && imageState.kind === 'loaded' && imageState.dimensions) {
+      // Give the piece a little bit of breathing room. This might be an issue
+      // if we ever support landscape view (turning your phone horizontally).
+      const MAX_HEIGHT = windowDimensions.height - 400;
+
+      // Width is the width of the parent view (the screen - some padding)
+      // Height is the max height for the image
+      //
+      // This will fit the image to the screen appropriately.
+      const containerDimensions: Dimensions = { width: viewDimensions.width, height: MAX_HEIGHT };
+
+      return fitDimensionsToContainerContain({
+        container: containerDimensions,
+        source: imageState.dimensions,
+      });
+    }
+
+    // This is a fallback for when we don't have the image dimensions yet.
+    // The user will never see the image in this state since it will be covered
+    // by a loading skeleton UI anyway.
+    return { width: 300, height: 300 };
+  }, [imageState, viewDimensions, windowDimensions.height]);
+
+  return {
+    imageState,
+    handleLoad,
+    viewDimensions,
+    handleViewLayout,
+    finalAssetDimensions,
+  };
+}

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
@@ -10,6 +10,7 @@ import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { Pill } from '~/components/Pill';
 import { NftDetailScreenInnerQuery } from '~/generated/NftDetailScreenInnerQuery.graphql';
 import { MainTabStackNavigatorParamList, MainTabStackNavigatorProp } from '~/navigation/types';
+import { NftDetailAssetCacheSwapper } from '~/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetCacheSwapper';
 
 import { IconContainer } from '../../components/IconContainer';
 import { InteractiveLink } from '../../components/InteractiveLink';
@@ -127,7 +128,9 @@ export function NftDetailScreenInner() {
             />
           </View>
 
-          <NftDetailAsset tokenRef={token} />
+          <NftDetailAssetCacheSwapper cachedPreviewAssetUrl={route.params.cachedPreviewAssetUrl}>
+            <NftDetailAsset tokenRef={token} />
+          </NftDetailAssetCacheSwapper>
         </View>
 
         <View className="flex flex-col space-y-4">


### PR DESCRIPTION
## Demo
Here's a demo w/ an artificial 1 second delay on the network request from the API (not the detail asset).

The loading time of the detail asset varies from asset to asset so you'll see different loading times in the video.

https://github.com/gallery-so/gallery/assets/6754223/769d2914-f555-4772-a89b-a5b974f68c8b

