### PR TITLE
[GAL-3959] Discard modal fix

### DIFF
--- a/apps/web/src/components/Posts/PostComposerModal.tsx
+++ b/apps/web/src/components/Posts/PostComposerModal.tsx
@@ -65,6 +65,7 @@ export function PostComposerModalWithSelector({ tokensRef, queryRef, preSelected
 
   const onBackClick = useCallback(() => {
     showModal({
+      headerText: 'Are you sure?',
       content: (
         <DiscardPostConfirmation
           onDiscard={() => {


### PR DESCRIPTION
### Summary of Changes

Add a header for the Discard Confirmational modal whenever this modal is shown (from clicking back button and clicking 'x' on modal and clicking outside modal when trying to create a post)

### Before
<img width="500" alt="Screenshot 2023-08-07 at 10 02 49 PM" src="https://github.com/gallery-so/gallery/assets/49758803/4609a94a-01cf-409d-a134-a8fe5dfcaa20"> |
After

<img width="500" alt="Screenshot 2023-08-07 at 10 03 02 PM" src="https://github.com/gallery-so/gallery/assets/49758803/0a9c6f49-88e2-4bda-9f9c-e83090274fbb">

### Testing Steps

can test locally

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
