### PR TITLE
make view more comment and comment icon open same sheet

### DIFF
--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
@@ -111,7 +111,7 @@ export function CommentsBottomSheet({ bottomSheetRef, feedId, type }: CommentsBo
           Comments
         </Typography>
 
-        <View className="flex-grow">
+        <View className="flex-grow px-1">
           <Suspense fallback={<CommentListFallback />}>
             {isOpen && <ConnectedCommentsList type={type} feedId={feedId} />}
           </Suspense>
@@ -192,7 +192,18 @@ function ConnectedEventCommentsList({ feedId }: { feedId: string }) {
 
   return (
     <View className="flex-1">
-      <CommentsBottomSheetList onLoadMore={handleLoadMore} commentRefs={comments} />
+      {comments.length > 0 ? (
+        <CommentsBottomSheetList onLoadMore={handleLoadMore} commentRefs={comments} />
+      ) : (
+        <View className="flex items-center justify-center h-full">
+          <Typography
+            className="text-sm px-4 text-shadow"
+            font={{ family: 'ABCDiatype', weight: 'Bold' }}
+          >
+            No comments yet
+          </Typography>
+        </View>
+      )}
     </View>
   );
 }
@@ -251,7 +262,18 @@ function ConnectedPostCommentsList({ feedId }: { feedId: string }) {
 
   return (
     <View className="flex-1">
-      <CommentsBottomSheetList onLoadMore={handleLoadMore} commentRefs={comments} />
+      {comments.length > 0 ? (
+        <CommentsBottomSheetList onLoadMore={handleLoadMore} commentRefs={comments} />
+      ) : (
+        <View className="flex items-center justify-center h-full">
+          <Typography
+            className="text-sm px-4 text-shadow"
+            font={{ family: 'ABCDiatype', weight: 'Bold' }}
+          >
+            No comments yet
+          </Typography>
+        </View>
+      )}
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
@@ -31,24 +31,26 @@ export function CommentsBottomSheetLine({ commentRef }: CommentLineProps) {
   const timeAgo = getTimeSince(comment.creationTime);
 
   return (
-    <View className="flex flex-row justify-between items-center px-4">
-      <View>
-        <View className="flex flex-row space-x-1 items-center">
-          {comment.commenter && <ProfilePicture userRef={comment.commenter} size="sm" />}
-          <View className="flex flex-row space-x-1 h-5 -mt-2">
-            <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-              {comment.commenter?.username}
-            </Typography>
-            <Typography
-              className="text-xxs text-metal -mt-1"
-              font={{ family: 'ABCDiatype', weight: 'Regular' }}
-            >
-              {timeAgo}
-            </Typography>
-          </View>
+    <View className="flex flex-row space-x-2 px-2">
+      {comment.commenter && (
+        <View className="mt-1">
+          <ProfilePicture userRef={comment.commenter} size="sm" />
         </View>
-        <View className="pl-7 -mt-2.5">
-          <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+      )}
+      <View className="flex flex-col grow-0">
+        <View className="flex flex-row space-x-1">
+          <Typography className="text-sm leading-4" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+            {comment.commenter?.username}
+          </Typography>
+          <Typography
+            className="text-xxs text-metal leading-4"
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
+          >
+            {timeAgo}
+          </Typography>
+        </View>
+        <View className="flex">
+          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
             {comment.comment}
           </Typography>
         </View>

--- a/apps/mobile/src/components/Feed/Posts/FeedPostSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Posts/FeedPostSocializeSection.tsx
@@ -133,7 +133,6 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef, onCommentPress
             type="Post"
             feedId={post.dbid}
             onClick={onCommentPress}
-            // onSubmit={handleSubmit}
             isSubmittingComment={isSubmittingComment}
             bottomSheetRef={bottomSheetRef}
           />

--- a/apps/mobile/src/components/Feed/Posts/FeedPostSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Posts/FeedPostSocializeSection.tsx
@@ -75,17 +75,7 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef, onCommentPress
     queryRef: query,
   });
 
-  const { submitComment, isSubmittingComment } = usePostComment();
-
-  const handleSubmit = useCallback(
-    (value: string) => {
-      submitComment({
-        feedId: post.dbid,
-        value,
-      });
-    },
-    [post.dbid, submitComment]
-  );
+  const { isSubmittingComment } = usePostComment();
 
   const nonNullComments = useMemo(() => {
     const comments = [];
@@ -140,8 +130,10 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef, onCommentPress
         <View className="flex flex-row space-x-1">
           <AdmireButton onPress={toggleAdmire} isAdmired={hasViewerAdmiredEvent} />
           <CommentButton
+            type="Post"
+            feedId={post.dbid}
             onClick={onCommentPress}
-            onSubmit={handleSubmit}
+            // onSubmit={handleSubmit}
             isSubmittingComment={isSubmittingComment}
             bottomSheetRef={bottomSheetRef}
           />

--- a/apps/mobile/src/components/Feed/Socialize/CommentBox.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentBox.tsx
@@ -1,14 +1,8 @@
 import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 import { useColorScheme } from 'nativewind';
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
-import { Text, View, ViewStyle } from 'react-native';
-import Animated, {
-  AnimatedStyleProp,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-} from 'react-native-reanimated';
-import { XMarkIcon } from 'src/icons/XMarkIcon';
+import { Text, View } from 'react-native';
+import Animated, { useSharedValue, withSpring } from 'react-native-reanimated';
 import useKeyboardStatus from 'src/utils/useKeyboardStatus';
 
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
@@ -73,13 +67,6 @@ export function CommentBox({
 
   const width = useSharedValue(0);
   const display = useSharedValue('none');
-  const xmarkIconStyle = useAnimatedStyle(() => {
-    return {
-      overflow: 'hidden',
-      width: width.value,
-      display: display.value,
-    } as AnimatedStyleProp<ViewStyle>;
-  });
 
   useLayoutEffect(() => {
     if (showXMark) {
@@ -92,7 +79,7 @@ export function CommentBox({
   }, [showXMark, width, display]);
 
   return (
-    <View className="px-2 pb-2 flex flex-row items-center space-x-3">
+    <View className="p-2 flex flex-row items-center space-x-3 border-t border-porcelain dark:border-black-500">
       <Animated.View className="flex-1 flex-row justify-between items-center bg-faint dark:bg-black-800 p-1.5 space-x-3">
         <BottomSheetTextInput
           value={value}
@@ -120,14 +107,6 @@ export function CommentBox({
         `}
           >
             <SendIcon />
-          </View>
-        </GalleryTouchableOpacity>
-      </Animated.View>
-
-      <Animated.View style={xmarkIconStyle}>
-        <GalleryTouchableOpacity eventElementId={null} eventName={null} onPress={handleDismiss}>
-          <View className="h-6 w-6  items-center justify-center rounded-full">
-            <XMarkIcon />
           </View>
         </GalleryTouchableOpacity>
       </Animated.View>

--- a/apps/mobile/src/components/Feed/Socialize/CommentButton.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentButton.tsx
@@ -1,44 +1,29 @@
-import { useColorScheme } from 'nativewind';
-import { ForwardedRef, useCallback, useMemo, useRef } from 'react';
-import { View, ViewProps } from 'react-native';
+import { ForwardedRef, useCallback, useRef } from 'react';
+import { ViewProps } from 'react-native';
 
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
+import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 
-import { CommentBox } from './CommentBox';
+import { CommentsBottomSheet } from '../CommentsBottomSheet/CommentsBottomSheet';
+import { FeedItemTypes } from '../createVirtualizedFeedEventItems';
 import { CommentIcon } from './CommentIcon';
 
 type Props = {
   style?: ViewProps['style'];
   onClick: () => void;
-  onSubmit: (value: string) => void;
+  feedId: string;
+  type: FeedItemTypes;
   isSubmittingComment: boolean;
 
   bottomSheetRef: ForwardedRef<GalleryBottomSheetModalType>;
 };
 
-export function CommentButton({
-  style,
-  onClick,
-  onSubmit,
-  isSubmittingComment,
-  bottomSheetRef,
-}: Props) {
-  const { colorScheme } = useColorScheme();
-
-  const snapPoints = useMemo(() => [52], []);
-  const internalRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const handleCloseCommentBox = useCallback(() => {
-    internalRef.current?.close();
-  }, []);
+export function CommentButton({ style, onClick, type, feedId }: Props) {
+  const commentsBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
   const toggleCommentBox = useCallback(() => {
     onClick();
-    internalRef.current?.present();
+    commentsBottomSheetRef.current?.present();
   }, [onClick]);
 
   return (
@@ -52,47 +37,7 @@ export function CommentButton({
       >
         <CommentIcon className="h-[20]" />
       </GalleryTouchableOpacity>
-      <GalleryBottomSheetModal
-        index={0}
-        ref={(value) => {
-          internalRef.current = value;
-
-          if (bottomSheetRef) {
-            if (typeof bottomSheetRef === 'function') {
-              bottomSheetRef(value);
-            } else {
-              bottomSheetRef.current = value;
-            }
-          }
-        }}
-        snapPoints={snapPoints}
-        enableHandlePanningGesture={false}
-        android_keyboardInputMode="adjustResize"
-        handleComponent={Handle}
-        handleIndicatorStyle={{
-          display: 'none',
-        }}
-      >
-        <View className={`${colorScheme === 'dark' ? 'bg-black' : 'bg-white'}`}>
-          <CommentBox
-            autoFocus
-            onClose={handleCloseCommentBox}
-            onSubmit={onSubmit}
-            isSubmittingComment={isSubmittingComment}
-          />
-        </View>
-      </GalleryBottomSheetModal>
+      <CommentsBottomSheet type={type} feedId={feedId} bottomSheetRef={commentsBottomSheetRef} />
     </>
-  );
-}
-
-function Handle() {
-  const { colorScheme } = useColorScheme();
-  return (
-    <View
-      className={`h-2 border-t ${
-        colorScheme === 'dark' ? 'bg-black border-black-800' : 'bg-white border-porcelain'
-      }`}
-    />
   );
 }

--- a/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -133,7 +133,6 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
           type="FeedEvent"
           feedId={event.dbid}
           onClick={onCommentPress}
-          // onSubmit={handleSubmit}
           isSubmittingComment={isSubmittingComment}
           bottomSheetRef={bottomSheetRef}
         />

--- a/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { useEventComment } from 'src/hooks/useEventComment';
@@ -77,7 +77,7 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
     queryRef: query,
   });
 
-  const { submitComment, isSubmittingComment } = useEventComment();
+  const { isSubmittingComment } = useEventComment();
 
   const nonNullComments = useMemo(() => {
     const comments = [];
@@ -109,17 +109,6 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
 
   const totalAdmires = event.admires?.pageInfo?.total ?? 0;
 
-  const handleSubmit = useCallback(
-    (value: string) => {
-      submitComment({
-        feedEventId: event.dbid,
-        value,
-        onSuccess: () => {},
-      });
-    },
-    [event.dbid, submitComment]
-  );
-
   if (event.eventData?.__typename === 'UserFollowedUsersFeedEventData') {
     return <View className="pb-6" />;
   }
@@ -141,8 +130,10 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
       <View className="flex flex-row space-x-1">
         <AdmireButton onPress={toggleAdmire} isAdmired={hasViewerAdmiredEvent} />
         <CommentButton
+          type="FeedEvent"
+          feedId={event.dbid}
           onClick={onCommentPress}
-          onSubmit={handleSubmit}
+          // onSubmit={handleSubmit}
           isSubmittingComment={isSubmittingComment}
           bottomSheetRef={bottomSheetRef}
         />


### PR DESCRIPTION
### Summary of Changes

This PR makes tapping "View X other comments" and the Comment icon open the same comments sheet.
it also adds an empty state to the sheet, along with minor layout adjustments to the comment list.
there are further styling fixes we'll need to make to comments, but we'll address them as a follow up PR

- [x] comment icon + "View X other comments" opens same bottom sheet
- [x] empty state if no comments
- [x] remove close button
- [x] add top border above text input

### Demo or Before and After

https://github.com/gallery-so/gallery/assets/80802871/5991b577-1f39-4973-845b-af9dc058db44




### Edge Cases

- if no comments, show "No Comments"


dark mode looking good
<img width="446" alt="CleanShot 2023-08-17 at 22 55 31@2x" src="https://github.com/gallery-so/gallery/assets/80802871/b89e079f-67f6-4e53-91a4-0392dce92727">


### Testing Steps

Tap both things mentioned above
### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [x] MOBILE APP: The changes have been tested on both light and dark modes.
