### PR TITLE
Fix bug breaking page when admiring or commenting without pfp

### DIFF
--- a/apps/web/src/hooks/api/feedEvents/useAdmireFeedEvent.ts
+++ b/apps/web/src/hooks/api/feedEvents/useAdmireFeedEvent.ts
@@ -64,7 +64,7 @@ export default function useAdmireFeedEvent() {
         }
       };
       const optimisticId = Math.random().toString();
-      const hasProfileImage = optimisticUserInfo.profileImageUrl !== null;
+      const hasProfileImage = !!optimisticUserInfo.profileImageUrl;
 
       const tokenProfileImagePayload = hasProfileImage
         ? {

--- a/apps/web/src/hooks/api/feedEvents/useCommentOnFeedEvent.ts
+++ b/apps/web/src/hooks/api/feedEvents/useCommentOnFeedEvent.ts
@@ -69,7 +69,7 @@ export default function useCommentOnFeedEvent() {
         };
 
         const optimisticId = Math.random().toString();
-        const hasProfileImage = optimisticUserInfo.profileImageUrl !== null;
+        const hasProfileImage = !!optimisticUserInfo.profileImageUrl;
 
         const tokenProfileImagePayload = hasProfileImage
           ? {

--- a/apps/web/src/hooks/api/posts/useAdmirePost.ts
+++ b/apps/web/src/hooks/api/posts/useAdmirePost.ts
@@ -62,7 +62,7 @@ export default function useAdmirePost() {
       };
 
       const optimisticId = Math.random().toString();
-      const hasProfileImage = optimisticUserInfo.profileImageUrl !== null;
+      const hasProfileImage = !!optimisticUserInfo.profileImageUrl;
 
       const tokenProfileImagePayload = hasProfileImage
         ? {

--- a/apps/web/src/hooks/api/posts/useCommentOnPost.ts
+++ b/apps/web/src/hooks/api/posts/useCommentOnPost.ts
@@ -65,7 +65,7 @@ export default function useCommentOnPost() {
         };
 
         const optimisticId = Math.random().toString();
-        const hasProfileImage = optimisticUserInfo.profileImageUrl !== null;
+        const hasProfileImage = !!optimisticUserInfo.profileImageUrl;
 
         const tokenProfileImagePayload = hasProfileImage
           ? {


### PR DESCRIPTION
## Description

app blows up with full page error when admiring or commenting as a user without a pfp.

the cause was in the optimistic updater for the admire + comment hooks for both posts and feed events.

`const hasProfileImage = optimisticUserInfo.profileImageUrl !== null` was evaluated incorrectly because `optimisticUserInfo.profileImageUrl` was an empty string, not null, in cases where the user did not have a profile image.

fixed the hooks to evaluate this correctly 



## recordings
no errors for user without pfp

https://github.com/gallery-so/gallery/assets/80802871/3cbf26b6-a7d9-497b-912c-18e298f846df



no errors for user with pfp

https://github.com/gallery-so/gallery/assets/80802871/6038deaf-0333-49f9-a8e0-2a79b71a6d15

