### PR TITLE
[GAL-3841] Add Error State to Post Composer on web

### DIFF
--- a/apps/web/src/components/Posts/PostComposer.tsx
+++ b/apps/web/src/components/Posts/PostComposer.tsx
@@ -10,6 +10,7 @@ import useCreatePost from '~/hooks/api/posts/useCreatePost';
 import { ChevronLeftIcon } from '~/icons/ChevronLeftIcon';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { useReportError } from '~/shared/contexts/ErrorReportingContext';
+import colors from '~/shared/theme/colors';
 
 import breakpoints from '../core/breakpoints';
 import { Button } from '../core/Button/Button';
@@ -135,8 +136,12 @@ export default function PostComposer({ onBackClick, tokenRef }: Props) {
           </VStack>
         </ContentContainer>
       </VStack>
-      <HStack justify="flex-end" align="flex-end">
-        {generalError && <ErrorText message={generalError} />}
+      <HStack justify={generalError ? 'space-between' : 'flex-end'} align="flex-end">
+        {generalError && (
+          <StyledWrapper>
+            <StyledErrorText message={generalError} />
+          </StyledWrapper>
+        )}
         <Button
           variant="primary"
           onClick={handlePostClick}
@@ -170,4 +175,14 @@ const ContentContainer = styled.div`
   @media only screen and ${breakpoints.tablet} {
     flex-direction: row;
   }
+`;
+
+const StyledErrorText = styled(ErrorText)`
+  color: ${colors.red};
+`;
+
+const StyledWrapper = styled(HStack)`
+  display: flex;
+  height: 100%;
+  align-items: center;
 `;

--- a/apps/web/src/components/Posts/PostComposer.tsx
+++ b/apps/web/src/components/Posts/PostComposer.tsx
@@ -70,21 +70,18 @@ export default function PostComposer({ onBackClick, tokenRef }: Props) {
         tokens: [{ dbid: token.dbid, communityId: token.community?.id || '' }],
         caption: description,
       });
+      setIsSubmitting(false);
+      hideModal();
+      pushToast({
+        message: `Successfully posted ${token.name || 'item'}`,
+      });
     } catch (error) {
-      // TODO add error state GAL-3841
+      setIsSubmitting(false);
       if (error instanceof Error) {
         reportError(error);
       }
       setGeneralError('Post failed to upload, please try again');
-      setIsSubmitting(false);
-      return;
     }
-
-    setIsSubmitting(false);
-    pushToast({
-      message: `Successfully posted ${token.name || 'item'}`,
-    });
-    hideModal();
   }, [
     createPost,
     description,

--- a/apps/web/src/components/Posts/PostComposer.tsx
+++ b/apps/web/src/components/Posts/PostComposer.tsx
@@ -7,6 +7,7 @@ import { useModalActions } from '~/contexts/modal/ModalContext';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { PostComposerFragment$key } from '~/generated/PostComposerFragment.graphql';
 import useCreatePost from '~/hooks/api/posts/useCreatePost';
+import AlertTriangleIcon from '~/icons/AlertTriangleIcon';
 import { ChevronLeftIcon } from '~/icons/ChevronLeftIcon';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { useReportError } from '~/shared/contexts/ErrorReportingContext';
@@ -139,6 +140,7 @@ export default function PostComposer({ onBackClick, tokenRef }: Props) {
       <HStack justify={generalError ? 'space-between' : 'flex-end'} align="flex-end">
         {generalError && (
           <StyledWrapper>
+            <AlertTriangleIcon color={colors.red} />
             <StyledErrorText message={generalError} />
           </StyledWrapper>
         )}
@@ -184,5 +186,6 @@ const StyledErrorText = styled(ErrorText)`
 const StyledWrapper = styled(HStack)`
   display: flex;
   height: 100%;
+  gap: 4px;
   align-items: center;
 `;

--- a/apps/web/src/hooks/api/posts/useCreatePost.ts
+++ b/apps/web/src/hooks/api/posts/useCreatePost.ts
@@ -124,8 +124,9 @@ export default function useCreatePost() {
         if (error instanceof Error) {
           reportError(error);
         } else {
-          reportError(`Could not admire post for an unknown reason`);
+          reportError(`Could not upload post for an unknown reason`);
         }
+        throw Error;
       }
     },
     [createPost, reportError, router]


### PR DESCRIPTION
### Summary of Changes
Expected Behaviour:
-If the backend returns any errors after the user clicks "POST", display the generic error message in the footer as per design using the existing codebase icon.
-Immediately upon clicking "POST" again, the old error message should be cleared.

### After
![Screenshot 2023-08-09 at 6 25 36 PM](https://github.com/gallery-so/gallery/assets/49758803/8876b01f-8e5e-4469-a90e-c14279b61a5b)
When set to offline from network tab on chrome devtools, we see this general error message trying to post offline.
![Screenshot 2023-08-09 at 6 26 16 PM](https://github.com/gallery-so/gallery/assets/49758803/8f073112-dd48-4c17-9739-f0c03919e598)
Error clears up after connecting to network and 'POST' is clicked again.
![Image 09-08-23 at 6 39 PM](https://github.com/gallery-so/gallery/assets/49758803/bc74033b-b6e9-4570-a601-4d3b6dbd8dd1)

### Edge Cases
Tested responsiveness with different window sizes.

### Testing Steps
Can test locally on branch or preview on vercel.

### Checklist

- [x] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [x] MOBILE APP: The changes have been tested on both light and dark modes.
