### PR TITLE
[GAL-4142] Add skeleton state for Post Composer

### DIFF
--- a/apps/mobile/src/screens/PostScreen/PostComposerNftFallback.tsx
+++ b/apps/mobile/src/screens/PostScreen/PostComposerNftFallback.tsx
@@ -1,0 +1,20 @@
+import { View } from 'react-native';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
+
+import { GallerySkeleton } from '~/components/GallerySkeleton';
+
+export function PostComposerNftFallback() {
+  return (
+    <View className="flex-1 bg-white dark:bg-black">
+      <GallerySkeleton>
+        <SkeletonPlaceholder.Item flexDirection="column" width="100%">
+          <SkeletonPlaceholder.Item marginBottom={16} width="100%" height={330} />
+          <SkeletonPlaceholder.Item flexDirection="column" rowGap={16}>
+            <SkeletonPlaceholder.Item width={100} height={18} />
+            <SkeletonPlaceholder.Item width={100} height={18} />
+          </SkeletonPlaceholder.Item>
+        </SkeletonPlaceholder.Item>
+      </GallerySkeleton>
+    </View>
+  );
+}

--- a/apps/mobile/src/screens/PostScreen/PostComposerNftFallback.tsx
+++ b/apps/mobile/src/screens/PostScreen/PostComposerNftFallback.tsx
@@ -8,10 +8,10 @@ export function PostComposerNftFallback() {
     <View className="flex-1 bg-white dark:bg-black">
       <GallerySkeleton>
         <SkeletonPlaceholder.Item flexDirection="column" width="100%">
-          <SkeletonPlaceholder.Item marginBottom={16} width="100%" height={330} />
+          <SkeletonPlaceholder.Item marginBottom={16} width="100%" height={361} />
           <SkeletonPlaceholder.Item flexDirection="column" rowGap={16}>
-            <SkeletonPlaceholder.Item width={100} height={18} />
-            <SkeletonPlaceholder.Item width={100} height={18} />
+            <SkeletonPlaceholder.Item width={100} height={20} />
+            <SkeletonPlaceholder.Item width={100} height={20} />
           </SkeletonPlaceholder.Item>
         </SkeletonPlaceholder.Item>
       </GallerySkeleton>

--- a/apps/mobile/src/screens/PostScreen/PostComposerScreen.tsx
+++ b/apps/mobile/src/screens/PostScreen/PostComposerScreen.tsx
@@ -20,6 +20,7 @@ import {
   PostStackNavigatorParamList,
 } from '~/navigation/types';
 
+import { PostComposerNftFallback } from './PostComposerNftFallback';
 import { usePost } from './usePost';
 
 function PostComposerScreenInner() {
@@ -77,6 +78,7 @@ function PostComposerScreenInner() {
   }, [caption, navigation]);
 
   const { pushToast } = useToastActions();
+
   const handlePost = useCallback(async () => {
     const tokenId = token.dbid;
 
@@ -151,9 +153,10 @@ function PostComposerScreenInner() {
 
       <View className="px-4 flex flex-col flex-grow space-y-2">
         <PostInput value={caption} onChange={setCaption} tokenRef={token} />
-
         <View className="py-4">
-          <PostTokenPreview />
+          <Suspense fallback={<PostComposerNftFallback />}>
+            <PostTokenPreview />
+          </Suspense>
         </View>
       </View>
       <WarningPostBottomSheet ref={bottomSheetRef} />


### PR DESCRIPTION
### Summary of Changes
when transitioning from the NFT Selector to the Post Composer, there isn't a blank screen and instead there are placeholder elements for the Post Composer UI.
the suspense state for the nft is limited to the area with the token image and name

### Demo
When selecting token from NFT picker for post composer
<img width="250" alt="Screenshot 2023-08-29 at 5 28 31 PM" src="https://github.com/gallery-so/gallery/assets/49758803/10941783-5f41-4a81-8e41-fcc9ac7e131c">

| Before | Before 2 | After | After 2 |
|--------|--------|--------|--------|
| <img width="475" alt="Screenshot 2023-08-29 at 5 28 47 PM" src="https://github.com/gallery-so/gallery/assets/49758803/d32b6886-67f7-4044-8f58-25624cd54212"> | <img width="466" alt="Screenshot 2023-08-29 at 5 29 00 PM" src="https://github.com/gallery-so/gallery/assets/49758803/35125050-5b9f-45f7-a7bc-78e5d7a5ac91"> | <img width="533" alt="Screenshot 2023-08-29 at 5 23 25 PM" src="https://github.com/gallery-so/gallery/assets/49758803/d2577a06-ad5b-4c46-8ce8-9f28aa32d9c2"> | <img width="543" alt="Screenshot 2023-08-29 at 5 23 38 PM" src="https://github.com/gallery-so/gallery/assets/49758803/237135e6-4105-4472-acaf-0a88283b0099"> |

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots. You can type `/table` to quickly come up with a before/after table.

### Edge Cases
Tested dark mode

### Testing Steps
Can test locally on branch by trying to compose a post

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
