### PR TITLE
remove Hidden filter from nft selector

### DIFF
--- a/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorViewSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorViewSelector.tsx
@@ -49,9 +49,6 @@ export function NftSelectorViewSelector({
           <DropdownItem onClick={() => onSelectView('Collected')}>
             <BaseM>Collected</BaseM>
           </DropdownItem>
-          <DropdownItem onClick={() => onSelectView('Hidden')}>
-            <BaseM>Hidden</BaseM>
-          </DropdownItem>
           <DropdownItem onClick={() => onSelectView('Created')}>
             <BaseM color={colors.metal}>Created (Soon)</BaseM>
           </DropdownItem>


### PR DESCRIPTION
we don't expect people to set a spam nft as their pfp, so remove the Hidden option from nft selector dropdown.
only show Collected and Created.

![Screenshot 2023-07-07 at 13 24 29](https://github.com/gallery-so/gallery/assets/80802871/26baa814-474d-45ca-87f3-55379e56c98b)
