### PR TITLE
Disable global announcement query

### DIFF
--- a/apps/web/src/contexts/globalLayout/GlobalLayoutContext.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalLayoutContext.tsx
@@ -30,7 +30,7 @@ import { PreloadQueryArgs } from '~/types/PageComponentPreloadQuery';
 import isTouchscreenDevice from '~/utils/isTouchscreenDevice';
 
 import { FEATURED_COLLECTION_IDS } from './GlobalAnnouncementPopover/GlobalAnnouncementPopover';
-import useGlobalAnnouncementPopover from './GlobalAnnouncementPopover/useGlobalAnnouncementPopover';
+// import useGlobalAnnouncementPopover from './GlobalAnnouncementPopover/useGlobalAnnouncementPopover';
 import GlobalBanner, { CTAChip } from './GlobalBanner/GlobalBanner';
 import GlobalSidebar, { GLOBAL_SIDEBAR_DESKTOP_WIDTH } from './GlobalSidebar/GlobalSidebar';
 import {
@@ -79,10 +79,11 @@ type Props = { children: ReactNode; preloadedQuery: PreloadedQuery<GlobalLayoutC
 type FadeTriggerType = 'route' | 'scroll' | 'hover';
 
 const GlobalLayoutContextQueryNode = graphql`
-  query GlobalLayoutContextQuery($collectionIds: [DBID!]!) {
+  # query GlobalLayoutContextQuery($collectionIds: [DBID!]!) {
+  query GlobalLayoutContextQuery {
     ...GlobalLayoutContextNavbarFragment
     # Keeping this around for the next time we want to use it
-    ...useGlobalAnnouncementPopoverFragment
+    # ...useGlobalAnnouncementPopoverFragment
   }
 `;
 
@@ -231,7 +232,7 @@ const GlobalLayoutContextProvider = memo(({ children, preloadedQuery }: Props) =
   );
 
   // Keeping this around for the next time we want to use it
-  useGlobalAnnouncementPopover({ queryRef: query, authRequired: false, dismissVariant: 'global' });
+  // useGlobalAnnouncementPopover({ queryRef: query, authRequired: false, dismissVariant: 'global' });
 
   const locationKey = useStabilizedRouteTransitionKey();
 

--- a/apps/web/tests/graphql/mockGlobalLayoutQuery.ts
+++ b/apps/web/tests/graphql/mockGlobalLayoutQuery.ts
@@ -13,9 +13,9 @@ export function mockGlobalLayoutQuery() {
       user: {
         __typename: 'GalleryUser',
         id: GALLERY_USER_ID,
+        // @ts-expect-error not sure what the issue is
         username: 'Test Gallery User',
         wallets: [],
-        // @ts-expect-error not sure what the issue is
         roles: ['ADMIN'],
         primaryWallet: {
           __typename: 'Wallet',


### PR DESCRIPTION
Unnecessary fragment eating up a ton of resources when loading `GlobalContextQuery`