### PR TITLE
Fix optimistic update on Curated feed on prod

### DIFF
--- a/apps/web/src/hooks/api/posts/useCreatePost.ts
+++ b/apps/web/src/hooks/api/posts/useCreatePost.ts
@@ -70,6 +70,13 @@ export default function useCreatePost() {
             { includePosts: true }
           );
 
+          // this stuff will be cleaned up with [GAL-4175]
+          const otherCuratedFeedConnectionLol = ConnectionHandler.getConnection(
+            rootRecord,
+            'NonAuthedFeed_curatedFeed',
+            { includePosts: false }
+          );
+
           if (newPostRecord && curatedFeedConnection) {
             const edge = ConnectionHandler.createEdge(
               store,
@@ -78,6 +85,16 @@ export default function useCreatePost() {
               'FeedEdge'
             );
             ConnectionHandler.insertEdgeAfter(curatedFeedConnection, edge);
+          }
+
+          if (newPostRecord && otherCuratedFeedConnectionLol) {
+            const edge = ConnectionHandler.createEdge(
+              store,
+              otherCuratedFeedConnectionLol,
+              newPostRecord,
+              'FeedEdge'
+            );
+            ConnectionHandler.insertEdgeAfter(otherCuratedFeedConnectionLol, edge);
           }
 
           // UPDATE COMMUNITY FEED


### PR DESCRIPTION
### Summary of Changes

The production feed passes in `includePosts: false` when loading its curated feed, which was not handled by the optimistic update logic.

### Edge Cases

- [x] Tested this by pointing to prod and ensuring optimistic update
- [x] Ensure dev still works

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.

