### PR TITLE
update default comment row height

### DIFF
--- a/apps/web/src/components/Feed/Socialize/CommentsModal/CommentsModal.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentsModal/CommentsModal.tsx
@@ -66,7 +66,7 @@ export function CommentsModal({
     return new CellMeasurerCache({
       fixedWidth: true,
       minHeight: 0,
-      defaultHeight: 40,
+      defaultHeight: 56,
     });
   }, []);
 


### PR DESCRIPTION
### Summary of Changes

Updates the default row height we use for comments in the comment modal. we recently updated the comment row layout, so the modal wasn't fitting everything in.

### Demo or Before/After Pics
before
![CleanShot 2023-08-25 at 13 31 16](https://github.com/gallery-so/gallery/assets/80802871/a1be5c43-e55e-4a51-a66f-fce2ca911540)

after
![CleanShot 2023-08-25 at 13 31 05](https://github.com/gallery-so/gallery/assets/80802871/77fa639f-6de1-46f1-a1c4-598f4f4b3378)



### Edge Cases
still doesn't account for if the comment is 2 lines and taller than default, but we can follow up . this pr is an incremental improvement
![CleanShot 2023-08-25 at 14 26 55](https://github.com/gallery-so/gallery/assets/80802871/58645f0a-918f-4b0e-99ed-8da25a64bc0a)


### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
note: noticed an existing bug for mobile web, made a ticket https://linear.app/galleryso/issue/GAL-4136/comment-modal-list-doesnt-use-full-screen-height-on-web
- [ ] (if mobile) I've tested the changes on both light and dark modes.
