### PR TITLE
Fix NFT hover regressions

### DIFF
--- a/apps/web/src/components/GalleryEditor/CollectionEditor/UnstageButton.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionEditor/UnstageButton.tsx
@@ -40,6 +40,9 @@ export const StyledUnstageButton = styled.button`
   border: none;
   z-index: 4;
   cursor: pointer;
+
+  // dark magic that allows the child SVG to be visible regardless of background color
+  mix-blend-mode: exclusion;
 `;
 
 export default UnstageButton;

--- a/apps/web/src/components/NftPreview/NftPreview.tsx
+++ b/apps/web/src/components/NftPreview/NftPreview.tsx
@@ -288,6 +288,7 @@ const StyledNftLabel = styled(NftPreviewLabel)`
 const StyledNftFooter = styled.div`
   position: absolute;
   bottom: 0;
+  left: 0;
   width: 100%;
 
   transition: opacity ${transitions.cubic};


### PR DESCRIPTION
1. Ensure trash icon is visible on editor hover

<img width="301" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/7eb3161c-c5d2-4680-8d36-e91710803376">


2. fix label positioning bug

<img width="293" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/0cca8945-c60c-48e8-8137-c9d65be474e0">
