### PR TITLE
[GAL-3168] Update Footer styling

### DIFF
--- a/apps/mobile/src/navigation/MainTabNavigator/TabBar.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/TabBar.tsx
@@ -1,5 +1,6 @@
 import { MaterialTopTabBarProps } from '@react-navigation/material-top-tabs';
 import { NavigationRoute } from '@sentry/react-native/dist/js/tracing/reactnavigation';
+import clsx from 'clsx';
 import { ReactNode, Suspense, useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -38,25 +39,23 @@ function TabItem({ navigation, route, icon, activeRoute }: TabItemProps) {
     }
   }, [isFocused, navigation, route]);
 
-  const isHome = route.name === 'Home';
-
   return (
     <GalleryTouchableOpacity
       onPress={onPress}
       accessibilityRole="button"
       accessibilityState={isFocused ? { selected: true } : {}}
-      className={`px-0 ${isFocused ? 'opacity-100' : 'opacity-30'}`}
+      activeOpacity={1}
+      className={clsx(
+        `px-0 flex h-8 w-8 items-center justify-center rounded-full active:bg-faint dark:active:bg-[#2B2B2B]`,
+        {
+          'border border-black dark:border-white': isFocused,
+        }
+      )}
       eventElementId="Navigation Tab Item"
       eventName="Navigation Tab Item Clicked"
       properties={{ variant: 'Main', route: route.name }}
     >
-      <View
-        className={`flex h-8 w-8 items-center justify-center rounded-full ${
-          isFocused && !isHome && 'border border-black'
-        }`}
-      >
-        {icon}
-      </View>
+      {icon}
     </GalleryTouchableOpacity>
   );
 }
@@ -77,7 +76,7 @@ export function TabBar({ state, navigation }: TabBarProps) {
           ? { paddingBottom: bottom, paddingTop: 12 }
           : { paddingBottom: 12, paddingTop: 12 }
       }
-      className="bg-offWhite dark:bg-black flex flex-row items-center justify-evenly"
+      className="bg-white dark:bg-black flex flex-row items-center justify-evenly border-t border-porcelain dark:border-black-600"
     >
       {state.routes.map((route) => {
         let icon = null;


### PR DESCRIPTION
**I'm leaving out the color palette changes so we can land that in one go. I don't want the app to feel fragmented**

- Add top border to footer
- remove opacity from inactive icons to improve visibility
- include "pressed" state, which is different from "active" state. in the figma, you can toggle the "Hover" state on the icon to see what this looks like. This is styling that is visible when you're pressing the icon.
- update colors, (dark mode has slightly update palette)

| Light | Dark |
|--------|--------|
| <video src="https://github.com/gallery-so/gallery/assets/6754223/5acc8f3c-3eaa-423d-91a3-3e11ff47a889" /> | <video src="https://github.com/gallery-so/gallery/assets/6754223/d6df93ac-1afa-4a86-bd92-2e6cb5a5978a" /> | 






