### PR TITLE
Fix cursor pointer for pills on web

### DIFF
--- a/apps/web/src/components/Pill.tsx
+++ b/apps/web/src/components/Pill.tsx
@@ -40,7 +40,7 @@ export const ButtonPill = styled.button<{ active?: boolean }>`
   display: flex;
   align-items: center;
   background-color: ${colors.offWhite};
-  cursor: hover;
+  cursor: pointer;
 
   ${({ active }) =>
     active &&


### PR DESCRIPTION
### Summary of Changes

Due to a typo we weren't getting `cursor: pointer` for pills on web

<img width="235" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/4b1f4916-0a9f-48cf-be07-3b7445bddc67">



