### PR TITLE
[GAL-3928] show notifications for someone commented+admired your post

### DIFF
--- a/apps/web/src/components/Notifications/Notification.tsx
+++ b/apps/web/src/components/Notifications/Notification.tsx
@@ -169,6 +169,7 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
 
     return undefined;
   }, [
+    hideDrawer,
     notification.__typename,
     notification.count,
     notification.feedEvent,

--- a/apps/web/src/components/Notifications/Notification.tsx
+++ b/apps/web/src/components/Notifications/Notification.tsx
@@ -22,6 +22,9 @@ import { useClearNotifications } from '~/shared/relay/useClearNotifications';
 import colors from '~/shared/theme/colors';
 import { getTimeSince } from '~/shared/utils/time';
 
+import SomeoneAdmiredYourPost from './notifications/SomeoneAdmiredYourPost';
+import SomeoneCommentedOnYourPost from './notifications/SomeoneCommentedOnYourPost';
+
 type NotificationProps = {
   notificationRef: NotificationFragment$key;
   queryRef: NotificationQueryFragment$key;
@@ -62,6 +65,18 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
           count
         }
 
+        ... on SomeoneAdmiredYourPostNotification {
+          post {
+            dbid
+          }
+        }
+
+        ... on SomeoneCommentedOnYourPostNotification {
+          post {
+            dbid
+          }
+        }
+
         ...NotificationInnerFragment
       }
     `,
@@ -90,6 +105,7 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
   const { push } = useRouter();
 
   const clearAllNotifications = useClearNotifications();
+  const { hideDrawer } = useDrawerActions();
 
   /**
    * Bear with me here, this `useMemo` returns a stable function
@@ -123,6 +139,20 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
           if (username && eventId) {
             push({ pathname: '/[username]/activity', query: { username, eventId } });
           }
+          hideDrawer();
+        },
+      };
+    } else if (notification.post) {
+      const username = query.viewer?.user?.username;
+      const postId = notification.post.dbid;
+
+      return {
+        showCaret: false,
+        handleClick: function navigateToPostPage() {
+          if (username && postId) {
+            push({ pathname: '/post/[postId]', query: { postId } });
+          }
+          hideDrawer();
         },
       };
     } else if (notification.__typename === 'SomeoneViewedYourGalleryNotification') {
@@ -143,6 +173,7 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
     notification.count,
     notification.feedEvent,
     notification.id,
+    notification.post,
     notification.userViewers?.pageInfo?.total,
     push,
     query.viewer?.user?.username,
@@ -172,6 +203,8 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
       'SomeoneFollowedYouNotification',
       'SomeoneFollowedYouBackNotification',
       'SomeoneViewedYourGalleryNotification',
+      'SomeoneAdmiredYourPostNotification',
+      'SomeoneCommentedOnYourPostNotification',
     ].includes(notification.__typename)
   ) {
     return null;
@@ -179,21 +212,27 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
 
   return (
     <Container isClickable={isClickable} onClick={handleClick}>
-      <HStack gap={8} align="center">
-        {!notification.seen && (
-          <UnseenDotContainer>
-            <UnseenDot />
-          </UnseenDotContainer>
-        )}
+      <HStack gap={8} align="center" justify="space-between">
         <NotificationInner notificationRef={notification} queryRef={query} />
-        <HStack grow justify="flex-end" gap={16}>
-          <TimeAgoText color={colors.metal}>{timeAgo}</TimeAgoText>
-          {showCaret && <NotificationArrow />}
-        </HStack>
+        <StyledDotAndTimeAgo align="center" gap={4}>
+          <HStack grow justify="flex-end" gap={16}>
+            <TimeAgoText color={colors.metal}>{timeAgo}</TimeAgoText>
+            {showCaret && <NotificationArrow />}
+          </HStack>
+          {!notification.seen && (
+            <UnseenDotContainer>
+              <UnseenDot />
+            </UnseenDotContainer>
+          )}
+        </StyledDotAndTimeAgo>
       </HStack>
     </Container>
   );
 }
+
+const StyledDotAndTimeAgo = styled(HStack)`
+  width: 35px;
+`;
 
 type NotificationInnerProps = {
   notificationRef: NotificationInnerFragment$key;
@@ -228,6 +267,16 @@ function NotificationInner({ notificationRef, queryRef }: NotificationInnerProps
           __typename
           ...SomeoneViewedYourGalleryFragment
         }
+
+        ... on SomeoneAdmiredYourPostNotification {
+          __typename
+          ...SomeoneAdmiredYourPostFragment
+        }
+
+        ... on SomeoneCommentedOnYourPostNotification {
+          __typename
+          ...SomeoneCommentedOnYourPostFragment
+        }
       }
     `,
     notificationRef
@@ -259,6 +308,10 @@ function NotificationInner({ notificationRef, queryRef }: NotificationInnerProps
     return <SomeoneFollowedYouBack notificationRef={notification} onClose={handleClose} />;
   } else if (notification.__typename === 'SomeoneCommentedOnYourFeedEventNotification') {
     return <SomeoneCommentedOnYourFeedEvent notificationRef={notification} onClose={handleClose} />;
+  } else if (notification.__typename === 'SomeoneAdmiredYourPostNotification') {
+    return <SomeoneAdmiredYourPost notificationRef={notification} onClose={handleClose} />;
+  } else if (notification.__typename === 'SomeoneCommentedOnYourPostNotification') {
+    return <SomeoneCommentedOnYourPost notificationRef={notification} onClose={handleClose} />;
   }
 
   return null;
@@ -271,6 +324,8 @@ export const TimeAgoText = styled(BaseS)`
 
 const UnseenDotContainer = styled.div`
   align-self: stretch;
+  display: flex;
+  align-items: center;
 `;
 
 const UnseenDot = styled.div`
@@ -282,7 +337,7 @@ const UnseenDot = styled.div`
 `;
 
 const Container = styled.div<{ isClickable: boolean }>`
-  padding: 16px 12px;
+  padding: 16px;
 
   ${({ isClickable }) =>
     isClickable

--- a/apps/web/src/components/Notifications/notifications/SomeoneAdmiredYourFeedEvent.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneAdmiredYourFeedEvent.tsx
@@ -102,7 +102,7 @@ export function SomeoneAdmiredYourFeedEvent({
           {firstAdmirer ? (
             <>
               <StyledProfilePictureContainer>
-                <ProfilePicture size="sm" userRef={firstAdmirer} />
+                <ProfilePicture size="md" userRef={firstAdmirer} />
               </StyledProfilePictureContainer>
 
               <HoverCardOnUsername userRef={firstAdmirer} onClick={onClose} />
@@ -122,5 +122,5 @@ export function SomeoneAdmiredYourFeedEvent({
 
 const StyledProfilePictureContainer = styled.div`
   display: inline-block;
-  padding-right: 4px;
+  padding-right: 8px;
 `;

--- a/apps/web/src/components/Notifications/notifications/SomeoneAdmiredYourPost.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneAdmiredYourPost.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import { HStack } from '~/components/core/Spacer/Stack';
+import { BaseM } from '~/components/core/Text/Text';
+import HoverCardOnUsername from '~/components/HoverCard/HoverCardOnUsername';
+import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
+import { SomeoneAdmiredYourPostFragment$key } from '~/generated/SomeoneAdmiredYourPostFragment.graphql';
+import { useReportError } from '~/shared/contexts/ErrorReportingContext';
+import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
+
+type Props = {
+  notificationRef: SomeoneAdmiredYourPostFragment$key;
+  onClose: () => void;
+};
+
+export default function SomeoneAdmiredYourPost({ notificationRef, onClose }: Props) {
+  const notification = useFragment(
+    graphql`
+      fragment SomeoneAdmiredYourPostFragment on SomeoneAdmiredYourPostNotification {
+        __typename
+        dbid
+        post {
+          tokens {
+            ...getVideoOrImageUrlForNftPreviewFragment
+          }
+        }
+        count
+
+        admirers(last: 1) {
+          edges {
+            node {
+              ...HoverCardOnUsernameFragment
+              ...ProfilePictureFragment
+            }
+          }
+        }
+      }
+    `,
+    notificationRef
+  );
+  const reportError = useReportError();
+  const notificationCount = notification.count ?? 1;
+
+  const firstAdmirer = notification.admirers?.edges?.[0]?.node;
+  const token = notification.post?.tokens?.[0];
+  const previewUrlSet = useMemo(() => {
+    if (!token) return null;
+    return getVideoOrImageUrlForNftPreview({ tokenRef: token });
+  }, [token]);
+
+  if (!firstAdmirer) {
+    reportError(`SomeoneAdmiredYourPostNotification id:${notification.dbid} was missing admirer`);
+    return null;
+  }
+
+  return (
+    <StyledNotificationContent align="center" justify="space-between" gap={8}>
+      <HStack align="center" gap={8}>
+        <ProfilePicture size="md" userRef={firstAdmirer} />
+        <StyledTextWrapper align="center" as="span" wrap="wrap">
+          <HoverCardOnUsername userRef={firstAdmirer} onClick={onClose} />
+          &nbsp;
+          <BaseM as="span">
+            {notificationCount > 1 && (
+              <>
+                {'and '}
+                <strong>
+                  {notificationCount - 1} other{notificationCount - 1 > 1 && 's'}&nbsp;
+                </strong>
+              </>
+            )}
+            admired your <strong>post</strong>
+          </BaseM>
+        </StyledTextWrapper>
+      </HStack>
+      {previewUrlSet?.urls.small && <StyledPostPreview src={previewUrlSet?.urls.small} />}
+    </StyledNotificationContent>
+  );
+}
+
+const StyledPostPreview = styled.img`
+  height: 56px;
+  width: 56px;
+`;
+
+const StyledNotificationContent = styled(HStack)`
+  width: 100%;
+`;
+
+const StyledTextWrapper = styled(HStack)`
+  display: inline;
+`;

--- a/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourFeedEvent.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourFeedEvent.tsx
@@ -94,7 +94,7 @@ export function SomeoneCommentedOnYourFeedEvent({
         {notification.comment?.commenter ? (
           <>
             <StyledProfilePictureContainer>
-              <ProfilePicture size="sm" userRef={notification.comment?.commenter} />
+              <ProfilePicture size="md" userRef={notification.comment?.commenter} />
             </StyledProfilePictureContainer>
 
             <HoverCardOnUsername userRef={notification.comment?.commenter} onClick={onClose} />
@@ -122,5 +122,5 @@ const CommentPreviewContainer = styled.div`
 
 const StyledProfilePictureContainer = styled.div`
   display: inline-block;
-  padding-right: 4px;
+  padding-right: 8px;
 `;

--- a/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourPost.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourPost.tsx
@@ -1,0 +1,103 @@
+import { useMemo } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { BaseM } from '~/components/core/Text/Text';
+import HoverCardOnUsername from '~/components/HoverCard/HoverCardOnUsername';
+import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
+import { SomeoneCommentedOnYourPostFragment$key } from '~/generated/SomeoneCommentedOnYourPostFragment.graphql';
+import { useReportError } from '~/shared/contexts/ErrorReportingContext';
+import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
+import colors from '~/shared/theme/colors';
+type Props = {
+  notificationRef: SomeoneCommentedOnYourPostFragment$key;
+  onClose: () => void;
+};
+
+export default function SomeoneCommentedOnYourPost({ notificationRef, onClose }: Props) {
+  const notification = useFragment(
+    graphql`
+      fragment SomeoneCommentedOnYourPostFragment on SomeoneCommentedOnYourPostNotification {
+        __typename
+        dbid
+        post {
+          tokens {
+            ...getVideoOrImageUrlForNftPreviewFragment
+          }
+        }
+        comment {
+          commenter {
+            ...HoverCardOnUsernameFragment
+            ...ProfilePictureFragment
+          }
+          comment
+        }
+      }
+    `,
+    notificationRef
+  );
+  const { comment } = notification;
+
+  const reportError = useReportError();
+
+  const token = notification.post?.tokens?.[0];
+  const previewUrlSet = useMemo(() => {
+    if (!token) return null;
+    return getVideoOrImageUrlForNftPreview({ tokenRef: token });
+  }, [token]);
+
+  if (!comment || !comment.commenter || !comment.comment) {
+    reportError(
+      new Error(
+        `SomeoneCommentedOnYourPostNotification id:${notification.dbid} was missing comment or commenter`
+      )
+    );
+    return null;
+  }
+
+  const commenter = comment.commenter;
+
+  return (
+    <StyledNotificationContent align="center" justify="space-between" gap={8}>
+      <HStack align="center" gap={8}>
+        <ProfilePicture size="md" userRef={commenter} />
+        <VStack>
+          <StyledTextWrapper align="center" as="span" wrap="wrap">
+            <HoverCardOnUsername userRef={commenter} onClick={onClose} />
+            &nbsp;
+            <BaseM as="span">
+              commented on your <strong>post</strong>
+            </BaseM>
+          </StyledTextWrapper>
+          <StyledCaption>{comment.comment}</StyledCaption>
+        </VStack>
+      </HStack>
+      {previewUrlSet?.urls.small && <StyledPostPreview src={previewUrlSet?.urls.small} />}
+    </StyledNotificationContent>
+  );
+}
+
+const StyledPostPreview = styled.img`
+  height: 56px;
+  width: 56px;
+`;
+
+const StyledNotificationContent = styled(HStack)`
+  width: 100%;
+`;
+
+const StyledCaption = styled(BaseM)`
+  font-size: 12px;
+  border-left: 2px solid ${colors.porcelain};
+  padding-left: 8px;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+`;
+
+const StyledTextWrapper = styled(HStack)`
+  display: inline;
+`;

--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
@@ -94,8 +94,8 @@ export function SomeoneFollowedYou({
         ) : (
           <>
             {lastFollower ? (
-              <HStack gap={4} align="center">
-                <ProfilePicture size="sm" userRef={lastFollower} />
+              <HStack gap={8} align="center">
+                <ProfilePicture size="md" userRef={lastFollower} />
                 <HoverCardOnUsername userRef={lastFollower} onClick={onClose} />
               </HStack>
             ) : (

--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYouBack.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYouBack.tsx
@@ -43,8 +43,8 @@ export function SomeoneFollowedYouBack({ notificationRef, onClose }: SomeoneFoll
       ) : (
         <>
           {lastFollower ? (
-            <HStack align="center" gap={4} inline>
-              <ProfilePicture size="sm" userRef={lastFollower} />
+            <HStack align="center" gap={8} inline>
+              <ProfilePicture size="md" userRef={lastFollower} />
               <HoverCardOnUsername userRef={lastFollower} onClick={onClose} />
             </HStack>
           ) : (

--- a/apps/web/src/components/Notifications/notifications/SomeoneViewedYourGallery.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneViewedYourGallery.tsx
@@ -62,8 +62,8 @@ export function SomeoneViewedYourGallery({
       return (
         <HStack data-testid={testId} align="center" gap={4}>
           {lastViewer ? (
-            <HStack inline gap={4} align="center">
-              <ProfilePicture size="sm" userRef={lastViewer} />
+            <HStack inline gap={8} align="center">
+              <ProfilePicture size="md" userRef={lastViewer} />
               <HoverCardOnUsername onClick={onClose} userRef={lastViewer} />
             </HStack>
           ) : (
@@ -119,5 +119,5 @@ export function SomeoneViewedYourGallery({
 
 const StyledProfilePictureStackContainer = styled.div`
   display: inline-block;
-  padding-right: 4px;
+  padding-right: 8px;
 `;

--- a/packages/shared/src/utils/time.ts
+++ b/packages/shared/src/utils/time.ts
@@ -15,7 +15,7 @@ export const getTimeSince = (time: string) => {
   const interval = Math.floor(Date.now() - new Date(time).getTime());
 
   if (interval < MINUTE) {
-    return `just now`;
+    return `<1m`;
   }
   if (interval < HOUR) {
     return `${Math.floor(interval / MINUTE)}m`;


### PR DESCRIPTION
## Description

Adds notifications for
- someone commented on your post
- someone admired your post

![Screenshot 2023-08-04 at 15 38 46](https://github.com/gallery-so/gallery/assets/80802871/bbc3b924-1039-4853-bbcb-99408389f974)


- [x] Click on notification to navigate to post page
- [x] username shows hover card
- [x] support multiple admirers in one notification if bundled
- [x] text wraps for long usernames, smaller screens

also includes these related changes
- increase pfp size from sm to md for all notifications
- move unread dot from left to right of notification
- fix width of container of dot + timestamp to 35px for consistent spacing
- change "just now" to "<1m" for very new notifications, so that it fits in the fixed width container



### handling diff cases
multiple admirers in a notification
![Screenshot 2023-08-04 at 21 23 53](https://github.com/gallery-so/gallery/assets/80802871/9c7fad47-b480-46ac-96c9-6afe0616b859)

wrap text caused by long username
![Screenshot 2023-08-04 at 21 24 19](https://github.com/gallery-so/gallery/assets/80802871/6f31a301-4900-44f3-89a4-d966214bd836)

truncate long comments, clamp to 1 line
![Screenshot 2023-08-04 at 21 27 46](https://github.com/gallery-so/gallery/assets/80802871/e2342ead-6717-4b10-80ba-f69e57f3ab2d)


handling screen sizes narrower than standard notification drawer 
![Screenshot 2023-08-04 at 21 28 01](https://github.com/gallery-so/gallery/assets/80802871/98ee8556-bbf8-45ae-abaa-332b918ce68d)

handling screen sizes narrower than standard notification drawer 
![Screenshot 2023-08-04 at 21 28 05](https://github.com/gallery-so/gallery/assets/80802871/0e0f992f-f3ac-42af-98bf-cb9199c375f8)

