### PR TITLE
remove autofocus from mobile post composer input

### DIFF
--- a/apps/mobile/src/components/Post/PostInput.tsx
+++ b/apps/mobile/src/components/Post/PostInput.tsx
@@ -49,7 +49,6 @@ export function PostInput({ value, onChange, tokenRef }: Props) {
         selectionColor={colorScheme === 'dark' ? colors.white : colors.black['800']}
         placeholderTextColor={colorScheme === 'dark' ? colors.metal : colors.shadow}
         multiline
-        autoFocus
         maxLength={MAX_LENGTH}
         autoCapitalize="none"
         autoComplete="off"


### PR DESCRIPTION
### Summary of Changes

Removes auto focus from the mobile post composer input, based on feedback

### Demo or Before and After

https://github.com/gallery-so/gallery/assets/80802871/ddfe4be8-2cef-44bc-9f0a-4ef8beb7f7a6




### Edge Cases

N/A

### Testing Steps

Go to the post composer and notice the keyboard doesn't automatically appear when you select an NFT.

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [x] MOBILE APP: The changes have been tested on both light and dark modes.
