### PR TITLE
add community pfps

### DIFF
--- a/apps/web/pages/_/components.tsx
+++ b/apps/web/pages/_/components.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 import { Button, ButtonLink } from '~/components/core/Button/Button';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import { BaseM, TitleM } from '~/components/core/Text/Text';
-import { ProfilePictureStack } from '~/components/ProfilePictureStack';
-import { RawProfilePicture } from '~/components/RawProfilePicture';
+import { ProfilePictureStack } from '~/components/ProfilePicture/ProfilePictureStack';
+import { RawProfilePicture } from '~/components/ProfilePicture/RawProfilePicture';
 import icons from '~/icons/index';
 import colors from '~/shared/theme/colors';
 

--- a/apps/web/src/components/Feed/Socialize/AdmireLine.tsx
+++ b/apps/web/src/components/Feed/Socialize/AdmireLine.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { HStack } from '~/components/core/Spacer/Stack';
 import { BaseS } from '~/components/core/Text/Text';
-import { ProfilePictureStack } from '~/components/ProfilePictureStack';
+import { ProfilePictureStack } from '~/components/ProfilePicture/ProfilePictureStack';
 import { AdmireLineEventFragment$key } from '~/generated/AdmireLineEventFragment.graphql';
 import { AdmireLineQueryFragment$key } from '~/generated/AdmireLineQueryFragment.graphql';
 import { removeNullValues } from '~/shared/relay/removeNullValues';

--- a/apps/web/src/components/Notifications/notifications/SomeoneViewedYourGallery.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneViewedYourGallery.tsx
@@ -7,7 +7,7 @@ import { HStack } from '~/components/core/Spacer/Stack';
 import { BaseM } from '~/components/core/Text/Text';
 import HoverCardOnUsername from '~/components/HoverCard/HoverCardOnUsername';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
-import { ProfilePictureStack } from '~/components/ProfilePictureStack';
+import { ProfilePictureStack } from '~/components/ProfilePicture/ProfilePictureStack';
 import { SomeoneViewedYourGalleryFragment$key } from '~/generated/SomeoneViewedYourGalleryFragment.graphql';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 

--- a/apps/web/src/components/Profile/EditUserInfoForm.tsx
+++ b/apps/web/src/components/Profile/EditUserInfoForm.tsx
@@ -14,7 +14,7 @@ import unescape from '~/shared/utils/unescape';
 
 import useNftSelector from '../NftSelector/useNftSelector';
 import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
-import { RawProfilePicture } from '../RawProfilePicture';
+import { RawProfilePicture } from '../ProfilePicture/RawProfilePicture';
 import { ProfilePictureDropdown } from './ProfilePictureDropdown';
 
 type Props = {

--- a/apps/web/src/components/ProfilePicture/CommunityProfilePicture.tsx
+++ b/apps/web/src/components/ProfilePicture/CommunityProfilePicture.tsx
@@ -1,0 +1,29 @@
+import { graphql, useFragment } from 'react-relay';
+
+import { CommunityProfilePictureFragment$key } from '~/generated/CommunityProfilePictureFragment.graphql';
+
+import { RawProfilePicture, RawProfilePictureProps } from './RawProfilePicture';
+
+type Props = {
+  communityRef: CommunityProfilePictureFragment$key;
+} & Omit<RawProfilePictureProps, 'imageUrl'>;
+
+export default function CommunityProfilePicture({ communityRef, ...rest }: Props) {
+  const community = useFragment(
+    graphql`
+      fragment CommunityProfilePictureFragment on Community {
+        name
+        profileImageURL
+      }
+    `,
+    communityRef
+  );
+
+  const imageUrl = community?.profileImageURL;
+  if (imageUrl) {
+    return <RawProfilePicture imageUrl={imageUrl} {...rest} />;
+  }
+
+  const firstLetter = community?.name?.[0]?.toUpperCase();
+  return <RawProfilePicture letter={firstLetter ?? ''} {...rest} />;
+}

--- a/apps/web/src/components/ProfilePicture/ProfilePicture.tsx
+++ b/apps/web/src/components/ProfilePicture/ProfilePicture.tsx
@@ -4,7 +4,7 @@ import { ProfilePictureFragment$key } from '~/generated/ProfilePictureFragment.g
 import { CouldNotRenderNftError } from '~/shared/errors/CouldNotRenderNftError';
 import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
 
-import { RawProfilePicture, RawProfilePictureProps } from '../RawProfilePicture';
+import { RawProfilePicture, RawProfilePictureProps } from './RawProfilePicture';
 
 type Props = {
   userRef: ProfilePictureFragment$key;

--- a/apps/web/src/components/ProfilePicture/ProfilePictureStack.tsx
+++ b/apps/web/src/components/ProfilePicture/ProfilePictureStack.tsx
@@ -7,9 +7,9 @@ import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import colors from '~/shared/theme/colors';
 
-import { HStack, VStack } from './core/Spacer/Stack';
-import { TitleXS } from './core/Text/Text';
-import { ProfilePicture } from './ProfilePicture/ProfilePicture';
+import { HStack, VStack } from '../core/Spacer/Stack';
+import { TitleXS } from '../core/Text/Text';
+import { ProfilePicture } from './ProfilePicture';
 
 type Props = {
   usersRef: ProfilePictureStackFragment$key;

--- a/apps/web/src/components/ProfilePicture/RawProfilePicture.tsx
+++ b/apps/web/src/components/ProfilePicture/RawProfilePicture.tsx
@@ -152,7 +152,7 @@ const InnerCircle = styled(VStack)<{ hasImage?: boolean }>`
   height: 100%;
 
   background-color: ${colors.offWhite};
-  border: 1px solid ${({ hasImage }) => (hasImage ? 'transparent' : colors.black['800'])};
+  ${({ hasImage }) => !hasImage && `border: 1px solid ${colors.black['800']}`};
 
   transition: background 100ms ease-in-out;
 `;

--- a/apps/web/src/components/Search/Community/CommunitySearchResult.tsx
+++ b/apps/web/src/components/Search/Community/CommunitySearchResult.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
 
 import { LowercaseChain } from '~/components/GalleryEditor/PiecesSidebar/chains';
+import CommunityProfilePicture from '~/components/ProfilePicture/CommunityProfilePicture';
 import { CommunitySearchResultFragment$key } from '~/generated/CommunitySearchResultFragment.graphql';
 
 import SearchResult from '../SearchResult';
@@ -21,6 +22,7 @@ export default function CommunitySearchResult({ communityRef }: Props) {
           address
           chain
         }
+        ...CommunityProfilePictureFragment
       }
     `,
     communityRef
@@ -44,6 +46,7 @@ export default function CommunitySearchResult({ communityRef }: Props) {
       description={community.description ?? ''}
       path={route}
       type="community"
+      profilePicture={<CommunityProfilePicture communityRef={community} size="md" />}
     />
   );
 }

--- a/apps/web/src/components/Search/Gallery/GallerySearchResult.tsx
+++ b/apps/web/src/components/Search/Gallery/GallerySearchResult.tsx
@@ -1,6 +1,7 @@
 import { Route } from 'nextjs-routes';
 import { graphql, useFragment } from 'react-relay';
 
+import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { GallerySearchResultFragment$key } from '~/generated/GallerySearchResultFragment.graphql';
 
 import SearchResult from '../SearchResult';
@@ -17,7 +18,7 @@ export default function GallerySearchResult({ galleryRef }: Props) {
         name
         owner {
           username
-          ...SearchResultUserFragment
+          ...ProfilePictureFragment
         }
       }
     `,
@@ -35,7 +36,7 @@ export default function GallerySearchResult({ galleryRef }: Props) {
       description={gallery?.owner?.username ?? ''}
       path={route}
       type="gallery"
-      userRef={gallery.owner}
+      profilePicture={gallery.owner && <ProfilePicture userRef={gallery.owner} size="md" />}
     />
   );
 }

--- a/apps/web/src/components/Search/SearchResult.tsx
+++ b/apps/web/src/components/Search/SearchResult.tsx
@@ -1,18 +1,15 @@
 import Link, { LinkProps } from 'next/link';
 import { Route, route } from 'nextjs-routes';
-import { useCallback, useMemo } from 'react';
-import { graphql, useFragment } from 'react-relay';
+import { ReactNode, useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { useDrawerActions } from '~/contexts/globalLayout/GlobalSidebar/SidebarDrawerContext';
-import { SearchResultUserFragment$key } from '~/generated/SearchResultUserFragment.graphql';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';
 
 import Markdown from '../core/Markdown/Markdown';
 import { HStack, VStack } from '../core/Spacer/Stack';
 import { BaseM } from '../core/Text/Text';
-import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
 import { SearchFilterType } from './Search';
 import { useSearchContext } from './SearchContext';
 
@@ -21,22 +18,19 @@ type Props = {
   description: string;
   path: Route;
   type: SearchFilterType;
-  userRef?: SearchResultUserFragment$key | null;
+  profilePicture?: ReactNode;
 };
 
 const MAX_DESCRIPTION_CHARACTER = 150;
 
-export default function SearchResult({ name, description, path, type, userRef }: Props) {
-  const user = useFragment(
-    graphql`
-      fragment SearchResultUserFragment on GalleryUser {
-        __typename
-        ...ProfilePictureFragment
-      }
-    `,
-    userRef || null
-  );
+export default function SearchResult({
+  name,
+  description,
+  path,
+  type,
 
+  profilePicture,
+}: Props) {
   const { hideDrawer } = useDrawerActions();
   const { keyword } = useSearchContext();
 
@@ -85,11 +79,7 @@ export default function SearchResult({ name, description, path, type, userRef }:
   return (
     <StyledSearchResult className="SearchResult" href={path} onClick={handleClick}>
       <HStack gap={4} align="center">
-        {user && (
-          <div>
-            <ProfilePicture size="md" userRef={user} />
-          </div>
-        )}
+        {profilePicture}
         <VStack>
           <BaseM>
             <Markdown text={highlightedName} />

--- a/apps/web/src/components/Search/User/UserSearchResult.tsx
+++ b/apps/web/src/components/Search/User/UserSearchResult.tsx
@@ -1,6 +1,7 @@
 import { Route } from 'nextjs-routes';
 import { graphql, useFragment } from 'react-relay';
 
+import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { UserSearchResultFragment$key } from '~/generated/UserSearchResultFragment.graphql';
 
 import SearchResult from '../SearchResult';
@@ -15,7 +16,7 @@ export default function UserSearchResult({ userRef }: Props) {
       fragment UserSearchResultFragment on GalleryUser {
         username
         bio
-        ...SearchResultUserFragment
+        ...ProfilePictureFragment
       }
     `,
     userRef
@@ -32,7 +33,7 @@ export default function UserSearchResult({ userRef }: Props) {
       description={user.bio ?? ''}
       path={route}
       type="curator"
-      userRef={user}
+      profilePicture={<ProfilePicture userRef={user} size="md" />}
     />
   );
 }

--- a/apps/web/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -12,6 +12,7 @@ import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import Markdown from '~/components/core/Markdown/Markdown';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import { BaseM, TitleL, TitleXS } from '~/components/core/Text/Text';
+import CommunityProfilePicture from '~/components/ProfilePicture/CommunityProfilePicture';
 import MemberListFilter from '~/components/TokenHolderList/TokenHolderListFilter';
 import { GRID_ENABLED_COMMUNITY_ADDRESSES } from '~/constants/community';
 import MemberListPageProvider from '~/contexts/memberListPage/MemberListPageContext';
@@ -43,6 +44,7 @@ export default function CommunityPageView({ communityRef }: Props) {
 
         ...CommunityHolderGridFragment
         ...CommunityHolderListFragment
+        ...CommunityProfilePictureFragment
       }
     `,
     communityRef
@@ -96,8 +98,9 @@ export default function CommunityPageView({ communityRef }: Props) {
       <StyledCommunityPageContainer>
         <HStack>
           <StyledHeader gap={24}>
-            <VStack>
+            <VStack gap={24}>
               <HStack gap={12} align="center">
+                <CommunityProfilePicture communityRef={community} size="lg" />
                 <TitleL>{name}</TitleL>
                 {badgeURL && <StyledBadge src={badgeURL} />}
               </HStack>

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedFollowers.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedFollowers.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import { HStack } from '~/components/core/Spacer/Stack';
 import { BaseS } from '~/components/core/Text/Text';
-import { ProfilePictureStack } from '~/components/ProfilePictureStack';
+import { ProfilePictureStack } from '~/components/ProfilePicture/ProfilePictureStack';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { UserSharedFollowersFragment$key } from '~/generated/UserSharedFollowersFragment.graphql';
 import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';


### PR DESCRIPTION
Display Community PFPs on web

- [x] show pfp on community page
- [x] show pfp on community search result
- [x] fix bug where non-image pfps had a transparent border, effectively making them smaller than placeholder pfps
- [x] moved some PFP related components into ProfilePicture folder


Community Page 
before vs after
![Screenshot 2023-07-20 at 16 39 41](https://github.com/gallery-so/gallery/assets/80802871/2e18bc78-ed02-45de-990f-f7d6074e9e22)

Search result 
before vs after
![Screenshot 2023-07-20 at 16 35 49](https://github.com/gallery-so/gallery/assets/80802871/331ed98c-5d7d-4b39-a350-562e03df2e0f)
