### PR TITLE
[GAL-3849] Add Optimistic Syncing notification [web]

### DIFF
--- a/apps/web/src/components/Notifications/notifications/NewTokens.tsx
+++ b/apps/web/src/components/Notifications/notifications/NewTokens.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useMemo } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
+
+import { Button } from '~/components/core/Button/Button';
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { BaseM } from '~/components/core/Text/Text';
+import { PostComposerModal } from '~/components/Posts/PostComposerModal';
+import { useModalActions } from '~/contexts/modal/ModalContext';
+import { NewTokensFragment$key } from '~/generated/NewTokensFragment.graphql';
+import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
+import { useTrack } from '~/shared/contexts/AnalyticsContext';
+import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
+import colors from '~/shared/theme/colors';
+
+type Props = {
+  notificationRef: NewTokensFragment$key;
+  onClose: () => void;
+};
+
+export function NewTokens({ notificationRef, onClose }: Props) {
+  const notification = useFragment(
+    graphql`
+      fragment NewTokensFragment on NewTokensNotification {
+        __typename
+        count
+        token {
+          ... on Token {
+            __typename
+            ...getVideoOrImageUrlForNftPreviewFragment
+            ...PostComposerModalFragment
+            name
+          }
+        }
+      }
+    `,
+    notificationRef
+  );
+
+  const { token } = notification;
+  const isMobile = useIsMobileWindowWidth();
+  const track = useTrack();
+  const { showModal } = useModalActions();
+
+  if (token?.__typename !== 'Token') {
+    throw new Error("We couldn't find that token. Something went wrong and we're looking into it.");
+  }
+
+  const quantity = notification.count ?? 1;
+
+  const previewUrlSet = useMemo(() => {
+    if (!token) return null;
+    return getVideoOrImageUrlForNftPreview({ tokenRef: token });
+  }, [token]);
+
+  const handleCreatePostClick = useCallback(() => {
+    track('NFT Detail: Clicked Create Post');
+    showModal({
+      content: <PostComposerModal tokenRef={token} />,
+      headerVariant: 'thicc',
+      isFullPage: isMobile,
+    });
+    onClose();
+  }, [isMobile, onClose, showModal, token, track]);
+
+  return (
+    <StyledNotificationContent align="center" justify="space-between" gap={8}>
+      <HStack align="center" gap={8}>
+        {previewUrlSet?.urls.small && (
+          <TokenPreview count={quantity} tokenUrl={previewUrlSet?.urls.small} />
+        )}
+
+        <VStack>
+          <StyledTextWrapper align="center" as="span" wrap="wrap">
+            <BaseM>Minted {quantity > 1 && `${quantity}x`}</BaseM>
+            <BaseM as="span">
+              <strong>{token?.name ? token.name : 'Unknown'}</strong>
+            </BaseM>
+          </StyledTextWrapper>
+        </VStack>
+      </HStack>
+
+      <StyledPostButton variant="primary" onClick={handleCreatePostClick}>
+        Post
+      </StyledPostButton>
+    </StyledNotificationContent>
+  );
+}
+
+type TokenPreviewProps = {
+  tokenUrl: string;
+  count: number;
+};
+function TokenPreview({ count, tokenUrl }: TokenPreviewProps) {
+  return (
+    <StyledPostPreviewWrapper>
+      {count > 1 && <StyledPostPreview src={tokenUrl} count={count} stacked />}
+      <StyledPostPreview count={count} src={tokenUrl} />
+    </StyledPostPreviewWrapper>
+  );
+}
+
+const StyledNotificationContent = styled(HStack)`
+  width: 100%;
+`;
+
+const StyledTextWrapper = styled(HStack)`
+  display: inline;
+`;
+
+const StyledPostPreviewWrapper = styled.div`
+  position: relative;
+`;
+
+const StyledPostPreview = styled.img<{ stacked?: boolean; count: number }>`
+  height: 56px;
+  width: 56px;
+
+  ${({ count }) =>
+    count > 1 &&
+    `
+    height: 40px;
+    width: 40px;
+    border: 1px solid ${colors.offWhite}; 
+
+  `}
+
+  ${({ stacked }) =>
+    stacked
+      ? `
+        position: absolute;
+        bottom: -5px;
+        right: -5px;  `
+      : `
+        z-index: 2;
+        position: inherit;
+  `}
+`;
+
+const StyledPostButton = styled(Button)`
+  padding: 2px 8px;
+  width: 92px;
+  height: 24px;
+  font-weight: 600;
+  text-transform: capitalize;
+  border-radius: 2px;
+`;


### PR DESCRIPTION
### Summary of Changes

Display new notification token in the notification sidebar

### Demo or Before and After


**Minted 1 token**

<img width="470" alt="CleanShot 2023-08-17 at 09 07 34@2x" src="https://github.com/gallery-so/gallery/assets/4480258/c904699a-c6fc-4313-b4d7-34085dc9e162">



**If minted multiple tokens**

<img width="469" alt="CleanShot 2023-08-17 at 09 04 49@2x" src="https://github.com/gallery-so/gallery/assets/4480258/0a27e0fa-0e3b-4d32-9f14-e7c3e1173a94">


**Demo**


https://github.com/gallery-so/gallery/assets/4480258/92adefd7-d45c-4d64-8989-cd77ed978194




### Edge Cases

1. Submit a post from notification sidebar
2. Notification that has invalid media (shouldn't show in the list)
3. Notification that has multiple tokens
4. Test the feature flag whether the notification is shown or not

### Testing Steps

1. Login to web
2. You should see a new token notification
3. You're able to post directly from notification sidebar. It will open the post composer

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
