### PR TITLE
adjust line height for comment timestamp for alignment

### DIFF
--- a/apps/web/src/components/Feed/Socialize/CommentLine.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentLine.tsx
@@ -59,8 +59,8 @@ export function CommentLine({ commentRef }: CommentLineProps) {
 }
 const TimeAgoText = styled.div`
   font-family: ${BODY_FONT_FAMILY};
-  font-size: 12px;
-  line-height: 1;
+  font-size: 10px;
+  line-height: 18px;
   font-weight: 400;
 
   color: ${colors.metal};


### PR DESCRIPTION
### Summary of Changes

Comment timestamp was off on web, this fixes alignment so it appears centered against the first line of the comment 

### Demo or Before and After

before
<img width="401" alt="CleanShot 2023-08-22 at 00 44 54@2x" src="https://github.com/gallery-so/gallery/assets/80802871/b10157d7-ab51-4c26-b1dd-56097cc5952e">


after

<img width="396" alt="CleanShot 2023-08-22 at 00 39 24@2x" src="https://github.com/gallery-so/gallery/assets/80802871/63aaf0f0-55b4-4e6a-9851-54362e9d688d">

<img width="387" alt="CleanShot 2023-08-22 at 00 39 31@2x" src="https://github.com/gallery-so/gallery/assets/80802871/2ff2cc5c-c862-4835-86bb-2d2fa7b201a4">

### Edge Cases
multi line comments

### Testing Steps
check out a post + feed events with comments

### Checklist

Please make sure to review and check all of the following:

- [ ] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
