### PR TITLE
[GAL-3907] Add Sort filters to NFT Selector on mobile

### DIFF
--- a/apps/mobile/src/components/Select.tsx
+++ b/apps/mobile/src/components/Select.tsx
@@ -83,7 +83,7 @@ type OptionsProps<ValueType extends string> = {
   eventElementId: string;
 };
 
-function Options<ValueType extends string>({
+export function Options<ValueType extends string>({
   selected,
   options,
   style,
@@ -122,7 +122,7 @@ function Options<ValueType extends string>({
   );
 }
 
-function Section({ children, style }: PropsWithChildren<{ style?: ViewProps['style'] }>) {
+export function Section({ children, style }: PropsWithChildren<{ style?: ViewProps['style'] }>) {
   return (
     <View style={style} className="flex flex-col space-y-2">
       {children}

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorFilterBottomSheet.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorFilterBottomSheet.tsx
@@ -1,38 +1,122 @@
-import { ForwardedRef } from 'react';
+import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
+import { ForwardedRef, forwardRef, useRef } from 'react';
+import { View, ViewProps } from 'react-native';
 import { EthIcon } from 'src/icons/EthIcon';
 import { PoapIcon } from 'src/icons/PoapIcon';
 import { TezosIcon } from 'src/icons/TezosIcon';
 import { WorldIcon } from 'src/icons/WorldIcon';
 
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
-import { SelectBottomSheet } from '~/components/Select';
+import {
+  GalleryBottomSheetModal,
+  GalleryBottomSheetModalType,
+} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
+import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
+import { Options, Section } from '~/components/Select';
+import { Typography } from '~/components/Typography';
 
-type NftSelectorPickerFilterBottomSheetProps = {
+const SNAP_POINTS = ['CONTENT_HEIGHT'];
+
+const NETWORKS: { label: string; id: NetworkChoice; icon: JSX.Element }[] = [
+  { label: 'All Networks', id: 'all', icon: <WorldIcon /> },
+  { label: 'Ethereum', id: 'Ethereum', icon: <EthIcon /> },
+  { label: 'Tezos', id: 'Tezos', icon: <TezosIcon /> },
+  { label: 'POAP', id: 'POAP', icon: <PoapIcon className="w-4 h-4" /> },
+];
+
+const SORT_VIEWS: { label: string; id: NftSelectorSortView }[] = [
+  { label: 'Recently added', id: 'Recently added' },
+  { label: 'Oldest', id: 'Oldest' },
+  { label: 'Alphabetical', id: 'Alphabetical' },
+];
+
+type Props = {
   network: NetworkChoice;
-  onNetworkChange(network: NetworkChoice): void;
-  bottomSheetRef: ForwardedRef<GalleryBottomSheetModalType>;
+  onNetworkChange: (network: NetworkChoice) => void;
+
+  sortView: NftSelectorSortView;
+  onSortViewChange: (sortView: NftSelectorSortView) => void;
 };
-
 export type NetworkChoice = 'all' | 'Ethereum' | 'Tezos' | 'POAP';
+export type NftSelectorSortView = 'Recently added' | 'Oldest' | 'Alphabetical';
 
-export function NftSelectorFilterBottomSheet({
-  network,
-  onNetworkChange,
-  bottomSheetRef,
-}: NftSelectorPickerFilterBottomSheetProps) {
+function NftSelectorFilterBottomSheet(
+  { network, onNetworkChange, sortView, onSortViewChange }: Props,
+  ref: ForwardedRef<GalleryBottomSheetModalType>
+) {
+  const { bottom } = useSafeAreaPadding();
+
+  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+
+  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
+    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
+
   return (
-    <SelectBottomSheet
-      title="Filters"
-      bottomSheetRef={bottomSheetRef}
-      eventElementId="NftSelectorFilterBottomSheet Network Select"
-      onChange={onNetworkChange}
-      selected={network}
-      options={[
-        { label: 'All Networks', id: 'all', icon: <WorldIcon /> },
-        { label: 'Ethereum', id: 'Ethereum', icon: <EthIcon /> },
-        { label: 'Tezos', id: 'Tezos', icon: <TezosIcon /> },
-        { label: 'POAP', id: 'POAP', icon: <PoapIcon className="w-4 h-4" /> },
-      ]}
-    />
+    <GalleryBottomSheetModal
+      ref={(value) => {
+        bottomSheetRef.current = value;
+
+        if (typeof ref === 'function') {
+          ref(value);
+        } else if (ref) {
+          ref.current = value;
+        }
+      }}
+      snapPoints={animatedSnapPoints}
+      handleHeight={animatedHandleHeight}
+      contentHeight={animatedContentHeight}
+    >
+      <View
+        onLayout={handleContentLayout}
+        style={{ paddingBottom: bottom }}
+        className="p-4 flex flex-col space-y-6"
+      >
+        <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }} className="text-lg">
+          Filters
+        </Typography>
+        <View className="flex flex-col space-y-4">
+          <FilterSection title="Network">
+            <Section>
+              <Options
+                onChange={onNetworkChange}
+                selected={network}
+                options={NETWORKS}
+                eventElementId="Network filter"
+              />
+            </Section>
+          </FilterSection>
+          <FilterSection title="Sort by">
+            <Section>
+              <Options
+                onChange={onSortViewChange}
+                selected={sortView}
+                options={SORT_VIEWS}
+                eventElementId="Sort by filter"
+              />
+            </Section>
+          </FilterSection>
+        </View>
+      </View>
+    </GalleryBottomSheetModal>
   );
 }
+
+type FilterSectionProps = {
+  title: string;
+  children: React.ReactNode;
+  style?: ViewProps['style'];
+};
+function FilterSection({ title, children, style }: FilterSectionProps) {
+  return (
+    <View className="flex space-y-2" style={style}>
+      <Typography font={{ family: 'ABCDiatype', weight: 'Medium' }} className="text-xs uppercase">
+        {title}
+      </Typography>
+
+      {children}
+    </View>
+  );
+}
+
+const ForwardedNftSelectorFilterBottomSheet = forwardRef(NftSelectorFilterBottomSheet);
+
+export { ForwardedNftSelectorFilterBottomSheet as NftSelectorFilterBottomSheet };

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
@@ -16,7 +16,11 @@ import { NftSelectorPickerScreenQuery } from '~/generated/NftSelectorPickerScree
 import { SearchIcon } from '~/navigation/MainTabNavigator/SearchIcon';
 import { MainTabStackNavigatorParamList } from '~/navigation/types';
 
-import { NetworkChoice, NftSelectorFilterBottomSheet } from './NftSelectorFilterBottomSheet';
+import {
+  NetworkChoice,
+  NftSelectorFilterBottomSheet,
+  NftSelectorSortView,
+} from './NftSelectorFilterBottomSheet';
 import { NftSelectorPickerGrid } from './NftSelectorPickerGrid';
 import { NftSelectorScreenFallback } from './NftSelectorScreenFallback';
 
@@ -44,6 +48,7 @@ export function NftSelectorPickerScreen() {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [filter, setFilter] = useState<'Collected' | 'Created'>('Collected');
   const [networkFilter, setNetworkFilter] = useState<NetworkChoice>('all');
+  const [sortView, setSortView] = useState<NftSelectorSortView>('Recently added');
 
   const screenTitle = useMemo(() => {
     return currentScreen === 'ProfilePicture' ? 'Select a profile picture' : 'Select item to post';
@@ -108,9 +113,11 @@ export function NftSelectorPickerScreen() {
               />
 
               <NftSelectorFilterBottomSheet
+                ref={filterBottomSheetRef}
                 network={networkFilter}
                 onNetworkChange={setNetworkFilter}
-                bottomSheetRef={filterBottomSheetRef}
+                sortView={sortView}
+                onSortViewChange={setSortView}
               />
             </View>
           </View>
@@ -122,6 +129,7 @@ export function NftSelectorPickerScreen() {
                   searchQuery,
                   ownerFilter: filter,
                   networkFilter: networkFilter,
+                  sortView,
                 }}
                 queryRef={query}
                 screen={currentScreen}


### PR DESCRIPTION
### Summary of Changes

Added sort by filter to NFT selector

### Demo or Before and After

https://github.com/gallery-so/gallery/assets/4480258/dd28b302-b051-4530-b85d-c91d9402943b



### Edge Cases

- Sort by alphabet
- Tested on post and pfp screen

### Testing Steps

1. Go to nft selector through create new post / update your PFP
2. Click the filter icon
3. You should see there is filter by **network** and **sort by**

### Checklist

Please make sure to review and check all of the following:

- [x] MOBILE APP: The changes have been tested on both light and dark modes.
