### PR TITLE
GAL-4102 make Curated the default screen on mobile app

### DIFF
--- a/apps/mobile/src/navigation/FeedTabNavigator/FeedTabNavigator.tsx
+++ b/apps/mobile/src/navigation/FeedTabNavigator/FeedTabNavigator.tsx
@@ -17,7 +17,7 @@ export function FeedTabNavigator() {
   return (
     <Tab.Navigator
       tabBarPosition="top"
-      initialRouteName="Latest"
+      initialRouteName="Curated"
       tabBar={TabBar}
       screenOptions={{ lazy: true, swipeEnabled: false, animationEnabled: false }}
       sceneContainerStyle={{

--- a/apps/mobile/src/screens/HomeScreen/CuratedScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen/CuratedScreen.tsx
@@ -107,7 +107,7 @@ function CuratedScreenInner({ queryRef }: CuratedScreenInnerProps) {
         feedEventRefs={events}
         queryRef={query.data}
       />
-      {showWelcome && <WelcomeToBeta username={query.viewer?.user?.username ?? ''} />}
+      {showWelcome && <WelcomeToBeta username={query.data.viewer?.user?.username ?? ''} />}
     </>
   );
 }

--- a/apps/mobile/src/screens/HomeScreen/LatestScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen/LatestScreen.tsx
@@ -1,12 +1,10 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, useState } from 'react';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 import isFeatureEnabled, { FeatureFlag } from 'src/utils/isFeatureEnabled';
 
 import { FEED_PER_PAGE } from '~/components/Feed/constants';
 import { ActiveFeed } from '~/components/Feed/FeedFilter';
 import { FollowingFeed } from '~/components/Feed/FollowingFeed';
-import { WelcomeToBeta } from '~/components/WelcomeToBeta';
 import { LatestScreenFeatureQuery } from '~/generated/LatestScreenFeatureQuery.graphql';
 import { LatestScreenFragment$key } from '~/generated/LatestScreenFragment.graphql';
 import { LatestScreenQuery } from '~/generated/LatestScreenQuery.graphql';
@@ -24,14 +22,6 @@ function LatestScreenInner({ queryRef }: LatestScreenInnerProps) {
       fragment LatestScreenFragment on Query {
         ...FollowingFeedFragment
         ...WorldwideFeedFragment
-
-        viewer {
-          ... on Viewer {
-            user {
-              username
-            }
-          }
-        }
       }
     `,
     queryRef
@@ -39,33 +29,10 @@ function LatestScreenInner({ queryRef }: LatestScreenInnerProps) {
 
   const [activeFeed, setActiveFeed] = useState<ActiveFeed>('Worldwide');
 
-  const [showWelcome, setShowWelcome] = useState(false);
-
-  const checkShouldShowWelcome = useCallback(async () => {
-    const shown = await AsyncStorage.getItem('welcomeMessageShown');
-    if (shown !== 'true') {
-      setShowWelcome(true);
-      await AsyncStorage.setItem('welcomeMessageShown', 'true');
-    }
-  }, [setShowWelcome]);
-
-  useEffect(() => {
-    checkShouldShowWelcome();
-  }, [checkShouldShowWelcome]);
-
-  const FeedComponent = useMemo(() => {
-    if (activeFeed === 'Following') {
-      return <FollowingFeed queryRef={query} onChangeFeedMode={setActiveFeed} />;
-    } else {
-      return <WorldwideFeed queryRef={query} onChangeFeedMode={setActiveFeed} />;
-    }
-  }, [activeFeed, query]);
-
-  return (
-    <>
-      {FeedComponent}
-      {showWelcome && <WelcomeToBeta username={query.viewer?.user?.username ?? ''} />}
-    </>
+  return activeFeed === 'Following' ? (
+    <FollowingFeed queryRef={query} onChangeFeedMode={setActiveFeed} />
+  ) : (
+    <WorldwideFeed queryRef={query} onChangeFeedMode={setActiveFeed} />
   );
 }
 

--- a/apps/mobile/src/screens/Login/NotificationUpsellScreen.tsx
+++ b/apps/mobile/src/screens/Login/NotificationUpsellScreen.tsx
@@ -24,7 +24,7 @@ export function NotificationUpsellScreen() {
       routes: [
         {
           name: 'MainTabs',
-          params: { screen: 'HomeTab', params: { screen: 'Home', params: { screen: 'Latest' } } },
+          params: { screen: 'HomeTab', params: { screen: 'Home', params: { screen: 'Curated' } } },
         },
       ],
     });

--- a/apps/mobile/src/screens/Login/navigateToNotificationUpsellOrHomeScreen.ts
+++ b/apps/mobile/src/screens/Login/navigateToNotificationUpsellOrHomeScreen.ts
@@ -20,7 +20,7 @@ export async function navigateToNotificationUpsellOrHomeScreen(
       routes: [
         {
           name: 'MainTabs',
-          params: { screen: 'HomeTab', params: { screen: 'Home', params: { screen: 'Latest' } } },
+          params: { screen: 'HomeTab', params: { screen: 'Home', params: { screen: 'Curated' } } },
         },
       ],
     });


### PR DESCRIPTION
### Summary of Changes
Change the default screen on mobile app from Latest to Curated.
Also move the Beta Welcome bottom sheet from Latest to Curated so we can continue to show it.


### Demo or Before/After Pics
Before

https://github.com/gallery-so/gallery/assets/80802871/68b9c833-0665-49eb-823d-43b3ce5195a5




After
https://github.com/gallery-so/gallery/assets/80802871/8a48bde1-30da-4121-b792-a6cec1ce749e



### Edge Cases
- for first time sign in users we show a Welcome to the Beta bottom sheet. made sure we keep showing that

### Testing Steps
reboot the app, the first thing you should see is the Curated Screen

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.

