### PR TITLE
GAL-3892: fix shared following regression

### DIFF
--- a/apps/mobile/src/components/CommunitiesList/CommunityCard.tsx
+++ b/apps/mobile/src/components/CommunitiesList/CommunityCard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { useCallback } from 'react';
 import { View } from 'react-native';
 import { useFragment } from 'react-relay';

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { useNavigation } from '@react-navigation/native';
 import clsx from 'clsx';
 import { useColorScheme } from 'nativewind';

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
@@ -81,13 +81,17 @@ export default function ProfileViewSharedCommunities({ userRef }: Props) {
     <View className="flex flex-row items-center mt-3 mb-2 space-x-1">
       <CommunityProfilePictureBubblesWithCount
         onPress={handleSeeAllPress}
-        totalCount={sharedCommunities.length}
+        totalCount={totalSharedCommunities}
         eventElementId="Shared Followers Bubbles"
         eventName="Shared Followers Bubbles pressed"
         userRefs={sharedCommunities}
       />
 
-      <HoldsText onSeeAll={handleSeeAllPress} communityRefs={sharedCommunities} />
+      <HoldsText
+        onSeeAll={handleSeeAllPress}
+        communityRefs={sharedCommunities}
+        totalCount={totalSharedCommunities}
+      />
 
       <ProfileViewSharedCommunitiesSheet ref={bottomSheetRef} userRef={user} />
     </View>
@@ -98,9 +102,10 @@ type HoldsTextProps = {
   onSeeAll: () => void;
   style?: ViewProps['style'];
   communityRefs: ProfileViewSharedCommunitiesHoldsTextFragment$key;
+  totalCount: number;
 };
 
-function HoldsText({ communityRefs, onSeeAll, style }: HoldsTextProps) {
+function HoldsText({ communityRefs, onSeeAll, style, totalCount }: HoldsTextProps) {
   const communities = useFragment(
     graphql`
       fragment ProfileViewSharedCommunitiesHoldsTextFragment on Community @relay(plural: true) {
@@ -188,7 +193,7 @@ function HoldsText({ communityRefs, onSeeAll, style }: HoldsTextProps) {
               color: colorScheme === 'dark' ? colors.white : colors.black['800'],
             }}
           >
-            {communities.length - communitiesToShow.length} others
+            {totalCount - communitiesToShow.length} others
           </InteractiveLink>
         </View>
       )}

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunitiesSheet.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunitiesSheet.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { useNavigation } from '@react-navigation/native';
 import { ForwardedRef, forwardRef, useCallback, useMemo } from 'react';
 import { View } from 'react-native';

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { useNavigation } from '@react-navigation/native';
 import clsx from 'clsx';
 import { useColorScheme } from 'nativewind';
@@ -73,13 +74,17 @@ export default function ProfileViewSharedFollowers({ userRef }: Props) {
     <View className="flex flex-row flex-wrap space-x-1">
       <ProfilePictureBubblesWithCount
         onPress={handleSeeAllPress}
-        totalCount={sharedFollowers.length}
+        totalCount={totalSharedFollowers}
         eventElementId="Shared Followers Bubbles"
         eventName="Shared Followers Bubbles pressed"
         userRefs={sharedFollowers}
       />
 
-      <FollowingText onSeeAll={handleSeeAllPress} userRefs={sharedFollowers} />
+      <FollowingText
+        onSeeAll={handleSeeAllPress}
+        userRefs={sharedFollowers}
+        totalCount={totalSharedFollowers}
+      />
 
       <ProfileViewSharedFollowersSheet ref={bottomSheetRef} userRef={user} />
     </View>
@@ -90,9 +95,10 @@ type FollowingTextProps = {
   onSeeAll: () => void;
   style?: ViewProps['style'];
   userRefs: ProfileViewSharedFollowersFollowingTextFragment$key;
+  totalCount: number;
 };
 
-function FollowingText({ userRefs, onSeeAll, style }: FollowingTextProps) {
+function FollowingText({ userRefs, onSeeAll, style, totalCount }: FollowingTextProps) {
   const users = useFragment(
     graphql`
       fragment ProfileViewSharedFollowersFollowingTextFragment on GalleryUser @relay(plural: true) {
@@ -163,7 +169,7 @@ function FollowingText({ userRefs, onSeeAll, style }: FollowingTextProps) {
               color: colorScheme === 'dark' ? colors.white : colors.black['800'],
             }}
           >
-            {users.length - usersToShow.length} others
+            {totalCount - usersToShow.length} others
           </InteractiveLink>
         </View>
       )}

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { useNavigation } from '@react-navigation/native';
 import clsx from 'clsx';
 import { useColorScheme } from 'nativewind';


### PR DESCRIPTION
### Summary of Changes

So the problem was we were using the `length` of the `users` data returned by the `ProfileViewSharedFollowersFollowingTextFragment` query which actually paginated or lazy loaded.. That's why it was showing the false count in the first render but once you open bottom sheet and scroll, the count gets updated to the correct number. 

So what I did is just used the `totalSharedFollowers` or `totalSharedCommunities` that refers to `pageInfo.total` which actually has the total number of shared followers or communities.

### Demo or Before and After

#### Before
https://www.loom.com/share/d5718de1d03249558df7350a63174bbb?sid=d3e18ab5-5a4c-402b-a5e5-7850501c3027

#### After
https://www.loom.com/share/e9e3511f754d4d18b86f1b56be72baf8?sid=e608cda7-5e8c-4b41-a81a-4d4ef8ac214d

### Edge Cases
N/A

### Testing Steps

Note: Since this issue only happens when you have more than 20 shared followers or communities, we need to make sure we are testing against those kind of users.

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [x] MOBILE APP: The changes have been tested on both light and dark modes.
