### PR TITLE
Fix comment modal height on long comment

### DIFF
--- a/apps/web/src/components/Feed/Socialize/CommentsModal/CommentsModal.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentsModal/CommentsModal.tsx
@@ -44,6 +44,7 @@ export function CommentsModal({ eventRef, queryRef, fullscreen }: CommentsModalP
               __typename
 
               ... on Comment {
+                comment
                 ...CommentNoteFragment
               }
             }
@@ -124,13 +125,29 @@ export function CommentsModal({ eventRef, queryRef, fullscreen }: CommentsModalP
 
   const rowCount = hasPrevious ? nonNullInteractions.length + 1 : nonNullInteractions.length;
 
-  const estimatedItemHeight = 50;
-
   const estimatedContentHeight = useMemo(() => {
     // 420 is the max height of the modal
     // 121 is the height of the modal header + bottom padding + comment box
-    return Math.min(nonNullInteractions.length * estimatedItemHeight, 420 - 121);
-  }, [nonNullInteractions.length, estimatedItemHeight]);
+
+    let height = 0;
+
+    nonNullInteractions.forEach((interaction) => {
+      if (interaction.__typename === 'Comment') {
+        // If the comment more than 70 characters, we need to add extra height
+        // to account for the extra line
+        const commentLength = interaction.comment?.length ?? 0;
+
+        if (commentLength > 70) {
+          height += 70;
+          return;
+        }
+
+        height += 50;
+      }
+    });
+
+    return Math.min(height, 420 - 121);
+  }, [nonNullInteractions]);
 
   useEffect(
     function recalculateHeightsWhenEventsChange() {

--- a/apps/web/src/components/Feed/Socialize/CommentsModal/CommentsModal.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentsModal/CommentsModal.tsx
@@ -129,9 +129,6 @@ export function CommentsModal({ eventRef, queryRef, fullscreen }: CommentsModalP
   const rowCount = hasPrevious ? nonNullInteractions.length + 1 : nonNullInteractions.length;
 
   const estimatedContentHeight = useMemo(() => {
-    // 420 is the max height of the modal
-    // 121 is the height of the modal header + bottom padding + comment box
-
     // 24 is the padding between the comment box and the list
     let height = 24;
 
@@ -139,6 +136,8 @@ export function CommentsModal({ eventRef, queryRef, fullscreen }: CommentsModalP
       height += measurerCache.rowHeight({ index: i });
     }
 
+    // 420 is the max height of the modal
+    // 121 is the height of the modal header + bottom padding + comment box
     return Math.min(height, 420 - 121);
   }, [measurerCache, rowCount]);
 


### PR DESCRIPTION
The bug happens on the long comment text and only have one comment in the modal.


**Demo**

**Before**
![image](https://github.com/gallery-so/gallery/assets/4480258/e93ef90a-c9fc-4710-a72a-c4c93c62aeb5)

**After**

<img width="1072" alt="CleanShot 2023-07-13 at 16 14 41@2x" src="https://github.com/gallery-so/gallery/assets/4480258/cc1ddcf9-5b73-4568-b4ba-3c87eab9d9eb">

<img width="1210" alt="CleanShot 2023-07-13 at 16 14 30@2x" src="https://github.com/gallery-so/gallery/assets/4480258/6a6d53f7-2de4-4fb6-996b-0210c66bf8a8">


