### PR TITLE
[GAL-3182] [GAL-3183] [GAL-3213] [GAL-3027] fix feed/profile bug

### DIFF
--- a/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -9,6 +9,7 @@ import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { TokensAddedToCollectionFeedEventFragment$key } from '~/generated/TokensAddedToCollectionFeedEventFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
+import unescape from '~/shared/utils/unescape';
 
 import { Typography } from '../../Typography';
 import { EventTokenGrid } from '../EventTokenGrid';
@@ -60,6 +61,8 @@ export function TokensAddedToCollectionFeedEvent({
     );
   }, [eventData.collection?.tokens, eventData.isPreFeed, eventData.newTokens]);
 
+  const collectionName = unescape(eventData.collection?.name ?? '');
+
   return (
     <View className="flex flex-1 flex-col">
       <FeedEventCarouselCellHeader>
@@ -77,7 +80,7 @@ export function TokensAddedToCollectionFeedEvent({
             className="text-sm"
             font={{ family: 'ABCDiatype', weight: 'Bold' }}
           >
-            {eventData.collection?.name || 'their collection'}
+            {collectionName || 'their collection'}
           </Typography>
         </GalleryTouchableOpacity>
       </FeedEventCarouselCellHeader>

--- a/apps/mobile/src/components/Feed/FeedListSectionHeader.tsx
+++ b/apps/mobile/src/components/Feed/FeedListSectionHeader.tsx
@@ -7,6 +7,7 @@ import { graphql } from 'relay-runtime';
 import { FeedListSectionHeaderFragment$key } from '~/generated/FeedListSectionHeaderFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { getTimeSince } from '~/shared/utils/time';
+import unescape from '~/shared/utils/unescape';
 
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
 import { Typography } from '../Typography';
@@ -58,6 +59,8 @@ export function FeedListSectionHeader({ feedEventRef }: FeedListSectionHeaderPro
     return null;
   }
 
+  const galleryName = unescape(feedEvent.eventData.gallery?.name || '');
+
   return (
     <View className="flex flex-row items-center justify-between bg-white dark:bg-black px-3 pb-2">
       <View className="flex flex-row space-x-1">
@@ -82,7 +85,7 @@ export function FeedListSectionHeader({ feedEventRef }: FeedListSectionHeaderPro
           eventName="Feed Gallery Name Clicked"
         >
           <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-            {feedEvent.eventData.gallery?.name || 'their gallery'}
+            {galleryName || 'their gallery'}
           </Typography>
         </GalleryTouchableOpacity>
       </View>

--- a/apps/mobile/src/components/Markdown.tsx
+++ b/apps/mobile/src/components/Markdown.tsx
@@ -39,7 +39,7 @@ type GalleryMarkdownProps = PropsWithChildren<{
   style?: StyleProp<unknown>;
 }>;
 
-const markdownItOptions = MarkdownIt({ typographer: true, linkify: false });
+const markdownItOptions = MarkdownIt({ typographer: true, linkify: false }).disable(['lheading']);
 
 export function Markdown({
   children,

--- a/apps/mobile/src/components/Markdown.tsx
+++ b/apps/mobile/src/components/Markdown.tsx
@@ -11,7 +11,6 @@ import { GalleryTouchableOpacity } from './GalleryTouchableOpacity';
 const markdownStyles = {
   paragraph: {
     marginTop: 0,
-    marginBottom: 0,
   },
   body: {
     fontSize: 14,

--- a/apps/mobile/src/components/ProfileView/ProfileViewFallback.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewFallback.tsx
@@ -13,8 +13,8 @@ export function ProfileViewFallback() {
       <GalleryProfileNavbarFallback shouldShowBackButton={true} />
 
       <GallerySkeleton>
-        <SkeletonPlaceholder.Item flexDirection="column" width="100%">
-          <SkeletonPlaceholder.Item marginBottom={16} flexDirection="row" justifyContent="center">
+        <SkeletonPlaceholder.Item flexDirection="column" width="100%" paddingTop={16}>
+          <SkeletonPlaceholder.Item marginBottom={16} flexDirection="row">
             <SkeletonPlaceholder.Item width={100} height={32} />
           </SkeletonPlaceholder.Item>
 


### PR DESCRIPTION
**Bug Fixes**

1. Hamsun's profile's bio is large for some reason
2. Empty lines aren't being rendered in user bio on mobile app
3. Untitled Collections show up in event descriptions as blank space instead of "their collection"
4. Left align username on profiles in loading state skeleton

**Demo**

**Hamsun's profile's bio is large for some reason**

| Before | After |
|--------|--------|
| ![image](https://github.com/gallery-so/gallery/assets/4480258/cebf93a6-b3f4-464a-8223-2d31b569328e) | <img width="486" alt="CleanShot 2023-06-06 at 17 51 33@2x" src="https://github.com/gallery-so/gallery/assets/4480258/ab28ae8d-8657-45f6-84ee-756398cb2f9f"> |


**Empty lines aren't being rendered in user bio on mobile app**

| Before | After |
|--------|--------|
| ![image](https://github.com/gallery-so/gallery/assets/4480258/c8274dda-25e8-4f28-a046-df6da7b6eeee) | <img width="451" alt="CleanShot 2023-06-06 at 17 56 23@2x" src="https://github.com/gallery-so/gallery/assets/4480258/5e13a24d-df40-4c0a-b051-636c643c5e3d"> | 


**Untitled Collections show up in event descriptions as blank space instead of "their collection"**

| Before | After |
|--------|--------|
| <img width="639" alt="CleanShot 2023-06-06 at 18 02 24@2x" src="https://github.com/gallery-so/gallery/assets/4480258/09320344-9fa1-41da-bc6e-600520d3d127"> | <img width="399" alt="CleanShot 2023-06-06 at 18 03 01@2x" src="https://github.com/gallery-so/gallery/assets/4480258/0915b318-2395-49ff-85b4-bbdfe75e7a87"> | 



**Left align username on profiles in loading state skeleton**

| Before | After |
|--------|--------|
| <img width="469" alt="CleanShot 2023-06-06 at 18 09 04@2x" src="https://github.com/gallery-so/gallery/assets/4480258/53d7bb6e-5829-4913-b678-4a3975bcb5fd"> | <img width="470" alt="CleanShot 2023-06-06 at 18 03 41@2x" src="https://github.com/gallery-so/gallery/assets/4480258/f64c4235-eb45-4772-81c7-5162cfbbc348"> | 






