### PR TITLE
make comments tappable to open sheet, fix add comment tappable, adjus…

### DIFF
--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
@@ -32,7 +32,7 @@ import useKeyboardStatus from '../../../utils/useKeyboardStatus';
 import { FeedItemTypes } from '../createVirtualizedFeedEventItems';
 import { CommentListFallback } from './CommentListFallback';
 
-const SNAP_POINTS = [350];
+const SNAP_POINTS = [400];
 
 type CommentsBottomSheetProps = {
   feedId: string;

--- a/apps/mobile/src/components/Feed/Socialize/AdmireLine.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/AdmireLine.tsx
@@ -83,8 +83,13 @@ export function AdmireLine({
   }
 
   return (
-    <View style={style} className="flex flex-row items-center">
-      <GalleryTouchableOpacity onPress={onAdmirePress} eventElementId={null} eventName={null}>
+    <View style={style} className="flex flex-row items-center ">
+      <GalleryTouchableOpacity
+        onPress={onAdmirePress}
+        eventElementId={'AdmireLine First Admire CTA'}
+        eventName={'Tapped AdmireLine First Admire CTA'}
+        className="flex  justify-center h-6"
+      >
         <Typography className="text-xs" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
           Be the first to admire this
         </Typography>

--- a/apps/mobile/src/components/Feed/Socialize/CommentBox.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentBox.tsx
@@ -90,6 +90,7 @@ export function CommentBox({
           autoComplete="off"
           autoFocus={autoFocus}
           onBlur={handleDismiss}
+          placeholder="Add a comment..."
           onSubmitEditing={handleDismiss}
           keyboardAppearance={colorScheme}
           style={{ flex: 1, color: colorScheme === 'dark' ? colors.white : colors.black['800'] }}

--- a/apps/mobile/src/components/Feed/Socialize/CommentBox.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentBox.tsx
@@ -91,6 +91,7 @@ export function CommentBox({
           autoFocus={autoFocus}
           onBlur={handleDismiss}
           placeholder="Add a comment..."
+          placeholderTextColor={colorScheme === 'dark' ? colors.shadow : colors.metal}
           onSubmitEditing={handleDismiss}
           keyboardAppearance={colorScheme}
           style={{ flex: 1, color: colorScheme === 'dark' ? colors.white : colors.black['800'] }}

--- a/apps/mobile/src/components/Feed/Socialize/CommentButton.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentButton.tsx
@@ -1,43 +1,24 @@
-import { ForwardedRef, useCallback, useRef } from 'react';
 import { ViewProps } from 'react-native';
 
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 
-import { CommentsBottomSheet } from '../CommentsBottomSheet/CommentsBottomSheet';
-import { FeedItemTypes } from '../createVirtualizedFeedEventItems';
 import { CommentIcon } from './CommentIcon';
 
 type Props = {
   style?: ViewProps['style'];
-  onClick: () => void;
-  feedId: string;
-  type: FeedItemTypes;
-  isSubmittingComment: boolean;
-
-  bottomSheetRef: ForwardedRef<GalleryBottomSheetModalType>;
+  openCommentBottomSheet: () => void;
 };
 
-export function CommentButton({ style, onClick, type, feedId }: Props) {
-  const commentsBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const toggleCommentBox = useCallback(() => {
-    onClick();
-    commentsBottomSheetRef.current?.present();
-  }, [onClick]);
-
+export function CommentButton({ style, openCommentBottomSheet }: Props) {
   return (
-    <>
-      <GalleryTouchableOpacity
-        onPress={toggleCommentBox}
-        className="flex justify-center items-center w-[32] h-[32] pt-1 "
-        style={style}
-        eventElementId="Toggle Comment Box"
-        eventName="Toggle Comment Box Clicked"
-      >
-        <CommentIcon className="h-[20]" />
-      </GalleryTouchableOpacity>
-      <CommentsBottomSheet type={type} feedId={feedId} bottomSheetRef={commentsBottomSheetRef} />
-    </>
+    <GalleryTouchableOpacity
+      onPress={openCommentBottomSheet}
+      className="flex justify-center items-center w-[32] h-[32] pt-1 "
+      style={style}
+      eventElementId="Toggle Comment Box"
+      eventName="Toggle Comment Box Clicked"
+    >
+      <CommentIcon className="h-[20]" />
+    </GalleryTouchableOpacity>
   );
 }

--- a/apps/mobile/src/components/Feed/Socialize/CommentLine.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentLine.tsx
@@ -1,15 +1,18 @@
-import { Text, View, ViewProps } from 'react-native';
+import { View, ViewProps } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
+import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
+import { Typography } from '~/components/Typography';
 import { UsernameDisplay } from '~/components/UsernameDisplay';
 import { CommentLineFragment$key } from '~/generated/CommentLineFragment.graphql';
 
 type Props = {
   commentRef: CommentLineFragment$key;
   style?: ViewProps['style'];
+  onCommentPress?: () => void;
 };
 
-export function CommentLine({ commentRef, style }: Props) {
+export function CommentLine({ commentRef, style, onCommentPress }: Props) {
   const comment = useFragment(
     graphql`
       fragment CommentLineFragment on Comment {
@@ -23,11 +26,18 @@ export function CommentLine({ commentRef, style }: Props) {
   );
 
   return (
-    <View className="flex flex-row" style={style}>
-      <Text>
-        <UsernameDisplay userRef={comment.commenter} />
-        <Text className="text-xs dark:text-white flex-1"> {comment.comment}</Text>
-      </Text>
+    <View className="flex flex-row space-x-1" style={style}>
+      <UsernameDisplay userRef={comment.commenter} />
+      <GalleryTouchableOpacity
+        onPress={onCommentPress}
+        eventElementId={null}
+        eventName={null}
+        className="flex flex-row wrap"
+      >
+        <Typography className={`text-xs`} font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+          {comment.comment}
+        </Typography>
+      </GalleryTouchableOpacity>
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/Socialize/Interactions.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/Interactions.tsx
@@ -3,7 +3,6 @@ import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
 import { AdmireBottomSheet } from '~/components/Feed/AdmireBottomSheet/AdmireBottomSheet';
-import { CommentsBottomSheet } from '~/components/Feed/CommentsBottomSheet/CommentsBottomSheet';
 import { AdmireLine } from '~/components/Feed/Socialize/AdmireLine';
 import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { ProfilePictureBubblesWithCount } from '~/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers';
@@ -18,24 +17,25 @@ const PREVIEW_COMMENT_COUNT = 1;
 
 type Props = {
   type: FeedItemTypes;
-  commentRefs: InteractionsCommentsFragment$key;
-  admireRefs: InteractionsAdmiresFragment$key;
-  totalComments: number;
-  totalAdmires: number;
   feedId: string;
+  admireRefs: InteractionsAdmiresFragment$key;
+  commentRefs: InteractionsCommentsFragment$key;
+  totalAdmires: number;
+  totalComments: number;
 
   onAdmirePress: () => void;
+  openCommentBottomSheet: () => void;
 };
 
 export function Interactions({
+  type,
+  feedId,
   admireRefs,
   commentRefs,
-  feedId,
   totalAdmires,
   totalComments,
-  type,
-
   onAdmirePress,
+  openCommentBottomSheet,
 }: Props) {
   const comments = useFragment(
     graphql`
@@ -64,10 +64,6 @@ export function Interactions({
     admiresBottomSheetRef.current?.present();
   }, []);
 
-  const handleSeeAllComments = useCallback(() => {
-    commentsBottomSheetRef.current?.present();
-  }, []);
-
   const admireUsers = useMemo(() => {
     const users = [];
     for (const admire of admires) {
@@ -80,11 +76,10 @@ export function Interactions({
 
   const previewComments = comments.slice(-PREVIEW_COMMENT_COUNT);
 
-  const commentsBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
   const admiresBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
   return (
-    <View className="flex flex-col space-y-1">
+    <View className="flex flex-col space-y-2">
       <View className="flex flex-row space-x-1 items-center">
         {admireUsers.length > 0 && (
           <ProfilePictureBubblesWithCount
@@ -104,15 +99,21 @@ export function Interactions({
         />
       </View>
 
-      {previewComments.map((comment) => {
-        return <CommentLine key={comment.dbid} commentRef={comment} />;
-      })}
+      <View className="flex flex-col space-y-1">
+        {previewComments.map((comment) => {
+          return (
+            <CommentLine
+              key={comment.dbid}
+              commentRef={comment}
+              onCommentPress={openCommentBottomSheet}
+            />
+          );
+        })}
 
-      {totalComments > 1 && (
-        <RemainingCommentCount totalCount={totalComments} onPress={handleSeeAllComments} />
-      )}
-
-      <CommentsBottomSheet type={type} feedId={feedId} bottomSheetRef={commentsBottomSheetRef} />
+        {totalComments > 1 && (
+          <RemainingCommentCount totalCount={totalComments} onPress={openCommentBottomSheet} />
+        )}
+      </View>
 
       <AdmireBottomSheet type={type} feedId={feedId} bottomSheetRef={admiresBottomSheetRef} />
     </View>

--- a/apps/mobile/src/components/Feed/Socialize/RemainingCommentCount.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/RemainingCommentCount.tsx
@@ -22,7 +22,10 @@ export function RemainingCommentCount({ style, onPress, totalCount }: Props) {
         eventElementId="Expand Admirers Button"
         eventName="Expand Admirers Button Clicked"
       >
-        <Typography className="text-xs underline" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+        <Typography
+          className="text-xs  color-shadow"
+          font={{ family: 'ABCDiatype', weight: 'Regular' }}
+        >
           View all {totalCount} comments
         </Typography>
       </GalleryTouchableOpacity>

--- a/apps/mobile/src/components/Feed/Socialize/RemainingCommentCount.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/RemainingCommentCount.tsx
@@ -23,7 +23,7 @@ export function RemainingCommentCount({ style, onPress, totalCount }: Props) {
         eventName="Expand Admirers Button Clicked"
       >
         <Typography
-          className="text-xs  color-shadow"
+          className="text-xs color-shadow"
           font={{ family: 'ABCDiatype', weight: 'Regular' }}
         >
           View all {totalCount} comments


### PR DESCRIPTION



### Summary of Changes
This PR increases the tappable areas to open the Comment Bottom Sheet.
it also includes bug fixes and style fixes for various comment items listed below


- [x] Comments visible on the feed are tappable, and opens comment sheet
- [x] fixed add comment (wasn't opening sheet)
- [x] styling changes to first comment CTA and "view x other comments" 
- [x] vertically center "Be the first to admire this"
- [x] fixes the comment sheet shifting when opened due to suspense fallback component 
- [x] add temp placeholder to comment input

### Demo or Before and After

https://github.com/gallery-so/gallery/assets/80802871/a20e4ba9-f5a0-4c3c-bf05-ff62bd61e111

before
![CleanShot 2023-08-18 at 14 36 38](https://github.com/gallery-so/gallery/assets/80802871/00d6b6a9-6869-4e5c-9e3a-29f18461c7d4)


after
![CleanShot 2023-08-18 at 14 31 48](https://github.com/gallery-so/gallery/assets/80802871/ae491198-441c-4f98-b168-4efcf28338c9)


before
![CleanShot 2023-08-18 at 14 36 53](https://github.com/gallery-so/gallery/assets/80802871/86899be5-a008-4fd9-9b58-452f080239dc)

after
![CleanShot 2023-08-18 at 14 31 06](https://github.com/gallery-so/gallery/assets/80802871/9b418bf8-a995-48d8-9c07-d585d064ae93)

before

https://github.com/gallery-so/gallery/assets/80802871/e39a5e4e-9128-4601-bad2-af5907a87d9c

after

https://github.com/gallery-so/gallery/assets/80802871/67acee12-26d9-4d61-a512-309f83b6d5d3


placeholder  on light/dark mode

![CleanShot 2023-08-18 at 14 49 30](https://github.com/gallery-so/gallery/assets/80802871/1dc6b11b-d81b-4c67-ad1f-26a6b2f73844)

![CleanShot 2023-08-18 at 14 47 17](https://github.com/gallery-so/gallery/assets/80802871/d543c6bd-adfd-4142-8779-5492bcb82893)


### Edge Cases

Verified social sections for both Feed Event and Posts are good


### Testing Steps

Use comment feature on mobile app

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [x] MOBILE APP: The changes have been tested on both light and dark modes.
