### PR TITLE
fix edit mode regression

### DIFF
--- a/apps/web/src/components/MultiGallery/Gallery.tsx
+++ b/apps/web/src/components/MultiGallery/Gallery.tsx
@@ -1,5 +1,6 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useRouter } from 'next/router';
 import { Route } from 'nextjs-routes';
 import { useCallback, useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
@@ -94,6 +95,9 @@ export default function Gallery({
     `,
     queryRef
   );
+
+  const router = useRouter();
+  const { mode } = router.query;
 
   if (!gallery?.owner?.username) {
     throw new Error('This gallery does not have an owner.');
@@ -265,7 +269,7 @@ export default function Gallery({
 
   return (
     <StyledGalleryWrapper isDragging={isDragging}>
-      <UnstyledLink href={isAuthenticatedUser ? galleryEditLink : galleryLink}>
+      <UnstyledLink href={isAuthenticatedUser && mode === 'edit' ? galleryEditLink : galleryLink}>
         <StyledGalleryDraggable
           gap={12}
           isAuthedUser={isAuthenticatedUser}

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
@@ -193,7 +193,7 @@ export function StandardSidebar({ queryRef }: Props) {
   }, [username]);
 
   const editGalleriesRoute: Route = useMemo(() => {
-    return { pathname: '/[username]/galleries', query: { username } };
+    return { pathname: '/[username]/galleries', query: { username, mode: 'edit' } };
   }, [username]);
 
   const isLoggedInProfileActive = useMemo(() => {


### PR DESCRIPTION
## Description
- clicking on the edit icon in the sidebar now navigates user to `/user/galleries?mode=edit`
- the gallery tile component checks if the mode is set to `edit` and accordingly links either to the `gallery edit` page or the `gallery view` page

## Demo:
https://www.loom.com/share/51f2dd8131d34f2a972537a805abe3a0?sid=046637dd-7a97-43da-86d6-3b0b991768e8

