### PR TITLE
GAL-4078: show number of posts in community page tab on web

### DIFF
--- a/apps/web/src/hooks/api/posts/useCreatePost.ts
+++ b/apps/web/src/hooks/api/posts/useCreatePost.ts
@@ -104,9 +104,7 @@ export default function useCreatePost() {
 
             // Increment the displayed total number of posts in the community.
             // This count is a different record from the actual feed because we retrieve the count separately
-            const communityFeedPostsCountPageInfo = communityRoot
-              .getLinkedRecord('posts(last:0)')
-              ?.getLinkedRecord('pageInfo');
+            const communityFeedPostsCountPageInfo = communityFeedPosts?.getLinkedRecord('pageInfo');
 
             communityFeedPostsCountPageInfo?.setValue(
               ((communityFeedPostsCountPageInfo?.getValue('total') as number) ?? 0) + 1,

--- a/apps/web/src/hooks/api/posts/useDeletePost.ts
+++ b/apps/web/src/hooks/api/posts/useDeletePost.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { graphql, SelectorStoreUpdater } from 'relay-runtime';
+import { ConnectionHandler, graphql, SelectorStoreUpdater } from 'relay-runtime';
 
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { useDeletePostMutation } from '~/generated/useDeletePostMutation.graphql';
@@ -32,9 +32,11 @@ export default function useDeletePost() {
           // Decrement the post count on the community
           const communityRoot = store.get(communityId);
           if (communityRoot) {
-            const communityFeedPostsCountPageInfo = communityRoot
-              .getLinkedRecord('posts(last:0)')
-              ?.getLinkedRecord('pageInfo');
+            const communityFeedPosts = ConnectionHandler.getConnection(
+              communityRoot,
+              'CommunityFeed_posts'
+            );
+            const communityFeedPostsCountPageInfo = communityFeedPosts?.getLinkedRecord('pageInfo');
 
             communityFeedPostsCountPageInfo?.setValue(
               ((communityFeedPostsCountPageInfo?.getValue('total') as number) ?? 0) - 1,

--- a/apps/web/src/scenes/CommunityPage/CommunityPageTabs.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageTabs.tsx
@@ -20,12 +20,10 @@ export default function CommunityPageTabs({ onSelectTab, activeTab, communityRef
       fragment CommunityPageTabsFragment on Community {
         posts(before: $communityPostsBefore, last: $communityPostsLast)
           @connection(key: "CommunityFeed_posts") {
+          # Relay doesn't allow @connection w/o edges so we must query for it
+          # eslint-disable-next-line relay/unused-fields
           edges {
-            node {
-              ... on Post {
-                __typename
-              }
-            }
+            __typename
           }
           pageInfo {
             total

--- a/apps/web/src/scenes/CommunityPage/CommunityPageTabs.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageTabs.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
@@ -27,25 +27,16 @@ export default function CommunityPageTabs({ onSelectTab, activeTab, communityRef
               }
             }
           }
+          pageInfo {
+            total
+          }
         }
       }
     `,
     communityRef
   );
 
-  const feedData = useMemo(() => {
-    const events = [];
-
-    for (const edge of community.posts?.edges ?? []) {
-      if (edge?.node?.__typename === 'Post' && edge.node) {
-        events.push(edge.node);
-      }
-    }
-
-    return events;
-  }, [community.posts?.edges]);
-
-  const totalPosts = feedData?.length;
+  const totalPosts = community.posts?.pageInfo.total;
 
   const handleTabClick = useCallback(
     (tab: CommunityPageTab) => {

--- a/apps/web/src/scenes/CommunityPage/CommunityPageView.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageView.tsx
@@ -37,6 +37,7 @@ export default function CommunityPageView({ communityRef, queryRef }: Props) {
         }
 
         ...CommunityPageCollectorsTabFragment
+        ...CommunityPageTabsFragment
         ...CommunityPagePostsTabFragment
 
         ...CommunityPageViewHeaderFragment
@@ -78,7 +79,11 @@ export default function CommunityPageView({ communityRef, queryRef }: Props) {
             <CommunityPageViewHeader communityRef={community} queryRef={query} />
 
             {isKoalaEnabled && (
-              <CommunityPageTabs onSelectTab={setActiveTab} activeTab={activeTab} />
+              <CommunityPageTabs
+                onSelectTab={setActiveTab}
+                activeTab={activeTab}
+                communityRef={community}
+              />
             )}
 
             {activeTab === 'posts' && (


### PR DESCRIPTION
### Summary of Changes

show number of posts in community page tab on web

### Demo or Before and After

**Before:**
![CleanShot 2023-08-22 at 20 32 00@2x](https://github.com/gallery-so/gallery/assets/26466468/8cd39417-e713-451b-9d6c-abd200197d34)

**After:**
![CleanShot 2023-08-22 at 20 25 14@2x](https://github.com/gallery-so/gallery/assets/26466468/ebc28431-7b38-484e-84c0-e7e95fd89ef1)
![CleanShot 2023-08-22 at 20 34 37@2x](https://github.com/gallery-so/gallery/assets/26466468/587af04e-7e86-423e-b68b-216116a0efcf)

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
