### PR TITLE
remove logic to hide heading if no bio on mobile

### DIFF
--- a/apps/web/src/scenes/UserGalleryPage/UserNameAndDescriptionHeader.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserNameAndDescriptionHeader.tsx
@@ -95,11 +95,6 @@ export function UserNameAndDescriptionHeader({ userRef, queryRef }: Props) {
 
   const displayName = handleCustomDisplayName(username);
 
-  // If the user doesn't have a bio, don't render anything on mobile
-  if (isMobile && !unescapedBio) {
-    return null;
-  }
-
   return (
     <HeaderContainer
       gap={12}


### PR DESCRIPTION
### Summary of Changes

Old logic was preventing the username from appearing in the profile header if there was no bio

### Demo or Before and After

before
![CleanShot 2023-08-18 at 17 22 30](https://github.com/gallery-so/gallery/assets/80802871/29e7f6d9-8fba-40de-a1fb-a3eebde4f2ee)



after
![CleanShot 2023-08-18 at 17 22 20](https://github.com/gallery-so/gallery/assets/80802871/a006c983-fa36-4a93-aa9a-175358fb401f)


### Edge Cases
- still looks fine with or without bio

### Testing Steps
go to  a user without a bio (/jamiethetailor)

### Checklist

Please make sure to review and check all of the following:

- [ ] The changes have been tested and all tests pass.
- [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
