### PR TITLE
[GAL-3940] Remove show/hide detail link on detail page

### DIFF
--- a/apps/mobile/src/screens/NftDetailScreen/UniversalNftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/UniversalNftDetailScreenInner.tsx
@@ -1,5 +1,5 @@
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
 import { useLazyLoadQuery } from 'react-relay';
@@ -82,12 +82,6 @@ export function UniversalNftDetailScreenInner() {
   const track = useTrack();
 
   const navigation = useNavigation<MainTabStackNavigatorProp>();
-
-  const [showAdditionalDetails, setShowAdditionalDetails] = useState(false);
-
-  const toggleAdditionalDetails = useCallback(() => {
-    setShowAdditionalDetails((previous) => !previous);
-  }, []);
 
   const handleOpenCommunityScreen = useCallback(() => {
     const contractAddress = token.contract?.contractAddress;
@@ -219,15 +213,6 @@ export function UniversalNftDetailScreenInner() {
 
         <View className="flex-1">
           <NftAdditionalDetails tokenRef={token} />
-        </View>
-
-        <View>
-          <InteractiveLink
-            onPress={toggleAdditionalDetails}
-            type="NFT Detail Show Additional Details"
-          >
-            {showAdditionalDetails ? 'Hide Details' : 'Show Additional Details'}
-          </InteractiveLink>
         </View>
       </View>
     </ScrollView>


### PR DESCRIPTION
### Summary of Changes

Remove show/hide detail link on mobile nft detail page since now we show the expanded view by default.

### Before:
<img width="300" alt="Screenshot 2023-08-07 at 4 24 33 PM" src="https://github.com/gallery-so/gallery/assets/49758803/9ad84e1d-44a3-45c4-8ef2-5de8c58d88ee"> |
After: 
<img width="300" alt="Screenshot 2023-08-07 at 4 21 10 PM" src="https://github.com/gallery-so/gallery/assets/49758803/fc5b8cd6-bd53-4abc-85f9-fc329ad24369">

### Edge Cases
-Tested different chain tokens

### Testing Steps
Can check locally

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [x] MOBILE APP: The changes have been tested on both light and dark modes.
