### PR TITLE
[GAL-3931] Make Delete option red

### DIFF
--- a/apps/web/src/components/Feed/Posts/PostDropdown.tsx
+++ b/apps/web/src/components/Feed/Posts/PostDropdown.tsx
@@ -98,12 +98,12 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
               tokenId={token?.dbid}
             >
               <DropdownItem>
-                <BaseM>View Item Detailzz</BaseM>
+                <BaseM>View Item Detail</BaseM>
               </DropdownItem>
             </LinkToFullPageNftDetailModal>
           )}
-          <DropdownItem onClick={handleDeletePostClick} color={colors.error}>
-            <BaseM>Deletesss</BaseM>
+          <DropdownItem onClick={handleDeletePostClick}>
+            <BaseM color={colors.error}>Delete</BaseM>
           </DropdownItem>
         </DropdownSection>
       </SettingsDropdown>

--- a/apps/web/src/components/Feed/Posts/PostDropdown.tsx
+++ b/apps/web/src/components/Feed/Posts/PostDropdown.tsx
@@ -89,7 +89,7 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
         <DropdownSection>
           <CopyToClipboard textToCopy={postUrl}>
             <DropdownItem>
-              <BaseM color={colors.error}>Share</BaseM>
+              <BaseM>Share</BaseM>
             </DropdownItem>
           </CopyToClipboard>
           {token && (

--- a/apps/web/src/components/Feed/Posts/PostDropdown.tsx
+++ b/apps/web/src/components/Feed/Posts/PostDropdown.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import styled from 'styled-components';
 
 import CopyToClipboard from '~/components/CopyToClipboard/CopyToClipboard';
 import { DropdownItem } from '~/components/core/Dropdown/DropdownItem';
@@ -11,6 +10,7 @@ import { useModalActions } from '~/contexts/modal/ModalContext';
 import { PostDropdownFragment$key } from '~/generated/PostDropdownFragment.graphql';
 import { PostDropdownQueryFragment$key } from '~/generated/PostDropdownQueryFragment.graphql';
 import LinkToFullPageNftDetailModal from '~/scenes/NftDetailPage/LinkToFullPageNftDetailModal';
+import colors from '~/shared/theme/colors';
 import { getBaseUrl } from '~/utils/getBaseUrl';
 
 import DeletePostConfirmation from './DeletePostConfirmation';
@@ -89,7 +89,7 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
         <DropdownSection>
           <CopyToClipboard textToCopy={postUrl}>
             <DropdownItem>
-              <BaseM>Share</BaseM>
+              <BaseM color={colors.error}>Share</BaseM>
             </DropdownItem>
           </CopyToClipboard>
           {token && (
@@ -103,7 +103,7 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
             </LinkToFullPageNftDetailModal>
           )}
           <DropdownItem onClick={handleDeletePostClick}>
-            <StyledDeleteText>Delete</StyledDeleteText>
+            <BaseM color={colors.error}>Delete</BaseM>
           </DropdownItem>
         </DropdownSection>
       </SettingsDropdown>
@@ -136,7 +136,3 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
     </SettingsDropdown>
   );
 }
-
-const StyledDeleteText = styled(BaseM)`
-  color: #e12e16;
-`;

--- a/apps/web/src/components/Feed/Posts/PostDropdown.tsx
+++ b/apps/web/src/components/Feed/Posts/PostDropdown.tsx
@@ -98,12 +98,12 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
               tokenId={token?.dbid}
             >
               <DropdownItem>
-                <BaseM>View Item Detail</BaseM>
+                <BaseM>View Item Detailzz</BaseM>
               </DropdownItem>
             </LinkToFullPageNftDetailModal>
           )}
           <DropdownItem onClick={handleDeletePostClick} color={colors.error}>
-            <BaseM>Delete</BaseM>
+            <BaseM>Deletesss</BaseM>
           </DropdownItem>
         </DropdownSection>
       </SettingsDropdown>

--- a/apps/web/src/components/Feed/Posts/PostDropdown.tsx
+++ b/apps/web/src/components/Feed/Posts/PostDropdown.tsx
@@ -10,6 +10,7 @@ import { useModalActions } from '~/contexts/modal/ModalContext';
 import { PostDropdownFragment$key } from '~/generated/PostDropdownFragment.graphql';
 import { PostDropdownQueryFragment$key } from '~/generated/PostDropdownQueryFragment.graphql';
 import LinkToFullPageNftDetailModal from '~/scenes/NftDetailPage/LinkToFullPageNftDetailModal';
+import colors from '~/shared/theme/colors';
 import { getBaseUrl } from '~/utils/getBaseUrl';
 
 import DeletePostConfirmation from './DeletePostConfirmation';
@@ -101,7 +102,7 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
               </DropdownItem>
             </LinkToFullPageNftDetailModal>
           )}
-          <DropdownItem onClick={handleDeletePostClick}>
+          <DropdownItem onClick={handleDeletePostClick} color={colors.error}>
             <BaseM>Delete</BaseM>
           </DropdownItem>
         </DropdownSection>

--- a/apps/web/src/components/Feed/Posts/PostDropdown.tsx
+++ b/apps/web/src/components/Feed/Posts/PostDropdown.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
 
 import CopyToClipboard from '~/components/CopyToClipboard/CopyToClipboard';
 import { DropdownItem } from '~/components/core/Dropdown/DropdownItem';
@@ -10,7 +11,6 @@ import { useModalActions } from '~/contexts/modal/ModalContext';
 import { PostDropdownFragment$key } from '~/generated/PostDropdownFragment.graphql';
 import { PostDropdownQueryFragment$key } from '~/generated/PostDropdownQueryFragment.graphql';
 import LinkToFullPageNftDetailModal from '~/scenes/NftDetailPage/LinkToFullPageNftDetailModal';
-import colors from '~/shared/theme/colors';
 import { getBaseUrl } from '~/utils/getBaseUrl';
 
 import DeletePostConfirmation from './DeletePostConfirmation';
@@ -103,7 +103,7 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
             </LinkToFullPageNftDetailModal>
           )}
           <DropdownItem onClick={handleDeletePostClick}>
-            <BaseM color={colors.error}>Delete</BaseM>
+            <StyledDeleteText>Delete</StyledDeleteText>
           </DropdownItem>
         </DropdownSection>
       </SettingsDropdown>
@@ -136,3 +136,7 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
     </SettingsDropdown>
   );
 }
+
+const StyledDeleteText = styled(BaseM)`
+  color: #e12e16;
+`;

--- a/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionListItem.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionListItem.tsx
@@ -149,7 +149,7 @@ export function CollectionListItem({ collectionId, queryRef }: CollectionListIte
                 <BaseM>Move To...</BaseM>
               </DropdownItem>
               <DropdownItem onClick={handleDelete}>
-                <BaseM>Delete</BaseM>
+                <BaseM color={colors.error}>Delete</BaseM>
               </DropdownItem>
             </DropdownSection>
           </SettingsDropdown>

--- a/apps/web/src/components/MultiGallery/Gallery.tsx
+++ b/apps/web/src/components/MultiGallery/Gallery.tsx
@@ -326,7 +326,7 @@ export default function Gallery({
                           </>
                         )}
                         <DropdownItem onClick={handleDeleteGallery}>
-                          <BaseM>Delete</BaseM>
+                          <BaseM color={colors.error}>Delete</BaseM>
                         </DropdownItem>
                       </DropdownSection>
                     </SettingsDropdown>
@@ -454,4 +454,8 @@ const StyledOrderingButton = styled.button`
   &:last-child {
     border-left: 1px solid ${colors.faint};
   }
+`;
+
+const StyledDeleteText = styled(BaseM)`
+  color: #e12e16;
 `;

--- a/apps/web/src/components/MultiGallery/Gallery.tsx
+++ b/apps/web/src/components/MultiGallery/Gallery.tsx
@@ -455,7 +455,3 @@ const StyledOrderingButton = styled.button`
     border-left: 1px solid ${colors.faint};
   }
 `;
-
-const StyledDeleteText = styled(BaseM)`
-  color: #e12e16;
-`;


### PR DESCRIPTION
### Summary of Changes

on web in each Post's "…" dropdown, the delete option should be red to be consistent with our styling in other places like shown below

### Before
<img width="1248" alt="Screenshot 2023-08-07 at 4 54 28 PM" src="https://github.com/gallery-so/gallery/assets/49758803/cf857364-ebcc-44d7-b093-e0dbbe7f668c">
<img width="300" alt="Screenshot 2023-08-07 at 4 31 34 PM" src="https://github.com/gallery-so/gallery/assets/49758803/f9e87203-0cc5-4633-b6c0-8c16de32af85">
<img width="300" alt="Screenshot 2023-08-07 at 10 19 50 PM" src="https://github.com/gallery-so/gallery/assets/49758803/162267f8-cb01-4986-86c7-b8a4cdfab2dd">

After
<img width="391" alt="Screenshot 2023-08-07 at 10 33 38 PM" src="https://github.com/gallery-so/gallery/assets/49758803/b0ef6bb8-22cd-407d-a536-40dd04724e3b">
<img width="300" alt="Screenshot 2023-08-07 at 10 20 57 PM" src="https://github.com/gallery-so/gallery/assets/49758803/10338f4d-11e1-46fd-ab9f-6f35ba9277d9"> <img width="300" alt="Screenshot 2023-08-07 at 10 21 52 PM" src="https://github.com/gallery-so/gallery/assets/49758803/aaf24f53-7526-44e6-a921-ac431ca30158">

### Testing Steps
can test locally

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
