### PR TITLE
[GAL-3184] [GAL-3225] [GAL-3226] Fix notification / collection / commit hash

### DIFF
--- a/apps/mobile/src/components/Gallery/GalleryVirtualizedRow.tsx
+++ b/apps/mobile/src/components/Gallery/GalleryVirtualizedRow.tsx
@@ -39,7 +39,7 @@ export function GalleryVirtualizedRow({ item, isOnCollectionScreen }: Props) {
         <Markdown>{item.description}</Markdown>
       </View>
     );
-  } else if (item.kind === 'collection-title') {
+  } else if (item.kind === 'collection-title' && item.name) {
     const handlePress = () => {
       if (isOnCollectionScreen) return;
       navigation.push('Collection', { collectionId: item.id });

--- a/apps/mobile/src/components/Notification/Notifications/SomeoneFollowedYou.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/SomeoneFollowedYou.tsx
@@ -69,9 +69,7 @@ export function SomeoneFollowedYou({ notificationRef }: SomeoneFollowedYouProps)
           className="text-sm"
         >
           {count > 1 ? (
-            `
-          ${count} collectors
-        `
+            `${count} collectors`
           ) : (
             <>{lastFollower ? lastFollower.username : 'Someone'}</>
           )}

--- a/apps/mobile/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -51,6 +51,8 @@ export function SettingsScreen() {
     setBottomSectionHeight(event.nativeEvent.layout.height);
   }, []);
 
+  const formattedCommitHash = commitHash?.slice(0, 6);
+
   return (
     <View style={{ paddingTop: top }} className="relative flex-1 bg-white dark:bg-black-900">
       <View className="p-4">
@@ -106,16 +108,7 @@ export function SettingsScreen() {
               className="text-sm text-metal"
               font={{ family: 'ABCDiatype', weight: 'Regular' }}
             >
-              v{appVersion}
-            </Typography>
-          )}
-
-          {commitHash && (
-            <Typography
-              className="text-sm text-metal"
-              font={{ family: 'ABCDiatype', weight: 'Regular' }}
-            >
-              #{commitHash}
+              v{appVersion} {formattedCommitHash && `| ${formattedCommitHash}`}
             </Typography>
           )}
 


### PR DESCRIPTION
**Bug Fixes**

1. stacked formatting for multiple follows notification
2. Hide collection title on mobile if no title exists
3. truncate commit hash in settings to only display first 6 characters




**Hide collection title on mobile if no title exists**

| Before | After |
|--------|--------|
| <img alt="demo" src="https://github.com/gallery-so/gallery/assets/4480258/dc5c0152-943e-4261-9904-d23836785fe7"> | <img width="487" alt="CleanShot 2023-06-08 at 18 26 42@2x" src="https://github.com/gallery-so/gallery/assets/4480258/785efbde-0ce1-42f5-bc29-a9da7c4e9f20"> | 


**stacked formatting for multiple follows notification**

| Before | After |
|--------|--------|
| <img width="478" alt="CleanShot 2023-06-08 at 16 22 33@2x" src="https://github.com/gallery-so/gallery/assets/4480258/c945d5ce-03ef-4702-8bb6-0b35d62f5783"> | <img width="505" alt="CleanShot 2023-06-08 at 16 22 19@2x" src="https://github.com/gallery-so/gallery/assets/4480258/b19265ab-6838-46c9-b99f-61c4f44368fa"> | 


**truncate commit hash in settings to only display first 6 characters**

| Before | After |
|--------|--------|
| <img src="https://github.com/gallery-so/gallery/assets/4480258/8ac9b64e-2e46-4f33-b9da-c9a5a57b555b" /> | <img width="475" alt="CleanShot 2023-06-08 at 16 19 13@2x" src="https://github.com/gallery-so/gallery/assets/4480258/ec4d25fe-b464-45df-9929-74ced63eaa20"> | 

