### PR TITLE
enable refresh button for all ethereum based chains

### DIFF
--- a/apps/web/src/components/NftSelector/NftSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelector.tsx
@@ -10,7 +10,7 @@ import { RefreshIcon } from '~/icons/RefreshIcon';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import useDebounce from '~/shared/hooks/useDebounce';
 import { Chain } from '~/shared/utils/chains';
-import { doesUserOwnWalletFromChain } from '~/utils/doesUserOwnWalletFromChain';
+import { doesUserOwnWalletFromChainFamily } from '~/utils/doesUserOwnWalletFromChainFamily';
 
 import IconContainer from '../core/IconContainer';
 import { HStack, VStack } from '../core/Spacer/Stack';
@@ -76,7 +76,7 @@ export function NftSelector({
             }
           }
         }
-        ...doesUserOwnWalletFromChainFragment
+        ...doesUserOwnWalletFromChainFamilyFragment
         ...NftSelectorFilterNetworkFragment
       }
     `,
@@ -170,8 +170,9 @@ export function NftSelector({
   const isRefreshDisabledAtUserLevel = isRefreshDisabledForUser(query.viewer?.user?.dbid ?? '');
   const refreshDisabled =
     isRefreshDisabledAtUserLevel ||
-    !doesUserOwnWalletFromChain(selectedNetworkView, query) ||
+    !doesUserOwnWalletFromChainFamily(selectedNetworkView, query) ||
     isLocked;
+
   const handleRefresh = useCallback(async () => {
     if (refreshDisabled) {
       return;


### PR DESCRIPTION
### Summary of Changes

Enable refresh button in NFT Select based on chain family, not just chain.
L2s are considered to be in the Ethereum chain family so our current logic to enable the refresh button wasn't working for L2s. 
I replaced the usage of `doesUserOwnWalletFromChain` with `doesUserOwnWalletFromChainFamily` to make the refresh button available for related chains.

### Demo or Before and After

before
![CleanShot 2023-08-22 at 17 52 02](https://github.com/gallery-so/gallery/assets/80802871/db826ee4-04c8-4124-ad80-d162c2e2c0d7)

after
![CleanShot 2023-08-22 at 17 49 57](https://github.com/gallery-so/gallery/assets/80802871/a8165026-99db-4b9e-aa19-921d1948f235)



### Edge Cases

N/A


### Testing Steps

Go to NFT Selector, select an L2 like Base. the refresh button should be clickable and work.

### Checklist

Please make sure to review and check all of the following:

- [ ] The changes have been tested and all tests pass.
- [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
