### PR TITLE
Fix deep linking exclusion priority

### DIFF
--- a/apps/mobile/src/components/DeepLinkRegistrar.tsx
+++ b/apps/mobile/src/components/DeepLinkRegistrar.tsx
@@ -18,7 +18,7 @@ export function DeepLinkRegistrar() {
     // 2. /:username/:collectionId
     // 3. /:username/:collectionId/:tokenId
     // 4. /:username/galleries/:galleryId
-    const listener = Linking.addEventListener('url', async ({ url }) => {
+    async function handleDeepLinkToUrl({ url }: { url: string }) {
       track('Deep Link Opened', { url });
 
       const response = await fetchQuery<DeepLinkRegistrarAuthCheckQuery>(
@@ -95,6 +95,16 @@ export function DeepLinkRegistrar() {
             });
           }
         }
+      }
+    }
+
+    const listener = Linking.addEventListener('url', handleDeepLinkToUrl);
+
+    // Make sure we handle the case where the app is on a cold start
+    // and we don't receive an event.
+    Linking.getInitialURL().then((maybeUrl) => {
+      if (maybeUrl) {
+        handleDeepLinkToUrl({ url: maybeUrl });
       }
     });
 

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -5,7 +5,6 @@
       {
         "appID": "5SD5N7PXU5.com.usegallery.gallery",
         "paths": [
-          "/*",
           "NOT /auth",
           "NOT /about",
           "NOT /about",
@@ -59,6 +58,7 @@
           "NOT /verify",
           "NOT /welcome",
           "NOT /404"
+          "/*",
         ]
       }
     ]


### PR DESCRIPTION
Turns out it's very important that the exclusions come before the catch all.