### PR TITLE
community pfp regression

### DIFF
--- a/apps/mobile/src/components/InteractiveLink.tsx
+++ b/apps/mobile/src/components/InteractiveLink.tsx
@@ -10,6 +10,7 @@ import { Typography, TypographyProps } from './Typography';
 export type InteractiveLinkProps = PropsWithChildren<{
   href?: string;
   showUnderline?: boolean;
+  isSecondary?: boolean; // if true, the text color renders as normal Typography..
   onPress?: () => void;
   style?: TouchableOpacityProps['style'];
   // for tracking
@@ -24,6 +25,7 @@ export function InteractiveLink({
   style,
   onPress,
   showUnderline = false,
+  isSecondary = false,
   children,
   type,
   textStyle,
@@ -51,7 +53,8 @@ export function InteractiveLink({
       }}
     >
       <Typography
-        className={clsx(`text-shadow dark:text-white text-sm`, {
+        className={clsx(`text-sm`, {
+          'text-shadow dark:text-white': !isSecondary,
           underline: showUnderline,
         })}
         style={[textStyle, { lineHeight: undefined }]}

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
@@ -151,9 +151,10 @@ function HoldsText({ communityRefs, onSeeAll, style }: HoldsTextProps) {
               onPress={() =>
                 community.contractAddress && handleCommunityPress(community.contractAddress)
               }
-              textStyle={{ fontSize: 12, color: 'text-black-800' }}
+              textStyle={{ fontSize: 12 }}
               font={{ family: 'ABCDiatype', weight: 'Bold' }}
               type="Shared Communities Name"
+              isSecondary
             >
               {community.name}
             </InteractiveLink>
@@ -174,9 +175,10 @@ function HoldsText({ communityRefs, onSeeAll, style }: HoldsTextProps) {
 
           <InteractiveLink
             onPress={onSeeAll}
-            textStyle={{ fontSize: 12, color: 'text-black-800' }}
+            textStyle={{ fontSize: 12 }}
             font={{ family: 'ABCDiatype', weight: 'Bold' }}
             type="Shared Communities See All"
+            isSecondary
           >
             {communities.length - communitiesToShow.length} others
           </InteractiveLink>

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers.tsx
@@ -129,9 +129,10 @@ function FollowingText({ userRefs, onSeeAll, style }: FollowingTextProps) {
                   navigation.push('Profile', { username: user.username });
                 }
               }}
-              textStyle={{ fontSize: 12, color: 'text-black-800' }}
+              textStyle={{ fontSize: 12 }}
               font={{ family: 'ABCDiatype', weight: 'Bold' }}
               type="Shared Followers Username"
+              isSecondary
             >
               {user.username}
             </InteractiveLink>
@@ -152,9 +153,10 @@ function FollowingText({ userRefs, onSeeAll, style }: FollowingTextProps) {
 
           <InteractiveLink
             onPress={onSeeAll}
-            textStyle={{ fontSize: 12, color: 'text-black-800' }}
+            textStyle={{ fontSize: 12 }}
             font={{ family: 'ABCDiatype', weight: 'Bold' }}
             type="Shared Followers See All"
+            isSecondary
           >
             {users.length - usersToShow.length} others
           </InteractiveLink>


### PR DESCRIPTION
### Summary of Changes
The issue was I hardcoded the the text color of `<InteractiveLink />` component like this 👇 to match up to Fraser's design:
```
<InteractiveLink
  onPress={onSeeAll}
  textStyle={{ fontSize: 12, color: 'text-black-800' }} // hardcoded color value
  font={{ family: 'ABCDiatype', weight: 'Bold' }}
  type="Shared Communities See All"
 >
  {children}
</InteractiveLink>
 ```
 So what I did now is I added a new prop called `isSecondary` that applies the `text-shadow` & `dark:text-white` class conditionally.

### Demo or Before and After

#### Before:
![image](https://github.com/gallery-so/gallery/assets/26466468/82247b29-8609-4245-af54-a73446fa99e1)

#### After
![image](https://github.com/gallery-so/gallery/assets/26466468/75b9a885-fa50-4a50-b209-afbed5e36fe5)
![image](https://github.com/gallery-so/gallery/assets/26466468/1f2688cc-8218-4286-ac67-adb4798242ef)

### Edge Cases
N/A

### Testing Steps
Just toggle the dark mode to see if the `SharedInfo` texts are looking fine.. 

### Checklist

- [x] The changes have been tested and all tests pass.
- [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [x] MOBILE APP: The changes have been tested on both light and dark modes.
