### PR TITLE
Add external link for Prohibition items

### DIFF
--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetails.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetails.tsx
@@ -7,11 +7,10 @@ import { NftAdditionalDetailsPOAP } from '~/scenes/NftDetailPage/NftAdditionalDe
 import { NftAdditionalDetailsTezos } from '~/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsTezos';
 
 type NftAdditionalDetailsProps = {
-  showDetails: boolean;
   tokenRef: NftAdditionalDetailsFragment$key;
 };
 
-export function NftAdditionalDetails({ tokenRef, showDetails }: NftAdditionalDetailsProps) {
+export function NftAdditionalDetails({ tokenRef }: NftAdditionalDetailsProps) {
   const token = useFragment(
     graphql`
       fragment NftAdditionalDetailsFragment on Token {
@@ -26,10 +25,10 @@ export function NftAdditionalDetails({ tokenRef, showDetails }: NftAdditionalDet
   );
 
   if (token.chain === 'POAP') {
-    return <NftAdditionalDetailsPOAP showDetails={showDetails} tokenRef={token} />;
+    return <NftAdditionalDetailsPOAP tokenRef={token} />;
   } else if (token.chain === 'Tezos') {
-    return <NftAdditionalDetailsTezos showDetails={showDetails} tokenRef={token} />;
+    return <NftAdditionalDetailsTezos tokenRef={token} />;
   }
 
-  return <NftAdditionalDetailsEth showDetails={showDetails} tokenRef={token} />;
+  return <NftAdditionalDetailsEth tokenRef={token} />;
 }

--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsEth.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsEth.tsx
@@ -1,19 +1,15 @@
-import { useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import styled from 'styled-components';
 
-import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
 import { VStack } from '~/components/core/Spacer/Stack';
 import { BaseM, TitleXS } from '~/components/core/Text/Text';
 import { EnsOrAddress } from '~/components/EnsOrAddress';
 import { LinkableAddress } from '~/components/LinkableAddress';
 import { NftAdditionalDetailsEthFragment$key } from '~/generated/NftAdditionalDetailsEthFragment.graphql';
-import { useRefreshMetadata } from '~/scenes/NftDetailPage/NftAdditionalDetails/useRefreshMetadata';
-import { extractMirrorXyzUrl } from '~/shared/utils/extractMirrorXyzUrl';
-import { getOpenseaExternalUrl, hexHandler } from '~/shared/utils/getOpenseaExternalUrl';
+import { hexHandler } from '~/shared/utils/getOpenseaExternalUrl';
+
+import NftDetailsExternalLinksEth from './NftDetailsExternalLinksEth';
 
 type NftAdditionaDetailsNonPOAPProps = {
-  showDetails: boolean;
   tokenRef: NftAdditionalDetailsEthFragment$key;
 };
 
@@ -21,14 +17,10 @@ export function NftAdditionalDetailsEth({ tokenRef }: NftAdditionaDetailsNonPOAP
   const token = useFragment(
     graphql`
       fragment NftAdditionalDetailsEthFragment on Token {
-        externalUrl
         tokenId
-        chain
-        tokenMetadata
         contract {
           creatorAddress {
             address
-            ...LinkableAddressFragment
             ...EnsOrAddressWithSuspenseFragment
           }
           contractAddress {
@@ -37,31 +29,13 @@ export function NftAdditionalDetailsEth({ tokenRef }: NftAdditionaDetailsNonPOAP
           }
         }
 
-        ...useRefreshMetadataFragment
+        ...NftDetailsExternalLinksEthFragment
       }
     `,
     tokenRef
   );
 
-  const { tokenId, contract, externalUrl, tokenMetadata, chain } = token;
-
-  const [refresh, isRefreshing] = useRefreshMetadata(token);
-
-  const openSeaExternalUrl = useMemo(() => {
-    if (chain && contract?.contractAddress?.address && tokenId) {
-      return getOpenseaExternalUrl(chain, contract.contractAddress.address, tokenId);
-    }
-
-    return null;
-  }, [chain, contract?.contractAddress?.address, tokenId]);
-
-  const mirrorXyzUrl = useMemo(() => {
-    if (tokenMetadata) {
-      return extractMirrorXyzUrl(tokenMetadata);
-    }
-
-    return null;
-  }, [tokenMetadata]);
+  const { tokenId, contract } = token;
 
   return (
     <VStack gap={16}>
@@ -85,25 +59,7 @@ export function NftAdditionalDetailsEth({ tokenRef }: NftAdditionaDetailsNonPOAP
           <BaseM>{hexHandler(tokenId)}</BaseM>
         </div>
       )}
-
-      <StyledLinkContainer>
-        {mirrorXyzUrl && <InteractiveLink href={mirrorXyzUrl}>View on Mirror</InteractiveLink>}
-        {openSeaExternalUrl && (
-          <>
-            <InteractiveLink href={openSeaExternalUrl}>View on OpenSea</InteractiveLink>
-            <InteractiveLink onClick={refresh} disabled={isRefreshing}>
-              Refresh metadata
-            </InteractiveLink>
-          </>
-        )}
-        {externalUrl && <InteractiveLink href={externalUrl}>More Info</InteractiveLink>}
-      </StyledLinkContainer>
+      <NftDetailsExternalLinksEth tokenRef={token} />
     </VStack>
   );
 }
-
-const StyledLinkContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-`;

--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsPOAP.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsPOAP.tsx
@@ -6,11 +6,10 @@ import { BaseM, TitleXS } from '~/components/core/Text/Text';
 import { NftAdditionalDetailsPOAPFragment$key } from '~/generated/NftAdditionalDetailsPOAPFragment.graphql';
 
 type POAPNftDetailSectionProps = {
-  showDetails: boolean;
   tokenRef: NftAdditionalDetailsPOAPFragment$key;
 };
 
-export function NftAdditionalDetailsPOAP({ tokenRef, showDetails }: POAPNftDetailSectionProps) {
+export function NftAdditionalDetailsPOAP({ tokenRef }: POAPNftDetailSectionProps) {
   const token = useFragment(
     graphql`
       fragment NftAdditionalDetailsPOAPFragment on Token {
@@ -53,27 +52,23 @@ export function NftAdditionalDetailsPOAP({ tokenRef, showDetails }: POAPNftDetai
         </div>
       )}
 
-      {showDetails && (
-        <>
-          {id && (
-            <div>
-              <TitleXS>POAP ID</TitleXS>
-              <BaseM>{id}</BaseM>
-            </div>
-          )}
-          {supply && (
-            <div>
-              <TitleXS>SUPPLY</TitleXS>
-              <BaseM>{supply}</BaseM>
-            </div>
-          )}
-          {chain && (
-            <div>
-              <TitleXS>CHAIN</TitleXS>
-              <BaseM>{chain}</BaseM>
-            </div>
-          )}
-        </>
+      {id && (
+        <div>
+          <TitleXS>POAP ID</TitleXS>
+          <BaseM>{id}</BaseM>
+        </div>
+      )}
+      {supply && (
+        <div>
+          <TitleXS>SUPPLY</TitleXS>
+          <BaseM>{supply}</BaseM>
+        </div>
+      )}
+      {chain && (
+        <div>
+          <TitleXS>CHAIN</TitleXS>
+          <BaseM>{chain}</BaseM>
+        </div>
       )}
     </VStack>
   );

--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsTezos.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsTezos.tsx
@@ -13,7 +13,6 @@ import { hexHandler } from '~/shared/utils/getOpenseaExternalUrl';
 import { getFxHashExternalUrl, getObjktExternalUrl } from '~/shared/utils/getTezosExternalUrl';
 
 type NftAdditionaDetailsNonPOAPProps = {
-  showDetails: boolean;
   tokenRef: NftAdditionalDetailsTezosFragment$key;
 };
 

--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftDetailsExternalLinksEth.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftDetailsExternalLinksEth.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
+import { VStack } from '~/components/core/Spacer/Stack';
+import { NftDetailsExternalLinksEthFragment$key } from '~/generated/NftDetailsExternalLinksEthFragment.graphql';
+import { extractMirrorXyzUrl } from '~/shared/utils/extractMirrorXyzUrl';
+import { getOpenseaExternalUrl, hexHandler } from '~/shared/utils/getOpenseaExternalUrl';
+
+import { useRefreshMetadata } from './useRefreshMetadata';
+
+type Props = {
+  tokenRef: NftDetailsExternalLinksEthFragment$key;
+};
+
+const PROHIBITION_CONTRACT_ADDRESSES = ['0x47a91457a3a1f700097199fd63c039c4784384ab'];
+
+export default function NftDetailsExternalLinksEth({ tokenRef }: Props) {
+  const token = useFragment(
+    graphql`
+      fragment NftDetailsExternalLinksEthFragment on Token {
+        externalUrl
+        tokenId
+        tokenMetadata
+        chain
+        contract {
+          contractAddress {
+            address
+          }
+        }
+        ...useRefreshMetadataFragment
+      }
+    `,
+    tokenRef
+  );
+
+  const { tokenId, contract, externalUrl, tokenMetadata, chain } = token;
+
+  const [refresh, isRefreshing] = useRefreshMetadata(token);
+
+  const openSeaExternalUrl = useMemo(() => {
+    if (chain && contract?.contractAddress?.address && tokenId) {
+      return getOpenseaExternalUrl(chain, contract.contractAddress.address, tokenId);
+    }
+
+    return null;
+  }, [chain, contract?.contractAddress?.address, tokenId]);
+
+  const mirrorXyzUrl = useMemo(() => {
+    if (tokenMetadata) {
+      return extractMirrorXyzUrl(tokenMetadata);
+    }
+
+    return null;
+  }, [tokenMetadata]);
+
+  const prohibitionUrl = useMemo(() => {
+    if (!contract?.contractAddress?.address || !tokenId) {
+      return null;
+    }
+    if (PROHIBITION_CONTRACT_ADDRESSES.includes(contract?.contractAddress?.address)) {
+      return `https://prohibition.art/token/${contract?.contractAddress?.address}-${hexHandler(
+        tokenId
+      )}`;
+    }
+    return null;
+  }, [contract?.contractAddress?.address, tokenId]);
+
+  return (
+    <StyledExternalLinks gap={4}>
+      {mirrorXyzUrl && <InteractiveLink href={mirrorXyzUrl}>View on Mirror</InteractiveLink>}
+      {prohibitionUrl && (
+        <InteractiveLink href={prohibitionUrl}>View on Prohibition</InteractiveLink>
+      )}
+      {openSeaExternalUrl && (
+        <>
+          <InteractiveLink href={openSeaExternalUrl}>View on OpenSea</InteractiveLink>
+          <InteractiveLink onClick={refresh} disabled={isRefreshing}>
+            Refresh metadata
+          </InteractiveLink>
+        </>
+      )}
+      {externalUrl && <InteractiveLink href={externalUrl}>More Info</InteractiveLink>}
+    </StyledExternalLinks>
+  );
+}
+
+const StyledExternalLinks = styled(VStack)``;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -227,7 +227,7 @@ function NftDetailText({ tokenRef }: Props) {
           </VStack>
         ) : null}
 
-        {!showDetails && <TextButton text="More Info" onClick={handleToggleClick} />}
+        {!showDetails && <TextButton text="Show Details" onClick={handleToggleClick} />}
         {showDetails && <TextButton text="Hide Details" onClick={handleToggleClick} />}
       </VStack>
     </StyledDetailLabel>

--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -207,7 +207,7 @@ function NftDetailText({ tokenRef }: Props) {
 
         {showDetails || SHOW_BUY_NOW_BUTTON ? (
           <VStack gap={16}>
-            {showDetails && <NftAdditionalDetails showDetails={showDetails} tokenRef={token} />}
+            {showDetails && <NftAdditionalDetails tokenRef={token} />}
 
             {SHOW_BUY_NOW_BUTTON && (
               <VStack gap={24}>
@@ -227,7 +227,7 @@ function NftDetailText({ tokenRef }: Props) {
           </VStack>
         ) : null}
 
-        {!showDetails && <TextButton text="Show Details" onClick={handleToggleClick} />}
+        {!showDetails && <TextButton text="More Info" onClick={handleToggleClick} />}
         {showDetails && <TextButton text="Hide Details" onClick={handleToggleClick} />}
       </VStack>
     </StyledDetailLabel>


### PR DESCRIPTION
## Description
Adds external link for Prohibition items - links to detail page on prohibition site.
also moves external link logic into its own component to contain all the messy custom platform specific logic. 
also removes unused `showDetails` props

after:
https://github.com/gallery-so/gallery/assets/80802871/a555b00c-50eb-40ea-a4c4-a19258a15f80





regression checks:
poap links still good
![Screenshot 2023-07-25 at 21 40 06](https://github.com/gallery-so/gallery/assets/80802871/a160b3c4-17a9-40e4-8fb4-f33bc029b4eb)

mirror links still good
![Screenshot 2023-07-25 at 21 40 47](https://github.com/gallery-so/gallery/assets/80802871/604a36b2-1a74-497a-9854-9af2055a298a)

other tokens still good
![Screenshot 2023-07-25 at 21 40 37](https://github.com/gallery-so/gallery/assets/80802871/082eb8e4-de2f-460d-8982-9d0abc787569)
