### PR TITLE
[GAL-4076] Add empty state to comments on web

### DIFF
--- a/apps/web/src/components/Feed/Socialize/CommentsModal/CommentsModal.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentsModal/CommentsModal.tsx
@@ -12,11 +12,12 @@ import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
 import { VStack } from '~/components/core/Spacer/Stack';
-import { TitleDiatypeM } from '~/components/core/Text/Text';
+import { BaseM, TitleDiatypeM } from '~/components/core/Text/Text';
 import { CommentNote } from '~/components/Feed/Socialize/CommentsModal/CommentNote';
 import { MODAL_PADDING_PX } from '~/contexts/modal/constants';
 import { CommentsModalFragment$key } from '~/generated/CommentsModalFragment.graphql';
 import { CommentsModalQueryFragment$key } from '~/generated/CommentsModalQueryFragment.graphql';
+import colors from '~/shared/theme/colors';
 
 import { CommentBox } from '../CommentBox/CommentBox';
 
@@ -134,34 +135,40 @@ export function CommentsModal({
         <StyledHeader>
           <TitleDiatypeM>Comments</TitleDiatypeM>
         </StyledHeader>
-        <VStack grow>
-          <AutoSizer disableHeight>
-            {({ width }) => (
-              <InfiniteLoader
-                isRowLoaded={isRowLoaded}
-                loadMoreRows={handleLoadMore}
-                rowCount={rowCount}
-              >
-                {({ onRowsRendered, registerChild }) => (
-                  <div ref={(el) => registerChild(el)}>
-                    <List
-                      ref={virtualizedListRef}
-                      width={width}
-                      height={estimatedContentHeight}
-                      rowRenderer={rowRenderer}
-                      rowCount={comments.length}
-                      rowHeight={measurerCache.rowHeight}
-                      onRowsRendered={onRowsRendered}
-                      style={{
-                        paddingTop: '16px',
-                      }}
-                    />
-                  </div>
-                )}
-              </InfiniteLoader>
-            )}
-          </AutoSizer>
-        </VStack>
+        {rowCount === 0 ? (
+          <EmptyStateVStack align="center" justify="center">
+            <BaseM color={colors.metal}>No comments yet</BaseM>
+          </EmptyStateVStack>
+        ) : (
+          <VStack grow>
+            <AutoSizer disableHeight>
+              {({ width }) => (
+                <InfiniteLoader
+                  isRowLoaded={isRowLoaded}
+                  loadMoreRows={handleLoadMore}
+                  rowCount={rowCount}
+                >
+                  {({ onRowsRendered, registerChild }) => (
+                    <div ref={(el) => registerChild(el)}>
+                      <List
+                        ref={virtualizedListRef}
+                        width={width}
+                        height={estimatedContentHeight}
+                        rowRenderer={rowRenderer}
+                        rowCount={comments.length}
+                        rowHeight={measurerCache.rowHeight}
+                        onRowsRendered={onRowsRendered}
+                        style={{
+                          paddingTop: '16px',
+                        }}
+                      />
+                    </div>
+                  )}
+                </InfiniteLoader>
+              )}
+            </AutoSizer>
+          </VStack>
+        )}
         <CommentBox
           queryRef={query}
           onSubmitComment={onSubmitComment}
@@ -174,6 +181,11 @@ export function CommentsModal({
 
 const WrappingVStack = styled(VStack)`
   height: 100%;
+`;
+
+const EmptyStateVStack = styled(VStack)`
+  padding-top: 20px;
+  padding-bottom: 36px;
 `;
 
 const StyledHeader = styled.div`


### PR DESCRIPTION
### Summary of Changes
when 0 comments, modal has empty state message "No comments yet" in the color metal

### Before
![Screenshot 2023-08-23 at 7 15 14 PM](https://github.com/gallery-so/gallery/assets/49758803/7a57fe13-e021-4f55-b18e-97298a090db9)

### After
![Screenshot 2023-08-23 at 7 06 55 PM](https://github.com/gallery-so/gallery/assets/49758803/bf7226c2-cca8-4f29-bdcb-8c5288f4147c)
When comments > 0, no change is seen
![Screenshot 2023-08-23 at 7 09 11 PM](https://github.com/gallery-so/gallery/assets/49758803/06e50505-2781-44ee-b83f-da461ff55c6c)

### Edge Cases
Tested with 0, 1 and 1+ comments on modal and different window sizes

### Testing Steps
Can test locally on branch

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
