### PR TITLE
[GAL-3740] Update User Profile's Following tab layout on web

### DIFF
--- a/apps/web/pages/[username]/followers.tsx
+++ b/apps/web/pages/[username]/followers.tsx
@@ -42,7 +42,7 @@ function FollowersPage({ queryRef }: FollowersPageProps) {
   const isMobile = useIsMobileOrMobileLargeWindowWidth();
   return (
     <GalleryPageSpacing>
-      <VStack gap={isMobile ? 12 : 24}>
+      <VStack gap={isMobile ? 0 : 24}>
         <UserGalleryHeader userRef={query.userByUsername} queryRef={query} />
         <VStack align="center">
           <FollowList queryRef={query} userRef={query.userByUsername} />

--- a/apps/web/pages/[username]/followers.tsx
+++ b/apps/web/pages/[username]/followers.tsx
@@ -33,6 +33,7 @@ function FollowersPage({ queryRef }: FollowersPageProps) {
         }
 
         ...UserGalleryHeaderQueryFragment
+        ...FollowListQueryFragment
       }
     `,
     queryRef
@@ -44,7 +45,7 @@ function FollowersPage({ queryRef }: FollowersPageProps) {
       <VStack gap={isMobile ? 12 : 24}>
         <UserGalleryHeader userRef={query.userByUsername} queryRef={query} />
         <VStack align="center">
-          <FollowList userRef={query.userByUsername} />
+          <FollowList queryRef={query} userRef={query.userByUsername} />
         </VStack>
       </VStack>
     </GalleryPageSpacing>

--- a/apps/web/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/apps/web/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -75,7 +75,7 @@ export default function UserFollowedUsersFeedEvent({
             }
           }
         }
-        ...FollowListUsersQuery
+        ...FollowListUsersQueryFragment
       }
     `,
     queryRef

--- a/apps/web/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/apps/web/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -75,6 +75,7 @@ export default function UserFollowedUsersFeedEvent({
             }
           }
         }
+        ...FollowListUsersQuery
       }
     `,
     queryRef
@@ -131,7 +132,7 @@ export default function UserFollowedUsersFeedEvent({
       showModal({
         content: (
           <StyledFollowList fullscreen={isMobile}>
-            <FollowListUsers userRefs={flattenedGenericFollows} />
+            <FollowListUsers queryRef={query} userRefs={flattenedGenericFollows} />
           </StyledFollowList>
         ),
         isFullPage: isMobile,
@@ -139,7 +140,7 @@ export default function UserFollowedUsersFeedEvent({
         headerVariant: 'thicc',
       });
     },
-    [flattenedGenericFollows, isMobile, showModal, track]
+    [flattenedGenericFollows, isMobile, showModal, track, query]
   );
 
   const followedNoRemainingUsers = genericFollows.length === 0;

--- a/apps/web/src/components/Follow/FollowList.tsx
+++ b/apps/web/src/components/Follow/FollowList.tsx
@@ -107,7 +107,7 @@ const StyledSpan = styled.span<{ active: boolean }>`
   line-height: 21px;
   letter-spacing: -0.04em;
   font-weight: 500;
-  font-size: 18px;
+  font-size: 16px;
 
   @media only screen and ${breakpoints.tablet} {
     font-size: 18px;

--- a/apps/web/src/components/Follow/FollowList.tsx
+++ b/apps/web/src/components/Follow/FollowList.tsx
@@ -91,10 +91,14 @@ export default function FollowList({ userRef, queryRef }: Props) {
 const StyledFollowList = styled.div`
   height: 100%;
   width: 100%;
-  padding-top: 24px;
-  border-top: 1px solid ${colors.porcelain};
   display: flex;
   flex-direction: column;
+  padding-top: 24px;
+
+  @media only screen and ${breakpoints.tablet} {
+    padding-top: 24px;
+    border-top: 1px solid ${colors.porcelain};
+  }
 `;
 
 const StyledHeader = styled(HStack)`

--- a/apps/web/src/components/Follow/FollowList.tsx
+++ b/apps/web/src/components/Follow/FollowList.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components';
 
 import TextButton, { StyledButtonText } from '~/components/core/Button/TextButton';
 import { HStack } from '~/components/core/Spacer/Stack';
+import { BaseS } from '~/components/core/Text/Text';
 import { MODAL_PADDING_THICC_PX } from '~/contexts/modal/constants';
 import { FollowListFragment$key } from '~/generated/FollowListFragment.graphql';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
@@ -40,7 +41,7 @@ export default function FollowList({ userRef }: Props) {
 
   return (
     <StyledFollowList fullscreen={isMobile}>
-      <StyledHeader gap={16} justify="center">
+      <StyledHeader justify="space-between">
         <StyledHeaderTextRight>
           <StyledTextButton
             text="Followers"
@@ -54,6 +55,10 @@ export default function FollowList({ userRef }: Props) {
             onClick={() => setDisplayedList('following')}
             active={displayedList === 'following'}
           />
+          <HStack gap={4} align="baseline">
+            <span>Followers</span>
+            {userList.length > 0 && <BaseS>{userList.length}</BaseS>}
+          </HStack>
         </StyledHeaderText>
       </StyledHeader>
       <FollowListUsers

--- a/apps/web/src/components/Follow/FollowList.tsx
+++ b/apps/web/src/components/Follow/FollowList.tsx
@@ -56,7 +56,11 @@ export default function FollowList({ userRef, queryRef }: Props) {
         >
           <HStack gap={4} align="baseline">
             <span>Followers</span>
-            {user.followers.length > 0 && <BaseS>{user.followers.length}</BaseS>}
+            {user.followers.length > 0 && (
+              <BaseS color={displayedList === 'followers' ? colors.black['800'] : colors.metal}>
+                {user.followers.length}
+              </BaseS>
+            )}
           </HStack>
         </StyledSpan>
         <StyledSpan
@@ -65,7 +69,11 @@ export default function FollowList({ userRef, queryRef }: Props) {
         >
           <HStack gap={4} align="baseline">
             <span>Following</span>
-            {user.following.length > 0 && <BaseS>{user.following.length}</BaseS>}
+            {user.following.length > 0 && (
+              <BaseS color={displayedList === 'following' ? colors.black['800'] : colors.metal}>
+                {user.following.length}
+              </BaseS>
+            )}
           </HStack>
         </StyledSpan>
       </StyledHeader>
@@ -111,8 +119,4 @@ const StyledSpan = styled.span<{ active: boolean }>`
 
   cursor: pointer;
   text-decoration: none;
-
-  ${BaseS} {
-    color: ${({ active }) => (active ? colors.black['800'] : colors.metal)};
-  }
 `;

--- a/apps/web/src/components/Follow/FollowList.tsx
+++ b/apps/web/src/components/Follow/FollowList.tsx
@@ -1,13 +1,10 @@
-import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled, { css } from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
-import TextButton, { StyledButtonText } from '~/components/core/Button/TextButton';
 import { HStack } from '~/components/core/Spacer/Stack';
 import { BaseS, BODY_FONT_FAMILY } from '~/components/core/Text/Text';
-import { MODAL_PADDING_THICC_PX } from '~/contexts/modal/constants';
 import { FollowListFragment$key } from '~/generated/FollowListFragment.graphql';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
@@ -75,23 +72,14 @@ export default function FollowList({ userRef }: Props) {
 
 const StyledFollowList = styled.div<{ fullscreen: boolean }>`
   height: 100%;
-  width: ${({ fullscreen }) => (fullscreen ? '100%' : '540px')};
+  width: 100%;
+  padding-top: 24px;
+  border-top: 1px solid ${colors.porcelain};
   display: flex;
   flex-direction: column;
-
-  ${({ fullscreen }) =>
-    fullscreen
-      ? css`
-          width: 100%;
-          padding: ${MODAL_PADDING_THICC_PX}px 8px;
-        `
-      : css`
-          width: 540px;
-        `}
 `;
 
 const StyledHeader = styled(HStack)`
-  padding-bottom: ${MODAL_PADDING_THICC_PX}px;
   display: flex;
   gap: 12px;
 `;
@@ -101,10 +89,10 @@ const StyledSpan = styled.span<{ active: boolean }>`
   line-height: 21px;
   letter-spacing: -0.04em;
   font-weight: 500;
-  font-size: 16px;
+  font-size: 20px;
 
   @media only screen and ${breakpoints.tablet} {
-    font-size: 18px;
+    font-size: 20px;
   }
 
   margin: 0;

--- a/apps/web/src/components/Follow/FollowList.tsx
+++ b/apps/web/src/components/Follow/FollowList.tsx
@@ -1,10 +1,12 @@
+import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled, { css } from 'styled-components';
 
+import breakpoints from '~/components/core/breakpoints';
 import TextButton, { StyledButtonText } from '~/components/core/Button/TextButton';
 import { HStack } from '~/components/core/Spacer/Stack';
-import { BaseS } from '~/components/core/Text/Text';
+import { BaseS, BODY_FONT_FAMILY } from '~/components/core/Text/Text';
 import { MODAL_PADDING_THICC_PX } from '~/contexts/modal/constants';
 import { FollowListFragment$key } from '~/generated/FollowListFragment.graphql';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
@@ -41,25 +43,25 @@ export default function FollowList({ userRef }: Props) {
 
   return (
     <StyledFollowList fullscreen={isMobile}>
-      <StyledHeader justify="space-between">
-        <StyledHeaderTextRight>
-          <StyledTextButton
-            text="Followers"
-            onClick={() => setDisplayedList('followers')}
-            active={displayedList === 'followers'}
-          />
-        </StyledHeaderTextRight>
-        <StyledHeaderText>
-          <StyledTextButton
-            text="Following"
-            onClick={() => setDisplayedList('following')}
-            active={displayedList === 'following'}
-          />
+      <StyledHeader>
+        <StyledSpan
+          active={displayedList === 'followers'}
+          onClick={() => setDisplayedList('followers')}
+        >
           <HStack gap={4} align="baseline">
             <span>Followers</span>
-            {userList.length > 0 && <BaseS>{userList.length}</BaseS>}
+            {user.followers.length > 0 && <BaseS>{user.followers.length}</BaseS>}
           </HStack>
-        </StyledHeaderText>
+        </StyledSpan>
+        <StyledSpan
+          active={displayedList === 'following'}
+          onClick={() => setDisplayedList('following')}
+        >
+          <HStack gap={4} align="baseline">
+            <span>Following</span>
+            {user.following.length > 0 && <BaseS>{user.following.length}</BaseS>}
+          </HStack>
+        </StyledSpan>
       </StyledHeader>
       <FollowListUsers
         userRefs={nonNullUserList}
@@ -90,20 +92,29 @@ const StyledFollowList = styled.div<{ fullscreen: boolean }>`
 
 const StyledHeader = styled(HStack)`
   padding-bottom: ${MODAL_PADDING_THICC_PX}px;
-`;
-
-const StyledHeaderText = styled.div`
   display: flex;
+  gap: 12px;
 `;
 
-const StyledHeaderTextRight = styled(StyledHeaderText)`
-  justify-content: flex-end;
-`;
+const StyledSpan = styled.span<{ active: boolean }>`
+  font-family: ${BODY_FONT_FAMILY};
+  line-height: 21px;
+  letter-spacing: -0.04em;
+  font-weight: 500;
+  font-size: 16px;
 
-const StyledTextButton = styled(TextButton)<{ active: boolean }>`
-  ${({ active }) =>
-    active &&
-    `${StyledButtonText} {
-    color: ${colors.black['800']};
-  }`}
+  @media only screen and ${breakpoints.tablet} {
+    font-size: 18px;
+  }
+
+  margin: 0;
+
+  color: ${({ active }) => (active ? colors.black['800'] : colors.metal)};
+
+  cursor: pointer;
+  text-decoration: none;
+
+  ${BaseS} {
+    color: ${({ active }) => (active ? colors.black['800'] : colors.metal)};
+  }
 `;

--- a/apps/web/src/components/Follow/FollowList.tsx
+++ b/apps/web/src/components/Follow/FollowList.tsx
@@ -13,10 +13,20 @@ import colors from '~/shared/theme/colors';
 import FollowListUsers from './FollowListUsers';
 
 type Props = {
+  queryRef: FollowListQueryFragment$key;
   userRef: FollowListFragment$key;
 };
 
-export default function FollowList({ userRef }: Props) {
+export default function FollowList({ userRef, queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment FollowListQueryFragment on Query {
+        ...FollowListUsersQueryFragment
+      }
+    `,
+    queryRef
+  );
+
   const user = useFragment(
     graphql`
       fragment FollowListFragment on GalleryUser {
@@ -61,6 +71,7 @@ export default function FollowList({ userRef }: Props) {
         </StyledSpan>
       </StyledHeader>
       <FollowListUsers
+        queryRef={query}
         userRefs={nonNullUserList}
         emptyListText={
           displayedList === 'followers' ? 'No followers yet.' : 'Not following anyone yet.'
@@ -70,7 +81,7 @@ export default function FollowList({ userRef }: Props) {
   );
 }
 
-const StyledFollowList = styled.div<{ fullscreen: boolean }>`
+const StyledFollowList = styled.div`
   height: 100%;
   width: 100%;
   padding-top: 24px;
@@ -89,10 +100,10 @@ const StyledSpan = styled.span<{ active: boolean }>`
   line-height: 21px;
   letter-spacing: -0.04em;
   font-weight: 500;
-  font-size: 20px;
+  font-size: 18px;
 
   @media only screen and ${breakpoints.tablet} {
-    font-size: 20px;
+    font-size: 18px;
   }
 
   margin: 0;

--- a/apps/web/src/components/Follow/FollowList.tsx
+++ b/apps/web/src/components/Follow/FollowList.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
 import { HStack } from '~/components/core/Spacer/Stack';

--- a/apps/web/src/components/Follow/FollowList.tsx
+++ b/apps/web/src/components/Follow/FollowList.tsx
@@ -6,7 +6,7 @@ import breakpoints from '~/components/core/breakpoints';
 import { HStack } from '~/components/core/Spacer/Stack';
 import { BaseS, BODY_FONT_FAMILY } from '~/components/core/Text/Text';
 import { FollowListFragment$key } from '~/generated/FollowListFragment.graphql';
-import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
+import { FollowListQueryFragment$key } from '~/generated/FollowListQueryFragment.graphql';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import colors from '~/shared/theme/colors';
 
@@ -42,14 +42,13 @@ export default function FollowList({ userRef, queryRef }: Props) {
   );
 
   const [displayedList, setDisplayedList] = useState<'followers' | 'following'>('followers');
-  const isMobile = useIsMobileOrMobileLargeWindowWidth();
 
   const userList = displayedList === 'followers' ? user.followers : user.following;
 
   const nonNullUserList = useMemo(() => removeNullValues(userList), [userList]);
 
   return (
-    <StyledFollowList fullscreen={isMobile}>
+    <StyledFollowList>
       <StyledHeader>
         <StyledSpan
           active={displayedList === 'followers'}

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -136,7 +136,7 @@ const StyledBaseM = styled(BaseM)`
 `;
 
 const StyledContainer = styled(VStack)`
-  max-width: 250px;
+  max-width: 220px;
 
   @media only screen and ${breakpoints.desktop} {
     max-width: none;

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -56,10 +56,9 @@ export default function FollowListUserItem({
   const isMobile = useIsMobileOrMobileLargeWindowWidth();
   const formattedUserBio = useMemo(() => {
     const truncate = (bio: string) => {
-      if (bio.length > 250 && isMobile) {
-        return `${bio.slice(0, 250)}...`;
-      } else if (bio.length > 320) {
-        return `${bio.slice(0, 320)}...`;
+      const maxLength = isMobile ? 250 : 320;
+      if (bio.length > maxLength && isMobile) {
+        return `${bio.slice(0, maxLength)}...`;
       }
       return bio;
     };

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -72,6 +72,7 @@ export default function FollowListUserItem({
   const onMouseLeave = useCallback(() => {
     setFadeUsernames(false);
   }, [setFadeUsernames]);
+
   return (
     <StyledListItem
       onMouseEnter={onMouseEnter}
@@ -138,7 +139,7 @@ const StyledBaseM = styled(BaseM)`
 const StyledContainer = styled(VStack)`
   max-width: 220px;
 
-  @media only screen and ${breakpoints.desktop} {
+  @media only screen and ${breakpoints.tablet} {
     max-width: none;
   }
 `;

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -9,6 +9,7 @@ import { BaseM, TitleS } from '~/components/core/Text/Text';
 import FollowButton from '~/components/Follow/FollowButton';
 import { FollowListUserItemFragment$key } from '~/generated/FollowListUserItemFragment.graphql';
 import { FollowListUserItemQueryFragment$key } from '~/generated/FollowListUserItemQueryFragment.graphql';
+import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import colors from '~/shared/theme/colors';
 import { BREAK_LINES } from '~/utils/regex';
 
@@ -52,7 +53,18 @@ export default function FollowListUserItem({
     userRef
   );
 
-  const formattedUserBio = useMemo(() => (user.bio ?? '').replace(BREAK_LINES, ''), [user.bio]);
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
+  const formattedUserBio = useMemo(() => {
+    const truncate = (bio: string) => {
+      if (bio.length > 250 && isMobile) {
+        return `${bio.slice(0, 250)}...`;
+      } else if (bio.length > 320) {
+        return `${bio.slice(0, 320)}...`;
+      }
+      return bio;
+    };
+    return truncate((user.bio ?? '').replace(BREAK_LINES, ''));
+  }, [isMobile, user.bio]);
 
   const onMouseEnter = useCallback(() => {
     setFadeUsernames(true);

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -102,6 +102,7 @@ const StyledListItem = styled.a<{ fadeUsernames: boolean }>`
   transition: color 0.15s ease-in-out, opacity 0.15s ease-in-out;
   opacity: ${({ fadeUsernames }) => (fadeUsernames ? 0.5 : 1)};
   gap: 4px;
+  min-height: 72px;
 
   &:hover {
     color: ${colors.black['800']};

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -73,7 +73,6 @@ export default function FollowListUserItem({
   const onMouseLeave = useCallback(() => {
     setFadeUsernames(false);
   }, [setFadeUsernames]);
-
   return (
     <StyledListItem
       onMouseEnter={onMouseEnter}
@@ -89,9 +88,9 @@ export default function FollowListUserItem({
             <TitleS>{user.username}</TitleS>
             <StyledBaseM>
               {formattedUserBio && (
-                <VStack justify="center">
+                <StyledContainer justify="center">
                   <Markdown text={formattedUserBio} />
-                </VStack>
+                </StyledContainer>
               )}
             </StyledBaseM>
           </VStack>
@@ -133,6 +132,14 @@ const StyledBaseM = styled(BaseM)`
 
   p {
     padding-bottom: 0;
+  }
+`;
+
+const StyledContainer = styled(VStack)`
+  max-width: 250px;
+
+  @media only screen and ${breakpoints.desktop} {
+    max-width: none;
   }
 `;
 

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
@@ -10,6 +10,7 @@ import FollowButton from '~/components/Follow/FollowButton';
 import { FollowListUserItemFragment$key } from '~/generated/FollowListUserItemFragment.graphql';
 import { FollowListUserItemQueryFragment$key } from '~/generated/FollowListUserItemQueryFragment.graphql';
 import colors from '~/shared/theme/colors';
+import { BREAK_LINES } from '~/utils/regex';
 
 import HoverCardOnUsername from '../HoverCard/HoverCardOnUsername';
 import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
@@ -17,8 +18,6 @@ import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
 type Props = {
   queryRef: FollowListUserItemQueryFragment$key;
   userRef: FollowListUserItemFragment$key;
-  username: string;
-  bio?: string;
   fadeUsernames: boolean;
   setFadeUsernames: (val: boolean) => void;
   handleClick: () => void;
@@ -27,8 +26,6 @@ type Props = {
 export default function FollowListUserItem({
   queryRef,
   userRef,
-  username,
-  bio,
   fadeUsernames,
   handleClick,
   setFadeUsernames,
@@ -45,6 +42,8 @@ export default function FollowListUserItem({
   const user = useFragment(
     graphql`
       fragment FollowListUserItemFragment on GalleryUser {
+        bio
+        username
         ...FollowButtonUserFragment
         ...HoverCardOnUsernameFragment
         ...ProfilePictureFragment
@@ -52,6 +51,8 @@ export default function FollowListUserItem({
     `,
     userRef
   );
+
+  const formattedUserBio = useMemo(() => (user.bio ?? '').replace(BREAK_LINES, ''), [user.bio]);
 
   const onMouseEnter = useCallback(() => {
     setFadeUsernames(true);
@@ -65,7 +66,7 @@ export default function FollowListUserItem({
     <StyledListItem
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      href={`/${username}`}
+      href={`/${user.username}`}
       onClick={handleClick}
       fadeUsernames={fadeUsernames}
     >
@@ -73,22 +74,20 @@ export default function FollowListUserItem({
         <ProfilePicture userRef={user} size="md" />
         <HoverCardOnUsername userRef={user}>
           <VStack inline>
-            <TitleS>{username}</TitleS>
+            <TitleS>{user.username}</TitleS>
             <StyledBaseM>
-              {bio && (
+              {formattedUserBio && (
                 <VStack justify="center">
-                  <Markdown text={bio} />
+                  <Markdown text={formattedUserBio} />
                 </VStack>
               )}
             </StyledBaseM>
           </VStack>
         </HoverCardOnUsername>
       </HStack>
-      {query && user && (
-        <VStack justify="center">
-          <StyledFollowButton queryRef={query} userRef={user} />
-        </VStack>
-      )}
+      <VStack justify="center">
+        <StyledFollowButton queryRef={query} userRef={user} />
+      </VStack>
     </StyledListItem>
   );
 }

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -57,7 +57,7 @@ export default function FollowListUserItem({
   const formattedUserBio = useMemo(() => {
     const truncate = (bio: string) => {
       const maxLength = isMobile ? 250 : 320;
-      if (bio.length > maxLength && isMobile) {
+      if (bio.length > maxLength) {
         return `${bio.slice(0, maxLength)}...`;
       }
       return bio;
@@ -103,15 +103,16 @@ export default function FollowListUserItem({
 }
 
 const StyledListItem = styled.a<{ fadeUsernames: boolean }>`
+  text-decoration: none;
   display: flex;
+  justify-content: space-between;
   padding-top: 16px;
   padding-bottom: 16px;
-  text-decoration: none;
-  justify-content: space-between;
-  transition: color 0.15s ease-in-out, opacity 0.15s ease-in-out;
-  opacity: ${({ fadeUsernames }) => (fadeUsernames ? 0.5 : 1)};
   gap: 4px;
   min-height: 72px;
+
+  transition: color 0.15s ease-in-out, opacity 0.15s ease-in-out;
+  opacity: ${({ fadeUsernames }) => (fadeUsernames ? 0.5 : 1)};
 
   &:hover {
     color: ${colors.black['800']};

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -9,8 +9,6 @@ import { BaseM, TitleS } from '~/components/core/Text/Text';
 import FollowButton from '~/components/Follow/FollowButton';
 import { FollowListUserItemFragment$key } from '~/generated/FollowListUserItemFragment.graphql';
 import { FollowListUserItemQueryFragment$key } from '~/generated/FollowListUserItemQueryFragment.graphql';
-import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
-import useDebounce from '~/shared/hooks/useDebounce';
 import colors from '~/shared/theme/colors';
 
 import HoverCardOnUsername from '../HoverCard/HoverCardOnUsername';
@@ -55,15 +53,11 @@ export default function FollowListUserItem({
     userRef
   );
 
-  const [isHovering, setIsHovering] = useState(false);
-
   const onMouseEnter = useCallback(() => {
-    setIsHovering(true);
     setFadeUsernames(true);
   }, [setFadeUsernames]);
 
   const onMouseLeave = useCallback(() => {
-    setIsHovering(false);
     setFadeUsernames(false);
   }, [setFadeUsernames]);
 
@@ -128,11 +122,6 @@ const StyledBaseM = styled(BaseM)`
   p {
     padding-bottom: 0;
   }
-`;
-
-const StyledHStack = styled(HStack)`
-  display: flex;
-  width: 100%;
 `;
 
 const StyledFollowButton = styled(FollowButton)`

--- a/apps/web/src/components/Follow/FollowListUserItem.tsx
+++ b/apps/web/src/components/Follow/FollowListUserItem.tsx
@@ -1,0 +1,110 @@
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import breakpoints from '~/components/core/breakpoints';
+import Markdown from '~/components/core/Markdown/Markdown';
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { BaseM } from '~/components/core/Text/Text';
+import FollowButton from '~/components/Follow/FollowButton';
+import { FollowListUserItemFragment$key } from '~/generated/FollowListUserItemFragment.graphql';
+import { FollowListUserItemQueryFragment$key } from '~/generated/FollowListUserItemQueryFragment.graphql';
+import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
+import colors from '~/shared/theme/colors';
+
+import HoverCardOnUsername from '../HoverCard/HoverCardOnUsername';
+import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
+
+type Props = {
+  queryRef: FollowListUserItemQueryFragment$key;
+  userRef: FollowListUserItemFragment$key;
+  username: string;
+  bio?: string;
+  handleClick: () => void;
+};
+
+export default function FollowListUserItem({
+  queryRef,
+  userRef,
+  username,
+  bio,
+  handleClick,
+}: Props) {
+  const query = useFragment(
+    graphql`
+      fragment FollowListUserItemQueryFragment on Query {
+        ...FollowButtonQueryFragment
+      }
+    `,
+    queryRef
+  );
+
+  const user = useFragment(
+    graphql`
+      fragment FollowListUserItemFragment on GalleryUser {
+        ...FollowButtonUserFragment
+        ...HoverCardOnUsernameFragment
+        ...ProfilePictureFragment
+      }
+    `,
+    userRef
+  );
+
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
+
+  return (
+    <StyledListItem href={`/${username}`} onClick={handleClick} isMobile={isMobile}>
+      <HStack gap={8} align="center">
+        <ProfilePicture userRef={user} size="md" />
+        <VStack inline>
+          <HoverCardOnUsername userRef={user}></HoverCardOnUsername>
+          <StyledBaseM>
+            {bio && (
+              <VStack justify="center">
+                <Markdown text={bio} />
+              </VStack>
+            )}
+          </StyledBaseM>
+        </VStack>
+      </HStack>
+      {query && user && (
+        <VStack justify="center">
+          <StyledFollowButton queryRef={query} userRef={user} />
+        </VStack>
+      )}
+    </StyledListItem>
+  );
+}
+
+const StyledListItem = styled.a<{ isMobile: boolean }>`
+  display: flex;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  text-decoration: none;
+  justify-content: space-between;
+  gap: 4px;
+
+  &:hover {
+    background: ${colors.offWhite};
+  }
+
+  @media only screen and ${breakpoints.desktop} {
+    gap: 72px;
+  }
+`;
+
+const StyledBaseM = styled(BaseM)`
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  p {
+    padding-bottom: 0;
+  }
+`;
+
+const StyledFollowButton = styled(FollowButton)`
+  padding: 2px 8px;
+  width: 92px;
+  height: 24px;
+`;

--- a/apps/web/src/components/Follow/FollowListUsers.tsx
+++ b/apps/web/src/components/Follow/FollowListUsers.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
@@ -7,7 +7,6 @@ import { BaseM } from '~/components/core/Text/Text';
 import { FollowListUsersFragment$key } from '~/generated/FollowListUsersFragment.graphql';
 import { FollowListUsersQueryFragment$key } from '~/generated/FollowListUsersQueryFragment.graphql';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
-import { BREAK_LINES } from '~/utils/regex';
 
 import FollowListUserItem from './FollowListUserItem';
 
@@ -37,8 +36,6 @@ export default function FollowListUsers({
     graphql`
       fragment FollowListUsersFragment on GalleryUser @relay(plural: true) {
         dbid
-        bio
-        username
         ...FollowListUserItemFragment
       }
     `,
@@ -50,30 +47,20 @@ export default function FollowListUsers({
   }, [track]);
 
   const [fadeUsernames, setFadeUsernames] = useState(false);
-  const formattedUsersBio = useMemo(() => {
-    return users.map((user) => {
-      return {
-        ...user,
-        bio: (user.bio ?? '').replace(BREAK_LINES, ''),
-      };
-    });
-  }, [users]);
 
   return (
     <StyledList>
-      {formattedUsersBio.map((user) => (
+      {users.map((user) => (
         <FollowListUserItem
           key={user.dbid}
-          username={user.username ?? ''}
           handleClick={handleClick}
-          bio={user.bio}
           queryRef={query}
           userRef={user}
           fadeUsernames={fadeUsernames}
           setFadeUsernames={(val) => setFadeUsernames(val)}
         />
       ))}
-      {formattedUsersBio.length === 0 && (
+      {users.length === 0 && (
         <StyledEmptyList gap={48} align="center" justify="center">
           <BaseM>{emptyListText}</BaseM>
         </StyledEmptyList>

--- a/apps/web/src/components/Follow/FollowListUsers.tsx
+++ b/apps/web/src/components/Follow/FollowListUsers.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
+import breakpoints from '~/components/core/breakpoints';
 import { VStack } from '~/components/core/Spacer/Stack';
 import { BaseM } from '~/components/core/Text/Text';
 import { FollowListUsersFragment$key } from '~/generated/FollowListUsersFragment.graphql';
@@ -73,7 +74,10 @@ const StyledList = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding-top: 12px;
+  margin-bottom: 24px;
+  @media only screen and ${breakpoints.desktop} {
+    padding-top: 12px;
+  }
 `;
 
 const StyledEmptyList = styled(VStack)`

--- a/apps/web/src/components/Follow/FollowListUsers.tsx
+++ b/apps/web/src/components/Follow/FollowListUsers.tsx
@@ -1,19 +1,14 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
-import Markdown from '~/components/core/Markdown/Markdown';
-import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM, TitleS } from '~/components/core/Text/Text';
-import FollowButton from '~/components/Follow/FollowButton';
+import { VStack } from '~/components/core/Spacer/Stack';
+import { BaseM } from '~/components/core/Text/Text';
 import { FollowListUsersFragment$key } from '~/generated/FollowListUsersFragment.graphql';
 import { FollowListUsersQueryFragment$key } from '~/generated/FollowListUsersQueryFragment.graphql';
-import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
-import colors from '~/shared/theme/colors';
 import { BREAK_LINES } from '~/utils/regex';
 
-import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
 import FollowListUserItem from './FollowListUserItem';
 
 type Props = {
@@ -45,19 +40,16 @@ export default function FollowListUsers({
         bio
         username
         ...FollowListUserItemFragment
-        ...ProfilePictureFragment
-        ...FollowButtonUserFragment
       }
     `,
     userRefs
   );
 
-  const isMobile = useIsMobileOrMobileLargeWindowWidth();
-
   const handleClick = useCallback(() => {
     track('Follower List Username Click');
   }, [track]);
 
+  const [fadeUsernames, setFadeUsernames] = useState(false);
   const formattedUsersBio = useMemo(() => {
     return users.map((user) => {
       return {
@@ -77,6 +69,8 @@ export default function FollowListUsers({
           bio={user.bio}
           queryRef={query}
           userRef={user}
+          fadeUsernames={fadeUsernames}
+          setFadeUsernames={(val) => setFadeUsernames(val)}
         />
       ))}
       {formattedUsersBio.length === 0 && (
@@ -88,17 +82,6 @@ export default function FollowListUsers({
   );
 }
 
-const StyledBaseM = styled(BaseM)`
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-
-  p {
-    padding-bottom: 0;
-  }
-`;
-
 const StyledList = styled.div`
   display: flex;
   flex-direction: column;
@@ -106,25 +89,6 @@ const StyledList = styled.div`
   padding-top: 12px;
 `;
 
-const StyledListItem = styled.a<{ isMobile: boolean }>`
-  display: flex;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  text-decoration: none;
-  gap: ${({ isMobile }) => (isMobile ? '4px' : '72px')};
-  justify-content: space-between;
-
-  &:hover {
-    background: ${colors.offWhite};
-  }
-`;
-
 const StyledEmptyList = styled(VStack)`
   height: 100%;
-`;
-
-const StyledFollowButton = styled(FollowButton)`
-  padding: 2px 8px;
-  width: 92px;
-  height: 24px;
 `;

--- a/apps/web/src/components/Follow/FollowListUsers.tsx
+++ b/apps/web/src/components/Follow/FollowListUsers.tsx
@@ -14,6 +14,7 @@ import colors from '~/shared/theme/colors';
 import { BREAK_LINES } from '~/utils/regex';
 
 import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
+import FollowListUserItem from './FollowListUserItem';
 
 type Props = {
   queryRef: FollowListUsersQueryFragment$key;
@@ -31,7 +32,7 @@ export default function FollowListUsers({
   const query = useFragment(
     graphql`
       fragment FollowListUsersQueryFragment on Query {
-        ...FollowButtonQueryFragment
+        ...FollowListUserItemQueryFragment
       }
     `,
     queryRef
@@ -43,6 +44,7 @@ export default function FollowListUsers({
         dbid
         bio
         username
+        ...FollowListUserItemFragment
         ...ProfilePictureFragment
         ...FollowButtonUserFragment
       }
@@ -68,31 +70,14 @@ export default function FollowListUsers({
   return (
     <StyledList>
       {formattedUsersBio.map((user) => (
-        <StyledListItem
+        <FollowListUserItem
           key={user.dbid}
-          href={`/${user.username}`}
-          onClick={handleClick}
-          isMobile={isMobile}
-        >
-          <HStack gap={8} align="center">
-            <ProfilePicture userRef={user} size="md" />
-            <VStack inline>
-              <TitleS>{user.username}</TitleS>
-              <StyledBaseM>
-                {user.bio && (
-                  <VStack justify="center">
-                    <Markdown text={user.bio} />
-                  </VStack>
-                )}
-              </StyledBaseM>
-            </VStack>
-          </HStack>
-          {query && user && (
-            <VStack justify="center">
-              <StyledFollowButton queryRef={query} userRef={user} />
-            </VStack>
-          )}
-        </StyledListItem>
+          username={user.username ?? ''}
+          handleClick={handleClick}
+          bio={user.bio}
+          queryRef={query}
+          userRef={user}
+        />
       ))}
       {formattedUsersBio.length === 0 && (
         <StyledEmptyList gap={48} align="center" justify="center">

--- a/apps/web/src/components/Follow/FollowListUsers.tsx
+++ b/apps/web/src/components/Follow/FollowListUsers.tsx
@@ -125,7 +125,6 @@ const StyledList = styled.div`
 
 const StyledListItem = styled.a<{ isMobile: boolean }>`
   display: flex;
-  padding: 12px;
   padding-top: 16px;
   padding-bottom: 16px;
   text-decoration: none;

--- a/apps/web/src/components/Follow/FollowListUsers.tsx
+++ b/apps/web/src/components/Follow/FollowListUsers.tsx
@@ -7,6 +7,7 @@ import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import { BaseM, TitleS } from '~/components/core/Text/Text';
 import FollowButton from '~/components/Follow/FollowButton';
 import { FollowListUsersFragment$key } from '~/generated/FollowListUsersFragment.graphql';
+import { FollowListUsersQueryFragment$key } from '~/generated/FollowListUsersQueryFragment.graphql';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';

--- a/apps/web/src/components/Follow/FollowListUsers.tsx
+++ b/apps/web/src/components/Follow/FollowListUsers.tsx
@@ -74,20 +74,18 @@ export default function FollowListUsers({
           onClick={handleClick}
           isMobile={isMobile}
         >
-          <HStack gap={8}>
+          <HStack gap={8} align="center">
             <ProfilePicture userRef={user} size="md" />
-            {user.bio ? (
-              <VStack inline>
-                <TitleS>{user.username}</TitleS>
-                <StyledBaseM>
-                  <Markdown text={user.bio} />
-                </StyledBaseM>
-              </VStack>
-            ) : (
-              <VStack justify="center">
-                <TitleS>{user.username}</TitleS>
-              </VStack>
-            )}
+            <VStack inline>
+              <TitleS>{user.username}</TitleS>
+              <StyledBaseM>
+                {user.bio && (
+                  <VStack justify="center">
+                    <Markdown text={user.bio} />
+                  </VStack>
+                )}
+              </StyledBaseM>
+            </VStack>
           </HStack>
           {query && user && (
             <VStack justify="center">

--- a/apps/web/src/components/Follow/FollowListUsers.tsx
+++ b/apps/web/src/components/Follow/FollowListUsers.tsx
@@ -15,7 +15,7 @@ import { BREAK_LINES } from '~/utils/regex';
 import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
 
 type Props = {
-  queryRef: FollowListQueryFragment$key;
+  queryRef: FollowListUsersQueryFragment$key;
   userRefs: FollowListUsersFragment$key;
   emptyListText?: string;
 };

--- a/apps/web/src/components/Follow/FollowListUsers.tsx
+++ b/apps/web/src/components/Follow/FollowListUsers.tsx
@@ -83,7 +83,7 @@ const StyledList = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding-top: 32px;
+  padding-top: 12px;
 `;
 const StyledListItem = styled.a`
   padding: 16px;

--- a/apps/web/src/components/HoverCard/HoverCard.tsx
+++ b/apps/web/src/components/HoverCard/HoverCard.tsx
@@ -144,6 +144,7 @@ const StyledCardHeaderContainer = styled(VStack)`
 
 const StyledLink = styled(Link)`
   text-decoration: none;
+  outline: none;
   min-width: 0;
 `;
 


### PR DESCRIPTION
### Summary of Changes

Update User Profile's Following tab layout on web to match this [design](https://www.figma.com/file/X6iIs5hnI4NO3iKC3BAmJs/PFPs?type=design&node-id=4453-12328&mode=design&t=iX2lMVq9Jjcm7QUq-0)
some [slack design context](https://galleryso.slack.com/archives/C058WRKCPR6/p1691135549158799)

### Demo
Check out this [Loom](https://www.loom.com/share/0417ba1197b94fc08828fd2397a2b944)
Before: 
<img width="400" alt="Screenshot 2023-08-07 at 2 39 54 PM" src="https://github.com/gallery-so/gallery/assets/49758803/a1b61e49-44ef-4a7f-ad47-9e36cb71cbe2">
After: 
<img width="1000" alt="Screenshot 2023-08-07 at 2 40 42 PM" src="https://github.com/gallery-so/gallery/assets/49758803/0af31ce6-13f3-40e7-82fb-6a3eaba33de1">
<img width="1000" alt="Screenshot 2023-08-07 at 2 40 58 PM" src="https://github.com/gallery-so/gallery/assets/49758803/b9aaa1df-c3ed-4009-86e1-4143a3cbfd17">

### Edge Cases
-truncating the bio when long so it has spacing between the bio and the follow-back button
-tested different window sizes on desktop

### Testing steps
can check out deployment or pull down branch and test locally
