### PR TITLE
[GAL-4034] Add refresh to nft selector

### DIFF
--- a/apps/mobile/src/components/Toast/Toast.tsx
+++ b/apps/mobile/src/components/Toast/Toast.tsx
@@ -16,9 +16,16 @@ type Props = {
   onClose?: () => void;
   autoClose?: boolean;
   children?: ReactNode;
+  withoutNavbar?: boolean;
 };
 
-export function AnimatedToast({ message, onClose = () => {}, autoClose = true, children }: Props) {
+export function AnimatedToast({
+  message,
+  onClose = () => {},
+  autoClose = true,
+  children,
+  withoutNavbar,
+}: Props) {
   const animationValue = useState(new Animated.Value(0))[0];
 
   const { bottom } = useSafeAreaInsets();
@@ -67,7 +74,7 @@ export function AnimatedToast({ message, onClose = () => {}, autoClose = true, c
       style={[
         {
           // 56 is the height of the bottom navigation bar
-          bottom: bottom + 56,
+          bottom: bottom + (withoutNavbar ? 0 : 56),
         },
         animatedStyles,
       ]}

--- a/apps/mobile/src/contexts/ToastContext.tsx
+++ b/apps/mobile/src/contexts/ToastContext.tsx
@@ -9,10 +9,17 @@ type ToastProps = {
   onDismiss?: DismissToastHandler;
   autoClose?: boolean;
   children?: ReactNode;
+  withoutNavbar?: boolean;
 };
 
 type ToastActions = {
-  pushToast: ({ message, onDismiss, autoClose, children }: ToastProps) => void;
+  pushToast: ({
+    message,
+    onDismiss,
+    autoClose,
+    children,
+    withoutNavbar = false,
+  }: ToastProps) => void;
   dismissToast: (id: string) => void;
   dismissAllToasts: () => void;
 };
@@ -36,6 +43,7 @@ type ToastType = {
   onDismiss: DismissToastHandler;
   autoClose: boolean;
   children?: ReactNode;
+  withoutNavbar?: boolean;
 };
 
 type Props = { children: ReactNode };
@@ -44,10 +52,10 @@ const ToastProvider = memo(({ children }: Props) => {
   const [toasts, setToasts] = useState<ToastType[]>([]);
 
   const pushToast = useCallback(
-    ({ message, onDismiss = noop, autoClose = true, children }: ToastProps) => {
+    ({ message, onDismiss = noop, autoClose = true, children, withoutNavbar }: ToastProps) => {
       setToasts((previousMessages) => [
         ...previousMessages,
-        { message, onDismiss, autoClose, id: Date.now().toString(), children },
+        { message, onDismiss, autoClose, id: Date.now().toString(), children, withoutNavbar },
       ]);
     },
     []
@@ -84,13 +92,14 @@ const ToastProvider = memo(({ children }: Props) => {
 
   return (
     <ToastActionsContext.Provider value={value}>
-      {toasts.map(({ message, autoClose, id, children }) => (
+      {toasts.map(({ message, autoClose, id, children, withoutNavbar }) => (
         <AnimatedToast
           data-testid={id}
           key={id}
           message={message}
           onClose={() => dismissToast(id)}
           autoClose={autoClose}
+          withoutNavbar={withoutNavbar}
         >
           {children}
         </AnimatedToast>

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
@@ -179,6 +179,7 @@ function AnimatedRefreshIcon({ networkFilter, onRefresh }: AnimatedRefreshIconPr
     onRefresh();
     pushToast({
       message: 'Successfully refreshed your collection',
+      withoutNavbar: true,
     });
   }, [isSyncing, networkFilter, onRefresh, pushToast, syncTokens]);
 


### PR DESCRIPTION
### Summary of Changes

- Add refresh functionality to nft selector
- Add positioning support to Toast

### Demo or Before and After

https://github.com/gallery-so/gallery/assets/4480258/95245038-a5c9-45fe-af29-650a0aec76ce


### Edge Cases

1. Test refresh from nft selector
2. Check whether the new nft show up
3. Only show the refresh icon if single network was selected

### Testing Steps

1. Open nft selector through pfp/post
2. Click the refresh icon

### Checklist

Please make sure to review and check all of the following:

- [x] MOBILE APP: The changes have been tested on both light and dark modes.
