### PR TITLE
Support previews for PDF Media

### DIFF
--- a/apps/mobile/src/components/SvgWebView.tsx
+++ b/apps/mobile/src/components/SvgWebView.tsx
@@ -85,13 +85,15 @@ const getHTML = (svgContent: string) => `
         height: 100${heightUnits};
         background-color: transparent;
         display: flex;
-        justify-content: center;
-        align-items: center;
       }
       svg {
-        min-height: 100%;
-        min-width: 100%;
-        overflow: hidden;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        max-width: 100vw;
+        max-height: 100vh;
       }
     </style>
   </head>

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
@@ -7,11 +7,13 @@ import { graphql } from 'relay-runtime';
 
 import { BackButton } from '~/components/BackButton';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
+import { NftPreviewErrorFallback } from '~/components/NftPreview/NftPreviewErrorFallback';
 import { Pill } from '~/components/Pill';
 import { NftDetailScreenInnerQuery } from '~/generated/NftDetailScreenInnerQuery.graphql';
 import { MainTabStackNavigatorParamList, MainTabStackNavigatorProp } from '~/navigation/types';
 import { NftDetailAssetCacheSwapper } from '~/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetCacheSwapper';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
+import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 
 import { IconContainer } from '../../components/IconContainer';
 import { InteractiveLink } from '../../components/InteractiveLink';
@@ -164,9 +166,21 @@ export function NftDetailScreenInner() {
             />
           </View>
 
-          <NftDetailAssetCacheSwapper cachedPreviewAssetUrl={route.params.cachedPreviewAssetUrl}>
-            <NftDetailAsset tokenRef={token} />
-          </NftDetailAssetCacheSwapper>
+          <View>
+            <ReportingErrorBoundary
+              fallback={
+                <View className="w-full aspect-square">
+                  <NftPreviewErrorFallback />
+                </View>
+              }
+            >
+              <NftDetailAssetCacheSwapper
+                cachedPreviewAssetUrl={route.params.cachedPreviewAssetUrl}
+              >
+                <NftDetailAsset tokenRef={token} />
+              </NftDetailAssetCacheSwapper>
+            </ReportingErrorBoundary>
+          </View>
         </View>
 
         <View className="flex flex-col space-y-4">

--- a/packages/shared/src/relay/getVideoOrImageUrlForNftPreview.ts
+++ b/packages/shared/src/relay/getVideoOrImageUrlForNftPreview.ts
@@ -140,6 +140,18 @@ export default function getVideoOrImageUrlForNftPreview({
             }
           }
 
+          ... on PdfMedia {
+            __typename
+            previewURLs {
+              small
+              medium
+              large
+            }
+            fallbackMedia {
+              mediaURL
+            }
+          }
+
           ... on UnknownMedia {
             __typename
             previewURLs {


### PR DESCRIPTION
- we still don't support rendering these on the NFT Detail screen
- I also made SVG rendering a little bit better by consulting w/ chat gpt.
- I added a fallback view on the detail screen for when we fail (pdfs)