### PR TITLE
ux polish around community info

### DIFF
--- a/apps/mobile/src/components/Community/CommunityView.tsx
+++ b/apps/mobile/src/components/Community/CommunityView.tsx
@@ -149,7 +149,7 @@ export function CommunityView({ queryRef }: Props) {
                 {showAddressOrGalleryUser}
               </View>
             )}
-            <View className="flex flex-column  space-y-1">
+            <View className="flex flex-column space-y-1">
               <Typography
                 font={{ family: 'ABCDiatype', weight: 'Regular' }}
                 className="text-xs uppercase"

--- a/apps/mobile/src/components/Community/CommunityView.tsx
+++ b/apps/mobile/src/components/Community/CommunityView.tsx
@@ -8,6 +8,7 @@ import { TezosIcon } from 'src/icons/TezosIcon';
 
 import { Chain, CommunityViewFragment$key } from '~/generated/CommunityViewFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
+import colors from '~/shared/theme/colors';
 
 import { BackButton } from '../BackButton';
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
@@ -116,6 +117,7 @@ export function CommunityView({ queryRef }: Props) {
           <LinkableAddress
             chainAddressRef={community.contractAddress}
             type="Community Contract Address"
+            textStyle={{ color: colors.shadow }}
           />
         </View>
       );
@@ -137,23 +139,17 @@ export function CommunityView({ queryRef }: Props) {
           <CommunityHeader communityRef={community} />
           <View className="mb-4 flex flex-row space-x-6">
             {community?.chain !== 'POAP' && (
-              <View className="space-y-1">
+              <View className="flex flex-column space-y-1">
                 <Typography
                   font={{ family: 'ABCDiatype', weight: 'Regular' }}
                   className="text-xs uppercase"
                 >
                   created by
                 </Typography>
-
-                <Typography
-                  font={{ family: 'ABCDiatype', weight: 'Regular' }}
-                  className="text-sm text-shadow"
-                >
-                  {showAddressOrGalleryUser}
-                </Typography>
+                {showAddressOrGalleryUser}
               </View>
             )}
-            <View className="space-y-1">
+            <View className="flex flex-column  space-y-1">
               <Typography
                 font={{ family: 'ABCDiatype', weight: 'Regular' }}
                 className="text-xs uppercase"

--- a/apps/mobile/src/components/LinkableAddress.tsx
+++ b/apps/mobile/src/components/LinkableAddress.tsx
@@ -1,4 +1,4 @@
-import { ViewProps } from 'react-native';
+import { TextProps, ViewProps } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
@@ -12,9 +12,10 @@ type LinkableAddressProps = {
   chainAddressRef: LinkableAddressFragment$key;
   type: InteractiveLinkProps['type'];
   style?: ViewProps['style'];
+  textStyle?: TextProps['style'];
 };
 
-export function LinkableAddress({ chainAddressRef, type, style }: LinkableAddressProps) {
+export function LinkableAddress({ chainAddressRef, type, style, textStyle }: LinkableAddressProps) {
   const address = useFragment(
     graphql`
       fragment LinkableAddressFragment on ChainAddress {
@@ -48,6 +49,7 @@ export function LinkableAddress({ chainAddressRef, type, style }: LinkableAddres
         truncatedAddress={truncatedAddress}
         address={address.address}
         style={style}
+        textStyle={textStyle}
       />
     );
   } else {
@@ -61,6 +63,7 @@ type RawLinkableAddressProps = {
   truncatedAddress: string | null;
   type: InteractiveLinkProps['type'];
   style?: ViewProps['style'];
+  textStyle?: TextProps['style'];
 };
 
 export function RawLinkableAddress({
@@ -69,9 +72,10 @@ export function RawLinkableAddress({
   address,
   type,
   style,
+  textStyle,
 }: RawLinkableAddressProps) {
   return (
-    <InteractiveLink href={link} type={type} showUnderline style={style}>
+    <InteractiveLink href={link} type={type} style={style} textStyle={textStyle}>
       {truncatedAddress || address}
     </InteractiveLink>
   );

--- a/apps/mobile/src/components/Search/Community/CommunitySearchResult.tsx
+++ b/apps/mobile/src/components/Search/Community/CommunitySearchResult.tsx
@@ -44,7 +44,7 @@ export function CommunitySearchResult({ communityRef }: Props) {
 
   return (
     <SearchResult
-      profilePicture={<CommunityProfilePicture communityRef={community} size="sm" />}
+      profilePicture={<CommunityProfilePicture communityRef={community} size="md" />}
       onPress={handlePress}
       title={community?.name ?? ''}
       description={community?.description ?? ''}

--- a/apps/mobile/src/components/Search/SearchResult.tsx
+++ b/apps/mobile/src/components/Search/SearchResult.tsx
@@ -70,11 +70,15 @@ export function SearchResult({ title, description, variant, profilePicture, ...p
       {...props}
     >
       {profilePicture}
-      <View className="flex flex-grow flex-1 flex-col">
-        <Markdown style={markdownStyles}>{highlightedName}</Markdown>
-        <Markdown style={markdownStyles} numberOfLines={1}>
-          {highlightedDescription}
-        </Markdown>
+      <View className="flex flex-grow flex-1 flex-col space-y-1">
+        <View>
+          <Markdown style={markdownStyles}>{highlightedName}</Markdown>
+        </View>
+        <View>
+          <Markdown style={markdownStyles} numberOfLines={1}>
+            {highlightedDescription}
+          </Markdown>
+        </View>
       </View>
     </GalleryTouchableOpacity>
   );

--- a/apps/mobile/src/components/Search/SearchSection.tsx
+++ b/apps/mobile/src/components/Search/SearchSection.tsx
@@ -15,7 +15,7 @@ export function SearchSection({ isShowAll, numResults, onShowAll, title }: Props
   if (!isShowAll && numResults === 0) return null;
 
   return (
-    <View className="flex flex-row items-center justify-between p-4">
+    <View className="flex flex-row items-center justify-between px-4 pt-2 pb-0">
       <Typography
         font={{
           family: 'ABCDiatype',

--- a/apps/mobile/src/components/Search/User/UserSearchResult.tsx
+++ b/apps/mobile/src/components/Search/User/UserSearchResult.tsx
@@ -34,7 +34,7 @@ export function UserSearchResult({ userRef }: Props) {
 
   return (
     <SearchResult
-      profilePicture={<ProfilePicture userRef={user} size="sm" />}
+      profilePicture={<ProfilePicture userRef={user} size="md" />}
       onPress={handlePress}
       title={user?.username ?? ''}
       description={user?.bio ?? ''}

--- a/apps/mobile/src/components/UserFollowList/UserFollowCard.tsx
+++ b/apps/mobile/src/components/UserFollowList/UserFollowCard.tsx
@@ -66,8 +66,6 @@ export function UserFollowCard({ userRef, queryRef, onPress }: UserFollowCardPro
             {bioFirstLine && <Markdown numberOfLines={1}>{bioFirstLine}</Markdown>}
           </View>
         </View>
-
-        <View></View>
       </GalleryTouchableOpacity>
 
       <FollowButton queryRef={query} userRef={user} />

--- a/apps/mobile/src/components/UserFollowList/UserFollowCard.tsx
+++ b/apps/mobile/src/components/UserFollowList/UserFollowCard.tsx
@@ -58,16 +58,16 @@ export function UserFollowCard({ userRef, queryRef, onPress }: UserFollowCardPro
         eventName="User Follow Username Clicked"
       >
         <View className="flex flex-row items-center space-x-2">
-          <ProfilePicture userRef={user} size="sm" />
-
-          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-            {user.username}
-          </Typography>
+          <ProfilePicture userRef={user} size="md" />
+          <View>
+            <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+              {user.username}
+            </Typography>
+            {bioFirstLine && <Markdown numberOfLines={1}>{bioFirstLine}</Markdown>}
+          </View>
         </View>
 
-        <View>
-          <Markdown numberOfLines={1}>{bioFirstLine}</Markdown>
-        </View>
+        <View></View>
       </GalleryTouchableOpacity>
 
       <FollowButton queryRef={query} userRef={user} />


### PR DESCRIPTION



- center username and bio vertically relative to pfp
- before
![Screenshot 2023-07-20 at 13 12 38](https://github.com/gallery-so/gallery/assets/80802871/4ba5de6c-f560-41a8-9e72-b58390e3cf98)

after
![Screenshot 2023-07-20 at 13 10 45](https://github.com/gallery-so/gallery/assets/80802871/1a168612-ce37-4e0e-9a9a-338d949bc3dd)
 
- remove underline styling from link, fix color
before
![Screenshot 2023-07-20 at 13 13 08](https://github.com/gallery-so/gallery/assets/80802871/7c7b062e-ead0-46b3-8bb5-91f727693777)

after
![Screenshot 2023-07-20 at 13 13 20](https://github.com/gallery-so/gallery/assets/80802871/e0ae9888-f671-4ed2-881d-874693bdbd27)


- name should be bold on search results, make sure gap is enough 
realized title should actually only bold the keyword match, we can address as a follow up. fixed the gap, seen in screenshot below

- decrease gap between search section label (ie “CURATORS”) and first result
before
![Screenshot 2023-07-20 at 13 12 35](https://github.com/gallery-so/gallery/assets/80802871/c627a03c-ec8a-44a7-9ebe-12c69bb7ead8)
after
![Screenshot 2023-07-20 at 13 10 54](https://github.com/gallery-so/gallery/assets/80802871/40280c79-bfae-49e5-ae3d-205f33c0e611)
