### PR TITLE
GAL-4069 GAL-4138 update nftselector proper placeholders and also add to contract groups

### DIFF
--- a/apps/mobile/src/components/GallerySkeleton.tsx
+++ b/apps/mobile/src/components/GallerySkeleton.tsx
@@ -7,7 +7,13 @@ import colors from '~/shared/theme/colors';
 // The types here are not great from the Skeleton library
 // Idiomatically, the type of children would ReactNode so
 // we could use PropsWithChildren, but this is fine.
-export function GallerySkeleton({ children }: { children: JSX.Element }) {
+export function GallerySkeleton({
+  children,
+  borderRadius = 4,
+}: {
+  children: JSX.Element;
+  borderRadius?: number;
+}) {
   const speed = useMemo(() => {
     return 800 + Math.random() * 800;
   }, []);
@@ -17,7 +23,7 @@ export function GallerySkeleton({ children }: { children: JSX.Element }) {
   return (
     <SkeletonPlaceholder
       speed={speed}
-      borderRadius={4}
+      borderRadius={borderRadius}
       highlightColor={colorScheme === 'dark' ? colors.black['500'] : colors.faint}
       backgroundColor={colorScheme === 'dark' ? colors.black['800'] : colors.porcelain}
     >

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorContractScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorContractScreen.tsx
@@ -90,11 +90,12 @@ export function NftSelectorContractScreen() {
               <View key={index} className="flex flex-row space-x-4">
                 {row.map((token) => {
                   return (
-                    <NftSelectorPickerSingularAsset
+                    <View
                       key={token.dbid}
-                      onSelect={handleSelectNft}
-                      tokenRef={token}
-                    />
+                      className="flex-1 aspect-square bg-offWhite dark:bg-black-800"
+                    >
+                      <NftSelectorPickerSingularAsset onSelect={handleSelectNft} tokenRef={token} />
+                    </View>
                   );
                 })}
 

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorContractScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorContractScreen.tsx
@@ -90,12 +90,11 @@ export function NftSelectorContractScreen() {
               <View key={index} className="flex flex-row space-x-4">
                 {row.map((token) => {
                   return (
-                    <View
+                    <NftSelectorPickerSingularAsset
                       key={token.dbid}
-                      className="flex-1 aspect-square bg-offWhite dark:bg-black-800"
-                    >
-                      <NftSelectorPickerSingularAsset onSelect={handleSelectNft} tokenRef={token} />
-                    </View>
+                      onSelect={handleSelectNft}
+                      tokenRef={token}
+                    />
                   );
                 })}
 

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerGrid.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerGrid.tsx
@@ -1,11 +1,13 @@
 import { useNavigation } from '@react-navigation/native';
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 import { ResizeMode } from 'expo-av';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { View, ViewProps } from 'react-native';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
+import { GallerySkeleton } from '~/components/GallerySkeleton';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { NftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
 import { Typography } from '~/components/Typography';
@@ -246,6 +248,25 @@ export function NftSelectorPickerGrid({
   );
 }
 
+function TokenGridSinglePreview({ tokenUrl }: { tokenUrl: string }) {
+  const [assetLoaded, setAssetLoaded] = useState(false);
+  const handleAssetLoad = useCallback(() => {
+    setAssetLoaded(true);
+  }, []);
+  return (
+    <>
+      <NftPreviewAsset tokenUrl={tokenUrl} resizeMode={ResizeMode.COVER} onLoad={handleAssetLoad} />
+      {!assetLoaded && (
+        <View className="absolute inset-0">
+          <GallerySkeleton borderRadius={0}>
+            <SkeletonPlaceholder.Item width="100%" height="100%" />
+          </GallerySkeleton>
+        </View>
+      )}
+    </>
+  );
+}
+
 type TokenGridProps = {
   style?: ViewProps['style'];
   tokenRefs: NftSelectorPickerGridTokenGridFragment$key;
@@ -300,7 +321,7 @@ function TokenGrid({ tokenRefs, contractAddress, screen, style }: TokenGridProps
               {row.tokens.map((tokenUrl) => {
                 return (
                   <View key={tokenUrl} className="flex-1 aspect-square">
-                    <NftPreviewAsset tokenUrl={tokenUrl} resizeMode={ResizeMode.COVER} />
+                    <TokenGridSinglePreview tokenUrl={tokenUrl} />
                   </View>
                 );
               })}

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerSingularAsset.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerSingularAsset.tsx
@@ -2,9 +2,11 @@ import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { ResizeMode } from 'expo-av';
 import { useCallback, useState } from 'react';
 import { ActivityIndicator, View, ViewProps } from 'react-native';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
+import { GallerySkeleton } from '~/components/GallerySkeleton';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { NftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
 import { NftPreviewErrorFallback } from '~/components/NftPreview/NftPreviewErrorFallback';
@@ -68,6 +70,16 @@ export function NftSelectorPickerSingularAsset({
       });
     }
   }, [currentScreen, navigation, onSelect, setProfileImage, token.dbid]);
+
+  const [assetLoaded, setAssetLoaded] = useState(false);
+  const handleAssetLoad = useCallback(() => {
+    setAssetLoaded(true);
+  }, []);
+
+  if (!tokenUrl) {
+    return <NftPreviewErrorFallback />;
+  }
+
   return (
     <ReportingErrorBoundary fallback={<NftPreviewErrorFallback />}>
       <GalleryTouchableOpacity
@@ -79,10 +91,17 @@ export function NftSelectorPickerSingularAsset({
         eventName="NftSelectorPickerImage pressed"
         properties={{ tokenId: token.dbid }}
       >
-        {tokenUrl ? (
-          <NftPreviewAsset tokenUrl={tokenUrl} resizeMode={ResizeMode.COVER} />
-        ) : (
-          <NftPreviewErrorFallback />
+        <NftPreviewAsset
+          tokenUrl={tokenUrl}
+          resizeMode={ResizeMode.COVER}
+          onLoad={handleAssetLoad}
+        />
+        {!assetLoaded && (
+          <View className="absolute inset-0">
+            <GallerySkeleton borderRadius={0}>
+              <SkeletonPlaceholder.Item width="100%" height="100%" />
+            </GallerySkeleton>
+          </View>
         )}
 
         {isSettingProfileImage && (


### PR DESCRIPTION
### Summary of Changes

Added skeleton placeholders to loading assets in the NFT Selector

- [x] added skeleton to single asset for both default grid and contract grid
- [x] added skeleton to assets in contract group in default grid

other changes
- added an optional `borderRadius` prop on `GallerySkeleton`

### Demo or Before/After Pics
before

https://github.com/gallery-so/gallery/assets/80802871/66994cdf-9b29-4fc5-8e0e-4731857b1e3e



after

https://github.com/gallery-so/gallery/assets/80802871/7d51f0f6-1c31-4bcb-8ef9-86a6fb40c1cb


### Edge Cases
check both the default grid and also tap into a contract


### Testing Steps

Go to the nft selector and watch the items load

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if mobile) I've tested the changes on both light and dark modes.
