### PR TITLE
Add dropdown menu to posts

### DIFF
--- a/apps/web/src/components/Feed/FeedItem.tsx
+++ b/apps/web/src/components/Feed/FeedItem.tsx
@@ -50,13 +50,14 @@ function FeedItem({ eventRef, queryRef, feedMode }: FeedItemProps) {
     graphql`
       fragment FeedItemQueryFragment on Query {
         ...FeedEventDataQueryFragment
+        ...PostDataQueryFragment
       }
     `,
     queryRef
   );
 
   if (postOrFeedEvent.__typename === 'Post') {
-    return <PostData postRef={postOrFeedEvent} />;
+    return <PostData postRef={postOrFeedEvent} queryRef={query} />;
   }
 
   if (postOrFeedEvent.__typename === 'FeedEvent') {

--- a/apps/web/src/components/Feed/Posts/DeletePostConfirmation.tsx
+++ b/apps/web/src/components/Feed/Posts/DeletePostConfirmation.tsx
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react';
+import styled from 'styled-components';
+
+import { Button } from '~/components/core/Button/Button';
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { BaseM } from '~/components/core/Text/Text';
+import { useModalActions } from '~/contexts/modal/ModalContext';
+import useDeletePost from '~/hooks/api/posts/useDeletePost';
+
+type Props = {
+  postId: string;
+};
+
+export default function DeletePostConfirmation({ postId }: Props) {
+  const [isLoading, setIsLoading] = useState(false);
+  const deletePost = useDeletePost();
+  const { hideModal } = useModalActions();
+
+  const handleConfirmClick = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      await deletePost(postId);
+    } catch (error) {
+      return;
+    }
+    setIsLoading(false);
+    hideModal();
+  }, [deletePost, hideModal, postId]);
+  return (
+    <VStack gap={16}>
+      <VStack>
+        <BaseM>Are you sure you want to delete this post?</BaseM>
+        <BaseM>This cannot be undone.</BaseM>
+      </VStack>
+      <HStack justify="flex-end">
+        <StyledButton onClick={handleConfirmClick} disabled={isLoading} pending={isLoading}>
+          Delete
+        </StyledButton>
+      </HStack>
+    </VStack>
+  );
+}
+
+const StyledButton = styled(Button)`
+  width: 80px;
+`;

--- a/apps/web/src/components/Feed/Posts/PostData.tsx
+++ b/apps/web/src/components/Feed/Posts/PostData.tsx
@@ -8,6 +8,7 @@ import { BaseM, BaseS } from '~/components/core/Text/Text';
 import HoverCardOnUsername from '~/components/HoverCard/HoverCardOnUsername';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { PostDataFragment$key } from '~/generated/PostDataFragment.graphql';
+import { PostDataQueryFragment$key } from '~/generated/PostDataQueryFragment.graphql';
 import useWindowSize, { useBreakpoint } from '~/hooks/useWindowSize';
 import colors from '~/shared/theme/colors';
 import { getTimeSince } from '~/shared/utils/time';

--- a/apps/web/src/components/Feed/Posts/PostData.tsx
+++ b/apps/web/src/components/Feed/Posts/PostData.tsx
@@ -15,13 +15,15 @@ import { getCommunityUrlForToken } from '~/utils/getCommunityUrlForToken';
 
 import { getFeedTokenDimensions } from '../dimensions';
 import { StyledTime } from '../Events/EventStyles';
+import PostDropdown from './PostDropdown';
 import PostNftPreview from './PostNftPreview';
 
 type Props = {
   postRef: PostDataFragment$key;
+  queryRef: PostDataQueryFragment$key;
 };
 
-export default function PostData({ postRef }: Props) {
+export default function PostData({ postRef, queryRef }: Props) {
   const post = useFragment(
     graphql`
       fragment PostDataFragment on Post {
@@ -42,9 +44,19 @@ export default function PostData({ postRef }: Props) {
           ...PostNftPreviewFragment
         }
         creationTime
+        ...PostDropdownFragment
       }
     `,
     postRef
+  );
+
+  const query = useFragment(
+    graphql`
+      fragment PostDataQueryFragment on Query {
+        ...PostDropdownQueryFragment
+      }
+    `,
+    queryRef
   );
 
   const breakpoint = useBreakpoint();
@@ -82,13 +94,19 @@ export default function PostData({ postRef }: Props) {
               )}
             </VStack>
           </HStack>
-          <StyledTime>{getTimeSince(post.creationTime)}</StyledTime>
+          <HStack align="center" gap={4}>
+            <StyledTime>{getTimeSince(post.creationTime)}</StyledTime>
+            <PostDropdown postRef={post} queryRef={query} />
+          </HStack>
         </HStack>
         <StyledCaption>{post.caption}</StyledCaption>
       </VStack>
       <StyledTokenContainer justify="center" align="center">
-        {token && <PostNftPreview tokenRef={token} tokenSize={tokenSize} />}
-        {!token && <BaseM color={colors.shadow}>There was an error displaying this item</BaseM>}
+        {token ? (
+          <PostNftPreview tokenRef={token} tokenSize={tokenSize} />
+        ) : (
+          <BaseM color={colors.shadow}>There was an error displaying this item</BaseM>
+        )}
       </StyledTokenContainer>
     </StyledPost>
   );

--- a/apps/web/src/components/Feed/Posts/PostDropdown.tsx
+++ b/apps/web/src/components/Feed/Posts/PostDropdown.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useMemo } from 'react';
+import { graphql, useFragment } from 'react-relay';
+
+import CopyToClipboard from '~/components/CopyToClipboard/CopyToClipboard';
+import { DropdownItem } from '~/components/core/Dropdown/DropdownItem';
+import { DropdownSection } from '~/components/core/Dropdown/DropdownSection';
+import SettingsDropdown from '~/components/core/Dropdown/SettingsDropdown';
+import { BaseM } from '~/components/core/Text/Text';
+import { useModalActions } from '~/contexts/modal/ModalContext';
+import { PostDropdownFragment$key } from '~/generated/PostDropdownFragment.graphql';
+import { PostDropdownQueryFragment$key } from '~/generated/PostDropdownQueryFragment.graphql';
+import useTokenDetailModal from '~/hooks/useTokenDetailModal';
+import { getBaseUrl } from '~/utils/getBaseUrl';
+
+import DeletePostConfirmation from './DeletePostConfirmation';
+
+type Props = {
+  postRef: PostDropdownFragment$key;
+  queryRef: PostDropdownQueryFragment$key;
+};
+
+export default function PostDropdown({ postRef, queryRef }: Props) {
+  const post = useFragment(
+    graphql`
+      fragment PostDropdownFragment on Post {
+        __typename
+        dbid
+        author @required(action: THROW) {
+          ... on GalleryUser {
+            dbid
+            username
+          }
+        }
+        tokens {
+          dbid
+          owner {
+            username
+          }
+        }
+        #
+      }
+    `,
+    postRef
+  );
+
+  const query = useFragment(
+    graphql`
+      fragment PostDropdownQueryFragment on Query {
+        viewer {
+          ... on Viewer {
+            __typename
+            user {
+              dbid
+            }
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  const viewerIsPostAuthor =
+    query.viewer?.__typename === 'Viewer' && query.viewer?.user?.dbid === post.author.dbid;
+
+  const token = post.tokens && post.tokens[0];
+
+  const postUrl = useMemo(() => {
+    return `${getBaseUrl()}/post/${post.dbid}`;
+  }, [post.dbid]);
+
+  const showTokenDetailModal = useTokenDetailModal();
+  const { showModal } = useModalActions();
+
+  const handleViewDetailsClick = useCallback(() => {
+    if (!token) {
+      return;
+    }
+    const ownerUsername = token.owner?.username ?? '';
+    showTokenDetailModal(ownerUsername, token.dbid);
+  }, [showTokenDetailModal, token]);
+
+  const handleDeletePostClick = useCallback(() => {
+    showModal({
+      content: <DeletePostConfirmation postId={post.dbid} />,
+      headerText: 'Delete Post',
+    });
+  }, [post.dbid, showModal]);
+
+  if (viewerIsPostAuthor) {
+    return (
+      <SettingsDropdown iconVariant="default">
+        <DropdownSection>
+          <CopyToClipboard textToCopy={postUrl}>
+            <DropdownItem onClick={() => {}}>
+              <BaseM>Share</BaseM>
+            </DropdownItem>
+          </CopyToClipboard>
+          {token && (
+            <DropdownItem onClick={handleViewDetailsClick}>
+              <BaseM>View Item Detail</BaseM>
+            </DropdownItem>
+          )}
+          <DropdownItem onClick={handleDeletePostClick}>
+            <BaseM>Delete</BaseM>
+          </DropdownItem>
+        </DropdownSection>
+      </SettingsDropdown>
+    );
+  }
+
+  return (
+    <SettingsDropdown iconVariant="default">
+      <DropdownSection>
+        <DropdownItem onClick={() => {}}>
+          <BaseM>Share</BaseM>
+        </DropdownItem>
+        {/* <DropdownItem onClick={handleFollowClick}>
+          <BaseM>Follow</BaseM>
+        </DropdownItem> */}
+        {token && (
+          <DropdownItem onClick={handleViewDetailsClick}>
+            <BaseM>View Item Detail</BaseM>
+          </DropdownItem>
+        )}
+      </DropdownSection>
+    </SettingsDropdown>
+  );
+}

--- a/apps/web/src/components/Feed/Posts/PostDropdown.tsx
+++ b/apps/web/src/components/Feed/Posts/PostDropdown.tsx
@@ -114,6 +114,7 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
         <DropdownItem onClick={() => {}}>
           <BaseM>Share</BaseM>
         </DropdownItem>
+        {/* Follow up: GAL-3862 */}
         {/* <DropdownItem onClick={handleFollowClick}>
           <BaseM>Follow</BaseM>
         </DropdownItem> */}

--- a/apps/web/src/components/Feed/Posts/PostNftPreview.tsx
+++ b/apps/web/src/components/Feed/Posts/PostNftPreview.tsx
@@ -1,18 +1,14 @@
-import { useRouter } from 'next/router';
-import { Suspense, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
-import breakpoints from '~/components/core/breakpoints';
-import FullPageLoader from '~/components/core/Loader/FullPageLoader';
 import { StyledImageWithLoading } from '~/components/LoadingAsset/ImageWithLoading';
 import NftPreview from '~/components/NftPreview/NftPreview';
-import { useModalActions } from '~/contexts/modal/ModalContext';
 import ShimmerProvider from '~/contexts/shimmer/ShimmerContext';
 import { PostNftPreviewFragment$key } from '~/generated/PostNftPreviewFragment.graphql';
+import useTokenDetailModal from '~/hooks/useTokenDetailModal';
 import { StyledVideo } from '~/scenes/NftDetailPage/NftDetailVideo';
-import { LoadableTokenDetailView } from '~/scenes/TokenDetailPage/TokenDetailView';
 
 type Props = {
   tokenRef: PostNftPreviewFragment$key;
@@ -33,36 +29,13 @@ export default function PostNftPreview({ tokenRef, tokenSize }: Props) {
     tokenRef
   );
 
-  const { showModal } = useModalActions();
-  const router = useRouter();
+  const showTokenDetailModal = useTokenDetailModal();
 
   const handleClick = useCallback(() => {
-    const ownerUsername = token.owner?.username;
+    const ownerUsername = token.owner?.username ?? '';
 
-    const currentUrl = router.asPath;
-    const newUrl = `/${ownerUsername}/token/${token.dbid}`;
-    // set Token Detail Page url without reloading the page. This allows the modal to open quickly, and the user can copy the url
-    window.history.replaceState({ ...window.history.state, as: newUrl, url: newUrl }, '', newUrl);
-
-    showModal({
-      content: (
-        <StyledTokenPreviewModal>
-          <Suspense fallback={<FullPageLoader />}>
-            <LoadableTokenDetailView tokenId={token.dbid} />
-          </Suspense>
-        </StyledTokenPreviewModal>
-      ),
-      isFullPage: true,
-      onClose: () => {
-        // reset url to previous url without reloading the page
-        window.history.replaceState(
-          { ...window.history.state, as: currentUrl, url: currentUrl },
-          '',
-          currentUrl
-        );
-      },
-    });
-  }, [router.asPath, showModal, token.dbid, token.owner?.username]);
+    showTokenDetailModal(ownerUsername, token.dbid);
+  }, [showTokenDetailModal, token.dbid, token.owner?.username]);
 
   return (
     <StyledPostNftPreview width={tokenSize} height={tokenSize}>
@@ -86,16 +59,5 @@ const StyledPostNftPreview = styled.div<{ width: number; height: number }>`
   ${StyledImageWithLoading}, ${StyledVideo} {
     max-width: ${({ width }) => width}px;
     max-height: ${({ height }) => height}px;
-  }
-`;
-
-const StyledTokenPreviewModal = styled.div`
-  display: flex;
-  justify-content: center;
-  height: 100%;
-  padding: 80px 0;
-
-  @media only screen and ${breakpoints.desktop} {
-    padding: 0;
   }
 `;

--- a/apps/web/src/components/core/Dropdown/Dropdown.tsx
+++ b/apps/web/src/components/core/Dropdown/Dropdown.tsx
@@ -52,6 +52,7 @@ export function Dropdown({
         active={active}
         onMouseLeave={onMouseLeave}
         onMouseEnter={onMouseEnter}
+        onClick={handleClose}
       >
         {children}
       </DropdownContainer>

--- a/apps/web/src/components/core/Dropdown/DropdownItem.tsx
+++ b/apps/web/src/components/core/Dropdown/DropdownItem.tsx
@@ -10,6 +10,7 @@ export const DropdownItem = styled.div<{ disabled?: boolean }>`
   font-weight: 400;
   font-size: 12px;
   line-height: 16px;
+  width: 100%;
 
   color: ${({ disabled }) => (disabled ? '#c2c2c2' : colors.shadow)};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};

--- a/apps/web/src/hooks/api/posts/useDeletePost.ts
+++ b/apps/web/src/hooks/api/posts/useDeletePost.ts
@@ -1,0 +1,65 @@
+import { useCallback } from 'react';
+import { graphql, SelectorStoreUpdater } from 'relay-runtime';
+
+import { useToastActions } from '~/contexts/toast/ToastContext';
+import { useDeletePostMutation } from '~/generated/useDeletePostMutation.graphql';
+import { useReportError } from '~/shared/contexts/ErrorReportingContext';
+import { usePromisifiedMutation } from '~/shared/relay/usePromisifiedMutation';
+
+export default function useDeletePost() {
+  const [deletePost] = usePromisifiedMutation<useDeletePostMutation>(graphql`
+    mutation useDeletePostMutation($postId: DBID!) @raw_response_type {
+      deletePost(postId: $postId) {
+        ... on DeletePostPayload {
+          __typename
+        }
+      }
+    }
+  `);
+
+  const { pushToast } = useToastActions();
+  const reportError = useReportError();
+
+  return useCallback(
+    async (postDbid: string) => {
+      const updater: SelectorStoreUpdater<useDeletePostMutation['response']> = (
+        store,
+        response
+      ) => {
+        if (response.deletePost?.__typename === 'DeletePostPayload') {
+          store.delete(`Post:${postDbid}`);
+        }
+      };
+
+      try {
+        const response = await deletePost({
+          updater,
+          variables: {
+            postId: postDbid,
+          },
+        });
+
+        if (response?.deletePost?.__typename === 'DeletePostPayload') {
+          pushToast({
+            autoClose: true,
+            message: `Your post has been deleted.`,
+          });
+        } else {
+          pushToast({
+            autoClose: true,
+            message: `Something went wrong while deleting this post. We're looking into it.`,
+          });
+        }
+        return;
+      } catch (error) {
+        if (error instanceof Error) {
+          reportError(error);
+        } else {
+          reportError(`Could not remove admire on post for an unknown reason`);
+        }
+        throw error;
+      }
+    },
+    [deletePost, pushToast, reportError]
+  );
+}

--- a/apps/web/src/hooks/useTokenDetailModal.tsx
+++ b/apps/web/src/hooks/useTokenDetailModal.tsx
@@ -1,0 +1,51 @@
+import { useRouter } from 'next/router';
+import { Suspense, useCallback } from 'react';
+import styled from 'styled-components';
+
+import breakpoints from '~/components/core/breakpoints';
+import FullPageLoader from '~/components/core/Loader/FullPageLoader';
+import { useModalActions } from '~/contexts/modal/ModalContext';
+import { LoadableTokenDetailView } from '~/scenes/TokenDetailPage/TokenDetailView';
+
+export default function useTokenDetailModal() {
+  const { showModal } = useModalActions();
+  const router = useRouter();
+
+  return useCallback(
+    (ownerUsername: string, tokenDbid: string) => {
+      const currentUrl = router.asPath;
+      const newUrl = `/${ownerUsername}/token/${tokenDbid}`;
+      // set Token Detail Page url without reloading the page. This allows the modal to open quickly, and the user can copy the url
+      window.history.replaceState({ ...window.history.state, as: newUrl, url: newUrl }, '', newUrl);
+      showModal({
+        content: (
+          <StyledTokenPreviewModal>
+            <Suspense fallback={<FullPageLoader />}>
+              <LoadableTokenDetailView tokenId={tokenDbid} />
+            </Suspense>
+          </StyledTokenPreviewModal>
+        ),
+        isFullPage: true,
+        onClose: () => {
+          // reset url to previous url without reloading the page
+          window.history.replaceState(
+            { ...window.history.state, as: currentUrl, url: currentUrl },
+            '',
+            currentUrl
+          );
+        },
+      });
+    },
+    [router.asPath, showModal]
+  );
+}
+const StyledTokenPreviewModal = styled.div`
+  display: flex;
+  justify-content: center;
+  height: 100%;
+  padding: 80px 0;
+
+  @media only screen and ${breakpoints.desktop} {
+    padding: 0;
+  }
+`;


### PR DESCRIPTION
## Description
Adds a dropdown menu to posts for sharing, deletion, etc


There are 2 states
**User is author of post:**

- [x] Share: copies Post page url
- [x] View Item Detail: opens token detail page
- [x] Delete: shows Delete Confirmation and lets user delete the post

![Screenshot 2023-07-27 at 17 29 09](https://github.com/gallery-so/gallery/assets/80802871/9efa2de4-8a3e-42cf-943d-89205dc5ad94)


**Someone else's post:**

- [x] Share: copies Post page url
- [x] View Item Detail: opens token detail page
- [ ] Follow: lets user follow or unfollow author (coming soon, can be follow up) GAL-3862

![Screenshot 2023-07-27 at 17 28 54](https://github.com/gallery-so/gallery/assets/80802871/f7501a69-2539-411d-b939-e34d0c1450ae)





What deleting looks like:

https://github.com/gallery-so/gallery/assets/80802871/b6e1d1ec-5430-4498-843b-47a0c28463e9

