### PR TITLE
move live display toggle to top left to avoid clashing with label

### DIFF
--- a/apps/web/src/components/GalleryEditor/CollectionEditor/LiveDisplayButton.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionEditor/LiveDisplayButton.tsx
@@ -45,8 +45,7 @@ export default function LiveDisplayButton({ id }: Props) {
 const sharedStyles = `
   position: absolute;
   left: 8px;
-  bottom: 8px;
-  z-index: 11; // above the gradient
+  top: 8px;
 `;
 
 const StyledTooltip = styled(Tooltip)<{ showTooltip: boolean }>`


### PR DESCRIPTION
move live display toggle to top left to avoid clashing with label

Before
![Screenshot 2023-06-20 at 22 02 28](https://github.com/gallery-so/gallery/assets/80802871/4ff51f63-6262-4501-a785-2e5e3907b1dd)



After
![Screenshot 2023-06-20 at 22 01 35](https://github.com/gallery-so/gallery/assets/80802871/debd6dea-e723-47cd-992a-151a0cb6931c)
