### PR TITLE
[GAL-4167] styling fix for community page header 

### DIFF
--- a/apps/web/src/scenes/CommunityPage/CommunityPageMetadata.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageMetadata.tsx
@@ -213,6 +213,10 @@ const StyledMetadata = styled(HStack)`
     gap: 0 48px;
   }
 
+  @media only screen and ${breakpoints.mobileLarge} {
+    gap: 8px 48px;
+  }
+
   width: 100%;
 `;
 


### PR DESCRIPTION
### Summary of Changes
Fix placement of items of community page header on tablet web, while keeping mobile web view **unchanged**

### Before
| mobile | mobile 2 | tablet | tablet 2 |
|--------|--------|--------|--------|
| <img width="686" alt="Screenshot 2023-08-30 at 3 29 52 PM" src="https://github.com/gallery-so/gallery/assets/49758803/4a434a2d-62b0-4f85-bfb1-e2d4fec56aa9"> | <img width="546" alt="Screenshot 2023-08-30 at 3 38 41 PM" src="https://github.com/gallery-so/gallery/assets/49758803/f854ca73-fbc4-4533-af16-d18f617bfa8b"> | <img width="645" alt="Screenshot 2023-08-30 at 3 36 53 PM" src="https://github.com/gallery-so/gallery/assets/49758803/37d0ea9b-f890-4b14-bab3-c0855cf786bf"> | <img width="802" alt="Screenshot 2023-08-30 at 3 38 53 PM" src="https://github.com/gallery-so/gallery/assets/49758803/8f9a068c-3138-45c6-bf2d-bd147bb99564"> |
### After
| mobile | mobile 2 | tablet | tablet 2 |
|--------|--------|--------|--------|
| <img width="451" alt="Screenshot 2023-08-30 at 3 37 23 PM" src="https://github.com/gallery-so/gallery/assets/49758803/58db00da-7129-4a27-985b-96b1b3a3097e"> | <img width="546" alt="Screenshot 2023-08-30 at 3 38 41 PM" src="https://github.com/gallery-so/gallery/assets/49758803/773583c2-1c9e-427c-9fcb-027951484da2"> | <img width="922" alt="Screenshot 2023-08-30 at 3 29 34 PM" src="https://github.com/gallery-so/gallery/assets/49758803/a32cf178-5311-483c-8c74-52d010d06823"> | <img width="953" alt="Screenshot 2023-08-30 at 3 29 07 PM" src="https://github.com/gallery-so/gallery/assets/49758803/ef75589a-0794-4648-aecf-b10d26a18bdc">

### Edge Cases
Tested different communities and different window widths


### Testing Steps
Can test locally by visiting a community page

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
