### PR TITLE
Stop requesting twitter content

### DIFF
--- a/apps/web/pages/explore.tsx
+++ b/apps/web/pages/explore.tsx
@@ -1,31 +1,52 @@
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
-import useOpenTwitterFollowingModal from '~/components/Twitter/useOpenTwitterFollowingModal';
-import { USER_PER_PAGE } from '~/constants/twitter';
 import { HomeNavbar } from '~/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar';
 import { StandardSidebar } from '~/contexts/globalLayout/GlobalSidebar/StandardSidebar';
 import { exploreQuery } from '~/generated/exploreQuery.graphql';
 import GalleryRoute from '~/scenes/_Router/GalleryRoute';
 import ExplorePage from '~/scenes/Home/ExploreHomePage';
 
+// [GAL-3763] Revive this if / when elon lets us import twitter follower graphs again
+//
+// export default function Explore() {
+//   const query = useLazyLoadQuery<exploreQuery>(
+//     graphql`
+//       query exploreQuery($twitterListFirst: Int!, $twitterListAfter: String) {
+//         ...ExploreHomePageFragment
+//         ...HomeNavbarFragment
+//         ...StandardSidebarFragment
+
+//         ...useOpenTwitterFollowingModalFragment
+//       }
+//     `,
+//     {
+//       twitterListFirst: USER_PER_PAGE,
+//       twitterListAfter: null,
+//     }
+//   );
+
+//   useOpenTwitterFollowingModal(query);
+
+//   return (
+//     <GalleryRoute
+//       navbar={<HomeNavbar queryRef={query} />}
+//       sidebar={<StandardSidebar queryRef={query} />}
+//       element={<ExplorePage queryRef={query} />}
+//     />
+//   );
+// }
+
 export default function Explore() {
   const query = useLazyLoadQuery<exploreQuery>(
     graphql`
-      query exploreQuery($twitterListFirst: Int!, $twitterListAfter: String) {
+      query exploreQuery {
         ...ExploreHomePageFragment
         ...HomeNavbarFragment
         ...StandardSidebarFragment
-
-        ...useOpenTwitterFollowingModalFragment
       }
     `,
-    {
-      twitterListFirst: USER_PER_PAGE,
-      twitterListAfter: null,
-    }
+    {}
   );
-
-  useOpenTwitterFollowingModal(query);
 
   return (
     <GalleryRoute

--- a/apps/web/src/components/Explore/Explore.tsx
+++ b/apps/web/src/components/Explore/Explore.tsx
@@ -2,12 +2,9 @@ import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import { ExploreFragment$key } from '~/generated/ExploreFragment.graphql';
-import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 
 import { VStack } from '../core/Spacer/Stack';
-import SuggestedSection from './SuggestedSection';
 import TrendingSection from './TrendingSection';
-import TwitterSection from './TwitterSection';
 
 type Props = {
   queryRef: ExploreFragment$key;
@@ -43,7 +40,8 @@ export default function Explore({ queryRef }: Props) {
 
         ...TrendingSectionQueryFragment
         ...SuggestedSectionQueryFragment
-        ...TwitterSectionQueryFragment
+        # [GAL-3763] Revive this if / when elon lets us import twitter follower graphs again
+        # ...TwitterSectionQueryFragment
       }
     `,
     queryRef
@@ -51,6 +49,7 @@ export default function Explore({ queryRef }: Props) {
 
   return (
     <StyledExplorePage gap={48}>
+      {/* [GAL-3763] Revive this if / when elon lets us import twitter follower graphs again
       {query.viewer?.__typename === 'Viewer' && (
         <>
           {query.viewer.socialAccounts?.twitter?.__typename && (
@@ -68,7 +67,7 @@ export default function Explore({ queryRef }: Props) {
             queryRef={query}
           />
         </>
-      )}
+      )} */}
       {query.trendingUsers5Days?.__typename === 'TrendingUsersPayload' && (
         <TrendingSection
           title="Weekly Leaderboard"


### PR DESCRIPTION
Twitter (slash Elon) updated their APIs recently to prevent clients from importing user social graphs to recommend others to follow. We're disabling the request from the frontend to reduce 403s.

<img width="537" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/e7a65163-1861-475d-a173-876f082b46c4">
