### PR TITLE
[GAL-4044] Caption in "user commented on your post" notification overlaps image

### DIFF
--- a/apps/mobile/src/components/Notification/NotificationSkeleton.tsx
+++ b/apps/mobile/src/components/Notification/NotificationSkeleton.tsx
@@ -111,7 +111,7 @@ export function NotificationSkeleton({
           size="md"
         />
 
-        <Text className="dark:text-white mt-[1] pr-1">{children}</Text>
+        <Text className="dark:text-white mt-[1] pr-1 flex-1">{children}</Text>
       </View>
       <View className="flex flex-row items-center justify-between space-x-2">
         {tokenUrl ? (

--- a/apps/mobile/src/components/Notification/Notifications/SomeoneCommentedOnYourPost.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/SomeoneCommentedOnYourPost.tsx
@@ -99,33 +99,31 @@ export function SomeoneCommentedOnYourPost({
       notificationRef={notification}
       tokenUrl={tokenUrl ?? undefined}
     >
-      <View className="flex-row space-x-2">
-        <View className="flex space-y-2">
-          <Text className="dark:text-white">
-            <Typography
-              font={{
-                family: 'ABCDiatype',
-                weight: 'Bold',
-              }}
-              className="text-sm"
-            >
-              {commenter ? commenter.username : 'Someone'}
-            </Typography>{' '}
-            commented on your{' '}
-            <Typography
-              font={{
-                family: 'ABCDiatype',
-                weight: 'Bold',
-              }}
-              className="text-sm"
-            >
-              post
-            </Typography>
-          </Text>
+      <View className="flex space-y-2">
+        <Text className="dark:text-white">
+          <Typography
+            font={{
+              family: 'ABCDiatype',
+              weight: 'Bold',
+            }}
+            className="text-sm"
+          >
+            {commenter ? commenter.username : 'Someone'}
+          </Typography>{' '}
+          commented on your{' '}
+          <Typography
+            font={{
+              family: 'ABCDiatype',
+              weight: 'Bold',
+            }}
+            className="text-sm"
+          >
+            post
+          </Typography>
+        </Text>
 
-          <View className="border-l-2 border-[#d9d9d9] pl-2">
-            <Text className="dark:text-white">{notification.comment?.comment ?? ''}</Text>
-          </View>
+        <View className="border-l-2 border-[#d9d9d9] pl-2">
+          <Text className="dark:text-white">{notification.comment?.comment ?? ''}</Text>
         </View>
       </View>
     </NotificationSkeleton>


### PR DESCRIPTION
### Summary of Changes

Fix overlap comment in the notification

### Demo or Before and After

| Before | After |
|--------|--------|
| ![image](https://github.com/gallery-so/gallery/assets/4480258/04703608-8c41-4925-ac9f-92cccf71a3e2) | <img width="459" alt="CleanShot 2023-08-18 at 13 53 38@2x" src="https://github.com/gallery-so/gallery/assets/4480258/7557bd58-0256-4802-bd4f-f632f52ad8f7">| 

### Edge Cases

1. Display with one line comment
2. two line comment
3. three line comment
4. Make sure it didn't affect other notification

### Testing Steps

1. Open notification screen
2. You should see the text didn't overlap the image

### Checklist

Please make sure to review and check all of the following:

- [x] MOBILE APP: The changes have been tested on both light and dark modes.
