### PR TITLE
GAL-3955 optimistically update curated feed with post

### DIFF
--- a/apps/web/src/hooks/api/posts/useCreatePost.ts
+++ b/apps/web/src/hooks/api/posts/useCreatePost.ts
@@ -62,6 +62,24 @@ export default function useCreatePost() {
           const newPostRootField = store.getRootField('postTokens');
           const newPostRecord = newPostRootField?.getLinkedRecord('post');
 
+          // UPDATE CURATED FEED
+          const rootRecord = store.getRoot();
+          const curatedFeedConnection = ConnectionHandler.getConnection(
+            rootRecord,
+            'NonAuthedFeed_curatedFeed',
+            { includePosts: true }
+          );
+
+          if (newPostRecord && curatedFeedConnection) {
+            const edge = ConnectionHandler.createEdge(
+              store,
+              curatedFeedConnection,
+              newPostRecord,
+              'FeedEdge'
+            );
+            ConnectionHandler.insertEdgeAfter(curatedFeedConnection, edge);
+          }
+
           // UPDATE COMMUNITY FEED
           // Get a reference to current posts in the community feed
           const communityRoot = store.get(token.communityId);


### PR DESCRIPTION
### Summary of Changes

This PR updates the useCreatePost hook to optimistically update the curated feed with the new post.

### Demo or Before and After

https://github.com/gallery-so/gallery/assets/80802871/403f198e-4e43-4c0e-83d7-50850d2db6a4



### Edge Cases

- this only handles if you're already viewing the Curated feed. and if you refresh, it'll disappear since the post won't actually be included in the curated feed provided by the backend. this is expected.

### Testing Steps

Go to /home and create a post.

### Checklist

Please make sure to review and check all of the following:

- [ ] The changes have been tested and all tests pass.

