### PR TITLE
add error boundary around nftselector nft to prevent whole page crash

### DIFF
--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerSingularAsset.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerSingularAsset.tsx
@@ -10,6 +10,7 @@ import { NftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
 import { NftPreviewErrorFallback } from '~/components/NftPreview/NftPreviewErrorFallback';
 import { NftSelectorPickerSingularAssetFragment$key } from '~/generated/NftSelectorPickerSingularAssetFragment.graphql';
 import { MainTabStackNavigatorProp, RootStackNavigatorParamList } from '~/navigation/types';
+import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
 import colors from '~/shared/theme/colors';
 
@@ -68,26 +69,28 @@ export function NftSelectorPickerSingularAsset({
     }
   }, [currentScreen, navigation, onSelect, setProfileImage, token.dbid]);
   return (
-    <GalleryTouchableOpacity
-      style={style}
-      disabled={isSettingProfileImage}
-      onPress={handlePress}
-      className="flex-1 aspect-square relative"
-      eventElementId="NftSelectorPickerImage"
-      eventName="NftSelectorPickerImage pressed"
-      properties={{ tokenId: token.dbid }}
-    >
-      {tokenUrl ? (
-        <NftPreviewAsset tokenUrl={tokenUrl} resizeMode={ResizeMode.COVER} />
-      ) : (
-        <NftPreviewErrorFallback />
-      )}
+    <ReportingErrorBoundary fallback={<NftPreviewErrorFallback />}>
+      <GalleryTouchableOpacity
+        style={style}
+        disabled={isSettingProfileImage}
+        onPress={handlePress}
+        className="flex-1 aspect-square relative"
+        eventElementId="NftSelectorPickerImage"
+        eventName="NftSelectorPickerImage pressed"
+        properties={{ tokenId: token.dbid }}
+      >
+        {tokenUrl ? (
+          <NftPreviewAsset tokenUrl={tokenUrl} resizeMode={ResizeMode.COVER} />
+        ) : (
+          <NftPreviewErrorFallback />
+        )}
 
-      {isSettingProfileImage && (
-        <View className="absolute inset-0 bg-black opacity-50 flex items-center justify-center">
-          <ActivityIndicator color={colors.white} />
-        </View>
-      )}
-    </GalleryTouchableOpacity>
+        {isSettingProfileImage && (
+          <View className="absolute inset-0 bg-black opacity-50 flex items-center justify-center">
+            <ActivityIndicator color={colors.white} />
+          </View>
+        )}
+      </GalleryTouchableOpacity>
+    </ReportingErrorBoundary>
   );
 }


### PR DESCRIPTION
### Summary of Changes
Add an error boundary around the the nft asset in the nft selector, to prevent an nft load error from crashing the whole screen.


### Demo or Before and After
before
https://github.com/gallery-so/gallery/assets/80802871/8a972643-9008-4dd8-a8d4-f154e8cf0b62

after

https://github.com/gallery-so/gallery/assets/80802871/991ef672-3ee3-4af7-a77a-b6b7f33ac958




### Edge Cases
N/A, this change is to specifically gracefully handle the crash caused by this error

### Testing Steps
With an affected user that has a broken NFT, go to the nft selector and select the chain with the bad nft. the screen should not crash

### Checklist

Please make sure to review and check all of the following:

- [ ] The changes have been tested and all tests pass.
- [ ] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
