### PR TITLE
[GAL-4174] Fix non-scalable eth icon

### DIFF
--- a/apps/mobile/src/icons/EthIcon.tsx
+++ b/apps/mobile/src/icons/EthIcon.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export function EthIcon({ height = 12, width = 12, ...props }: Props) {
   return (
-    <Svg width={width} height={height} fill="none" {...props}>
+    <Svg width={width} height={height} fill="none" viewBox="0 0 24 24" {...props}>
       <Path
         fill="#000"
         d="M11.997 9.137 5.25 12.204l6.747 3.989 6.75-3.989-6.75-3.067Z"


### PR DESCRIPTION
### Summary of Changes

Fix eth icon when we tried to scale it (different sizes)

### Demo or Before/After Pics

<img width="436" alt="CleanShot 2023-08-30 at 15 30 52@2x" src="https://github.com/gallery-so/gallery/assets/4480258/1b04a2ee-479a-4776-a4ee-d0ed55e79c02">

<img width="408" alt="CleanShot 2023-08-30 at 15 31 11@2x" src="https://github.com/gallery-so/gallery/assets/4480258/7149f3ae-bb09-48f5-a3ca-45c210045cd9">

<img width="454" alt="CleanShot 2023-08-30 at 15 35 15@2x" src="https://github.com/gallery-so/gallery/assets/4480258/222a8081-d82a-4c5c-a6c6-033b4bb18f06">


### Edge Cases

1. Check the eth icon in wallet selector (wallet connect)
2. Community screen
3. NFT selector (chain filter)

### Testing Steps

1. Go to wallet connect authentication
2. Check any ethereum community screen
3. NFT selector (during post / pfp)

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if mobile) I've tested the changes on both light and dark modes.
