### PR TITLE
[GAL-4072] Show Posts skeleton state in Community Page

### DIFF
--- a/apps/mobile/src/components/Community/CommunityPostListFallback.tsx
+++ b/apps/mobile/src/components/Community/CommunityPostListFallback.tsx
@@ -3,7 +3,7 @@ import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 
 import { GallerySkeleton } from '~/components/GallerySkeleton';
 
-// 20 18 24
+// 36 14 440
 export function CommunityPostCardFallback() {
   return (
     <View className="px-4 py-3">

--- a/apps/mobile/src/components/Community/CommunityPostListFallback.tsx
+++ b/apps/mobile/src/components/Community/CommunityPostListFallback.tsx
@@ -1,0 +1,41 @@
+import { View } from 'react-native';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
+
+import { GallerySkeleton } from '~/components/GallerySkeleton';
+
+// 20 18 24
+export function CommunityPostCardFallback() {
+  return (
+    <View className="px-4 py-3">
+      <GallerySkeleton>
+        <SkeletonPlaceholder.Item flexDirection="column" width="100%" paddingTop={16}>
+          <SkeletonPlaceholder.Item
+            alignItems="center"
+            flexDirection="row"
+            justifyContent="space-between"
+          >
+            <SkeletonPlaceholder.Item flexDirection="row" gap={8}>
+              <SkeletonPlaceholder.Item width={36} height={36} borderRadius={100} />
+              <SkeletonPlaceholder.Item flexDirection="column" rowGap={4}>
+                <SkeletonPlaceholder.Item width={100} height={16} />
+                <SkeletonPlaceholder.Item width={100} height={12} />
+              </SkeletonPlaceholder.Item>
+            </SkeletonPlaceholder.Item>
+            <SkeletonPlaceholder.Item width={50} height={12} />
+          </SkeletonPlaceholder.Item>
+            <SkeletonPlaceholder.Item marginTop={18} width={100} height={14} />
+          <SkeletonPlaceholder.Item marginVertical={18} width="100%" height={330} />
+        </SkeletonPlaceholder.Item>
+      </GallerySkeleton>
+    </View>
+  );
+}
+
+export function CommunityPostListFallback() {
+  return (
+    <View className="flex flex-col">
+      <CommunityPostCardFallback />
+      <CommunityPostCardFallback />
+    </View>
+  );
+}

--- a/apps/mobile/src/components/Community/CommunityPostListFallback.tsx
+++ b/apps/mobile/src/components/Community/CommunityPostListFallback.tsx
@@ -35,7 +35,6 @@ export function CommunityPostListFallback() {
   return (
     <View className="flex flex-col">
       <CommunityPostCardFallback />
-      <CommunityPostCardFallback />
     </View>
   );
 }

--- a/apps/mobile/src/components/Community/CommunityPostListFallback.tsx
+++ b/apps/mobile/src/components/Community/CommunityPostListFallback.tsx
@@ -23,7 +23,7 @@ export function CommunityPostCardFallback() {
             </SkeletonPlaceholder.Item>
             <SkeletonPlaceholder.Item width={50} height={12} />
           </SkeletonPlaceholder.Item>
-            <SkeletonPlaceholder.Item marginTop={18} width={100} height={14} />
+          <SkeletonPlaceholder.Item marginTop={18} width={100} height={14} />
           <SkeletonPlaceholder.Item marginVertical={18} width="100%" height={330} />
         </SkeletonPlaceholder.Item>
       </GallerySkeleton>

--- a/apps/mobile/src/components/Community/CommunityViewFallback.tsx
+++ b/apps/mobile/src/components/Community/CommunityViewFallback.tsx
@@ -4,6 +4,7 @@ import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { GallerySkeleton } from '~/components/GallerySkeleton';
 import { GalleryProfileNavbarFallback } from '~/components/ProfileView/GalleryProfileNavBar';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
+
 import { CommunityPostListFallback } from './CommunityPostListFallback';
 
 export function CommunityViewFallback() {
@@ -46,8 +47,14 @@ export function CommunityViewFallback() {
             </SkeletonPlaceholder.Item>
           </SkeletonPlaceholder.Item>
 
-          <SkeletonPlaceholder.Item flexDirection="row" gap={20} alignItems="center" justifyContent="center" marginBottom={32} marginTop={16}
-             >
+          <SkeletonPlaceholder.Item
+            flexDirection="row"
+            gap={20}
+            alignItems="center"
+            justifyContent="center"
+            marginBottom={32}
+            marginTop={16}
+          >
             <SkeletonPlaceholder.Item width="25%" height={16} />
             <SkeletonPlaceholder.Item width="25%" height={16} />
           </SkeletonPlaceholder.Item>

--- a/apps/mobile/src/components/Community/CommunityViewFallback.tsx
+++ b/apps/mobile/src/components/Community/CommunityViewFallback.tsx
@@ -4,7 +4,7 @@ import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { GallerySkeleton } from '~/components/GallerySkeleton';
 import { GalleryProfileNavbarFallback } from '~/components/ProfileView/GalleryProfileNavBar';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
-import { UserFollowListFallback } from '~/components/UserFollowList/UserFollowListFallback';
+import { CommunityPostListFallback } from './CommunityPostListFallback';
 
 export function CommunityViewFallback() {
   const { top } = useSafeAreaPadding();
@@ -46,14 +46,16 @@ export function CommunityViewFallback() {
             </SkeletonPlaceholder.Item>
           </SkeletonPlaceholder.Item>
 
-          <SkeletonPlaceholder.Item flexDirection="column" gap={4} marginBottom={16}>
-            <SkeletonPlaceholder.Item width="40%" height={12} />
+          <SkeletonPlaceholder.Item flexDirection="row" gap={20} alignItems="center" justifyContent="center" marginBottom={32} marginTop={16}
+             >
+            <SkeletonPlaceholder.Item width="25%" height={16} />
+            <SkeletonPlaceholder.Item width="25%" height={16} />
           </SkeletonPlaceholder.Item>
         </SkeletonPlaceholder.Item>
       </GallerySkeleton>
 
       <View className="-mx-4">
-        <UserFollowListFallback />
+        <CommunityPostListFallback />
       </View>
     </View>
   );


### PR DESCRIPTION
### Summary of Changes
when entering community page and Posts tab is active (it is by default), show an empty state reflecting posts, not collectors

### Before
![Screenshot 2023-08-28 at 6 02 21 PM (2)](https://github.com/gallery-so/gallery/assets/49758803/e81d73ee-8f92-4e1f-987d-c3fd2c069cbd)

### After
![Screenshot 2023-08-28 at 7 29 22 PM](https://github.com/gallery-so/gallery/assets/49758803/e7b3d524-d983-4039-884f-e84a629eb254)
![Screenshot 2023-08-28 at 7 28 21 PM](https://github.com/gallery-so/gallery/assets/49758803/49061dbf-1c5d-46a8-8a6e-efec144a6c4c)


### Edge Cases
Testing communities that do not have posts enabled by default

### Testing Steps
Can test locally on branch and visit a community with posts enabled

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
