### PR TITLE
Fix OG Image on Empty Gallery

### DIFF
--- a/apps/web/pages/opengraph/user/[username].tsx
+++ b/apps/web/pages/opengraph/user/[username].tsx
@@ -46,8 +46,12 @@ export default function OpenGraphUserPage() {
 
   const { user } = queryResponse;
 
+  const nonEmptyGalleries = user.galleries?.filter((gallery) =>
+    gallery?.collections?.some((collection) => collection?.tokens?.length)
+  );
+
   const imageUrls = removeNullValues(
-    user.galleries?.[0]?.collections
+    nonEmptyGalleries?.[0]?.collections
       ?.filter((collection) => !collection?.hidden)
       .flatMap((collection) => collection?.tokens)
       .map((galleryToken) => {


### PR DESCRIPTION
**Problem**

In this case, the first gallery in the **lau** profile is empty. Previously, we always select the first gallery to show in the OG image. 

Solved it just by filter the non empty gallery. 

**Demo**

**Before**
<img width="1275" alt="CleanShot 2023-06-06 at 16 04 49@2x" src="https://github.com/gallery-so/gallery/assets/4480258/d8626a02-bac6-4d96-9182-9e73d3dd4253">



**After**
<img width="1252" alt="CleanShot 2023-06-06 at 16 04 21@2x" src="https://github.com/gallery-so/gallery/assets/4480258/673cdfea-a0f5-4a9b-8023-60031bb21183">
