### PR TITLE
bump admire double tap window from 200 to 250ms

### DIFF
--- a/apps/mobile/src/components/Feed/EventTokenGrid.tsx
+++ b/apps/mobile/src/components/Feed/EventTokenGrid.tsx
@@ -80,7 +80,7 @@ export function EventTokenGrid({
       // ChatGPT says 200ms is at the fast end for double tapping.
       // I want the single tap flow to feel fast, so I'm going for speed here.
       // Our users better be nimble af.
-      const DOUBLE_TAP_WINDOW = 200;
+      const DOUBLE_TAP_WINDOW = 250;
 
       if (singleTapTimeoutRef.current) {
         clearTimeout(singleTapTimeoutRef.current);


### PR DESCRIPTION
Title says it all.
addressing feedback that the window feels a bit tight and sometimes accidentally navigate to the NFT Detail Page instead of admiring.
it's a feel thing so we'll try 250 and see if it makes a tangible difference