### PR TITLE
retrieve and display ens pfps

### DIFF
--- a/apps/mobile/src/components/ProfilePicture/ProfilePicture.tsx
+++ b/apps/mobile/src/components/ProfilePicture/ProfilePicture.tsx
@@ -24,9 +24,18 @@ export function ProfilePicture({ userRef, style, ...rest }: ProfilePictureProps)
               media {
                 ... on Media {
                   previewURLs {
-                    medium
+                    small
                   }
                 }
+              }
+            }
+          }
+          ... on EnsProfileImage {
+            __typename
+            profileImage {
+              __typename
+              previewURLs {
+                small
               }
             }
           }
@@ -36,7 +45,9 @@ export function ProfilePicture({ userRef, style, ...rest }: ProfilePictureProps)
     userRef
   );
 
-  const imageUrl = user?.profileImage?.token?.media?.previewURLs?.medium;
+  const { token, profileImage: ensImage } = user?.profileImage ?? {};
+  const imageUrl = token?.media?.previewURLs?.small ?? ensImage?.previewURLs?.small;
+
   const letter = user?.username?.[0]?.toUpperCase();
 
   const fallbackProfilePicture = (


### PR DESCRIPTION
## Description
we weren't showing ens pfps in the mobile app.
this change will start querying + displaying them wherever we display pfps

before
<img width="415" alt="Screenshot 2023-07-13 at 12 56 28" src="https://github.com/gallery-so/gallery/assets/80802871/afc7b926-3929-4ea4-a877-13556a51493d">



after
<img width="415" alt="Screenshot 2023-07-13 at 12 56 18" src="https://github.com/gallery-so/gallery/assets/80802871/85aef650-3708-46af-9103-b7b5b25d0e0d">
