### PR TITLE
Fix collection title text overflow

### DIFF
--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarList/CollectionTitle.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarList/CollectionTitle.tsx
@@ -53,11 +53,12 @@ export default function CollectionTitle({
         onMouseLeave={() => setIsMouseHovering(false)}
         align="center"
         justify="space-between"
+        gap={4}
       >
-        <HStack align="center">
+        <LeftContent align="center">
           <ExpandedIcon expanded={row.expanded} />
           <CollectionTitleText title={row.title}>{row.title}</CollectionTitleText>
-        </HStack>
+        </LeftContent>
         {shouldDisplayToggleSpamIcon ? (
           <ToggleSpamIcon
             row={row}
@@ -88,6 +89,10 @@ export default function CollectionTitle({
     </CollectionTitleRow>
   );
 }
+
+const LeftContent = styled(HStack)`
+  overflow: hidden;
+`;
 
 const CollectionTitleText = styled(TitleXS)`
   white-space: nowrap;


### PR DESCRIPTION
Previously, if a title was too long you weren't able to mark it as spam or see its token count

| Before | After |
|--------|--------|
| <img width="250" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/76db822e-a287-4f0a-9a85-6649ee35720c"> | <img width="248" alt="Screenshot 2023-06-23 at 10 07 41 PM" src="https://github.com/gallery-so/gallery/assets/12162433/212e984d-8de2-46a5-a497-086354d2d927"> | 