### PR TITLE
make nft selector work with all our enabled chains

### DIFF
--- a/apps/web/src/components/NftSelector/NftSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelector.tsx
@@ -14,15 +14,13 @@ import { doesUserOwnWalletFromChain } from '~/utils/doesUserOwnWalletFromChain';
 import IconContainer from '../core/IconContainer';
 import { HStack, VStack } from '../core/Spacer/Stack';
 import { BaseM } from '../core/Text/Text';
+import { Chain } from '../GalleryEditor/PiecesSidebar/chains';
 import isRefreshDisabledForUser from '../GalleryEditor/PiecesSidebar/isRefreshDisabledForUser';
 import { SidebarView } from '../GalleryEditor/PiecesSidebar/SidebarViewSelector';
 import { NewTooltip } from '../Tooltip/NewTooltip';
 import { useTooltipHover } from '../Tooltip/useTooltipHover';
 import { NftSelectorCollectionGroup } from './groupNftSelectorCollectionsByAddress';
-import {
-  NftSelectorFilterNetwork,
-  NftSelectorNetworkView,
-} from './NftSelectorFilter/NftSelectorFilterNetwork';
+import { NftSelectorFilterNetwork } from './NftSelectorFilter/NftSelectorFilterNetwork';
 import {
   NftSelectorFilterSort,
   NftSelectorSortView,
@@ -70,6 +68,7 @@ export function NftSelector({ tokensRef, queryRef }: Props) {
           }
         }
         ...doesUserOwnWalletFromChainFragment
+        ...NftSelectorFilterNetworkFragment
       }
     `,
     queryRef
@@ -80,8 +79,7 @@ export function NftSelector({ tokensRef, queryRef }: Props) {
 
   const [selectedView, setSelectedView] = useState<SidebarView>('Collected');
   const [selectedSortView, setSelectedSortView] = useState<NftSelectorSortView>('Recently added');
-  const [selectedNetworkView, setSelectedNetworkView] =
-    useState<NftSelectorNetworkView>('Ethereum');
+  const [selectedNetworkView, setSelectedNetworkView] = useState<Chain>('Ethereum');
 
   const [selectedContract, setSelectedContract] = useState<NftSelectorContractType>(null);
 
@@ -220,8 +218,10 @@ export function NftSelector({ tokensRef, queryRef }: Props) {
               onSelectedViewChange={setSelectedSortView}
             />
             <NftSelectorFilterNetwork
-              selectedView={selectedNetworkView}
+              selectedMode={selectedView}
+              selectedNetwork={selectedNetworkView}
               onSelectedViewChange={setSelectedNetworkView}
+              queryRef={query}
             />
 
             <IconContainer

--- a/apps/web/src/components/NftSelector/NftSelectorView.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorView.tsx
@@ -10,17 +10,17 @@ import useAddWalletModal from '~/hooks/useAddWalletModal';
 import { Button } from '../core/Button/Button';
 import { VStack } from '../core/Spacer/Stack';
 import { BaseXL } from '../core/Text/Text';
+import { Chain } from '../GalleryEditor/PiecesSidebar/chains';
 import {
   groupNftSelectorCollectionsByAddress,
   NftSelectorCollectionGroup,
 } from './groupNftSelectorCollectionsByAddress';
 import { NftSelectorContractType } from './NftSelector';
-import { NftSelectorNetworkView } from './NftSelectorFilter/NftSelectorFilterNetwork';
 import { NftSelectorTokenPreview } from './NftSelectorTokenPreview';
 
 type Props = {
   selectedContractAddress: string | null;
-  selectedNetworkView: NftSelectorNetworkView;
+  selectedNetworkView: Chain;
   onSelectContract: (collection: NftSelectorContractType) => void;
   tokenRefs: NftSelectorViewFragment$key;
   hasSearchKeyword: boolean;


### PR DESCRIPTION
## Description
Update the NFT Selector network dropdown to display options based on all the chains defined in the chains.ts file, instead of hardcoded options. This way we'll automatically show the same available chains in the NFT Selector as the Gallery Editor. 

demo of Setting an Optimism token as a pfp:

https://github.com/gallery-so/gallery/assets/80802871/9435b8f0-8a51-4acd-966f-62ecf8425f46


non admin mode:
<img width="401" alt="Screenshot 2023-07-13 at 22 44 16" src="https://github.com/gallery-so/gallery/assets/80802871/0fda0706-35ba-452d-b037-849f048285c5">


admin mode: 
<img width="465" alt="Screenshot 2023-07-13 at 22 44 02" src="https://github.com/gallery-so/gallery/assets/80802871/80c1903c-0f3e-4f7b-b71b-19b7878c161a">

