### PR TITLE
[GAL-4139] Post composer context, improve discard modal handling

### DIFF
--- a/apps/web/src/components/Posts/DiscardPostConfirmation.tsx
+++ b/apps/web/src/components/Posts/DiscardPostConfirmation.tsx
@@ -2,6 +2,9 @@ import { useCallback } from 'react';
 import styled from 'styled-components';
 
 import { useModalActions } from '~/contexts/modal/ModalContext';
+import { EditPencilIcon } from '~/icons/EditPencilIcon';
+import { TrashIconNew } from '~/icons/TrashIconNew';
+import colors from '~/shared/theme/colors';
 
 import { Button } from '../core/Button/Button';
 import { HStack } from '../core/Spacer/Stack';
@@ -30,9 +33,15 @@ export default function DiscardPostConfirmation({ onSaveDraft, onDiscard }: Prop
       <BaseM>If you go back now, this post will be discarded.</BaseM>
       <HStack justify="flex-end" gap={8}>
         <StyledButton onClick={handleSaveDraftClick} variant="secondary">
-          SAVE DRAFT
+          <HStack align="center" gap={6}>
+            <EditPencilIcon width={12} height={12} /> SAVE DRAFT
+          </HStack>
         </StyledButton>
-        <StyledButton onClick={handleDiscardConfirmClick}>DISCARD</StyledButton>
+        <StyledButton onClick={handleDiscardConfirmClick}>
+          <HStack align="center" gap={6}>
+            <TrashIconNew color={colors.white} /> DISCARD
+          </HStack>
+        </StyledButton>
       </HStack>
     </StyledConfirmation>
   );

--- a/apps/web/src/components/Posts/DiscardPostConfirmation.tsx
+++ b/apps/web/src/components/Posts/DiscardPostConfirmation.tsx
@@ -8,11 +8,17 @@ import { HStack } from '../core/Spacer/Stack';
 import { BaseM } from '../core/Text/Text';
 
 type Props = {
+  onSaveDraft: () => void;
   onDiscard: () => void;
 };
 
-export default function DiscardPostConfirmation({ onDiscard }: Props) {
+export default function DiscardPostConfirmation({ onSaveDraft, onDiscard }: Props) {
   const { hideModal } = useModalActions();
+
+  const handleSaveDraftClick = useCallback(() => {
+    hideModal();
+    onSaveDraft();
+  }, [onSaveDraft, hideModal]);
 
   const handleDiscardConfirmClick = useCallback(() => {
     hideModal();
@@ -22,21 +28,22 @@ export default function DiscardPostConfirmation({ onDiscard }: Props) {
   return (
     <StyledConfirmation>
       <BaseM>If you go back now, this post will be discarded.</BaseM>
-      <HStack justify="flex-end">
-        <StyledButton onClick={handleDiscardConfirmClick}>DISCARD POST</StyledButton>
+      <HStack justify="flex-end" gap={8}>
+        <StyledButton onClick={handleSaveDraftClick} variant="secondary">
+          SAVE DRAFT
+        </StyledButton>
+        <StyledButton onClick={handleDiscardConfirmClick}>DISCARD</StyledButton>
       </HStack>
     </StyledConfirmation>
   );
 }
 
 const StyledConfirmation = styled.div`
-  width: 311px;
+  width: 375px;
   max-width: 100%;
 `;
 
 const StyledButton = styled(Button)`
   margin-top: 16px;
-  width: 120px;
-  padding-left: 0px;
-  padding-right: 0px;
+  padding: 8px 16px;
 `;

--- a/apps/web/src/components/Posts/PostComposer.tsx
+++ b/apps/web/src/components/Posts/PostComposer.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import ErrorText from '~/components/core/Text/ErrorText';
 import { useModalActions } from '~/contexts/modal/ModalContext';
+import { usePostComposerContext } from '~/contexts/postComposer/PostComposerContext';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { PostComposerFragment$key } from '~/generated/PostComposerFragment.graphql';
 import useCreatePost from '~/hooks/api/posts/useCreatePost';
@@ -44,14 +45,16 @@ export default function PostComposer({ onBackClick, tokenRef }: Props) {
     tokenRef
   );
 
-  const [description, setDescription] = useState('');
-  const handleDescriptionChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setDescription(event.target.value);
-  }, []);
+  const { caption, setCaption, captionRef } = usePostComposerContext();
 
-  const descriptionOverLengthLimit = useMemo(() => {
-    return description.length > DESCRIPTION_MAX_LENGTH;
-  }, [description]);
+  const handleDescriptionChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setCaption(event.target.value);
+    },
+    [setCaption]
+  );
+
+  const descriptionOverLengthLimit = caption.length > DESCRIPTION_MAX_LENGTH;
 
   const createPost = useCreatePost();
 
@@ -65,12 +68,12 @@ export default function PostComposer({ onBackClick, tokenRef }: Props) {
   const handlePostClick = useCallback(async () => {
     setIsSubmitting(true);
     track('Clicked Post in Post Composer', {
-      added_description: Boolean(description),
+      added_description: Boolean(captionRef.current),
     });
     try {
       await createPost({
         tokens: [{ dbid: token.dbid, communityId: token.community?.id || '' }],
-        caption: description,
+        caption: captionRef.current,
       });
       setIsSubmitting(false);
       hideModal();
@@ -86,7 +89,7 @@ export default function PostComposer({ onBackClick, tokenRef }: Props) {
     }
   }, [
     createPost,
-    description,
+    captionRef,
     hideModal,
     pushToast,
     token.community,
@@ -126,9 +129,10 @@ export default function PostComposer({ onBackClick, tokenRef }: Props) {
           <PostComposerNft tokenRef={token} />
           <VStack grow>
             <TextAreaWithCharCount
-              currentCharCount={description.length}
-              maxCharCount={DESCRIPTION_MAX_LENGTH}
+              defaultValue={caption}
               placeholder={`Say something about ${inputPlaceholderTokenName}`}
+              currentCharCount={caption.length}
+              maxCharCount={DESCRIPTION_MAX_LENGTH}
               textAreaHeight="117px"
               onChange={handleDescriptionChange}
               autoFocus

--- a/apps/web/src/components/Posts/PostComposer.tsx
+++ b/apps/web/src/components/Posts/PostComposer.tsx
@@ -80,6 +80,7 @@ export default function PostComposer({ onBackClick, tokenRef }: Props) {
       pushToast({
         message: `Successfully posted ${token.name || 'item'}`,
       });
+      setCaption('');
     } catch (error) {
       setIsSubmitting(false);
       if (error instanceof Error) {
@@ -88,15 +89,15 @@ export default function PostComposer({ onBackClick, tokenRef }: Props) {
       setGeneralError('Post failed to upload, please try again');
     }
   }, [
-    createPost,
+    track,
     captionRef,
+    createPost,
+    token.dbid,
+    token.community?.id,
+    token.name,
     hideModal,
     pushToast,
-    token.community,
-    token.dbid,
-    token.name,
-    track,
-    setGeneralError,
+    setCaption,
     reportError,
   ]);
 

--- a/apps/web/src/components/Posts/PostComposerModal.tsx
+++ b/apps/web/src/components/Posts/PostComposerModal.tsx
@@ -72,7 +72,7 @@ export function PostComposerModalWithSelector({ viewerRef, queryRef, preSelected
 
   const { showModal } = useModalActions();
 
-  const { captionRef } = usePostComposerContext();
+  const { captionRef, setCaption } = usePostComposerContext();
 
   const onBackClick = useCallback(() => {
     if (!captionRef.current) {
@@ -84,14 +84,18 @@ export function PostComposerModalWithSelector({ viewerRef, queryRef, preSelected
       headerText: 'Are you sure?',
       content: (
         <DiscardPostConfirmation
+          onSaveDraft={() => {
+            returnUserToSelectorStep();
+          }}
           onDiscard={() => {
             returnUserToSelectorStep();
+            setCaption('');
           }}
         />
       ),
       isFullPage: false,
     });
-  }, [showModal, returnUserToSelectorStep, captionRef]);
+  }, [captionRef, showModal, returnUserToSelectorStep, setCaption]);
 
   return (
     <StyledPostComposerModal>

--- a/apps/web/src/components/Posts/PostComposerModal.tsx
+++ b/apps/web/src/components/Posts/PostComposerModal.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import ErrorBoundary from '~/contexts/boundary/ErrorBoundary';
 import { useModalActions } from '~/contexts/modal/ModalContext';
+import { usePostComposerContext } from '~/contexts/postComposer/PostComposerContext';
 import { PostComposerModalFragment$key } from '~/generated/PostComposerModalFragment.graphql';
 import { PostComposerModalWithSelectorFragment$key } from '~/generated/PostComposerModalWithSelectorFragment.graphql';
 import { PostComposerModalWithSelectorQueryFragment$key } from '~/generated/PostComposerModalWithSelectorQueryFragment.graphql';
@@ -65,25 +66,32 @@ export function PostComposerModalWithSelector({ viewerRef, queryRef, preSelected
     setSelectedTokenId(tokenId);
   }, []);
 
-  const clearSelectedTokenId = useCallback(() => {
+  const returnUserToSelectorStep = useCallback(() => {
     setSelectedTokenId(null);
   }, []);
 
   const { showModal } = useModalActions();
 
+  const { captionRef } = usePostComposerContext();
+
   const onBackClick = useCallback(() => {
+    if (!captionRef.current) {
+      returnUserToSelectorStep();
+      return;
+    }
+
     showModal({
       headerText: 'Are you sure?',
       content: (
         <DiscardPostConfirmation
           onDiscard={() => {
-            clearSelectedTokenId();
+            returnUserToSelectorStep();
           }}
         />
       ),
       isFullPage: false,
     });
-  }, [showModal, clearSelectedTokenId]);
+  }, [showModal, returnUserToSelectorStep, captionRef]);
 
   return (
     <StyledPostComposerModal>

--- a/apps/web/src/contexts/AppProvider.tsx
+++ b/apps/web/src/contexts/AppProvider.tsx
@@ -15,6 +15,7 @@ import { WebErrorReportingProvider } from './errorReporting/WebErrorReportingPro
 import GlobalLayoutContextProvider from './globalLayout/GlobalLayoutContext';
 import SidebarDrawerProvider from './globalLayout/GlobalSidebar/SidebarDrawerContext';
 import ModalProvider from './modal/ModalContext';
+import PostComposerProvider from './postComposer/PostComposerContext';
 import { SwrProvider } from './swr/SwrContext';
 import ToastProvider from './toast/ToastContext';
 
@@ -45,19 +46,21 @@ export default function AppProvider({
                 <GalleryNavigationProvider>
                   <NftErrorProvider>
                     <SyncTokensLockProvider>
-                      <ModalProvider>
-                        <SidebarDrawerProvider>
-                          <SearchProvider>
-                            <GlobalLayoutContextProvider
-                              preloadedQuery={globalLayoutContextPreloadedQuery}
-                            >
-                              <FullPageNftDetailModalListener />
-                              {isProd ? null : <Debugger />}
-                              {children}
-                            </GlobalLayoutContextProvider>
-                          </SearchProvider>
-                        </SidebarDrawerProvider>
-                      </ModalProvider>
+                      <PostComposerProvider>
+                        <ModalProvider>
+                          <SidebarDrawerProvider>
+                            <SearchProvider>
+                              <GlobalLayoutContextProvider
+                                preloadedQuery={globalLayoutContextPreloadedQuery}
+                              >
+                                <FullPageNftDetailModalListener />
+                                {isProd ? null : <Debugger />}
+                                {children}
+                              </GlobalLayoutContextProvider>
+                            </SearchProvider>
+                          </SidebarDrawerProvider>
+                        </ModalProvider>
+                      </PostComposerProvider>
                     </SyncTokensLockProvider>
                   </NftErrorProvider>
                 </GalleryNavigationProvider>

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
@@ -122,7 +122,7 @@ export function StandardSidebar({ queryRef }: Props) {
 
   const username = (isLoggedIn && query.viewer.user?.username) || '';
 
-  const { showModal, hideModal } = useModalActions();
+  const { showModal } = useModalActions();
   const isMobile = useIsMobileOrMobileLargeWindowWidth();
 
   const handleSettingsClick = useCallback(() => {
@@ -159,7 +159,7 @@ export function StandardSidebar({ queryRef }: Props) {
     track('Sidebar Home Click');
   }, [hideDrawer, track]);
 
-  const { captionRef } = usePostComposerContext();
+  const { captionRef, setCaption } = usePostComposerContext();
 
   const handleCreatePostClick = useCallback(() => {
     hideDrawer();
@@ -173,17 +173,22 @@ export function StandardSidebar({ queryRef }: Props) {
       content: <PostComposerModalWithSelector viewerRef={query?.viewer} queryRef={query} />,
       headerVariant: 'thicc',
       isFullPage: isMobile,
-      onCloseOverride: () => {
+      onCloseOverride: (onClose: () => void) => {
         if (!captionRef.current) {
-          hideModal({ id: 'post-composer' });
+          onClose();
           return;
         }
+
         showModal({
           headerText: 'Are you sure?',
           content: (
             <DiscardPostConfirmation
+              onSaveDraft={() => {
+                onClose();
+              }}
               onDiscard={() => {
-                hideModal({ id: 'post-composer' });
+                setCaption('');
+                onClose();
               }}
             />
           ),
@@ -192,7 +197,7 @@ export function StandardSidebar({ queryRef }: Props) {
       },
     });
     track('Sidebar Create Post Click');
-  }, [hideDrawer, isLoggedIn, showModal, query, isMobile, track, captionRef, hideModal]);
+  }, [hideDrawer, isLoggedIn, showModal, query, isMobile, track, captionRef, setCaption]);
 
   const handleSearchClick = useCallback(() => {
     track('Sidebar Search Click');

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
@@ -13,6 +13,7 @@ import { PostComposerModalWithSelector } from '~/components/Posts/PostComposerMo
 import Search from '~/components/Search/Search';
 import Settings from '~/components/Settings/Settings';
 import { useModalActions } from '~/contexts/modal/ModalContext';
+import { usePostComposerContext } from '~/contexts/postComposer/PostComposerContext';
 import { StandardSidebarFragment$key } from '~/generated/StandardSidebarFragment.graphql';
 import useAuthModal from '~/hooks/useAuthModal';
 import { useSearchHotkey } from '~/hooks/useSearchHotkey';
@@ -158,6 +159,8 @@ export function StandardSidebar({ queryRef }: Props) {
     track('Sidebar Home Click');
   }, [hideDrawer, track]);
 
+  const { captionRef } = usePostComposerContext();
+
   const handleCreatePostClick = useCallback(() => {
     hideDrawer();
 
@@ -171,6 +174,10 @@ export function StandardSidebar({ queryRef }: Props) {
       headerVariant: 'thicc',
       isFullPage: isMobile,
       onCloseOverride: () => {
+        if (!captionRef.current) {
+          hideModal({ id: 'post-composer' });
+          return;
+        }
         showModal({
           headerText: 'Are you sure?',
           content: (
@@ -185,7 +192,7 @@ export function StandardSidebar({ queryRef }: Props) {
       },
     });
     track('Sidebar Create Post Click');
-  }, [hideDrawer, isLoggedIn, showModal, query, isMobile, track, hideModal]);
+  }, [hideDrawer, isLoggedIn, showModal, query, isMobile, track, captionRef, hideModal]);
 
   const handleSearchClick = useCallback(() => {
     track('Sidebar Search Click');

--- a/apps/web/src/contexts/modal/AnimatedModal.tsx
+++ b/apps/web/src/contexts/modal/AnimatedModal.tsx
@@ -31,7 +31,7 @@ export type AnimatedModalProps = {
   headerText: string;
   headerVariant: ModalPaddingVariant;
   hideClose: boolean;
-  onCloseOverride: (onClose: () => void) => void;
+  onCloseOverride?: (onClose: () => void) => void;
 };
 
 function AnimatedModal({
@@ -83,10 +83,15 @@ function AnimatedModal({
     return 'unset';
   }, [isFullPage, isMobile]);
 
-  const handleClick = useCallback(
-    () => (onCloseOverride ? onCloseOverride(hideModal) : hideModal()),
-    [onCloseOverride, hideModal]
-  );
+  const handleClick = useCallback(() => {
+    if (onCloseOverride) {
+      console.log('oncloseoverride');
+      onCloseOverride(hideModal);
+      return;
+    }
+    console.log('hidemodal');
+    hideModal();
+  }, [onCloseOverride, hideModal]);
 
   return (
     <_ToggleFade isActive={isActive}>

--- a/apps/web/src/contexts/modal/AnimatedModal.tsx
+++ b/apps/web/src/contexts/modal/AnimatedModal.tsx
@@ -14,7 +14,7 @@ import colors from '~/shared/theme/colors';
 
 import { MODAL_PADDING_PX, ModalPaddingVariant } from './constants';
 
-type Props = {
+export type AnimatedModalProps = {
   /**
    * `hideModal` and `dismountModal` are used separately.
    * hideModal begins the process for removing the modal, and
@@ -30,8 +30,8 @@ type Props = {
   headerActions?: JSX.Element | false;
   headerText: string;
   headerVariant: ModalPaddingVariant;
-  hideClose?: boolean;
-  onCloseOverride?: () => void;
+  hideClose: boolean;
+  onCloseOverride: (onClose: () => void) => void;
 };
 
 function AnimatedModal({
@@ -46,7 +46,7 @@ function AnimatedModal({
   headerVariant,
   hideClose,
   onCloseOverride,
-}: Props) {
+}: AnimatedModalProps) {
   useEffect(() => {
     if (!isActive) {
       setTimeout(dismountModal, ANIMATED_COMPONENT_TRANSITION_MS);
@@ -84,7 +84,7 @@ function AnimatedModal({
   }, [isFullPage, isMobile]);
 
   const handleClick = useCallback(
-    () => (onCloseOverride ? onCloseOverride() : hideModal()),
+    () => (onCloseOverride ? onCloseOverride(hideModal) : hideModal()),
     [onCloseOverride, hideModal]
   );
 

--- a/apps/web/src/contexts/modal/AnimatedModal.tsx
+++ b/apps/web/src/contexts/modal/AnimatedModal.tsx
@@ -85,11 +85,9 @@ function AnimatedModal({
 
   const handleClick = useCallback(() => {
     if (onCloseOverride) {
-      console.log('oncloseoverride');
       onCloseOverride(hideModal);
       return;
     }
-    console.log('hidemodal');
     hideModal();
   }, [onCloseOverride, hideModal]);
 

--- a/apps/web/src/contexts/modal/ModalContext.tsx
+++ b/apps/web/src/contexts/modal/ModalContext.tsx
@@ -18,7 +18,7 @@ import { getScrollBarWidth } from '~/utils/getScrollbarWidth';
 import noop from '~/utils/noop';
 
 import useStabilizedRouteTransitionKey from '../globalLayout/useStabilizedRouteTransitionKey';
-import AnimatedModal from './AnimatedModal';
+import AnimatedModal, { AnimatedModalProps } from './AnimatedModal';
 import { ModalPaddingVariant } from './constants';
 
 type ModalState = {
@@ -39,14 +39,14 @@ export const useModalState = (): ModalState => {
 type ShowModalFnProps = {
   id?: string;
   content: ReactElement;
+  headerActions?: JSX.Element | false;
   headerText?: string;
   headerVariant?: ModalPaddingVariant;
   isFullPage?: boolean;
   hideClose?: boolean;
   isPaddingDisabled?: boolean;
   onClose?: () => void;
-  onCloseOverride?: () => void;
-  headerActions?: JSX.Element | false;
+  onCloseOverride?: AnimatedModalProps['onCloseOverride'];
 };
 
 type HideModalFnProps = {
@@ -75,17 +75,8 @@ type Props = { children: ReactNode };
 
 type Modal = {
   id: string;
-  isActive: boolean;
-  content: ReactElement;
-  headerActions?: JSX.Element | false;
-  headerText: string;
-  headerVariant: ModalPaddingVariant;
-  isFullPage: boolean;
-  isPaddingDisabled: boolean;
-  hideClose: boolean;
   onClose: () => void;
-  onCloseOverride?: () => void;
-};
+} & Omit<AnimatedModalProps, 'hideModal' | 'dismountModal'>;
 
 function ModalProvider({ children }: Props) {
   const [modals, setModals] = useState<Modal[]>([]);
@@ -110,7 +101,7 @@ function ModalProvider({ children }: Props) {
       isFullPage = false,
       isPaddingDisabled = false,
       onClose = noop,
-      onCloseOverride,
+      onCloseOverride = () => {},
     }: ShowModalFnProps) => {
       setModals((prevModals) => [
         ...prevModals,
@@ -259,11 +250,15 @@ function ModalProvider({ children }: Props) {
             hideClose,
             onCloseOverride,
           }) => {
+            const hideCurrentModal = () => {
+              hideModal({ id });
+            };
+
             return (
               <AnimatedModal
                 key={id}
                 isActive={isActive}
-                hideModal={hideModal}
+                hideModal={hideCurrentModal}
                 onCloseOverride={onCloseOverride}
                 dismountModal={() => dismountModal(id)}
                 content={content}

--- a/apps/web/src/contexts/modal/ModalContext.tsx
+++ b/apps/web/src/contexts/modal/ModalContext.tsx
@@ -101,7 +101,7 @@ function ModalProvider({ children }: Props) {
       isFullPage = false,
       isPaddingDisabled = false,
       onClose = noop,
-      onCloseOverride = () => {},
+      onCloseOverride,
     }: ShowModalFnProps) => {
       setModals((prevModals) => [
         ...prevModals,

--- a/apps/web/src/contexts/postComposer/PostComposerContext.tsx
+++ b/apps/web/src/contexts/postComposer/PostComposerContext.tsx
@@ -1,0 +1,69 @@
+import { useRouter } from 'next/router';
+import {
+  createContext,
+  memo,
+  MutableRefObject,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+type PostComposerState = {
+  caption: string;
+  setCaption: (s: string) => void;
+  captionRef: MutableRefObject<string>;
+};
+
+const PostComposerContext = createContext<PostComposerState | undefined>(undefined);
+
+export const usePostComposerContext = (): PostComposerState => {
+  const context = useContext(PostComposerContext);
+  if (!context) {
+    throw new Error('Attempted to use PostComposerContext without a provider!');
+  }
+  return context;
+};
+
+type Props = { children: ReactNode };
+
+const PostComposerProvider = memo(({ children }: Props) => {
+  const {
+    query: {
+      // optional pre-populated caption provided in URL params
+      caption: queryCaption,
+    },
+  } = useRouter();
+
+  const defaultCaption = useMemo(() => {
+    if (typeof queryCaption === 'string') {
+      return queryCaption;
+    }
+    return '';
+  }, [queryCaption]);
+
+  const [caption, setCaption] = useState(defaultCaption);
+
+  const captionRef = useRef('');
+
+  useEffect(() => {
+    captionRef.current = caption;
+  }, [caption]);
+
+  const value = useMemo(
+    () => ({
+      caption,
+      setCaption,
+      captionRef,
+    }),
+    [caption]
+  );
+
+  return <PostComposerContext.Provider value={value}>{children}</PostComposerContext.Provider>;
+});
+
+PostComposerProvider.displayName = 'PostComposerProvider';
+
+export default PostComposerProvider;

--- a/apps/web/src/icons/TrashIconNew.tsx
+++ b/apps/web/src/icons/TrashIconNew.tsx
@@ -1,9 +1,14 @@
-type Props = {
-  color?: string;
-};
-export function TrashIconNew({ color = 'currentColor' }: Props) {
+export function TrashIconNew(_props: JSX.IntrinsicElements['svg']) {
+  const { color = 'currentColor', ...props } = _props;
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <path d="M2 4.66666H3.33333H14" stroke={color} />
       <path
         d="M12.3334 4.66668L11.6667 14H4.33341L3.66675 4.66668M5.33341 4.66668L5.66675 2.33334H10.3334L10.6667 4.66668"


### PR DESCRIPTION
### Summary of Changes

- Remove unnecessary `Discard Post` modal when user leaves flow without writing a caption
- Add ability to save post drafts
- Create post composer context to store drafts and custom URL param state
- Typescript improvements for modal context
- Ergonomic `onCloseOverride` handler

### Demo or Before/After Pics

_Discard Post, Save Draft Flow_ 📹 
https://github.com/gallery-so/gallery/assets/12162433/07ea22f3-b345-4d44-878a-efaa816abf8a

_URL param autofill_
<img width="833" alt="Screenshot 2023-08-30 at 11 53 34 PM" src="https://github.com/gallery-so/gallery/assets/12162433/d18b0610-655f-429f-a44d-f27b4e9376da">

### Edge Cases

- [x] Closing modal with caption triggers modal
- [x] Closing modal without caption closes modal
- [x] Clicking back with caption triggers modal
- [x] Clicking back without caption takes user back
- [x] Save draft vs. discarding works
- [x] tested URL param

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
