### PR TITLE
Bring mobile web user profiles to parity with mobile app profiles

### DIFF
--- a/apps/web/pages/[username]/activity.tsx
+++ b/apps/web/pages/[username]/activity.tsx
@@ -10,6 +10,8 @@ import { activityQuery } from '~/generated/activityQuery.graphql';
 import { MetaTagProps } from '~/pages/_app';
 import GalleryRoute from '~/scenes/_Router/GalleryRoute';
 import UserActivityPage from '~/scenes/UserActivityPage/UserActivityPage';
+import { COMMUNITIES_PER_PAGE } from '~/scenes/UserGalleryPage/UserSharedInfo/UserSharedCommunities';
+import { FOLLOWERS_PER_PAGE } from '~/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList';
 import GalleryViewEmitter from '~/shared/components/GalleryViewEmitter';
 import { PreloadQueryArgs } from '~/types/PageComponentPreloadQuery';
 import { openGraphMetaTags } from '~/utils/openGraphMetaTags';
@@ -23,6 +25,10 @@ const activityQueryNode = graphql`
     $viewerBefore: String
     $visibleTokensPerFeedEvent: Int!
     $topEventId: DBID!
+    $sharedCommunitiesFirst: Int
+    $sharedCommunitiesAfter: String
+    $sharedFollowersFirst: Int
+    $sharedFollowersAfter: String
   ) {
     ...UserActivityPageFragment
     ...GalleryNavbarFragment
@@ -66,6 +72,8 @@ UserFeed.preloadQuery = ({ relayEnvironment, query }: PreloadQueryArgs) => {
         interactionsFirst: NOTES_PER_PAGE,
         viewerLast: ITEMS_PER_PAGE,
         visibleTokensPerFeedEvent: MAX_PIECES_DISPLAYED_PER_FEED_EVENT,
+        sharedCommunitiesFirst: COMMUNITIES_PER_PAGE,
+        sharedFollowersFirst: FOLLOWERS_PER_PAGE,
       },
       { fetchPolicy: 'store-or-network' }
     );

--- a/apps/web/pages/[username]/galleries.tsx
+++ b/apps/web/pages/[username]/galleries.tsx
@@ -7,6 +7,8 @@ import { StandardSidebar } from '~/contexts/globalLayout/GlobalSidebar/StandardS
 import { galleriesQuery } from '~/generated/galleriesQuery.graphql';
 import GalleryRoute from '~/scenes/_Router/GalleryRoute';
 import GalleriesPage from '~/scenes/GalleryPage/GalleriesPage';
+import { COMMUNITIES_PER_PAGE } from '~/scenes/UserGalleryPage/UserSharedInfo/UserSharedCommunities';
+import { FOLLOWERS_PER_PAGE } from '~/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList';
 import GalleryViewEmitter from '~/shared/components/GalleryViewEmitter';
 
 type GalleriesProps = {
@@ -16,14 +18,24 @@ type GalleriesProps = {
 export default function Galleries({ username }: GalleriesProps) {
   const query = useLazyLoadQuery<galleriesQuery>(
     graphql`
-      query galleriesQuery($username: String!) {
+      query galleriesQuery(
+        $username: String!
+        $sharedCommunitiesFirst: Int
+        $sharedCommunitiesAfter: String
+        $sharedFollowersFirst: Int
+        $sharedFollowersAfter: String
+      ) {
         ...GalleryNavbarFragment
         ...GalleryViewEmitterWithSuspenseFragment
         ...GalleriesPageQueryFragment
         ...StandardSidebarFragment
       }
     `,
-    { username },
+    {
+      username,
+      sharedCommunitiesFirst: COMMUNITIES_PER_PAGE,
+      sharedFollowersFirst: FOLLOWERS_PER_PAGE,
+    },
     { fetchPolicy: 'network-only' }
   );
 
@@ -32,6 +44,7 @@ export default function Galleries({ username }: GalleriesProps) {
       element={
         <>
           <GalleryViewEmitter queryRef={query} />
+
           <GalleriesPage queryRef={query} />
         </>
       }

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionNavbar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionNavbar.tsx
@@ -5,7 +5,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
-import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { HStack } from '~/components/core/Spacer/Stack';
 import { Paragraph, TITLE_FONT_FAMILY } from '~/components/core/Text/Text';
 import NavActionFollow from '~/components/Follow/NavActionFollow';
 import { CollectionRightContent } from '~/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionRightContent';
@@ -67,8 +67,6 @@ export function CollectionNavbar({ queryRef, username, collectionId }: Collectio
 
   const isMobile = useIsMobileOrMobileLargeWindowWidth();
 
-  const usernameRoute: Route = { pathname: '/[username]', query: { username } };
-
   const galleryRoute: Route = {
     pathname: '/[username]/galleries/[galleryId]',
     query: { username, galleryId: query.collectionById?.gallery.dbid },
@@ -109,16 +107,7 @@ export function CollectionNavbar({ queryRef, username, collectionId }: Collectio
       </NavbarLeftContent>
 
       <NavbarCenterContent>
-        {isMobile ? (
-          <VStack align="center" shrink>
-            <Link href={usernameRoute} legacyBehavior>
-              <MobileUsernameText>{username}</MobileUsernameText>
-            </Link>
-            <BreadcrumbText>{unescapedCollectionName}</BreadcrumbText>
-          </VStack>
-        ) : (
-          <GalleryNavLinks username={username} queryRef={query.userByUsername} />
-        )}
+        {!isMobile && <GalleryNavLinks username={username} queryRef={query.userByUsername} />}
       </NavbarCenterContent>
 
       <NavbarRightContent>
@@ -139,17 +128,6 @@ const StyledBreadCrumbs = styled(HStack)`
 const CollectionNameText = styled(BreadcrumbText)`
   overflow: hidden;
   text-overflow: ellipsis;
-`;
-
-const MobileUsernameText = styled(Paragraph)`
-  font-family: ${TITLE_FONT_FAMILY};
-  font-style: normal;
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 18px;
-  letter-spacing: -0.04em;
-
-  color: ${colors.shadow};
 `;
 
 const SlashText = styled(Paragraph)`

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionRightContent.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionRightContent.tsx
@@ -1,5 +1,5 @@
 import { Route } from 'nextjs-routes';
-import { useCallback, useMemo, useState } from 'react';
+import { Suspense, useCallback, useMemo, useState } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
@@ -9,6 +9,7 @@ import { DropdownItem } from '~/components/core/Dropdown/DropdownItem';
 import { DropdownLink } from '~/components/core/Dropdown/DropdownLink';
 import { DropdownSection } from '~/components/core/Dropdown/DropdownSection';
 import { HStack } from '~/components/core/Spacer/Stack';
+import FollowButton from '~/components/Follow/FollowButton';
 import { EditLink } from '~/contexts/globalLayout/GlobalNavbar/CollectionNavbar/EditLink';
 import { SignInButton } from '~/contexts/globalLayout/GlobalNavbar/SignInButton';
 import { useModalActions } from '~/contexts/modal/ModalContext';
@@ -36,6 +37,7 @@ export function CollectionRightContent({
         userByUsername(username: $username) {
           ... on GalleryUser {
             dbid
+            ...FollowButtonUserFragment
           }
         }
 
@@ -57,6 +59,7 @@ export function CollectionRightContent({
         }
 
         ...EditUserInfoModalFragment
+        ...FollowButtonQueryFragment
       }
     `,
     queryRef
@@ -133,6 +136,11 @@ export function CollectionRightContent({
 
             {dropdown}
           </EditLinkWrapper>
+        )}
+        {query.userByUsername && (
+          <Suspense fallback={null}>
+            <FollowButton queryRef={query} userRef={query.userByUsername} source="navbar mobile" />
+          </Suspense>
         )}
       </HStack>
     );

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavLinks.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavLinks.tsx
@@ -41,12 +41,23 @@ export function GalleryNavLinks({ username, queryRef }: Props) {
 
   const { pathname } = useRouter();
 
+  const featuredRoute: Route = { pathname: '/[username]', query: { username } };
   const galleriesRoute: Route = { pathname: '/[username]/galleries', query: { username } };
   const followersRoute: Route = { pathname: '/[username]/followers', query: { username } };
   const activityRoute: Route = { pathname: '/[username]/activity', query: { username } };
 
   return (
     <HStack gap={8}>
+      <NavbarLink
+        // @ts-expect-error We're not using the legacy Link
+        href={route(featuredRoute)}
+        active={pathname === featuredRoute.pathname}
+      >
+        <HStack gap={4} align="baseline">
+          <span>Featured</span>
+        </HStack>
+      </NavbarLink>
+
       <NavbarLink
         // @ts-expect-error We're not using the legacy Link
         href={route(galleriesRoute)}

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavbar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavbar.tsx
@@ -1,20 +1,11 @@
-import Link from 'next/link';
-import { useRouter } from 'next/router';
-import { Route, route } from 'nextjs-routes';
-import { Suspense, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
-import styled, { css } from 'styled-components';
 
-import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import FollowButton from '~/components/Follow/FollowButton';
+import { VStack } from '~/components/core/Spacer/Stack';
 import GalleryLeftContent from '~/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryLeftContent';
 import { GalleryNavLinks } from '~/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavLinks';
 import { GalleryRightContent } from '~/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryRightContent';
-import {
-  BreadcrumbLink,
-  BreadcrumbText,
-} from '~/contexts/globalLayout/GlobalNavbar/ProfileDropdown/Breadcrumbs';
 import {
   NavbarCenterContent,
   NavbarLeftContent,
@@ -24,8 +15,6 @@ import {
 import { GalleryNavbarFragment$key } from '~/generated/GalleryNavbarFragment.graphql';
 import { GalleryNavbarGalleryFragment$key } from '~/generated/GalleryNavbarGalleryFragment.graphql';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
-import colors from '~/shared/theme/colors';
-import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 
 type Props = {
   username: string;
@@ -45,11 +34,9 @@ export function GalleryNavbar({
       fragment GalleryNavbarFragment on Query {
         ...GalleryLeftContentFragment
         ...GalleryRightContentFragment
-        ...FollowButtonQueryFragment
 
         userByUsername(username: $username) @required(action: THROW) {
           ...GalleryNavLinksFragment
-          ...FollowButtonUserFragment
         }
       }
     `,
@@ -67,11 +54,7 @@ export function GalleryNavbar({
     galleryRef
   );
 
-  const displayName = handleCustomDisplayName(username);
   const isMobile = useIsMobileOrMobileLargeWindowWidth();
-  const { pathname } = useRouter();
-
-  const userGalleryRoute: Route = { pathname: '/[username]', query: { username } };
 
   const displayGalleryName = useMemo(() => {
     if (!showGalleryNameBreadcrumb) {
@@ -89,66 +72,13 @@ export function GalleryNavbar({
         </NavbarLeftContent>
 
         <NavbarCenterContent>
-          {isMobile ? (
-            <HStack style={{ overflow: 'hidden' }} gap={4}>
-              <Link href={userGalleryRoute} legacyBehavior>
-                <UsernameBreadcrumbLink
-                  href={route(userGalleryRoute)}
-                  mainGalleryPage={pathname === '/[username]'}
-                >
-                  {displayName}{' '}
-                  {displayGalleryName && <BreadcrumbText>/ {displayGalleryName}</BreadcrumbText>}
-                </UsernameBreadcrumbLink>
-              </Link>
-
-              {!displayGalleryName && (
-                <>
-                  {query.userByUsername && (
-                    <Suspense fallback={null}>
-                      <FollowButton
-                        queryRef={query}
-                        userRef={query.userByUsername}
-                        source="navbar mobile"
-                      />
-                    </Suspense>
-                  )}
-                </>
-              )}
-            </HStack>
-          ) : (
-            <GalleryNavLinks username={username} queryRef={query.userByUsername} />
-          )}
+          {!isMobile && <GalleryNavLinks username={username} queryRef={query.userByUsername} />}
         </NavbarCenterContent>
 
         <NavbarRightContent>
           <GalleryRightContent galleryRef={gallery} username={username} queryRef={query} />
         </NavbarRightContent>
       </StandardNavbarContainer>
-
-      {/* This is the next row for mobile content */}
-      {isMobile && (
-        <StandardNavbarContainer>
-          <MobileNavLinks justify="center" grow>
-            <GalleryNavLinks username={username} queryRef={query.userByUsername} />
-          </MobileNavLinks>
-        </StandardNavbarContainer>
-      )}
     </VStack>
   );
 }
-
-const UsernameBreadcrumbLink = styled(BreadcrumbLink)<{ mainGalleryPage: boolean }>`
-  ${({ mainGalleryPage }) =>
-    mainGalleryPage
-      ? css`
-          color: ${colors.black['800']};
-        `
-      : css`
-          color: ${colors.shadow};
-        `};
-`;
-
-const MobileNavLinks = styled(HStack)`
-  padding: 4px 0 16px 0;
-  border-bottom: 1px solid #e7e7e7;
-`;

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryRightContent.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryRightContent.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { Route } from 'nextjs-routes';
-import { useCallback, useMemo, useState } from 'react';
+import { Suspense, useCallback, useMemo, useState } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
@@ -11,6 +11,7 @@ import { DropdownItem } from '~/components/core/Dropdown/DropdownItem';
 import { DropdownLink } from '~/components/core/Dropdown/DropdownLink';
 import { DropdownSection } from '~/components/core/Dropdown/DropdownSection';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import FollowButton from '~/components/Follow/FollowButton';
 import useCreateGallery from '~/components/MultiGallery/useCreateGallery';
 import { EditLink } from '~/contexts/globalLayout/GlobalNavbar/CollectionNavbar/EditLink';
 import { SignInButton } from '~/contexts/globalLayout/GlobalNavbar/SignInButton';
@@ -36,6 +37,7 @@ export function GalleryRightContent({ queryRef, galleryRef, username }: GalleryR
     graphql`
       fragment GalleryRightContentFragment on Query {
         ...EditUserInfoModalFragment
+        ...FollowButtonQueryFragment
 
         viewer {
           ... on Viewer {
@@ -52,6 +54,7 @@ export function GalleryRightContent({ queryRef, galleryRef, username }: GalleryR
             galleries {
               __typename
             }
+            ...FollowButtonUserFragment
           }
         }
       }
@@ -158,6 +161,11 @@ export function GalleryRightContent({ queryRef, galleryRef, username }: GalleryR
 
             {dropdown}
           </EditLinkWrapper>
+        )}
+        {query.userByUsername && (
+          <Suspense fallback={null}>
+            <FollowButton queryRef={query} userRef={query.userByUsername} source="navbar mobile" />
+          </Suspense>
         )}
       </HStack>
     );

--- a/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
+++ b/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
@@ -13,7 +13,7 @@ import SettingsDropdown from '~/components/core/Dropdown/SettingsDropdown';
 import { DisplayLayout } from '~/components/core/enums';
 import Markdown from '~/components/core/Markdown/Markdown';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM, TitleL } from '~/components/core/Text/Text';
+import { BaseM, TitleDiatypeM, TitleL } from '~/components/core/Text/Text';
 import { CollectionCreateOrEditForm } from '~/components/GalleryEditor/CollectionCreateOrEditForm';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { CollectionGalleryHeaderFragment$key } from '~/generated/CollectionGalleryHeaderFragment.graphql';
@@ -23,6 +23,8 @@ import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import MobileLayoutToggle from '~/scenes/UserGalleryPage/MobileLayoutToggle';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import unescape from '~/shared/utils/unescape';
+
+import GalleryTitleBreadcrumb from '../UserGalleryPage/GalleryTitleBreadcrumb';
 
 type Props = {
   queryRef: CollectionGalleryHeaderQueryFragment$key;
@@ -62,9 +64,11 @@ function CollectionGalleryHeader({
         collectorsNote
         gallery @required(action: THROW) {
           dbid
+          name
           owner {
             username
           }
+          ...GalleryTitleBreadcrumbFragment
         }
 
         tokens {
@@ -136,13 +140,23 @@ function CollectionGalleryHeader({
     return (
       <StyledCollectionGalleryHeaderWrapper>
         <HStack align="flex-start" justify="space-between">
-          {unescapedCollectorsNote ? (
-            <StyledCollectionNote>
-              <Markdown text={unescapedCollectorsNote} />
-            </StyledCollectionNote>
-          ) : (
-            <div />
-          )}
+          <VStack grow gap={16}>
+            <GalleryTitleBreadcrumb username={username ?? ''} galleryRef={collection.gallery} />
+            <VStack>
+              <StyledBreadcrumbsWrapper>
+                <StyledCollectionName>
+                  <TitleDiatypeM>{unescapedCollectionName}</TitleDiatypeM>
+                </StyledCollectionName>
+              </StyledBreadcrumbsWrapper>
+              {unescapedCollectorsNote ? (
+                <StyledCollectionNote>
+                  <Markdown text={unescapedCollectorsNote} />
+                </StyledCollectionNote>
+              ) : (
+                <div />
+              )}
+            </VStack>
+          </VStack>
 
           {shouldDisplayMobileLayoutToggle && (
             <StyledMobileLayoutToggleContainer>

--- a/apps/web/src/scenes/UserActivityPage/UserActivityPage.tsx
+++ b/apps/web/src/scenes/UserActivityPage/UserActivityPage.tsx
@@ -3,10 +3,13 @@ import { useEffect } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
+import { VStack } from '~/components/core/Spacer/Stack';
 import { UserActivityPageFragment$key } from '~/generated/UserActivityPageFragment.graphql';
+import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import { GalleryPageSpacing } from '~/pages/[username]';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 
+import UserGalleryHeader from '../UserGalleryPage/UserGalleryHeader';
 import UserActivity from './UserActivity';
 
 type UserActivityPageProps = {
@@ -18,7 +21,11 @@ function UserActivityPage({ queryRef, username }: UserActivityPageProps) {
   const query = useFragment(
     graphql`
       fragment UserActivityPageFragment on Query {
+        userByUsername(username: $username) {
+          ...UserGalleryHeaderFragment
+        }
         ...UserActivityFragment
+        ...UserGalleryHeaderQueryFragment
       }
     `,
     queryRef
@@ -32,13 +39,20 @@ function UserActivityPage({ queryRef, username }: UserActivityPageProps) {
     track('Page View: User Gallery', { username }, true);
   }, [username, track]);
 
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
+
   return (
     <>
       <Head>
         <title>{headTitle}</title>
       </Head>
       <GalleryPageSpacing>
-        <UserActivity queryRef={query} />
+        <VStack gap={isMobile ? 12 : 24}>
+          {query.userByUsername && (
+            <UserGalleryHeader queryRef={query} userRef={query.userByUsername} />
+          )}
+          <UserActivity queryRef={query} />
+        </VStack>
       </GalleryPageSpacing>
     </>
   );

--- a/apps/web/src/scenes/UserGalleryPage/GalleryNameDescriptionHeader.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/GalleryNameDescriptionHeader.tsx
@@ -15,6 +15,7 @@ import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import colors from '~/shared/theme/colors';
 import unescape from '~/shared/utils/unescape';
 
+import GalleryTitleBreadcrumb from './GalleryTitleBreadcrumb';
 import MobileLayoutToggle from './MobileLayoutToggle';
 
 type Props = {
@@ -42,6 +43,7 @@ function GalleryNameDescriptionHeader({
         owner @required(action: THROW) {
           username @required(action: THROW)
         }
+        ...GalleryTitleBreadcrumbFragment
       }
     `,
     galleryRef
@@ -52,7 +54,7 @@ function GalleryNameDescriptionHeader({
   const username = gallery.owner.username;
   const galleryId = gallery.dbid;
 
-  const unescapedBio = useMemo(
+  const unescapedDescription = useMemo(
     () => (gallery.description ? unescape(gallery.description) : ''),
     [gallery.description]
   );
@@ -64,36 +66,39 @@ function GalleryNameDescriptionHeader({
 
   const galleryName = useMemo(() => {
     if (isMobile) {
-      <GalleryNameMobile color={noLink ? colors.black['800'] : colors.shadow}>
-        {gallery.name}
-      </GalleryNameMobile>;
+      return <GalleryTitleBreadcrumb username={username} galleryRef={gallery} />;
     }
 
     return (
       <GalleryName color={noLink ? colors.black['800'] : colors.shadow}>{gallery.name}</GalleryName>
     );
-  }, [gallery.name, isMobile, noLink]);
+  }, [gallery, isMobile, noLink, username]);
 
   return (
     <Container gap={2}>
-      <Link href={galleryRoute} legacyBehavior>
-        {noLink ? galleryName : <GalleryLink href={route(galleryRoute)}>{galleryName}</GalleryLink>}
-      </Link>
-
       <HStack align="flex-start" justify="space-between">
-        <HStack align="center" gap={8} grow>
-          <StyledUserDetails>
-            <StyledBioWrapper>
-              <Markdown text={unescapedBio} />
-            </StyledBioWrapper>
-          </StyledUserDetails>
-        </HStack>
-
+        <Link href={galleryRoute} legacyBehavior>
+          {noLink ? (
+            galleryName
+          ) : (
+            <GalleryLink href={route(galleryRoute)}>{galleryName}</GalleryLink>
+          )}
+        </Link>
         {showMobileLayoutToggle && (
           <StyledButtonsWrapper gap={8} align="center" justify="space-between">
             <MobileLayoutToggle mobileLayout={mobileLayout} setMobileLayout={setMobileLayout} />
           </StyledButtonsWrapper>
         )}
+      </HStack>
+
+      <HStack align="flex-start" justify="space-between">
+        <HStack align="center" gap={8} grow>
+          <StyledUserDetails>
+            <StyledBioWrapper>
+              <Markdown text={unescapedDescription} />
+            </StyledBioWrapper>
+          </StyledUserDetails>
+        </HStack>
       </HStack>
     </Container>
   );
@@ -108,12 +113,6 @@ const StyledBioWrapper = styled(BaseM)`
 
 const GalleryName = styled(TitleM)`
   font-style: normal;
-  overflow-wrap: break-word;
-`;
-
-const GalleryNameMobile = styled(TitleM)`
-  font-style: normal;
-  font-size: 18px;
   overflow-wrap: break-word;
 `;
 

--- a/apps/web/src/scenes/UserGalleryPage/GalleryTitleBreadcrumb.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/GalleryTitleBreadcrumb.tsx
@@ -51,7 +51,7 @@ export default function GalleryTitleBreadcrumb({ username, galleryRef }: Props) 
               {username}
             </StyledBreadcrumbLink>
           </Link>
-          <BreadcrumbText>&nbsp;/</BreadcrumbText>
+          <StyledBreadcrumbText>&nbsp;/</StyledBreadcrumbText>
         </>
       )}
 
@@ -70,5 +70,12 @@ export default function GalleryTitleBreadcrumb({ username, galleryRef }: Props) 
 }
 
 const StyledBreadcrumbLink = styled(BreadcrumbLink)<{ isActive: boolean }>`
-  color: ${({ isActive }) => (isActive ? colors.black['800'] : colors.shadow)};
+  color: ${({ isActive }) => (isActive ? colors.black['800'] : colors.metal)};
+  font-size: 20px;
+  line-height: 28px;
+`;
+
+const StyledBreadcrumbText = styled(BreadcrumbText)`
+  font-size: 20px;
+  line-height: 28px;
 `;

--- a/apps/web/src/scenes/UserGalleryPage/GalleryTitleBreadcrumb.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/GalleryTitleBreadcrumb.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { Route, route } from 'nextjs-routes';
+import { useMemo } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import { HStack } from '~/components/core/Spacer/Stack';
+import {
+  BreadcrumbLink,
+  BreadcrumbText,
+} from '~/contexts/globalLayout/GlobalNavbar/ProfileDropdown/Breadcrumbs';
+import { GalleryTitleBreadcrumbFragment$key } from '~/generated/GalleryTitleBreadcrumbFragment.graphql';
+import colors from '~/shared/theme/colors';
+
+type Props = {
+  username: string;
+  galleryRef: GalleryTitleBreadcrumbFragment$key;
+};
+
+export default function GalleryTitleBreadcrumb({ username, galleryRef }: Props) {
+  const gallery = useFragment(
+    graphql`
+      fragment GalleryTitleBreadcrumbFragment on Gallery {
+        dbid
+        name
+      }
+    `,
+    galleryRef
+  );
+
+  const { pathname } = useRouter();
+  const userGalleryRoute: Route = useMemo(
+    () => ({ pathname: '/[username]', query: { username } }),
+    [username]
+  );
+
+  const galleryRoute: Route = {
+    pathname: '/[username]/galleries/[galleryId]',
+    query: { username, galleryId: gallery.dbid },
+  };
+
+  const isHome = userGalleryRoute.pathname === pathname;
+
+  return (
+    <HStack>
+      {!isHome && (
+        <>
+          <Link href={userGalleryRoute} legacyBehavior>
+            <StyledBreadcrumbLink href={route(userGalleryRoute)} isActive={false}>
+              {username}
+            </StyledBreadcrumbLink>
+          </Link>
+          <BreadcrumbText>&nbsp;/</BreadcrumbText>
+        </>
+      )}
+
+      {gallery.name && (
+        <Link href={galleryRoute} legacyBehavior>
+          <StyledBreadcrumbLink
+            href={route(galleryRoute)}
+            isActive={pathname === galleryRoute.pathname || isHome}
+          >
+            {gallery.name}
+          </StyledBreadcrumbLink>
+        </Link>
+      )}
+    </HStack>
+  );
+}
+
+const StyledBreadcrumbLink = styled(BreadcrumbLink)<{ isActive: boolean }>`
+  color: ${({ isActive }) => (isActive ? colors.black['800'] : colors.shadow)};
+`;

--- a/apps/web/src/scenes/UserGalleryPage/UserGallery.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGallery.tsx
@@ -2,7 +2,6 @@ import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
-import styled from 'styled-components';
 
 import { VStack } from '~/components/core/Spacer/Stack';
 import { useModalState } from '~/contexts/modal/ModalContext';
@@ -12,10 +11,8 @@ import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import useDisplayFullPageNftDetailModal from '~/scenes/NftDetailPage/useDisplayFullPageNftDetailModal';
 import NotFound from '~/scenes/NotFound/NotFound';
 import { UserGalleryLayout } from '~/scenes/UserGalleryPage/UserGalleryLayout';
-import { UserNameAndDescriptionHeader } from '~/scenes/UserGalleryPage/UserNameAndDescriptionHeader';
 
-import UserSharedInfo from './UserSharedInfo/UserSharedInfo';
-import UserTwitterSection from './UserTwitterSection';
+import UserGalleryHeader from './UserGalleryHeader';
 
 type Props = {
   queryRef: UserGalleryFragment$key;
@@ -47,9 +44,7 @@ function UserGallery({ queryRef }: Props) {
               ...UserGalleryLayoutFragment
             }
 
-            ...UserNameAndDescriptionHeader
-            ...UserTwitterSectionFragment
-            ...UserSharedInfoFragment
+            ...UserGalleryHeaderFragment
           }
           ... on ErrUserNotFound {
             __typename
@@ -57,8 +52,7 @@ function UserGallery({ queryRef }: Props) {
         }
 
         ...UserGalleryLayoutQueryFragment
-        ...UserNameAndDescriptionHeaderQueryFragment
-        ...UserTwitterSectionQueryFragment
+        ...UserGalleryHeaderQueryFragment
       }
     `,
     queryRef
@@ -93,28 +87,13 @@ function UserGallery({ queryRef }: Props) {
     throw new Error(`Expected user to be type GalleryUser. Received: ${user.__typename}`);
   }
 
-  const isAuthenticatedUsersPage = loggedInUserId === user?.dbid;
-
   return (
     <VStack gap={isMobile ? 12 : 24}>
-      <VStack gap={12}>
-        <UserNameAndDescriptionHeader userRef={user} queryRef={query} />
+      <UserGalleryHeader userRef={user} queryRef={query} />
 
-        {isLoggedIn && !isAuthenticatedUsersPage && <UserSharedInfo userRef={user} />}
-
-        <UserTwitterSection userRef={user} queryRef={query} />
-      </VStack>
-
-      <Divider />
       <UserGalleryLayout galleryRef={user.featuredGallery} queryRef={query} />
     </VStack>
   );
 }
-
-const Divider = styled.div`
-  width: 100%;
-  height: 1px;
-  background-color: #e7e7e7;
-`;
 
 export default UserGallery;

--- a/apps/web/src/scenes/UserGalleryPage/UserGalleryHeader.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGalleryHeader.tsx
@@ -1,0 +1,75 @@
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { GalleryNavLinks } from '~/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavLinks';
+import { UserGalleryHeaderFragment$key } from '~/generated/UserGalleryHeaderFragment.graphql';
+import { UserGalleryHeaderQueryFragment$key } from '~/generated/UserGalleryHeaderQueryFragment.graphql';
+import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
+import colors from '~/shared/theme/colors';
+
+import { UserNameAndDescriptionHeader } from './UserNameAndDescriptionHeader';
+import UserSharedInfo from './UserSharedInfo/UserSharedInfo';
+import UserTwitterSection from './UserTwitterSection';
+
+type Props = {
+  userRef: UserGalleryHeaderFragment$key;
+  queryRef: UserGalleryHeaderQueryFragment$key;
+};
+
+export default function UserGalleryHeader({ userRef, queryRef }: Props) {
+  const user = useFragment(
+    graphql`
+      fragment UserGalleryHeaderFragment on GalleryUser {
+        username
+        dbid
+
+        ...UserNameAndDescriptionHeaderFragment
+        ...UserTwitterSectionFragment
+        ...UserSharedInfoFragment
+        ...GalleryNavLinksFragment
+      }
+    `,
+    userRef
+  );
+
+  const query = useFragment(
+    graphql`
+      fragment UserGalleryHeaderQueryFragment on Query {
+        viewer {
+          ... on Viewer {
+            user {
+              dbid
+            }
+          }
+        }
+        ...UserNameAndDescriptionHeaderQueryFragment
+        ...UserTwitterSectionQueryFragment
+      }
+    `,
+    queryRef
+  );
+
+  const loggedInUserId = query.viewer?.user?.dbid;
+  const isLoggedIn = Boolean(loggedInUserId);
+  const isAuthenticatedUsersPage = loggedInUserId === user?.dbid;
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
+  return (
+    <VStack gap={12}>
+      <UserNameAndDescriptionHeader userRef={user} queryRef={query} />
+      {isLoggedIn && !isAuthenticatedUsersPage && <UserSharedInfo userRef={user} />}
+      <UserTwitterSection userRef={user} queryRef={query} />
+      {isMobile && (
+        <MobileNavLinks align="center" justify="center">
+          <GalleryNavLinks username={user.username ?? ''} queryRef={user} />
+        </MobileNavLinks>
+      )}
+    </VStack>
+  );
+}
+
+const MobileNavLinks = styled(HStack)`
+  padding: 16px 0;
+  border-bottom: 1px solid ${colors.porcelain};
+  border-top: 1px solid ${colors.porcelain};
+`;

--- a/apps/web/src/scenes/UserGalleryPage/UserNameAndDescriptionHeader.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserNameAndDescriptionHeader.tsx
@@ -12,7 +12,7 @@ import Markdown from '~/components/core/Markdown/Markdown';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import { BaseM, TitleM } from '~/components/core/Text/Text';
 import { useModalActions } from '~/contexts/modal/ModalContext';
-import { UserNameAndDescriptionHeader$key } from '~/generated/UserNameAndDescriptionHeader.graphql';
+import { UserNameAndDescriptionHeaderFragment$key } from '~/generated/UserNameAndDescriptionHeaderFragment.graphql';
 import { UserNameAndDescriptionHeaderQueryFragment$key } from '~/generated/UserNameAndDescriptionHeaderQueryFragment.graphql';
 import useIs3acProfilePage from '~/hooks/oneOffs/useIs3acProfilePage';
 import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
@@ -27,14 +27,14 @@ import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 import EditUserInfoModal from './EditUserInfoModal';
 
 type Props = {
-  userRef: UserNameAndDescriptionHeader$key;
+  userRef: UserNameAndDescriptionHeaderFragment$key;
   queryRef: UserNameAndDescriptionHeaderQueryFragment$key;
 };
 
 export function UserNameAndDescriptionHeader({ userRef, queryRef }: Props) {
   const user = useFragment(
     graphql`
-      fragment UserNameAndDescriptionHeader on GalleryUser {
+      fragment UserNameAndDescriptionHeaderFragment on GalleryUser {
         id
         username
         bio
@@ -105,17 +105,17 @@ export function UserNameAndDescriptionHeader({ userRef, queryRef }: Props) {
       hasMobileContent={isMobile && !!unescapedBio}
     >
       <Container gap={2}>
-        {!isMobile && (
-          <HStack align="center" gap={4}>
-            <StyledUsername>{displayName}</StyledUsername>
+        {/* {!isMobile && ( */}
+        <HStack align="center" gap={4}>
+          <StyledUsername>{displayName}</StyledUsername>
 
-            <HStack align="center" gap={0}>
-              {userBadges.map((badge) =>
-                badge ? <Badge key={badge.name} badgeRef={badge} /> : null
-              )}
-            </HStack>
+          <HStack align="center" gap={0}>
+            {userBadges.map((badge) =>
+              badge ? <Badge key={badge.name} badgeRef={badge} /> : null
+            )}
           </HStack>
-        )}
+        </HStack>
+        {/* )} */}
 
         <HStack align="center" gap={8} grow>
           <StyledUserDetails>

--- a/apps/web/src/scenes/UserGalleryPage/UserNameAndDescriptionHeader.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserNameAndDescriptionHeader.tsx
@@ -105,7 +105,6 @@ export function UserNameAndDescriptionHeader({ userRef, queryRef }: Props) {
       hasMobileContent={isMobile && !!unescapedBio}
     >
       <Container gap={2}>
-        {/* {!isMobile && ( */}
         <HStack align="center" gap={4}>
           <StyledUsername>{displayName}</StyledUsername>
 
@@ -115,7 +114,6 @@ export function UserNameAndDescriptionHeader({ userRef, queryRef }: Props) {
             )}
           </HStack>
         </HStack>
-        {/* )} */}
 
         <HStack align="center" gap={8} grow>
           <StyledUserDetails>

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedCommunities.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedCommunities.tsx
@@ -97,7 +97,7 @@ export default function UserSharedCommunities({ queryRef }: Props) {
     if (totalSharedCommunities > 3) {
       result.push(
         <StyledInteractiveLink onClick={handleShowAllClick}>
-          {totalSharedCommunities - 2} others you own
+          {totalSharedCommunities - 2} others
         </StyledInteractiveLink>
       );
     }

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedFollowers.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedFollowers.tsx
@@ -89,7 +89,7 @@ export default function UserSharedFollowers({ queryRef }: Props) {
     if (totalSharedFollowers > 3) {
       result.push(
         <StyledInteractiveLink onClick={handleShowAllFollowersClick}>
-          {totalSharedFollowers - 2} others you follow
+          {totalSharedFollowers - 2} others
         </StyledInteractiveLink>
       );
     }


### PR DESCRIPTION
This PR makes the profile page on mobile web look closer to the mobile app. currently they have a different layout, making it more complicated to make changes that apply to both the app and mobile web.

- this affects the Featured, Galleries, Followers, Activities tabs on a user profile. 
- It also affects the individual gallery and collection screens.
- We now display the user profile info (bio, shared communities+followers, twitter handle) on every tab on the profile like we do in the mobile app.



screenshots
each screenshot contains 3 screens: Web Before, Web After, Mobile App for comparison


User Profile screen (featured tab)
![Screenshot 2023-06-30 at 17 02 42](https://github.com/gallery-so/gallery/assets/80802871/f5507adf-e2be-4e70-a0d9-4007f96c4afb)

User Profile screen (galleries tab)
![Screenshot 2023-06-30 at 17 09 15](https://github.com/gallery-so/gallery/assets/80802871/967a656e-e7dd-4e65-9044-33839f069d1c)


Gallery screen
![Screenshot 2023-06-30 at 17 03 18](https://github.com/gallery-so/gallery/assets/80802871/f54aa807-49e9-4af2-8e95-652eab4d775e)


Collection screen
![Screenshot 2023-06-30 at 17 04 46](https://github.com/gallery-so/gallery/assets/80802871/4ed42c29-fb9a-4431-9923-33bc3f221673)



bonus:
Updated copy in shared communities and followers to match mobile (removed the text "you own" and "you follow")
![Screenshot 2023-06-30 at 17 10 02](https://github.com/gallery-so/gallery/assets/80802871/10933484-6ad8-4f93-91df-960975a7e59a)

remaining items:
get updated designs for Following and Activity tabs on mobile since the content is narrower than the header and looks off