### PR TITLE
[GAL-4059] Remove All Networks view from Selector for now

### DIFF
--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorFilterBottomSheet.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorFilterBottomSheet.tsx
@@ -1,7 +1,6 @@
 import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
 import { ForwardedRef, forwardRef, useCallback, useRef } from 'react';
 import { View, ViewProps } from 'react-native';
-import { WorldIcon } from 'src/icons/WorldIcon';
 import { getChainIconComponent } from 'src/utils/getChainIconComponent';
 
 import {
@@ -16,7 +15,6 @@ import { ChainMetadata, chains } from '~/shared/utils/chains';
 const SNAP_POINTS = ['CONTENT_HEIGHT'];
 
 const NETWORKS: { label: string; id: NetworkChoice; icon: JSX.Element }[] = [
-  { label: 'All Networks', id: 'all', icon: <WorldIcon /> },
   ...chains.map((chain) => ({
     label: chain.name,
     id: chain.name,
@@ -38,7 +36,7 @@ type Props = {
   onSortViewChange: (sortView: NftSelectorSortView) => void;
 };
 
-export type NetworkChoice = 'all' | ChainMetadata['name'];
+export type NetworkChoice = ChainMetadata['name'];
 export type NftSelectorSortView = 'Recently added' | 'Oldest' | 'Alphabetical';
 
 function NftSelectorFilterBottomSheet(

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerGrid.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerGrid.tsx
@@ -112,10 +112,6 @@ export function NftSelectorPickerGrid({
           .includes(searchCriteria.searchQuery.toLowerCase());
       })
       .filter((token) => {
-        if (searchCriteria.networkFilter === 'all') {
-          return true;
-        }
-
         return token.chain === searchCriteria.networkFilter;
       })
       .filter((token) => {

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
@@ -1,8 +1,7 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Animated, View } from 'react-native';
+import { Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { View } from 'react-native';
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
-import { RefreshIcon } from 'src/icons/RefreshIcon';
 import { SlidersIcon } from 'src/icons/SlidersIcon';
 
 import { BackButton } from '~/components/BackButton';
@@ -12,7 +11,6 @@ import { IconContainer } from '~/components/IconContainer';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 import { Select } from '~/components/Select';
 import { Typography } from '~/components/Typography';
-import { useToastActions } from '~/contexts/ToastContext';
 import { NftSelectorPickerScreenFragment$key } from '~/generated/NftSelectorPickerScreenFragment.graphql';
 import { NftSelectorPickerScreenQuery } from '~/generated/NftSelectorPickerScreenQuery.graphql';
 import { NftSelectorPickerScreenRefetchQuery } from '~/generated/NftSelectorPickerScreenRefetchQuery.graphql';
@@ -26,7 +24,6 @@ import {
 } from './NftSelectorFilterBottomSheet';
 import { NftSelectorPickerGrid } from './NftSelectorPickerGrid';
 import { NftSelectorScreenFallback } from './NftSelectorScreenFallback';
-import useSyncTokens from './useSyncTokens';
 
 export function NftSelectorPickerScreen() {
   const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'ProfilePicturePicker'>>();
@@ -149,69 +146,5 @@ export function NftSelectorPickerScreen() {
         </View>
       </View>
     </View>
-  );
-}
-
-type AnimatedRefreshIconProps = {
-  networkFilter: NetworkChoice;
-  onRefresh: () => void;
-};
-
-function AnimatedRefreshIcon({ networkFilter, onRefresh }: AnimatedRefreshIconProps) {
-  const { isSyncing, syncTokens } = useSyncTokens();
-  const { pushToast } = useToastActions();
-
-  const handleSync = useCallback(async () => {
-    if (isSyncing) return;
-
-    await syncTokens(networkFilter);
-    onRefresh();
-    pushToast({
-      message: 'Successfully refreshed your collection',
-      withoutNavbar: true,
-    });
-  }, [isSyncing, networkFilter, onRefresh, pushToast, syncTokens]);
-
-  const spinValue = useRef(new Animated.Value(0)).current;
-
-  const spin = useCallback(() => {
-    spinValue.setValue(0);
-    Animated.timing(spinValue, {
-      toValue: 1,
-      duration: 1000,
-      useNativeDriver: true,
-    }).start(({ finished }) => {
-      // Only repeat the animation if it completed (wasn't interrupted) and isSyncing is still true
-      if (finished && isSyncing) {
-        spin();
-      }
-    });
-  }, [isSyncing, spinValue]);
-
-  const spinAnimation = spinValue.interpolate({
-    inputRange: [0, 1],
-    outputRange: ['0deg', '360deg'],
-  });
-
-  useEffect(() => {
-    if (isSyncing) {
-      spin();
-    } else {
-      spinValue.stopAnimation();
-    }
-  }, [isSyncing, spin, spinValue]);
-
-  return (
-    <IconContainer
-      size="sm"
-      onPress={handleSync}
-      icon={
-        <Animated.View style={{ transform: [{ rotate: spinAnimation }] }}>
-          <RefreshIcon />
-        </Animated.View>
-      }
-      eventElementId="NftSelectorSelectorRefreshButton"
-      eventName="NftSelectoreSelectorRefreshButton pressed"
-    />
   );
 }

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
@@ -1,7 +1,8 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
-import { Suspense, useCallback, useMemo, useRef, useState } from 'react';
-import { View } from 'react-native';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Animated, View } from 'react-native';
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
+import { RefreshIcon } from 'src/icons/RefreshIcon';
 import { SlidersIcon } from 'src/icons/SlidersIcon';
 
 import { BackButton } from '~/components/BackButton';
@@ -11,6 +12,7 @@ import { IconContainer } from '~/components/IconContainer';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 import { Select } from '~/components/Select';
 import { Typography } from '~/components/Typography';
+import { useToastActions } from '~/contexts/ToastContext';
 import { NftSelectorPickerScreenFragment$key } from '~/generated/NftSelectorPickerScreenFragment.graphql';
 import { NftSelectorPickerScreenQuery } from '~/generated/NftSelectorPickerScreenQuery.graphql';
 import { NftSelectorPickerScreenRefetchQuery } from '~/generated/NftSelectorPickerScreenRefetchQuery.graphql';
@@ -24,6 +26,7 @@ import {
 } from './NftSelectorFilterBottomSheet';
 import { NftSelectorPickerGrid } from './NftSelectorPickerGrid';
 import { NftSelectorScreenFallback } from './NftSelectorScreenFallback';
+import useSyncTokens from './useSyncTokens';
 
 export function NftSelectorPickerScreen() {
   const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'ProfilePicturePicker'>>();
@@ -37,7 +40,7 @@ export function NftSelectorPickerScreen() {
     {}
   );
 
-  const [data] = useRefetchableFragment<
+  const [data, refetch] = useRefetchableFragment<
     NftSelectorPickerScreenRefetchQuery,
     NftSelectorPickerScreenFragment$key
   >(
@@ -67,6 +70,10 @@ export function NftSelectorPickerScreen() {
   const screenTitle = useMemo(() => {
     return currentScreen === 'ProfilePicture' ? 'Select a profile picture' : 'Select item to post';
   }, [currentScreen]);
+
+  const handleRefresh = useCallback(() => {
+    refetch({ networkFilter }, { fetchPolicy: 'network-only' });
+  }, [networkFilter, refetch]);
 
   return (
     <View className="flex-1 bg-white dark:bg-black-900" style={{ paddingTop: top }}>
@@ -111,6 +118,7 @@ export function NftSelectorPickerScreen() {
             />
 
             <View className="flex flex-row space-x-1">
+              <AnimatedRefreshIcon networkFilter={networkFilter} onRefresh={handleRefresh} />
               <IconContainer
                 size="sm"
                 onPress={handleSettingsPress}
@@ -146,5 +154,69 @@ export function NftSelectorPickerScreen() {
         </View>
       </View>
     </View>
+  );
+}
+
+type AnimatedRefreshIconProps = {
+  networkFilter: NetworkChoice;
+  onRefresh: () => void;
+};
+
+function AnimatedRefreshIcon({ networkFilter, onRefresh }: AnimatedRefreshIconProps) {
+  const { isSyncing, syncTokens } = useSyncTokens();
+  const { pushToast } = useToastActions();
+
+  const handleSync = useCallback(async () => {
+    if (isSyncing) return;
+
+    await syncTokens(networkFilter);
+    onRefresh();
+    pushToast({
+      message: 'Successfully refreshed your collection',
+      withoutNavbar: true,
+    });
+  }, [isSyncing, networkFilter, onRefresh, pushToast, syncTokens]);
+
+  const spinValue = useRef(new Animated.Value(0)).current;
+
+  const spin = useCallback(() => {
+    spinValue.setValue(0);
+    Animated.timing(spinValue, {
+      toValue: 1,
+      duration: 1000,
+      useNativeDriver: true,
+    }).start(({ finished }) => {
+      // Only repeat the animation if it completed (wasn't interrupted) and isSyncing is still true
+      if (finished && isSyncing) {
+        spin();
+      }
+    });
+  }, [isSyncing, spinValue]);
+
+  const spinAnimation = spinValue.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '360deg'],
+  });
+
+  useEffect(() => {
+    if (isSyncing) {
+      spin();
+    } else {
+      spinValue.stopAnimation();
+    }
+  }, [isSyncing, spin, spinValue]);
+
+  return (
+    <IconContainer
+      size="sm"
+      onPress={handleSync}
+      icon={
+        <Animated.View style={{ transform: [{ rotate: spinAnimation }] }}>
+          <RefreshIcon />
+        </Animated.View>
+      }
+      eventElementId="NftSelectorSelectorRefreshButton"
+      eventName="NftSelectoreSelectorRefreshButton pressed"
+    />
   );
 }

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
@@ -40,7 +40,7 @@ export function NftSelectorPickerScreen() {
     {}
   );
 
-  const [data, refetch] = useRefetchableFragment<
+  const [data] = useRefetchableFragment<
     NftSelectorPickerScreenRefetchQuery,
     NftSelectorPickerScreenFragment$key
   >(
@@ -64,20 +64,12 @@ export function NftSelectorPickerScreen() {
 
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [filter, setFilter] = useState<'Collected' | 'Created'>('Collected');
-  const [networkFilter, setNetworkFilter] = useState<NetworkChoice>('all');
+  const [networkFilter, setNetworkFilter] = useState<NetworkChoice>('Ethereum');
   const [sortView, setSortView] = useState<NftSelectorSortView>('Recently added');
 
   const screenTitle = useMemo(() => {
     return currentScreen === 'ProfilePicture' ? 'Select a profile picture' : 'Select item to post';
   }, [currentScreen]);
-
-  const showRefreshIcon = useMemo(() => {
-    return networkFilter !== 'all';
-  }, [networkFilter]);
-
-  const handleRefresh = useCallback(() => {
-    refetch({ networkFilter }, { fetchPolicy: 'network-only' });
-  }, [networkFilter, refetch]);
 
   return (
     <View className="flex-1 bg-white dark:bg-black-900" style={{ paddingTop: top }}>
@@ -122,9 +114,6 @@ export function NftSelectorPickerScreen() {
             />
 
             <View className="flex flex-row space-x-1">
-              {showRefreshIcon && (
-                <AnimatedRefreshIcon networkFilter={networkFilter} onRefresh={handleRefresh} />
-              )}
               <IconContainer
                 size="sm"
                 onPress={handleSettingsPress}
@@ -173,7 +162,7 @@ function AnimatedRefreshIcon({ networkFilter, onRefresh }: AnimatedRefreshIconPr
   const { pushToast } = useToastActions();
 
   const handleSync = useCallback(async () => {
-    if (networkFilter === 'all' || isSyncing) return;
+    if (isSyncing) return;
 
     await syncTokens(networkFilter);
     onRefresh();

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -1,6 +1,6 @@
 # API URL
 # To use mock server set url to "/api"
-NEXT_PUBLIC_API_BASE_URL=https://api.dev.gallery.so
+NEXT_PUBLIC_API_BASE_URL=https://api.gallery.so
 NEXT_PUBLIC_GRAPHQL_SUBSCRIPTION_URL=wss://api.gallery.so/glry/graphql/query
 
 # Ethereum Chain ID for reading contract data using Network Connector

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -1,6 +1,6 @@
 # API URL
 # To use mock server set url to "/api"
-NEXT_PUBLIC_API_BASE_URL=https://api.gallery.so
+NEXT_PUBLIC_API_BASE_URL=https://api.dev.gallery.so
 NEXT_PUBLIC_GRAPHQL_SUBSCRIPTION_URL=wss://api.gallery.so/glry/graphql/query
 
 # Ethereum Chain ID for reading contract data using Network Connector


### PR DESCRIPTION
### Summary of Changes
on mobile app, we default to Ethereum in the NFT Selector similar to web as we can't show a refresh button for 'all' option only

### Demo
| Before | Before 2 | After | After 2 |
|--------|--------|--------|--------|
| ![Screenshot 2023-08-29 at 3 20 48 PM](https://github.com/gallery-so/gallery/assets/49758803/30932de2-6a5d-40c5-93f8-5b98fcb53045) | ![Screenshot 2023-08-29 at 3 20 59 PM](https://github.com/gallery-so/gallery/assets/49758803/837768bc-ab17-4a67-b676-5b5c8050d32d) | ![Screenshot 2023-08-29 at 5 54 47 PM](https://github.com/gallery-so/gallery/assets/49758803/06e2a71e-7b48-4d07-9956-f8f04b9f581f) | ![Screenshot 2023-08-29 at 3 15 39 PM](https://github.com/gallery-so/gallery/assets/49758803/a1d718a0-c893-413f-8aa5-5437e2b1d3f9) |

### Edge Cases
Hmm not sure about what else to consider

### Testing Steps
Can test locally on branch by trying to compose a post and see the default filters

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
