### PR TITLE
fix x collectors admired this copy count

### DIFF
--- a/apps/mobile/src/components/Feed/Socialize/AdmireLine.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/AdmireLine.tsx
@@ -11,11 +11,12 @@ import { MainTabStackNavigatorProp } from '~/navigation/types';
 type AdmireLineProps = {
   style?: ViewProps['style'];
   userRefs: AdmireLineFragment$key;
+  totalAdmires: number;
 
   onMultiUserPress: () => void;
 };
 
-export function AdmireLine({ userRefs, onMultiUserPress, style }: AdmireLineProps) {
+export function AdmireLine({ userRefs, totalAdmires, onMultiUserPress, style }: AdmireLineProps) {
   const users = useFragment(
     graphql`
       fragment AdmireLineFragment on GalleryUser @relay(plural: true) {
@@ -29,7 +30,7 @@ export function AdmireLine({ userRefs, onMultiUserPress, style }: AdmireLineProp
   const navigation = useNavigation<MainTabStackNavigatorProp>();
 
   const [firstUser] = users;
-  if (users.length === 1 && firstUser) {
+  if (totalAdmires === 1 && firstUser) {
     function handleUserPress() {
       if (firstUser?.username) {
         navigation.push('Profile', { username: firstUser.username, hideBackButton: false });
@@ -54,7 +55,7 @@ export function AdmireLine({ userRefs, onMultiUserPress, style }: AdmireLineProp
         </Typography>
       </View>
     );
-  } else if (users.length > 1) {
+  } else if (totalAdmires > 1) {
     return (
       <View style={style} className="flex flex-row items-center">
         <GalleryTouchableOpacity
@@ -63,7 +64,7 @@ export function AdmireLine({ userRefs, onMultiUserPress, style }: AdmireLineProp
           eventName={'AdmireLine Single User'}
         >
           <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-            {users.length} collectors{' '}
+            {totalAdmires} collectors{' '}
           </Typography>
         </GalleryTouchableOpacity>
 

--- a/apps/mobile/src/components/Feed/Socialize/Interactions.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/Interactions.tsx
@@ -121,7 +121,11 @@ export function Interactions({ eventRef }: Props) {
           totalCount={totalAdmires}
         />
 
-        <AdmireLine onMultiUserPress={handleSeeAllAdmires} userRefs={admireUsers} />
+        <AdmireLine
+          onMultiUserPress={handleSeeAllAdmires}
+          userRefs={admireUsers}
+          totalAdmires={totalAdmires}
+        />
       </View>
 
       {previewComments.map((comment) => {


### PR DESCRIPTION
## Description

Fixes "x collectors admired this" showing the wrong number - it was maxed at 5 even if there were more admires.

Uses the total count returned by the pagination query instead of the page length.


before
<img width="239" alt="Screenshot 2023-07-13 at 12 19 06" src="https://github.com/gallery-so/gallery/assets/80802871/2febd5cc-2e67-4703-993b-085cfee0ef6b">


after
<img width="250" alt="Screenshot 2023-07-13 at 12 18 14" src="https://github.com/gallery-so/gallery/assets/80802871/2f3d6599-0704-4160-b631-06f926cc5dde">

