### PR TITLE
fix animated modal height

### DIFF
--- a/apps/web/src/contexts/modal/AnimatedModal.tsx
+++ b/apps/web/src/contexts/modal/AnimatedModal.tsx
@@ -207,6 +207,9 @@ const StyledContainer = styled.div<{
   max-width: ${({ maxWidth }) => maxWidth};
   width: ${({ width }) => width};
   height: 100%;
+
+  display: flex;
+  flex-direction: column;
 `;
 
 const StyledContent = styled.div<{ padding: string }>`


### PR DESCRIPTION
before
![Screenshot 2023-07-07 at 12 50 22](https://github.com/gallery-so/gallery/assets/80802871/efa5b9d2-1259-4f0c-b1cc-8db22cd15673)


after
![Screenshot 2023-07-07 at 12 50 15](https://github.com/gallery-so/gallery/assets/80802871/433ab5cf-9e0f-4b43-996e-9c4075c4376c)



admire/comment modals should still be ok after this change
![Screenshot 2023-07-07 at 12 51 03](https://github.com/gallery-so/gallery/assets/80802871/c249bb55-36cc-4711-b79e-a8911d6ac044)
![Screenshot 2023-07-07 at 12 49 43](https://github.com/gallery-so/gallery/assets/80802871/5cca950e-6477-486a-9fcc-3d0082516325)

