### PR TITLE
show pfp in left hand nav instead of profile icon

### DIFF
--- a/apps/web/src/components/NftSelector/groupNftSelectorCollectionsByAddress.ts
+++ b/apps/web/src/components/NftSelector/groupNftSelectorCollectionsByAddress.ts
@@ -25,7 +25,6 @@ export function groupNftSelectorCollectionsByAddress({
     readInlineData<groupNftSelectorCollectionsByAddressTokenFragment$key>(
       graphql`
         fragment groupNftSelectorCollectionsByAddressTokenFragment on Token @inline {
-          dbid
           chain
           isSpamByProvider
           isSpamByUser

--- a/apps/web/src/components/NftSelector/groupNftSelectorCollectionsByAddress.ts
+++ b/apps/web/src/components/NftSelector/groupNftSelectorCollectionsByAddress.ts
@@ -25,6 +25,7 @@ export function groupNftSelectorCollectionsByAddress({
     readInlineData<groupNftSelectorCollectionsByAddressTokenFragment$key>(
       graphql`
         fragment groupNftSelectorCollectionsByAddressTokenFragment on Token @inline {
+          dbid
           chain
           isSpamByProvider
           isSpamByUser

--- a/apps/web/src/components/RawProfilePicture.tsx
+++ b/apps/web/src/components/RawProfilePicture.tsx
@@ -83,7 +83,7 @@ export function RawProfilePicture({
               fontSize,
             }}
           >
-            {rest.letter.toUpperCase()}
+            <InlineBlockWrapper>{rest.letter.toUpperCase()}</InlineBlockWrapper>
           </ProfilePictureText>
         )}
 
@@ -208,4 +208,11 @@ const ProfilePictureText = styled.div`
   line-height: 13px;
   font-family: ${TITLE_FONT_FAMILY};
   color: ${colors.black['800']};
+  display: inline-block;
+`;
+
+// This prevents the placeholder Letter from inheriting text-decoration: underline from any ancestor <a> tags.
+// This only works if it's nested within ProfilePictureText for some reason, so we have to use this wrapper.
+const InlineBlockWrapper = styled.div`
+  display: inline-block;
 `;

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/SidebarPfp.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/SidebarPfp.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link';
+import { Route } from 'nextjs-routes';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
+import { NewTooltip } from '~/components/Tooltip/NewTooltip';
+import { useTooltipHover } from '~/components/Tooltip/useTooltipHover';
+import { SidebarPfpFragment$key } from '~/generated/SidebarPfpFragment.graphql';
+
+type Props = {
+  userRef: SidebarPfpFragment$key;
+  href: Route;
+  onClick: () => void;
+};
+
+export default function SidebarPfp({ userRef, href, onClick }: Props) {
+  const user = useFragment(
+    graphql`
+      fragment SidebarPfpFragment on GalleryUser {
+        ...ProfilePictureFragment
+      }
+    `,
+    userRef
+  );
+  const { floating, reference, getFloatingProps, getReferenceProps, floatingStyle } =
+    useTooltipHover({ placement: 'right' });
+  return (
+    <StyledSidebarPfp onClick={onClick}>
+      <Link href={href}>
+        <StyledProfilePictureWrapper {...getReferenceProps()} ref={reference}>
+          <ProfilePicture size="md" userRef={user} />
+        </StyledProfilePictureWrapper>
+        <NewTooltip
+          {...getFloatingProps()}
+          style={floatingStyle}
+          ref={floating}
+          text="My profile"
+        />
+      </Link>
+    </StyledSidebarPfp>
+  );
+}
+
+const StyledSidebarPfp = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+`;
+
+const StyledProfilePictureWrapper = styled.div`
+  &:hover {
+    filter: brightness(90%);
+  }
+`;

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
@@ -23,6 +23,7 @@ import ShopIcon from '~/icons/ShopIcon';
 import UserIcon from '~/icons/UserIcon';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import useExperience from '~/utils/graphql/experiences/useExperience';
+import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
 
 import { useDrawerActions, useDrawerState } from './SidebarDrawerContext';
 import SidebarIcon from './SidebarIcon';
@@ -57,6 +58,7 @@ export function StandardSidebar({ queryRef }: Props) {
         ...SettingsFragment
         ...useExperienceFragment
         ...useAnnouncementFragment
+        ...isFeatureEnabledFragment
       }
     `,
     queryRef
@@ -182,6 +184,8 @@ export function StandardSidebar({ queryRef }: Props) {
     return JSON.stringify(editGalleriesRoute) === JSON.stringify(currentRoute);
   }, [activeDrawerType, pathname, routerQuery, editGalleriesRoute]);
 
+  const isPfpEnabled = isFeatureEnabled(FeatureFlag.PFP, query);
+
   useSearchHotkey(() => {
     showDrawer({
       content: <Search />,
@@ -250,13 +254,23 @@ export function StandardSidebar({ queryRef }: Props) {
             onClick={handleHomeIconClick}
             icon={<GLogoIcon />}
           />
-          {isLoggedIn && query.viewer.user && (
-            <SidebarPfp
-              userRef={query.viewer.user}
-              href={userGalleryRoute}
-              onClick={handleProfileClick}
-            />
-          )}
+          {isLoggedIn &&
+            query.viewer.user &&
+            (isPfpEnabled ? (
+              <SidebarPfp
+                userRef={query.viewer.user}
+                href={userGalleryRoute}
+                onClick={handleProfileClick}
+              />
+            ) : (
+              <SidebarIcon
+                href={userGalleryRoute}
+                tooltipLabel="My Profile"
+                onClick={handleProfileClick}
+                icon={<UserIcon />}
+                isActive={isLoggedInProfileActive}
+              />
+            ))}
         </VStack>
         {isLoggedIn ? (
           <VStack gap={32}>

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
@@ -26,6 +26,7 @@ import useExperience from '~/utils/graphql/experiences/useExperience';
 
 import { useDrawerActions, useDrawerState } from './SidebarDrawerContext';
 import SidebarIcon from './SidebarIcon';
+import SidebarPfp from './SidebarPfp';
 
 type Props = {
   queryRef: StandardSidebarFragment$key;
@@ -40,6 +41,7 @@ export function StandardSidebar({ queryRef }: Props) {
             __typename
             user {
               username
+              ...SidebarPfpFragment
             }
             notifications(last: 1) @connection(key: "StandardSidebarFragment_notifications") {
               unseenCount
@@ -171,6 +173,15 @@ export function StandardSidebar({ queryRef }: Props) {
     return JSON.stringify(userGalleryRoute) === JSON.stringify(currentRoute);
   }, [activeDrawerType, pathname, routerQuery, userGalleryRoute]);
 
+  const isEditGalleriesActive = useMemo(() => {
+    // prevent highlight if another item in the drawer is selected
+    if (activeDrawerType) {
+      return false;
+    }
+    const currentRoute = { pathname, query: routerQuery };
+    return JSON.stringify(editGalleriesRoute) === JSON.stringify(currentRoute);
+  }, [activeDrawerType, pathname, routerQuery, editGalleriesRoute]);
+
   useSearchHotkey(() => {
     showDrawer({
       content: <Search />,
@@ -239,24 +250,22 @@ export function StandardSidebar({ queryRef }: Props) {
             onClick={handleHomeIconClick}
             icon={<GLogoIcon />}
           />
-          {isLoggedIn && (
-            <SidebarIcon
-              href={editGalleriesRoute}
-              tooltipLabel="Edit galleries"
-              onClick={handleEditClick}
-              icon={<EditPencilIcon />}
-              showBorderByDefault
+          {isLoggedIn && query.viewer.user && (
+            <SidebarPfp
+              userRef={query.viewer.user}
+              href={userGalleryRoute}
+              onClick={handleProfileClick}
             />
           )}
         </VStack>
         {isLoggedIn ? (
           <VStack gap={32}>
             <SidebarIcon
-              href={userGalleryRoute}
-              tooltipLabel="My profile"
-              onClick={handleProfileClick}
-              icon={<UserIcon />}
-              isActive={isLoggedInProfileActive}
+              href={editGalleriesRoute}
+              tooltipLabel="Edit galleries"
+              onClick={handleEditClick}
+              icon={<EditPencilIcon />}
+              isActive={isEditGalleriesActive}
             />
             <SidebarIcon
               tooltipLabel="Search"


### PR DESCRIPTION
show pfp in left hand nav instead of profile icon , desktop only

Before
![Screenshot 2023-07-10 at 14 42 50](https://github.com/gallery-so/gallery/assets/80802871/f00b7b43-f80c-4b8b-9126-7f5f7126ef68)


After
(image)
![Screenshot 2023-07-10 at 14 16 32](https://github.com/gallery-so/gallery/assets/80802871/82ef2c90-7b09-4a37-bfe1-b739ec908418)


(placeholder)
![Screenshot 2023-07-10 at 14 39 02](https://github.com/gallery-so/gallery/assets/80802871/ed2ea04b-9106-4759-8f5c-6649031e1e71)

(feature flag off)
![Uploading Screenshot 2023-07-10 at 16.19.15.png…]()



- [x] swap Edit Galleries and Profile position
- [x] image and placeholder pfps both look ok
- [x] maintain onClick behaviors
- [x] add active state to edit galleries
- [x] feature flag