### PR TITLE
Fix stale composer refresh

### DIFF
--- a/apps/web/src/components/Posts/PostComposerModal.tsx
+++ b/apps/web/src/components/Posts/PostComposerModal.tsx
@@ -18,23 +18,31 @@ import DiscardPostConfirmation from './DiscardPostConfirmation';
 import PostComposer from './PostComposer';
 
 type Props = {
-  tokensRef: PostComposerModalWithSelectorFragment$key;
+  viewerRef: PostComposerModalWithSelectorFragment$key;
   queryRef: PostComposerModalWithSelectorQueryFragment$key;
   preSelectedContract?: NftSelectorContractType;
 };
 
 // Modal with multiple steps: the NFT Selector -> then Post Composer
-export function PostComposerModalWithSelector({ tokensRef, queryRef, preSelectedContract }: Props) {
-  const tokens = useFragment(
+export function PostComposerModalWithSelector({ viewerRef, queryRef, preSelectedContract }: Props) {
+  const viewer = useFragment(
     graphql`
-      fragment PostComposerModalWithSelectorFragment on Token @relay(plural: true) {
-        dbid
-        ...NftSelectorFragment
-        ...PostComposerFragment
+      fragment PostComposerModalWithSelectorFragment on Viewer {
+        user {
+          tokens(ownershipFilter: [Creator, Holder]) {
+            dbid
+            ...NftSelectorFragment
+            ...PostComposerFragment
+          }
+        }
       }
     `,
-    tokensRef
+    viewerRef
   );
+
+  const tokens = useMemo(() => {
+    return removeNullValues(viewer?.user?.tokens) ?? [];
+  }, [viewer]);
 
   const query = useFragment(
     graphql`

--- a/apps/web/src/components/Profile/EditUserInfoForm.tsx
+++ b/apps/web/src/components/Profile/EditUserInfoForm.tsx
@@ -54,7 +54,7 @@ function UserInfoForm({
           __typename
         }
 
-        tokens {
+        tokens(ownershipFilter: [Creator, Holder]) {
           ...ProfilePictureDropdownFragment
           ...useNftSelectorFragment
         }

--- a/apps/web/src/hooks/api/tokens/useSyncTokens.ts
+++ b/apps/web/src/hooks/api/tokens/useSyncTokens.ts
@@ -22,6 +22,8 @@ export default function useSyncTokens() {
               # This should be sufficient to capture all the things
               # we want to refresh. Don't @me when this fails.
               ...GalleryEditorViewerFragment
+              # Refresh tokens for post composer
+              ...PostComposerModalWithSelectorFragment
 
               ... on Viewer {
                 user {

--- a/apps/web/src/scenes/CommunityPage/CommunityPageMetadata.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageMetadata.tsx
@@ -16,11 +16,9 @@ import { useIsMemberOfCommunity } from '~/contexts/communityPage/IsMemberOfCommu
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { CommunityPageMetadataFragment$key } from '~/generated/CommunityPageMetadataFragment.graphql';
 import { CommunityPageMetadataQueryFragment$key } from '~/generated/CommunityPageMetadataQueryFragment.graphql';
-import { PostComposerModalWithSelectorFragment$key } from '~/generated/PostComposerModalWithSelectorFragment.graphql';
 import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import { PlusSquareIcon } from '~/icons/PlusSquareIcon';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
-import { removeNullValues } from '~/shared/relay/removeNullValues';
 import colors from '~/shared/theme/colors';
 import { chains } from '~/shared/utils/chains';
 import { getExternalAddressLink, truncateAddress } from '~/shared/utils/wallet';
@@ -68,11 +66,7 @@ export default function CommunityPageMetadata({ communityRef, queryRef }: Props)
         viewer {
           __typename
           ... on Viewer {
-            user {
-              tokens {
-                ...PostComposerModalWithSelectorFragment
-              }
-            }
+            ...PostComposerModalWithSelectorFragment
           }
         }
         ...PostComposerModalWithSelectorQueryFragment
@@ -111,19 +105,16 @@ export default function CommunityPageMetadata({ communityRef, queryRef }: Props)
   const { showModal } = useModalActions();
   const isMobile = useIsMobileWindowWidth();
 
-  const tokens = useMemo<PostComposerModalWithSelectorFragment$key>(() => {
-    if (query?.viewer?.__typename !== 'Viewer') {
-      return [];
-    }
-    return removeNullValues(query?.viewer?.user?.tokens) ?? [];
-  }, [query?.viewer]);
-
   const handleCreatePostClick = useCallback(() => {
     track('Community Page: Clicked Enabled Post Button');
+    if (query?.viewer?.__typename !== 'Viewer') {
+      return;
+    }
+
     showModal({
       content: (
         <PostComposerModalWithSelector
-          tokensRef={tokens}
+          viewerRef={query?.viewer}
           queryRef={query}
           preSelectedContract={{
             title: community.name ?? '',
@@ -134,15 +125,7 @@ export default function CommunityPageMetadata({ communityRef, queryRef }: Props)
       headerVariant: 'thicc',
       isFullPage: isMobile,
     });
-  }, [
-    track,
-    showModal,
-    tokens,
-    query,
-    community.name,
-    community.contractAddress?.address,
-    isMobile,
-  ]);
+  }, [track, showModal, query, community.name, community.contractAddress?.address, isMobile]);
 
   const handleDisabledPostButtonClick = useCallback(() => {
     track('Community Page: Clicked Disabled Post Button');

--- a/apps/web/src/scenes/CommunityPage/CommunityPagePostsTab.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPagePostsTab.tsx
@@ -12,10 +12,8 @@ import { useIsMemberOfCommunity } from '~/contexts/communityPage/IsMemberOfCommu
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { CommunityPagePostsTabFragment$key } from '~/generated/CommunityPagePostsTabFragment.graphql';
 import { CommunityPagePostsTabQueryFragment$key } from '~/generated/CommunityPagePostsTabQueryFragment.graphql';
-import { PostComposerModalWithSelectorFragment$key } from '~/generated/PostComposerModalWithSelectorFragment.graphql';
 import { RefetchableCommunityFeedQuery } from '~/generated/RefetchableCommunityFeedQuery.graphql';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
-import { removeNullValues } from '~/shared/relay/removeNullValues';
 
 type Props = {
   communityRef: CommunityPagePostsTabFragment$key;
@@ -69,11 +67,7 @@ export default function CommunityPagePostsTab({ communityRef, queryRef }: Props)
         viewer {
           ... on Viewer {
             __typename
-            user {
-              tokens {
-                ...PostComposerModalWithSelectorFragment
-              }
-            }
+            ...PostComposerModalWithSelectorFragment
           }
         }
         ...FeedListFragment
@@ -93,18 +87,14 @@ export default function CommunityPagePostsTab({ communityRef, queryRef }: Props)
   const { showModal } = useModalActions();
   const isMobile = useIsMobileOrMobileLargeWindowWidth();
 
-  const tokens = useMemo<PostComposerModalWithSelectorFragment$key>(() => {
-    if (query?.viewer?.__typename !== 'Viewer') {
-      return [];
-    }
-    return removeNullValues(query?.viewer?.user?.tokens) ?? [];
-  }, [query?.viewer]);
-
   const handleCreatePostClick = useCallback(() => {
+    if (query?.viewer?.__typename !== 'Viewer') {
+      return;
+    }
     showModal({
       content: (
         <PostComposerModalWithSelector
-          tokensRef={tokens}
+          viewerRef={query?.viewer}
           queryRef={query}
           preSelectedContract={{
             title: community.name ?? '',
@@ -115,7 +105,7 @@ export default function CommunityPagePostsTab({ communityRef, queryRef }: Props)
       headerVariant: 'thicc',
       isFullPage: isMobile,
     });
-  }, [showModal, tokens, query, community.name, community.contractAddress?.address, isMobile]);
+  }, [showModal, query, community.name, community.contractAddress?.address, isMobile]);
 
   const { isMemberOfCommunity } = useIsMemberOfCommunity();
 


### PR DESCRIPTION
### Summary of Changes

Loom Overview, which contains Demo: https://www.loom.com/share/5060a674c9ac4aa7b2b8c60c3de317cb?sid=ca87088c-a695-491b-813a-330adb15ce9f

**TL;DR – when firing a mutation, we need to explicitly specify which fragments we want to update in the relay cache.** 

Without specifying the `PostComposerModalFragment` to be updated after calling `useSyncTokens`, the tokens remained stale in the post composer despite refreshing. The exact same issue occurred in the Editor in the past, which was fixed with #1659.

The way we need to remember to list which fragments to update in the relay cache is very annoying. I asked ChatGPT why this is necessary, and it provided some pros / cons:

<img width="754" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/3519ea09-1bb5-45cd-a88b-4f79b0e2bd9e">

<img width="741" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/a3650a35-3615-48b8-a267-7c0b33c789a9">
