### PR TITLE
hide unsupported notifications on web

### DIFF
--- a/apps/web/src/components/Notifications/Notification.tsx
+++ b/apps/web/src/components/Notifications/Notification.tsx
@@ -165,6 +165,18 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
 
   const timeAgo = getTimeSince(notification.updatedTime);
 
+  if (
+    ![
+      'SomeoneAdmiredYourFeedEventNotification',
+      'SomeoneCommentedOnYourFeedEventNotification',
+      'SomeoneFollowedYouNotification',
+      'SomeoneFollowedYouBackNotification',
+      'SomeoneViewedYourGalleryNotification',
+    ].includes(notification.__typename)
+  ) {
+    return null;
+  }
+
   return (
     <Container isClickable={isClickable} onClick={handleClick}>
       <HStack gap={8} align="center">


### PR DESCRIPTION
## Description
New not-yet supported notification types are showing up on prod , but empty.
we should not render a notification at all if the type isn't supported yet

before
![Screenshot 2023-08-03 at 9 55 19](https://github.com/gallery-so/gallery/assets/80802871/41514071-2825-445c-a99c-aa5a7b5cf7af)

after
![Screenshot 2023-08-03 at 9 55 11](https://github.com/gallery-so/gallery/assets/80802871/7ba3d8be-691f-47e6-a1bb-42dfb6941786)
