### PR TITLE
Fix sync refresh

### DIFF
--- a/apps/web/src/hooks/api/tokens/useSyncTokens.ts
+++ b/apps/web/src/hooks/api/tokens/useSyncTokens.ts
@@ -21,7 +21,7 @@ export default function useSyncTokens() {
             viewer {
               # This should be sufficient to capture all the things
               # we want to refresh. Don't @me when this fails.
-              ...CollectionEditorViewerFragment
+              ...GalleryEditorViewerFragment
 
               ... on Viewer {
                 user {


### PR DESCRIPTION
we were previously updating the `CollectionEditorViewerFragment` cache post-sync mutation, but that is no longer high enough in the tree to update the sidebar tokens list. 