### PR TITLE
GAL-4100: add collectors count in community tab [web]

### DIFF
--- a/apps/web/src/scenes/CommunityPage/CommunityPageTabs.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageTabs.tsx
@@ -29,12 +29,27 @@ export default function CommunityPageTabs({ onSelectTab, activeTab, communityRef
             total
           }
         }
+        owners(
+          first: $listOwnersFirst
+          after: $listOwnersAfter
+          onlyGalleryUsers: $onlyGalleryUsers
+        ) @connection(key: "CommunityPageView_owners") {
+          # Relay doesn't allow @connection w/o edges so we must query for it
+          # eslint-disable-next-line relay/unused-fields
+          edges {
+            __typename
+          }
+          pageInfo {
+            total
+          }
+        }
       }
     `,
     communityRef
   );
 
   const totalPosts = community.posts?.pageInfo.total;
+  const totalOwners = community.owners?.pageInfo.total;
 
   const handleTabClick = useCallback(
     (tab: CommunityPageTab) => {
@@ -56,7 +71,10 @@ export default function CommunityPageTabs({ onSelectTab, activeTab, communityRef
         <StyledTabLabel>Galleries</StyledTabLabel>
       </StyledTab> */}
       <StyledTab isActive={activeTab === 'collectors'} onClick={() => handleTabClick('collectors')}>
-        <StyledTabLabel>Collectors</StyledTabLabel>
+        <HStack gap={3}>
+          <StyledTabLabel>Collectors</StyledTabLabel>
+          {totalOwners !== 0 && <StyledTabLabelCount>{totalOwners}</StyledTabLabelCount>}
+        </HStack>
       </StyledTab>
     </StyledTabsContainer>
   );


### PR DESCRIPTION
### Summary of Changes

add totalCollectors count in community tab on web. for mobile, it's already implemented!

### Demo or Before and After

**Before:**
<img width="960" alt="CleanShot 2023-08-25 at 03 09 12@2x" src="https://github.com/gallery-so/gallery/assets/26466468/0ccd5158-e8a5-4e83-9ad3-0979f28fe62d">
**After:**
![image](https://github.com/gallery-so/gallery/assets/26466468/34c0cba5-8c3e-4c8a-b33b-714e70a33ded)

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] The changes have been tested and all tests pass.
- [x] WEB: The changes have been tested on various desktop screen sizes to ensure responsiveness.
- [ ] MOBILE APP: The changes have been tested on both light and dark modes.
