### PR TITLE
GAL-4103 dont show discard post confirmation if there's no caption

### DIFF
--- a/apps/mobile/src/screens/PostScreen/PostComposerScreen.tsx
+++ b/apps/mobile/src/screens/PostScreen/PostComposerScreen.tsx
@@ -61,15 +61,20 @@ function PostComposerScreenInner() {
 
   const [caption, setCaption] = useState('');
 
+  const mainTabNavigation = useNavigation<MainTabStackNavigatorProp>();
+  const feedTabNavigation = useNavigation<FeedTabNavigatorProp>();
+  const navigation = useNavigation();
+
   const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
   const handleBackPress = useCallback(() => {
+    if (!caption) {
+      navigation.goBack();
+      return;
+    }
     Keyboard.dismiss();
 
     bottomSheetRef.current?.present();
-  }, []);
-
-  const mainTabNavigation = useNavigation<MainTabStackNavigatorProp>();
-  const feedTabNavigation = useNavigation<FeedTabNavigatorProp>();
+  }, [caption, navigation]);
 
   const { pushToast } = useToastActions();
   const handlePost = useCallback(async () => {


### PR DESCRIPTION
### Summary of Changes

Updates the logic for the Discard Post Confirmation so that we only show it if the user has entered a caption. If the input is empty, don't show it. there's a separate ticket for web GAL-4139

### Demo or Before/After Pics
before

https://github.com/gallery-so/gallery/assets/80802871/25f967fb-c59e-4186-a35c-87b05805aa82




after
https://github.com/gallery-so/gallery/assets/80802871/d1b90878-d81a-46e7-9e6b-7f1e7bf1f717



### Edge Cases
cases tested:
Add caption -> show confirmation 
Don't add caption -> don't show confirmation 
add caption and then delete -> don't show confirmation 


### Testing Steps
go to nft selector, select an nft and then go back with or without a caption

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.

