### PR TITLE
add focus outline to composer input

### DIFF
--- a/apps/web/src/components/core/TextArea/TextArea.tsx
+++ b/apps/web/src/components/core/TextArea/TextArea.tsx
@@ -25,6 +25,8 @@ type TextAreaProps = {
   showMarkdownShortcuts?: boolean;
   hasPadding?: boolean;
   maxLength?: number;
+  onFocus?: () => void;
+  onBlur?: () => void;
 };
 
 function isCursorInsideParentheses(textarea: HTMLTextAreaElement) {
@@ -60,6 +62,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       showMarkdownShortcuts = false,
       hasPadding = false,
       maxLength,
+      onFocus = noop,
+      onBlur = noop,
     },
     ref
   ) => {
@@ -108,6 +112,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     return (
       <>
         <StyledTextArea
+          onFocus={onFocus}
+          onBlur={onBlur}
           className={className}
           placeholder={placeholder}
           defaultValue={defaultValue}
@@ -139,7 +145,7 @@ const StyledTextArea = styled.textarea<TextAreaProps>`
   height: 100%;
   padding: 12px;
   font-family: 'ABC Diatype', Helvetica, Arial, sans-serif;
-  border: 1px solid transparent;
+  border: none;
   border-bottom: 36px solid transparent;
   resize: none;
   font-size: 14px;
@@ -147,10 +153,6 @@ const StyledTextArea = styled.textarea<TextAreaProps>`
   background: none;
   color: ${colors.black['800']};
   ${({ textAreaHeight }) => `min-height: ${textAreaHeight}`};
-
-  &:focus {
-    border: 1px solid ${colors.porcelain};
-  }
 `;
 
 TextArea.displayName = 'TextArea';
@@ -168,14 +170,27 @@ export function TextAreaWithCharCount({
   ...textAreaProps
 }: TextAreaWithCharCountProps) {
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const [isFocused, setFocus] = useState(false);
+
+  const handleFocus = () => {
+    setFocus(true);
+  };
+
+  const handleBlur = () => {
+    setFocus(false);
+  };
 
   return (
     <>
-      <StyledTextAreaWithCharCount className={className}>
-        <TextArea ref={textAreaRef} {...textAreaProps} />
+      <StyledTextAreaWithCharCount
+        className={className}
+        hasError={currentCharCount > maxCharCount}
+        isFocused={isFocused}
+      >
+        <TextArea ref={textAreaRef} {...textAreaProps} onFocus={handleFocus} onBlur={handleBlur} />
 
         <StyledCharacterCounter
-          error={currentCharCount > maxCharCount}
+          hasError={currentCharCount > maxCharCount}
           hasPadding={textAreaProps?.hasPadding || false}
         >
           {currentCharCount}/{maxCharCount}
@@ -230,8 +245,22 @@ export function AutoResizingTextAreaWithCharCount({
     [textAreaProps]
   );
 
+  const [isFocused, setFocus] = useState(false);
+
+  const handleFocus = () => {
+    setFocus(true);
+  };
+
+  const handleBlur = () => {
+    setFocus(false);
+  };
+
   return (
-    <StyledTextAreaWithCharCount className={textAreaProps.className}>
+    <StyledTextAreaWithCharCount
+      className={textAreaProps.className}
+      hasError={textAreaProps.currentCharCount > textAreaProps.maxCharCount}
+      isFocused={isFocused}
+    >
       <StyledParentContainer
         style={{
           minHeight: parentHeight,
@@ -242,9 +271,11 @@ export function AutoResizingTextAreaWithCharCount({
           ref={textAreaRef}
           textAreaHeight={textAreaHeight}
           onChange={handleChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
         />
         <StyledCharacterCounter
-          error={textAreaProps.currentCharCount > textAreaProps.maxCharCount}
+          hasError={textAreaProps.currentCharCount > textAreaProps.maxCharCount}
           hasPadding={textAreaProps?.hasPadding || false}
         >
           {textAreaProps.currentCharCount}/{textAreaProps.maxCharCount}
@@ -254,22 +285,26 @@ export function AutoResizingTextAreaWithCharCount({
   );
 }
 
-const StyledTextAreaWithCharCount = styled.div`
+const StyledTextAreaWithCharCount = styled.div<{ hasError: boolean; isFocused: boolean }>`
   position: relative;
   background: ${colors.faint};
   padding-bottom: 1px; /* This fixes a FF bug where the bottom border does not appear */
+
+  border: 1px solid
+    ${({ hasError, isFocused }) =>
+      hasError ? colors.error : isFocused ? colors.porcelain : 'transparent'};
 `;
 
 const StyledParentContainer = styled.div`
   padding-bottom: 32px;
 `;
 
-const StyledCharacterCounter = styled(BaseM)<{ error: boolean; hasPadding: boolean }>`
+const StyledCharacterCounter = styled(BaseM)<{ hasError: boolean; hasPadding: boolean }>`
   position: absolute;
   bottom: ${({ hasPadding }) => (hasPadding ? '8px' : '0')};
   right: ${({ hasPadding }) => (hasPadding ? '8px' : '0')};
 
-  color: ${({ error }) => (error ? colors.red : colors.metal)};
+  color: ${({ hasError }) => (hasError ? colors.red : colors.metal)};
 `;
 
 const StyledMarkdownContainer = styled.div<{ hasPadding: boolean }>`

--- a/apps/web/src/components/core/TextArea/TextArea.tsx
+++ b/apps/web/src/components/core/TextArea/TextArea.tsx
@@ -172,13 +172,13 @@ export function TextAreaWithCharCount({
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const [isFocused, setFocus] = useState(false);
 
-  const handleFocus = () => {
+  const handleFocus = useCallback(() => {
     setFocus(true);
-  };
+  }, []);
 
-  const handleBlur = () => {
+  const handleBlur = useCallback(() => {
     setFocus(false);
-  };
+  }, []);
 
   return (
     <>
@@ -247,13 +247,13 @@ export function AutoResizingTextAreaWithCharCount({
 
   const [isFocused, setFocus] = useState(false);
 
-  const handleFocus = () => {
+  const handleFocus = useCallback(() => {
     setFocus(true);
-  };
+  }, []);
 
-  const handleBlur = () => {
+  const handleBlur = useCallback(() => {
     setFocus(false);
-  };
+  }, []);
 
   return (
     <StyledTextAreaWithCharCount

--- a/apps/web/src/components/core/TextArea/TextArea.tsx
+++ b/apps/web/src/components/core/TextArea/TextArea.tsx
@@ -139,7 +139,7 @@ const StyledTextArea = styled.textarea<TextAreaProps>`
   height: 100%;
   padding: 12px;
   font-family: 'ABC Diatype', Helvetica, Arial, sans-serif;
-  border: none;
+  border: 1px solid transparent;
   border-bottom: 36px solid transparent;
   resize: none;
   font-size: 14px;
@@ -147,6 +147,10 @@ const StyledTextArea = styled.textarea<TextAreaProps>`
   background: none;
   color: ${colors.black['800']};
   ${({ textAreaHeight }) => `min-height: ${textAreaHeight}`};
+
+  &:focus {
+    border: 1px solid ${colors.porcelain};
+  }
 `;
 
 TextArea.displayName = 'TextArea';


### PR DESCRIPTION
adds a faint border to the text input when active, and a red border when there's an error

![Screenshot 2023-07-27 at 22 03 14](https://github.com/gallery-so/gallery/assets/80802871/a40fb987-e91c-4246-9640-94c3857632a7)
