### PR TITLE
show push token for admin users

### DIFF
--- a/apps/mobile/src/screens/SettingsScreen/DebugBottomSheet.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/DebugBottomSheet.tsx
@@ -18,10 +18,8 @@ function DebugBottomSheet(props: Props, ref: ForwardedRef<GalleryBottomSheetModa
 
   useEffect(() => {
     const getToken = async () => {
-      try {
-        const token = await Notifications.getExpoPushTokenAsync();
-        setExpoPushToken(token.data);
-      } catch (error) {}
+      const token = await Notifications.getExpoPushTokenAsync();
+      setExpoPushToken(token.data);
     };
     getToken();
   }, []);

--- a/apps/mobile/src/screens/SettingsScreen/DebugBottomSheet.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/DebugBottomSheet.tsx
@@ -1,0 +1,41 @@
+import * as Notifications from 'expo-notifications';
+import { ForwardedRef, forwardRef, useEffect, useState } from 'react';
+import { View } from 'react-native';
+
+import {
+  GalleryBottomSheetModal,
+  GalleryBottomSheetModalType,
+} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
+import { Typography } from '~/components/Typography';
+
+const snapPoints = ['35%'];
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Props = {};
+
+function DebugBottomSheet(props: Props, ref: ForwardedRef<GalleryBottomSheetModalType>) {
+  const [expoPushToken, setExpoPushToken] = useState<string>('');
+
+  useEffect(() => {
+    const getToken = async () => {
+      try {
+        const token = await Notifications.getExpoPushTokenAsync();
+        setExpoPushToken(token.data);
+      } catch (error) {}
+    };
+    getToken();
+  }, []);
+
+  return (
+    <GalleryBottomSheetModal ref={ref} index={0} snapPoints={snapPoints}>
+      <View className="flex flex-column space-y-1 mx-4">
+        <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }}>Push Token</Typography>
+        <Typography font={{ family: 'ABCDiatype', weight: 'Regular' }}>{expoPushToken}</Typography>
+      </View>
+    </GalleryBottomSheetModal>
+  );
+}
+
+const ForwardedDebugBottomSheet = forwardRef<GalleryBottomSheetModalType, Props>(DebugBottomSheet);
+
+export { ForwardedDebugBottomSheet as DebugBottomSheet };


### PR DESCRIPTION
### Summary of Changes

This PR adds an admin only Debug panel in the Settings tab that will show some values like the notification push token that will help with debugging issues. 
We don't need to make this feature available for general users at the moment.



### Demo or Before and After

new "DEBUG" tappable element in Settings for users with Admin role
![CleanShot 2023-08-09 at 13 54 11](https://github.com/gallery-so/gallery/assets/80802871/2ab05182-b04c-4204-a6ac-17a2c8a8d4bc)

tapping will open bottom sheet with the push token 
![CleanShot 2023-08-09 at 13 54 05](https://github.com/gallery-so/gallery/assets/80802871/a2929528-f4de-43f2-80de-7c6d864cccc9)



### Edge Cases
The DEBUG element and bottom sheet do not appear for non-admin users.


### Testing Steps
Go to the Settings tab

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
