### PR TITLE
Proposal for adding PR Template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,26 @@
+### Summary of Changes
+
+Please provide a brief description of the changes made in this PR. Explain the problem are fixing or the feature you are adding.
+
+### Demo or Before and After
+
+If this is a new feature, it helps to include screenshots or recordings of the feature in action.
+If this PR makes visual changes, include before and after screenshots.
+
+### Edge Cases
+
+List any common edge cases that you have considered and tested.
+
+### Testing Steps
+
+Provide steps on how the reviewer can test the changes.
+
+### Checklist
+
+Please make sure to review and check all of the following:
+
+- [ ] The code follows the code style of the project.
+- [ ] The changes are documented appropriately.
+- [ ] The changes have been tested and all tests pass.
+- [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
+- [ ] MOBILE APP: The changes have been tested on both light and dark modes.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -19,8 +19,6 @@ Provide steps on how the reviewer can test the changes.
 
 Please make sure to review and check all of the following:
 
-- [ ] The code follows the code style of the project.
-- [ ] The changes are documented appropriately.
 - [ ] The changes have been tested and all tests pass.
 - [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
 - [ ] MOBILE APP: The changes have been tested on both light and dark modes.


### PR DESCRIPTION
This PR adds a template for PRs that will prepopulate the description field of new PRs.

The goal is to encourage a consistent format for PRs to make it easier for reviewers to understand the changes being added, and ensure the thoroughness and readiness of the PR for review.