### PR TITLE
GAL-4071 fix tiny typo in refresh bottom sheet and increase font size 

### DIFF
--- a/apps/mobile/src/components/Community/CommunityPostBottomSheet.tsx
+++ b/apps/mobile/src/components/Community/CommunityPostBottomSheet.tsx
@@ -96,7 +96,7 @@ function CommunityPostBottomSheet(
               font={{ family: 'ABCDiatype', weight: 'Regular' }}
             >
               Only {community.name} owners can post about {community.name}. If you own this item but
-              its not displaying try
+              it's not displaying try
             </Typography>{' '}
             <Typography
               className="text-sm text-black-900 dark:text-offWhite"

--- a/apps/mobile/src/components/Community/CommunityPostBottomSheet.tsx
+++ b/apps/mobile/src/components/Community/CommunityPostBottomSheet.tsx
@@ -92,14 +92,14 @@ function CommunityPostBottomSheet(
           </Typography>
           <Text>
             <Typography
-              className="text-sm text-black-900 dark:text-offWhite"
+              className="text-md text-black-900 dark:text-offWhite"
               font={{ family: 'ABCDiatype', weight: 'Regular' }}
             >
               Only {community.name} owners can post about {community.name}. If you own this item but
               it's not displaying try
             </Typography>{' '}
             <Typography
-              className="text-sm text-black-900 dark:text-offWhite"
+              className="text-md text-black-900 dark:text-offWhite"
               font={{ family: 'ABCDiatype', weight: 'Bold' }}
             >
               refreshing your collection.


### PR DESCRIPTION
### Summary of Changes

 fix tiny typo in refresh bottom sheet (its -> it's)
and increase font size (sm -> md)


### Demo or Before/After Pics
before
<img width="409" alt="CleanShot 2023-08-25 at 19 11 46@2x" src="https://github.com/gallery-so/gallery/assets/80802871/05247efc-4b0d-4807-9b26-cf4bc9e10feb">

after
<img width="422" alt="CleanShot 2023-08-25 at 19 10 36@2x" src="https://github.com/gallery-so/gallery/assets/80802871/b15e0acf-76d1-4fba-81c6-bfc4c23c9909">


### Edge Cases
n/a

### Testing Steps
go to a community page you don't have a token for and tap the post button

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
