### PR TITLE
[GAL-4074]: Add all icons for community page networks

### DIFF
--- a/apps/mobile/src/components/Community/CommunityMeta.tsx
+++ b/apps/mobile/src/components/Community/CommunityMeta.tsx
@@ -3,9 +3,14 @@ import { useColorScheme } from 'nativewind';
 import { useCallback, useMemo, useRef } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment, useRefetchableFragment } from 'react-relay';
+import { ArbitrumIcon } from 'src/icons/ArbitrumIcon';
+import { BaseIcon } from 'src/icons/BaseIcon';
 import { EthIcon } from 'src/icons/EthIcon';
+import { OptimismIcon } from 'src/icons/OptimismIcon';
 import { PoapIcon } from 'src/icons/PoapIcon';
+import { PolygonIcon } from 'src/icons/PolygonIcon';
 import { TezosIcon } from 'src/icons/TezosIcon';
+import { ZoraIcon } from 'src/icons/ZoraIcon';
 import isFeatureEnabled, { FeatureFlag } from 'src/utils/isFeatureEnabled';
 
 import { Chain, CommunityMetaFragment$key } from '~/generated/CommunityMetaFragment.graphql';
@@ -155,7 +160,7 @@ export function CommunityMeta({ communityRef, queryRef }: Props) {
       );
     } else if (community.contractAddress) {
       return (
-        <View className="flex flex-row space-x-1 items-center">
+        <View className="flex flex-row items-center space-x-1">
           <RawProfilePicture size="xs" default eventElementId={null} eventName={null} />
           <LinkableAddress
             chainAddressRef={community.contractAddress}
@@ -227,6 +232,16 @@ export function CommunityMeta({ communityRef, queryRef }: Props) {
 function NetworkIcon({ chain }: { chain: Chain }) {
   if (chain === 'Ethereum') {
     return <EthIcon />;
+  } else if (chain === 'Base') {
+    return <BaseIcon />;
+  } else if (chain === 'Zora') {
+    return <ZoraIcon />;
+  } else if (chain === 'Optimism') {
+    return <OptimismIcon />;
+  } else if (chain === 'Polygon') {
+    return <PolygonIcon />;
+  } else if (chain === 'Arbitrum') {
+    return <ArbitrumIcon />;
   } else if (chain === 'POAP') {
     return <PoapIcon className="w-4 h-4" />;
   } else if (chain === 'Tezos') {

--- a/apps/mobile/src/components/LinkableAddress.tsx
+++ b/apps/mobile/src/components/LinkableAddress.tsx
@@ -40,7 +40,11 @@ export function LinkableAddress({
 
   if (!link) {
     return (
-      <Typography className="text-sm" font={font ?? { family: 'ABCDiatype', weight: 'Regular' }}>
+      <Typography
+        className="text-sm"
+        font={font ?? { family: 'ABCDiatype', weight: 'Regular' }}
+        style={style}
+      >
         {truncatedAddress || address.address}
       </Typography>
     );


### PR DESCRIPTION
### Summary of Changes
seems like we don't show the network icon for a few icons on community pages on mobile

### Before
![Screenshot 2023-08-28 at 4 17 49 PM](https://github.com/gallery-so/gallery/assets/49758803/656288d7-0e5d-41e3-a0f6-bbe61220116d)
![Screenshot 2023-08-28 at 4 18 05 PM](https://github.com/gallery-so/gallery/assets/49758803/1da2a7d2-6ed1-445e-924d-5050305d948d)
![Screenshot 2023-08-28 at 4 18 26 PM](https://github.com/gallery-so/gallery/assets/49758803/0fec5f6e-e521-4bb8-bcdb-9c30f4d1df2c)
![Screenshot 2023-08-28 at 4 18 37 PM](https://github.com/gallery-so/gallery/assets/49758803/96afccfc-ed14-4d92-80ad-8be65195aa65)
![Screenshot 2023-08-28 at 4 18 46 PM](https://github.com/gallery-so/gallery/assets/49758803/40114f3a-995c-4f4b-849f-f44a3388416b)

### After
![Screenshot 2023-08-28 at 4 16 40 PM](https://github.com/gallery-so/gallery/assets/49758803/26e29ebe-9ad6-4faa-9ab5-c4ca762d8ed0)
![Screenshot 2023-08-28 at 4 15 43 PM](https://github.com/gallery-so/gallery/assets/49758803/d1e4aa46-39c6-4086-9fad-5a8f6d7cffcc)
![Screenshot 2023-08-28 at 3 58 10 PM](https://github.com/gallery-so/gallery/assets/49758803/3435b02a-e19e-4b1e-b119-db40eb010391)
![Screenshot 2023-08-28 at 4 13 39 PM](https://github.com/gallery-so/gallery/assets/49758803/a2f631f4-d9cd-45c9-b667-fa7a20a39878)
![Screenshot 2023-08-28 at 3 53 39 PM](https://github.com/gallery-so/gallery/assets/49758803/956b0e16-9cb5-4c0c-bf88-f83dfc5617fd)

### Edge Cases
No real edge cases I can think of.

### Testing Steps
Can test locally on the branch

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
