### PR TITLE
make live rendering iframes full height

### DIFF
--- a/apps/web/src/components/NftPreview/NftPreview.tsx
+++ b/apps/web/src/components/NftPreview/NftPreview.tsx
@@ -216,7 +216,11 @@ function NftPreview({
         {/* NextJS <Link> tags don't come with an anchor tag by default, so we're adding one here.
           This will inherit the `as` URL from the parent component. */}
         <StyledA data-tokenid={token.dbid} onClick={handleClick}>
-          <StyledNftPreview backgroundColorOverride={backgroundColorOverride} fullWidth={fullWidth}>
+          <StyledNftPreview
+            backgroundColorOverride={backgroundColorOverride}
+            fullWidth={fullWidth}
+            fullHeight={isIFrameLiveDisplay}
+          >
             <ReportingErrorBoundary
               fallback={
                 <RawNftPreviewAsset
@@ -278,6 +282,7 @@ const StyledNftFooter = styled.div`
 const StyledNftPreview = styled.div<{
   backgroundColorOverride: string;
   fullWidth: boolean;
+  fullHeight: boolean;
 }>`
   cursor: pointer;
 
@@ -288,7 +293,7 @@ const StyledNftPreview = styled.div<{
   overflow: hidden;
   max-height: 80vh;
   width: ${({ fullWidth }) => (fullWidth ? '100%' : 'auto')};
-  height: initial;
+  height: ${({ fullHeight }) => (fullHeight ? '100%' : 'initial')};
 
   ${({ backgroundColorOverride }) =>
     backgroundColorOverride && `background-color: ${backgroundColorOverride};`}


### PR DESCRIPTION
The idea here is iframes don't know how to size themselves, so we just tell them to fill their height. The downstream `aspect-ratio: 1` property seems to be helping figure out the corresponding width from that height.

| Before | After |
|--------|--------|
| <img width="1237" alt="Screenshot 2023-06-07 at 4 59 06 PM" src="https://github.com/gallery-so/gallery/assets/6754223/c3046d52-e5ba-41dd-81bc-6a51f032b00c"> | <img width="1237" alt="Screenshot 2023-06-07 at 4 59 00 PM" src="https://github.com/gallery-so/gallery/assets/6754223/bf615add-3990-4d3d-bec3-2394f143c69b"> |  