### PR TITLE
Temp disable PFP selector during onboarding

### DIFF
--- a/apps/web/pages/onboarding/add-user-info.tsx
+++ b/apps/web/pages/onboarding/add-user-info.tsx
@@ -28,15 +28,17 @@ function AddUserInfo() {
               bio
               username
 
-              ...UserInfoFormFragment
+              # ...UserInfoFormFragment
             }
           }
         }
-        ...UserInfoFormQueryFragment
+        # ...UserInfoFormQueryFragment
       }
     `,
     {}
   );
+
+  console.log({ query });
 
   const { push, back, query: urlQuery } = useRouter();
   const relayEnvironment = useRelayEnvironment();
@@ -97,11 +99,7 @@ function AddUserInfo() {
 
   const track = useTrack();
   const { isLocked, syncTokens } = useSyncTokens();
-  const user = query.viewer?.user;
-
-  if (!user) {
-    throw new Error('User not found');
-  }
+  // const user = query.viewer?.user;
 
   const handleSubmit = useCallback(async () => {
     const { success } = await onEditUser();
@@ -133,8 +131,8 @@ function AddUserInfo() {
             usernameError={usernameError}
             onUsernameChange={onUsernameChange}
             onBioChange={onBioChange}
-            userRef={user}
-            queryRef={query}
+            // userRef={user}
+            // queryRef={query}
           />
           <ErrorContainer>
             <ErrorText message={generalError} />

--- a/apps/web/src/components/Profile/EditUserInfoForm.tsx
+++ b/apps/web/src/components/Profile/EditUserInfoForm.tsx
@@ -1,22 +1,22 @@
 import { FormEvent, useCallback, useMemo, useState } from 'react';
-// import { graphql, useFragment } from 'react-relay';
+import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import Input from '~/components/core/Input/Input';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import { TitleS } from '~/components/core/Text/Text';
 import { TextAreaWithCharCount } from '~/components/core/TextArea/TextArea';
-// import { UserInfoFormFragment$key } from '~/generated/UserInfoFormFragment.graphql';
-// import { UserInfoFormQueryFragment$key } from '~/generated/UserInfoFormQueryFragment.graphql';
-// import { useTrack } from '~/shared/contexts/AnalyticsContext';
-// import { removeNullValues } from '~/shared/relay/removeNullValues';
+import { EditUserInfoFormFragment$key } from '~/generated/EditUserInfoFormFragment.graphql';
+import { EditUserInfoFormQueryFragment$key } from '~/generated/EditUserInfoFormQueryFragment.graphql';
+import { useTrack } from '~/shared/contexts/AnalyticsContext';
+import { removeNullValues } from '~/shared/relay/removeNullValues';
 import unescape from '~/shared/utils/unescape';
-// import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
+import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
-// import useNftSelector from '../NftSelector/useNftSelector';
-// import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
-// import { RawProfilePicture } from '../RawProfilePicture';
-// import { ProfilePictureDropdown } from './ProfilePictureDropdown';
+import useNftSelector from '../NftSelector/useNftSelector';
+import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
+import { RawProfilePicture } from '../RawProfilePicture';
+import { ProfilePictureDropdown } from './ProfilePictureDropdown';
 
 type Props = {
   className?: string;
@@ -28,8 +28,8 @@ type Props = {
   bio: string;
   onBioChange: (bio: string) => void;
 
-  // userRef: UserInfoFormFragment$key;
-  // queryRef: UserInfoFormQueryFragment$key;
+  userRef: EditUserInfoFormFragment$key;
+  queryRef: EditUserInfoFormQueryFragment$key;
 };
 
 export const BIO_MAX_CHAR_COUNT = 600;
@@ -43,54 +43,55 @@ function UserInfoForm({
   bio,
   onBioChange,
   mode,
-}: // userRef,
-// queryRef,
-Props) {
-  // const user = useFragment(
-  //   graphql`
-  //     fragment UserInfoFormFragment on GalleryUser {
-  //       ...ProfilePictureFragment
-  //       profileImage {
-  //         __typename
-  //       }
 
-  //       tokens {
-  //         ...ProfilePictureDropdownFragment
-  //         ...useNftSelectorFragment
-  //       }
-  //     }
-  //   `,
-  //   userRef
-  // );
+  userRef,
+  queryRef,
+}: Props) {
+  const user = useFragment(
+    graphql`
+      fragment EditUserInfoFormFragment on GalleryUser {
+        ...ProfilePictureFragment
+        profileImage {
+          __typename
+        }
 
-  // const query = useFragment(
-  //   graphql`
-  //     fragment UserInfoFormQueryFragment on Query {
-  //       ...isFeatureEnabledFragment
-  //       ...ProfilePictureDropdownQueryFragment
-  //       ...useNftSelectorQueryFragment
-  //     }
-  //   `,
-  //   queryRef
-  // );
+        tokens {
+          ...ProfilePictureDropdownFragment
+          ...useNftSelectorFragment
+        }
+      }
+    `,
+    userRef
+  );
 
-  // const [showPfpDropdown, setShowPfpDropdown] = useState(false);
+  const query = useFragment(
+    graphql`
+      fragment EditUserInfoFormQueryFragment on Query {
+        ...isFeatureEnabledFragment
+        ...ProfilePictureDropdownQueryFragment
+        ...useNftSelectorQueryFragment
+      }
+    `,
+    queryRef
+  );
+
+  const [showPfpDropdown, setShowPfpDropdown] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // const isPfpEnabled = isFeatureEnabled(FeatureFlag.PFP, query);
+  const isPfpEnabled = isFeatureEnabled(FeatureFlag.PFP, query);
 
-  // const tokens = removeNullValues(user.tokens) ?? [];
-  // const showNftSelector = useNftSelector({ tokensRef: tokens, queryRef: query });
-  // const track = useTrack();
+  const tokens = removeNullValues(user.tokens) ?? [];
+  const showNftSelector = useNftSelector({ tokensRef: tokens, queryRef: query });
+  const track = useTrack();
 
-  // const handleEditPfp = useCallback(() => {
-  //   track('PFP: Clicked PFP setup in Onboarding');
-  //   showNftSelector();
-  // }, [showNftSelector, track]);
+  const handleEditPfp = useCallback(() => {
+    track('PFP: Clicked PFP setup in Onboarding');
+    showNftSelector();
+  }, [showNftSelector, track]);
 
   const unescapedBio = useMemo(() => unescape(bio), [bio]);
 
-  // const hasProfileImage = user.profileImage?.__typename === 'TokenProfileImage';
+  const hasProfileImage = user.profileImage?.__typename === 'TokenProfileImage';
 
   const handleSubmit = useCallback(
     async (event: FormEvent) => {
@@ -128,21 +129,21 @@ Props) {
   // Otherwise, focus on bio
   const shouldAutofocusBio = !shouldAutofocusUsername;
 
-  // const handleOpenPfpDropdown = useCallback(() => {
-  //   setShowPfpDropdown(true);
-  // }, []);
-  // const handleClosePfpDropdown = useCallback(() => {
-  //   setShowPfpDropdown(false);
-  // }, []);
+  const handleOpenPfpDropdown = useCallback(() => {
+    setShowPfpDropdown(true);
+  }, []);
+  const handleClosePfpDropdown = useCallback(() => {
+    setShowPfpDropdown(false);
+  }, []);
 
-  // const firstLetter = username?.substring(0, 1) ?? undefined;
+  const firstLetter = username?.substring(0, 1) ?? undefined;
 
   return (
     <StyledUserInformContainer as="form" className={className} gap={16} onSubmit={handleSubmit}>
       {mode === 'Add' && (
         <>
           <TitleS>Let's set up your profile</TitleS>
-          {/* {isPfpEnabled && (
+          {isPfpEnabled && (
             <div onClick={handleEditPfp}>
               {hasProfileImage ? (
                 <ProfilePicture userRef={user} size="xl" isEditable hasInset />
@@ -150,12 +151,12 @@ Props) {
                 <RawProfilePicture letter={firstLetter} default hasInset isEditable size="xl" />
               )}
             </div>
-          )} */}
+          )}
         </>
       )}
 
       <HStack gap={16} align="center">
-        {/* {!mode && isPfpEnabled && (
+        {!mode && isPfpEnabled && (
           <StyledProfilePictureContainer onClick={handleOpenPfpDropdown}>
             <ProfilePicture userRef={user} size="xl" isEditable hasInset />
             <ProfilePictureDropdown
@@ -165,7 +166,7 @@ Props) {
               queryRef={query}
             />
           </StyledProfilePictureContainer>
-        )} */}
+        )}
 
         <StyledInputContainer>
           <Input
@@ -205,8 +206,8 @@ const StyledInputContainer = styled.div`
   width: 100%;
 `;
 
-// const StyledProfilePictureContainer = styled.div`
-//   position: relative;
-// `;
+const StyledProfilePictureContainer = styled.div`
+  position: relative;
+`;
 
 export default UserInfoForm;

--- a/apps/web/src/scenes/UserGalleryPage/EditUserInfoModal.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/EditUserInfoModal.tsx
@@ -7,7 +7,7 @@ import breakpoints from '~/components/core/breakpoints';
 import { Button } from '~/components/core/Button/Button';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import ErrorText from '~/components/core/Text/ErrorText';
-import UserInfoForm from '~/components/Profile/UserInfoForm';
+import EditUserInfoForm from '~/components/Profile/EditUserInfoForm';
 import useUserInfoForm from '~/components/Profile/useUserInfoForm';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { EditUserInfoModalFragment$key } from '~/generated/EditUserInfoModalFragment.graphql';
@@ -27,11 +27,11 @@ function EditUserInfoModal({ queryRef }: Props) {
               username
               bio
 
-              ...UserInfoFormFragment
+              ...EditUserInfoFormFragment
             }
           }
         }
-        ...UserInfoFormQueryFragment
+        ...EditUserInfoFormQueryFragment
       }
     `,
     queryRef
@@ -80,7 +80,7 @@ function EditUserInfoModal({ queryRef }: Props) {
   return (
     <StyledEditUserInfoModal gap={16}>
       <VStack gap={8}>
-        <UserInfoForm
+        <EditUserInfoForm
           onSubmit={handleSubmit}
           username={username}
           usernameError={usernameError}


### PR DESCRIPTION
**Problem**
We can't recycle the same `UserInfoForm` for both the onboarding flow and edit profile flow given that the form now requires a `viewer.user` to be present to set a PFP, as an authenticated user picks one from their tokens. The issue is a user does not yet exist at the `add-user-info` step during onboarding.

**Temp solution**
Disable PFP selection during onboarding

**Long-term solution**
Consider creating a user prior to the `add-user-info` step, at the `welcome-step`. This is harder to do though as they'd need to be given a temporary username.