### PR TITLE
[GAL-4022] Post button icon stroke weight update

### DIFF
--- a/apps/mobile/src/components/Community/CommunityMeta.tsx
+++ b/apps/mobile/src/components/Community/CommunityMeta.tsx
@@ -214,7 +214,7 @@ export function CommunityMeta({ communityRef, queryRef }: Props) {
           text="Post"
           className="w-[100px]"
           variant={isMemberOfCommunity ? 'primary' : 'disabled'}
-          icon={<PostIcon width={16} color={PostIconColor} />}
+          icon={<PostIcon width={16} color={PostIconColor} strokeWidth={2} />}
           onPress={handlePress}
           eventElementId={null}
           eventName={null}

--- a/apps/mobile/src/navigation/MainTabNavigator/PostIcon.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/PostIcon.tsx
@@ -4,6 +4,7 @@ type Props = {
   color: string;
   height?: number;
   width?: number;
+  strokeWidth?: number;
 } & SvgProps;
 
 export const PostIcon = ({ color, height = 24, width = 24, ...props }: Props) => {
@@ -12,6 +13,7 @@ export const PostIcon = ({ color, height = 24, width = 24, ...props }: Props) =>
       <Path
         stroke={color}
         strokeMiterlimit={10}
+        strokeWidth={2}
         d="M4.5 25.333V4.5h23v23h-23v-2.167ZM16 10.666v10.667M21.333 16H10.667"
       />
     </Svg>

--- a/apps/mobile/src/navigation/MainTabNavigator/PostIcon.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/PostIcon.tsx
@@ -7,13 +7,13 @@ type Props = {
   strokeWidth?: number;
 } & SvgProps;
 
-export const PostIcon = ({ color, height = 24, width = 24, ...props }: Props) => {
+export const PostIcon = ({ color, height = 24, width = 24, strokeWidth = 1, ...props }: Props) => {
   return (
     <Svg fill="none" width={width} height={height} viewBox="0 0 30 30" {...props}>
       <Path
         stroke={color}
         strokeMiterlimit={10}
-        strokeWidth={2}
+        strokeWidth={strokeWidth}
         d="M4.5 25.333V4.5h23v23h-23v-2.167ZM16 10.666v10.667M21.333 16H10.667"
       />
     </Svg>

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
@@ -293,6 +293,7 @@ export function NftDetailScreenInner() {
             icon={
               <PostIcon
                 width={24}
+                strokeWidth={1.5}
                 color={colorScheme === 'dark' ? colors.black['800'] : colors.white}
               />
             }


### PR DESCRIPTION
### Summary of Changes
Increase the stroke weight on the PostIcon in some instances to the design
<img width="700" alt="Screenshot 2023-08-16 at 4 54 50 pm" src="https://github.com/gallery-so/gallery/assets/49758803/7a241435-49f4-4278-b481-a3f26899ec36">

### Demo
| Before | Before 2 | 
|--------|--------|
| <img width="457" alt="Screenshot 2023-08-30 at 2 24 06 PM" src="https://github.com/gallery-so/gallery/assets/49758803/ade88158-0bff-4b9b-9a1b-6131bb6cdd6a"> | <img width="497" alt="Screenshot 2023-08-30 at 2 24 13 PM" src="https://github.com/gallery-so/gallery/assets/49758803/8f1a54ce-3256-4eb7-b6cd-0613452bfa7c"> | 

| After | After 2 |
|--------|--------|
| <img width="418" alt="Screenshot 2023-08-30 at 2 21 29 PM" src="https://github.com/gallery-so/gallery/assets/49758803/549dca1f-f525-474b-8d2e-78cb6b973d55"> | <img width="408" alt="Screenshot 2023-08-30 at 2 20 36 PM" src="https://github.com/gallery-so/gallery/assets/49758803/8ff025b9-b309-4c94-9bf3-02b06136c73e"> | 

### Edge Cases
Tested dark mode and checked all instances of use of <PostIcon/> in mobile

### Testing Steps
Can test locally on branch

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
