### PR TITLE
update username link styling on nft detail page

### DIFF
--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -182,15 +182,15 @@ function NftDetailText({ tokenRef, queryRef }: Props) {
           {token.owner?.username && (
             <VStack gap={2}>
               <TitleXS>OWNER</TitleXS>
-              <InteractiveLink
+              <StyledInteractiveLink
                 to={{ pathname: '/[username]', query: { username: token.owner.username } }}
                 onClick={handleCollectorNameClick}
               >
                 <HStack align="center" gap={4}>
                   {isPfpEnabled && <ProfilePicture size="sm" userRef={token.owner} />}
-                  <BaseM color={colors.shadow}>{token.owner.username}</BaseM>
+                  <TitleDiatypeM>{token.owner.username}</TitleDiatypeM>
                 </HStack>
-              </InteractiveLink>
+              </StyledInteractiveLink>
             </VStack>
           )}
           {ENABLED_CREATOR && (


### PR DESCRIPTION
now it's consistent with the feed usernames

before
![Screenshot 2023-07-07 at 10 57 26](https://github.com/gallery-so/gallery/assets/80802871/5648dc64-1315-44d4-b21c-b6032dbee895)

after
![Screenshot 2023-07-07 at 10 56 34](https://github.com/gallery-so/gallery/assets/80802871/3057ec73-2bd7-45dc-b756-1f62074f79af)
