### PR TITLE
[GAL-4046] show posts in following feed

### DIFF
--- a/apps/web/src/components/Feed/LatestFollowingFeed.tsx
+++ b/apps/web/src/components/Feed/LatestFollowingFeed.tsx
@@ -35,11 +35,7 @@ export function LatestFollowingFeed({ onSeeAll, queryRef }: Props) {
               @connection(key: "ViewerFeedFragment_feed") {
               edges {
                 node {
-                  ... on FeedEvent {
-                    __typename
-
-                    ...FeedListEventDataFragment
-                  }
+                  ...FeedListEventDataFragment
                 }
               }
             }
@@ -73,7 +69,7 @@ export function LatestFollowingFeed({ onSeeAll, queryRef }: Props) {
     const events = [];
 
     for (const edge of query.viewer?.feed?.edges ?? []) {
-      if (edge?.node?.__typename === 'FeedEvent' && edge.node) {
+      if (edge?.node) {
         events.push(edge.node);
       }
     }


### PR DESCRIPTION
### Summary of Changes

Show Posts in the following feed.

### Demo or Before and After
See url bar, it's showing the following feed
![CleanShot 2023-08-17 at 17 38 41](https://github.com/gallery-so/gallery/assets/80802871/dd3a14ac-6a49-4b50-96d7-d349082c33fb)



### Edge Cases
N/A

### Testing Steps

Go to `/latest/following` while signed in.

### Checklist

Please make sure to review and check all of the following:

- [ ] The changes have been tested and all tests pass.
- [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
