### PR TITLE
add notification setting + prompt

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -17,6 +17,7 @@
     "date-fns": "^2.29.3",
     "dotenv": "^16.0.3",
     "expo": "~48.0.18",
+    "expo-application": "~5.1.1",
     "expo-asset": "^8.9.1",
     "expo-av": "~13.2.1",
     "expo-barcode-scanner": "~12.3.2",

--- a/apps/mobile/src/navigation/MainTabStackNavigator.tsx
+++ b/apps/mobile/src/navigation/MainTabStackNavigator.tsx
@@ -15,6 +15,7 @@ import { PostScreen } from '~/screens/PostScreen/PostScreen';
 import { ProfileScreen } from '~/screens/ProfileScreen/ProfileScreen';
 import { SearchScreen } from '~/screens/SearchScreen';
 import { SettingsProfileScreen } from '~/screens/SettingsProfileScreen';
+import { NotificationSettingsScreen } from '~/screens/SettingsScreen/NotificationSettingsScreen';
 import { SettingsScreen } from '~/screens/SettingsScreen/SettingsScreen';
 
 const Stack = createNativeStackNavigator<MainTabStackNavigatorParamList>();
@@ -38,6 +39,7 @@ export function MainTabStackNavigator({ initialRouteName, initialProfileParams }
       <Stack.Screen name="NftSelectorContractScreen" component={NftSelectorContractScreen} />
       <Stack.Screen name="SettingsProfile" component={SettingsProfileScreen} />
       <Stack.Screen name="Post" component={PostScreen} />
+      <Stack.Screen name="NotificationSettingsScreen" component={NotificationSettingsScreen} />
 
       {/* The 5 main tabs excluding "Account" since that just uses Profile */}
       <Stack.Screen name="Home" component={HomeScreen} />

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -41,6 +41,7 @@ export type MainTabStackNavigatorParamList = {
   NftSelectorContractScreen: { contractAddress: string; page: ScreenWithNftSelector };
   SettingsProfile: undefined;
   Post: { postId: string };
+  NotificationSettingsScreen: undefined;
 
   // The main five tabs
   Account: undefined;

--- a/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
@@ -67,15 +67,15 @@ export function NotificationSettingsScreen() {
         </Typography>
         {isPushNotificationPermissionGranted ? (
           <Button
-            eventElementId={null}
+            eventElementId="Enable Push Notifications Button (Disabled) in Settings Screen"
             eventName={null}
             variant="disabled"
             text="Push notifications are enabled"
           />
         ) : (
           <Button
-            eventElementId={null}
-            eventName={null}
+            eventElementId="Enable Push Notifications Button in Settings Screen"
+            eventName="Enable Push Notifications Button in Settings Screen Pressed"
             text="Enable Push Notifications"
             onPress={handleResyncPushNotifications}
           />

--- a/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
@@ -1,0 +1,86 @@
+import * as Application from 'expo-application';
+import * as Notifications from 'expo-notifications';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert, Linking, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRelayEnvironment } from 'react-relay';
+
+import { BackButton } from '~/components/BackButton';
+import { Button } from '~/components/Button';
+import { registerNotificationToken } from '~/components/Notification/registerNotificationToken';
+import { Typography } from '~/components/Typography';
+
+export function NotificationSettingsScreen() {
+  const relayEnvironment = useRelayEnvironment();
+  const { top } = useSafeAreaInsets();
+
+  const [pushNotificationPermissions, setPushNotificationPermissions] =
+    useState<Notifications.NotificationPermissionsStatus | null>(null);
+
+  const checkPushNotificationPermission = useCallback(async () => {
+    const existingPermissions = await Notifications.getPermissionsAsync();
+    setPushNotificationPermissions(existingPermissions);
+  }, []);
+
+  useEffect(() => {
+    checkPushNotificationPermission();
+  }, [checkPushNotificationPermission]);
+
+  const handleResyncPushNotifications = useCallback(async () => {
+    if (pushNotificationPermissions?.canAskAgain === true) {
+      await registerNotificationToken({ shouldPrompt: true, relayEnvironment });
+      checkPushNotificationPermission();
+    } else {
+      Alert.alert(
+        'Enable Notifications',
+        'You can enable notifications via Settings > Notifications > Gallery Labs',
+        [
+          {
+            text: 'Cancel',
+            style: 'cancel',
+          },
+          {
+            text: 'Open Settings',
+            onPress: () => {
+              // This will open the native settings app on iOS. Need to test when we support Android
+              Linking.openURL(`App-Prefs:${Application.applicationId}`);
+            },
+          },
+        ]
+      );
+    }
+  }, [checkPushNotificationPermission, pushNotificationPermissions?.canAskAgain, relayEnvironment]);
+
+  const isPushNotificationPermissionGranted = useMemo(
+    () => pushNotificationPermissions?.status === 'granted',
+    [pushNotificationPermissions]
+  );
+
+  return (
+    <View style={{ paddingTop: top }} className="relative pt-4 flex-1 bg-white dark:bg-black-900">
+      <View className="px-4 relative mb-2">
+        <BackButton />
+      </View>
+      <View className="px-4 pt-8 space-y-6 flex flex-col">
+        <Typography className="text-xl" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+          Push notifications
+        </Typography>
+        {isPushNotificationPermissionGranted ? (
+          <Button
+            eventElementId={null}
+            eventName={null}
+            variant="disabled"
+            text="Push notifications are enabled"
+          />
+        ) : (
+          <Button
+            eventElementId={null}
+            eventName={null}
+            text="Enable Push Notifications"
+            onPress={handleResyncPushNotifications}
+          />
+        )}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from '@react-navigation/native';
 import Constants from 'expo-constants';
 import { PropsWithChildren, ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import { LayoutChangeEvent, Linking, ScrollView, Text, View, ViewProps } from 'react-native';
@@ -12,6 +13,8 @@ import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { InteractiveLink } from '~/components/InteractiveLink';
 import { Typography } from '~/components/Typography';
 import { SettingsScreenQuery } from '~/generated/SettingsScreenQuery.graphql';
+import { NotificationsIcon } from '~/navigation/MainTabNavigator/NotificationsIcon';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
 
 import { useLogout } from '../../hooks/useLogout';
 import { BugReportIcon } from '../../icons/BugReportIcon';
@@ -43,6 +46,7 @@ export function SettingsScreen() {
   const { top } = useSafeAreaInsets();
   const feedbackBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
   const debugBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
 
   const [bottomSectionHeight, setBottomSectionHeight] = useState(200);
 
@@ -65,6 +69,10 @@ export function SettingsScreen() {
   const handleTwitterPress = useCallback(() => {
     Linking.openURL('https://twitter.com/GALLERY');
   }, []);
+
+  const handleNotificationsPress = useCallback(() => {
+    navigation.navigate('NotificationSettingsScreen');
+  }, [navigation]);
 
   const [logout, isLoggingOut] = useLogout();
   const handleSignOut = useCallback(() => {
@@ -117,6 +125,13 @@ export function SettingsScreen() {
             text="Twitter"
             icon={<TwitterIcon width={24} />}
           />
+          {isAdminUser && (
+            <SettingsRow
+              onPress={handleNotificationsPress}
+              text="Notifications"
+              icon={<NotificationsIcon width={24} />}
+            />
+          )}
         </SettingsSection>
       </ScrollView>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25958,6 +25958,7 @@ __metadata:
     dotenv: ^16.0.3
     eas-cli: ^3.7.2
     expo: ~48.0.18
+    expo-application: ~5.1.1
     expo-asset: ^8.9.1
     expo-av: ~13.2.1
     expo-barcode-scanner: ~12.3.2


### PR DESCRIPTION
### Summary of Changes

This PR adds a Notification Settings screen to the Settings menu.
Currently this is an admin-only feature since we want to add a bit more design polish before making it available to all users.

The primary goal is to give a user a chance to opt in to Push Notifications if they find that they're not receiving any. These users likely fall into 2 groups
1. they've never been prompted with the Enabled Notifications native iOS prompt
2. they've seen in and denied permission / turned off push notifications since

In the first case, pressing the new Enable Push Notifications button will trigger the prompt so that they can opt in. By showing the prompt, the Gallery app will also be listed in their iOS Settings app, so that they can toggle these settings on their own later. Without seeing this prompt, the app doesn't appear to be listed in the iOS settings app.
![CleanShot 2023-08-10 at 16 50 38](https://github.com/gallery-so/gallery/assets/80802871/fbca2ebb-7086-486c-a0ca-a5a34bb263ba)



In the 2nd case, pressing the new Enable Push Notifications button will show a different prompt that gives them an option to navigate to the Settings app. this is because iOS does not allow re-prompting the user with the direct notification permission dialog. This will take the user directly to the Gallery app setting in the native Settings app.
![CleanShot 2023-08-10 at 16 50 44](https://github.com/gallery-so/gallery/assets/80802871/a58ecf92-acf3-4c0f-82f7-2738b846a145)

 

This is role-flagged behind the ADMIN role.


### Demo or Before and After

Case 1: prompting for permission directly
https://github.com/gallery-so/gallery/assets/80802871/6fcecadb-d1e3-4615-a4f3-9afa3fe20b7b

Case 2: prompting to navigate to Settings app

https://github.com/gallery-so/gallery/assets/80802871/10f47820-012a-49fb-8d2d-092c0bd0b302




If Push Notifications are enabled, this is what they see
![CleanShot 2023-08-10 at 16 52 05](https://github.com/gallery-so/gallery/assets/80802871/10bfc8e8-901f-4f01-9bcd-252b7c9c519f)


### Edge Cases

- [x] Push notifications are enabled
- [x] Push notifications aren't enabled. user has never seen the prompt
- [x] Push notifications aren't enabled, but user has seen the prompt
- [x] Not an admin user


### Testing Steps

Toggle your push notifications for Gallery on/off and go to the Notification Settings screen in app.

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
