### PR TITLE
Disable liverender again on mobile

### DIFF
--- a/apps/web/src/components/NftPreview/CollectionTokenPreview.tsx
+++ b/apps/web/src/components/NftPreview/CollectionTokenPreview.tsx
@@ -1,6 +1,7 @@
 import { graphql, useFragment } from 'react-relay';
 
 import { CollectionTokenPreviewFragment$key } from '~/generated/CollectionTokenPreviewFragment.graphql';
+import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 
 import NftPreview from './NftPreview';
 
@@ -40,7 +41,8 @@ export default function CollectionTokenPreview({
   );
 
   const { collection, tokenSettings } = collectionToken;
-  const shouldLiveRender = Boolean(tokenSettings?.renderLive);
+  const isMobileOrLargeMobile = useIsMobileOrMobileLargeWindowWidth();
+  const shouldLiveRender = Boolean(tokenSettings?.renderLive) && !isMobileOrLargeMobile;
 
   return (
     <NftPreview


### PR DESCRIPTION
### Summary of Changes

Fixes regression from https://github.com/gallery-so/gallery/pull/1727, and makes sure to disable live rendering elements on mobile web to allow heavier profiles to load.

### Demo or Before and After

https://gallery.so/mitchell is now actually scrollable on mobile web


