### PR TITLE
GAL-2990: last refreshed timestamp on NFT detail page

### DIFF
--- a/apps/web/src/components/Pill.tsx
+++ b/apps/web/src/components/Pill.tsx
@@ -40,6 +40,7 @@ export const ButtonPill = styled.button<{ active?: boolean }>`
   display: flex;
   align-items: center;
   background-color: ${colors.offWhite};
+  cursor: hover;
 
   ${({ active }) =>
     active &&

--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftDetailsExternalLinksEth.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftDetailsExternalLinksEth.tsx
@@ -83,7 +83,7 @@ export default function NftDetailsExternalLinksEth({ tokenRef }: Props) {
   }, [contract?.contractAddress?.address, tokenId]);
   const { floating, reference, getFloatingProps, getReferenceProps, floatingStyle } =
     useTooltipHover({
-      placement: 'right',
+      placement: 'top',
     });
 
   const lastUpdated = formatDateString(lastUpdatedRaw, DateFormatOption.ABBREVIATED);

--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftDetailsExternalLinksEth.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftDetailsExternalLinksEth.tsx
@@ -2,9 +2,15 @@ import { useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
+import IconContainer from '~/components/core/IconContainer';
 import InteractiveLink from '~/components/core/InteractiveLink/InteractiveLink';
-import { VStack } from '~/components/core/Spacer/Stack';
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { TitleDiatypeM } from '~/components/core/Text/Text';
+import { ButtonPill } from '~/components/Pill';
+import { NewTooltip } from '~/components/Tooltip/NewTooltip';
+import { useTooltipHover } from '~/components/Tooltip/useTooltipHover';
 import { NftDetailsExternalLinksEthFragment$key } from '~/generated/NftDetailsExternalLinksEthFragment.graphql';
+import { RefreshIcon } from '~/icons/RefreshIcon';
 import { extractMirrorXyzUrl } from '~/shared/utils/extractMirrorXyzUrl';
 import { getOpenseaExternalUrl, hexHandler } from '~/shared/utils/getOpenseaExternalUrl';
 
@@ -66,6 +72,10 @@ export default function NftDetailsExternalLinksEth({ tokenRef }: Props) {
     }
     return null;
   }, [contract?.contractAddress?.address, tokenId]);
+  const { floating, reference, getFloatingProps, getReferenceProps, floatingStyle } =
+    useTooltipHover({
+      placement: 'right',
+    });
 
   return (
     <StyledExternalLinks gap={4}>
@@ -74,12 +84,27 @@ export default function NftDetailsExternalLinksEth({ tokenRef }: Props) {
         <InteractiveLink href={prohibitionUrl}>View on Prohibition</InteractiveLink>
       )}
       {openSeaExternalUrl && (
-        <>
+        <VStack gap={14}>
           <InteractiveLink href={openSeaExternalUrl}>View on OpenSea</InteractiveLink>
-          <InteractiveLink onClick={refresh} disabled={isRefreshing}>
-            Refresh metadata
-          </InteractiveLink>
-        </>
+          <StartAlignedButtonPill
+            onClick={refresh}
+            disabled={isRefreshing}
+            ref={reference}
+            {...getReferenceProps()}
+          >
+            <HStack gap={6}>
+              <IconContainer size="xs" variant="default" icon={<RefreshIcon />} />
+              <TitleDiatypeM>Refresh metadata</TitleDiatypeM>
+            </HStack>
+            <NewTooltip
+              {...getFloatingProps()}
+              style={{ ...floatingStyle }}
+              ref={floating}
+              whiteSpace="pre-line"
+              text={`Last refreshed `}
+            />
+          </StartAlignedButtonPill>
+        </VStack>
       )}
       {externalUrl && <InteractiveLink href={externalUrl}>More Info</InteractiveLink>}
     </StyledExternalLinks>
@@ -87,3 +112,7 @@ export default function NftDetailsExternalLinksEth({ tokenRef }: Props) {
 }
 
 const StyledExternalLinks = styled(VStack)``;
+
+const StartAlignedButtonPill = styled(ButtonPill)`
+  align-self: start;
+`;

--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftDetailsExternalLinksEth.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftDetailsExternalLinksEth.tsx
@@ -89,7 +89,7 @@ export default function NftDetailsExternalLinksEth({ tokenRef }: Props) {
   const lastUpdated = formatDateString(lastUpdatedRaw, DateFormatOption.ABBREVIATED);
 
   return (
-    <StyledExternalLinks gap={4}>
+    <StyledExternalLinks gap={14}>
       {mirrorXyzUrl && <InteractiveLink href={mirrorXyzUrl}>View on Mirror</InteractiveLink>}
       {prohibitionUrl && (
         <InteractiveLink href={prohibitionUrl}>View on Prohibition</InteractiveLink>

--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftDetailsExternalLinksEth.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftDetailsExternalLinksEth.tsx
@@ -13,6 +13,7 @@ import { NftDetailsExternalLinksEthFragment$key } from '~/generated/NftDetailsEx
 import { RefreshIcon } from '~/icons/RefreshIcon';
 import { extractMirrorXyzUrl } from '~/shared/utils/extractMirrorXyzUrl';
 import { getOpenseaExternalUrl, hexHandler } from '~/shared/utils/getOpenseaExternalUrl';
+import { DateFormatOption, formatDateString } from '~/utils/formatDateString';
 
 import { useRefreshMetadata } from './useRefreshMetadata';
 
@@ -30,6 +31,7 @@ export default function NftDetailsExternalLinksEth({ tokenRef }: Props) {
         tokenId
         tokenMetadata
         chain
+        lastUpdated
         contract {
           contractAddress {
             address
@@ -41,7 +43,14 @@ export default function NftDetailsExternalLinksEth({ tokenRef }: Props) {
     tokenRef
   );
 
-  const { tokenId, contract, externalUrl, tokenMetadata, chain } = token;
+  const {
+    tokenId,
+    contract,
+    externalUrl,
+    tokenMetadata,
+    chain,
+    lastUpdated: lastUpdatedRaw,
+  } = token;
 
   const [refresh, isRefreshing] = useRefreshMetadata(token);
 
@@ -77,6 +86,8 @@ export default function NftDetailsExternalLinksEth({ tokenRef }: Props) {
       placement: 'right',
     });
 
+  const lastUpdated = formatDateString(lastUpdatedRaw, DateFormatOption.ABBREVIATED);
+
   return (
     <StyledExternalLinks gap={4}>
       {mirrorXyzUrl && <InteractiveLink href={mirrorXyzUrl}>View on Mirror</InteractiveLink>}
@@ -101,7 +112,7 @@ export default function NftDetailsExternalLinksEth({ tokenRef }: Props) {
               style={{ ...floatingStyle }}
               ref={floating}
               whiteSpace="pre-line"
-              text={`Last refreshed `}
+              text={`Last refreshed ${lastUpdated}`}
             />
           </StartAlignedButtonPill>
         </VStack>

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
@@ -57,6 +57,7 @@ const UnknownMediaResponse: NftDetailAssetTestQueryQuery = {
       dbid: 'testTokenId',
       chain: Chain.Ethereum,
       tokenMetadata: '{}',
+      lastUpdated: '2023-07-25T11:47:41.83653Z',
       owner: {
         id: 'GalleryUser:TestOwnerId',
         username: 'Test Username',

--- a/apps/web/src/utils/formatDateString.ts
+++ b/apps/web/src/utils/formatDateString.ts
@@ -1,0 +1,17 @@
+import { format } from 'date-fns';
+
+// Define an enum with user-friendly names for format options
+export enum DateFormatOption {
+  ABBREVIATED = 'MMM d h:mm a', // e.g., "Jul 28 4:47 PM"
+  FULL = 'MMMM d, yyyy h:mm a', // e.g., "July 28, 2023 4:47 PM"
+  ISO_8601 = 'yyyy-MM-dd HH:mm:ss', // e.g., "2023-07-28 15:47:51"
+}
+
+// Utility function to format a date string
+export const formatDateString = (
+  inputDateString: string,
+  formatOption: DateFormatOption
+): string => {
+  const date: Date = new Date(inputDateString);
+  return format(date, formatOption);
+};


### PR DESCRIPTION
## Description
change the Refresh Metadata `InteractiveLink` to a `ButtonPill` component that shows the **last refreshed timestamp** in the `ToolTip`

## TODOs
- [x] add necessary stylings for last refreshed metadata pill button
- [x] fetch the timestamp data from the backend & use it in the tooltip text
- [x] add the refresh pill component for Tezos details page
- [ ] test the tooltip text different screen sizes

## Demo
https://www.loom.com/share/26481b03fa5e4f8193d34a24c88fea79?sid=fc8b3c32-c734-42a9-8f91-3f845a77f9da

#### how it looks in different scenarios on Eth:
<img width="356" alt="CleanShot 2023-07-28 at 23 40 16@2x" src="https://github.com/gallery-so/gallery/assets/26466468/1072b978-622c-4eef-9307-4dc4fd8cc521">
<img width="367" alt="CleanShot 2023-07-28 at 23 41 51@2x" src="https://github.com/gallery-so/gallery/assets/26466468/d4dec56d-931e-4cde-9dad-0e5da3045b54">
<img width="371" alt="CleanShot 2023-07-28 at 23 42 40@2x" src="https://github.com/gallery-so/gallery/assets/26466468/a57b22c2-17b0-46e4-b54d-2833d70a097f">
<img width="432" alt="CleanShot 2023-07-28 at 23 44 05@2x" src="https://github.com/gallery-so/gallery/assets/26466468/7aa09c7b-c4f9-4900-bc29-d08c212f8a64">

#### how it looks on Tezos:
<img width="354" alt="CleanShot 2023-07-28 at 23 51 47@2x" src="https://github.com/gallery-so/gallery/assets/26466468/9d37d5df-8d8b-47fc-8a0f-00555472a474">
<img width="427" alt="CleanShot 2023-07-28 at 23 53 50@2x" src="https://github.com/gallery-so/gallery/assets/26466468/3765236d-1758-4063-a024-2886cebd069a">


