### PR TITLE
[GAL-4016] [GAL-4017] Nft Selector polish filter

### DIFF
--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorFilterBottomSheet.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorFilterBottomSheet.tsx
@@ -1,5 +1,5 @@
 import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
-import { ForwardedRef, forwardRef, useRef } from 'react';
+import { ForwardedRef, forwardRef, useCallback, useRef } from 'react';
 import { View, ViewProps } from 'react-native';
 import { WorldIcon } from 'src/icons/WorldIcon';
 import { getChainIconComponent } from 'src/utils/getChainIconComponent';
@@ -52,6 +52,26 @@ function NftSelectorFilterBottomSheet(
   const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
     useBottomSheetDynamicSnapPoints(SNAP_POINTS);
 
+  const handleClose = useCallback(() => {
+    bottomSheetRef.current?.close();
+  }, []);
+
+  const handleNetworkChange = useCallback(
+    (network: NetworkChoice) => {
+      onNetworkChange(network);
+      handleClose();
+    },
+    [onNetworkChange, handleClose]
+  );
+
+  const handleSortViewChange = useCallback(
+    (sortView: NftSelectorSortView) => {
+      onSortViewChange(sortView);
+      handleClose();
+    },
+    [onSortViewChange, handleClose]
+  );
+
   return (
     <GalleryBottomSheetModal
       ref={(value) => {
@@ -79,7 +99,7 @@ function NftSelectorFilterBottomSheet(
           <FilterSection title="Network">
             <Section>
               <Options
-                onChange={onNetworkChange}
+                onChange={handleNetworkChange}
                 selected={network}
                 options={NETWORKS}
                 eventElementId="Network filter"
@@ -89,7 +109,7 @@ function NftSelectorFilterBottomSheet(
           <FilterSection title="Sort by">
             <Section>
               <Options
-                onChange={onSortViewChange}
+                onChange={handleSortViewChange}
                 selected={sortView}
                 options={SORT_VIEWS}
                 eventElementId="Sort by filter"

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerGrid.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerGrid.tsx
@@ -8,6 +8,7 @@ import { graphql } from 'relay-runtime';
 
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { NftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
+import { Typography } from '~/components/Typography';
 import { NftSelectorPickerGridFragment$key } from '~/generated/NftSelectorPickerGridFragment.graphql';
 import { NftSelectorPickerGridOneOrManyFragment$key } from '~/generated/NftSelectorPickerGridOneOrManyFragment.graphql';
 import { NftSelectorPickerGridTokenGridFragment$key } from '~/generated/NftSelectorPickerGridTokenGridFragment.graphql';
@@ -227,6 +228,16 @@ export function NftSelectorPickerGrid({
     },
     [screen]
   );
+
+  if (!rows.length) {
+    return (
+      <View className="flex flex-col flex-1 pt-16" style={style}>
+        <Typography className="text-lg text-center" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+          No NFTs found
+        </Typography>
+      </View>
+    );
+  }
 
   return (
     <View className="flex flex-col flex-1" style={style}>


### PR DESCRIPTION
### Summary of Changes

- Auto close the bottom sheet whenever the user select any filter (network/sort)
- If there is no tokens filtered, show empty screen

### Demo or Before and After

**Auto close the bottom sheet whenever the user select any filter (network/sort)**

**Before**


https://github.com/gallery-so/gallery/assets/4480258/dce29242-c8ad-4f08-b713-7329b32736cd



**After**

https://github.com/gallery-so/gallery/assets/4480258/e0ca2b33-8522-4f80-9886-1c40d0e3cc47

**Empty Screen**

| Before | After |
|--------|--------|
| ![image](https://github.com/gallery-so/gallery/assets/4480258/4ff51a38-013c-47b0-930d-041a362a057a) | <img width="457" alt="CleanShot 2023-08-16 at 10 34 56@2x" src="https://github.com/gallery-so/gallery/assets/4480258/22239829-9665-4346-97ac-d286f430dabd"> | 





### Edge Cases

1. Filter any network that you don't have any nfts
2. Filter the network or sorting 

### Testing Steps

1. Open nft selector through post or pfp
2. Playing around with the filter
3. The filter should be auto close after selected
4. If there is no tokens, empty screen should show up

### Checklist

Please make sure to review and check all of the following:


- [x] MOBILE APP: The changes have been tested on both light and dark modes.
