### PR TITLE
[GAL-4110] fix navigation in shared followers, communities modal

### DIFF
--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
@@ -113,12 +113,11 @@ export function SomeoneFollowedYou({
 }
 
 const StyledHStack = styled(HStack)`
-  flex-wrap: wrap;
-  row-gap: 10px;
   width: 100%;
 `;
 
 const StyledFollowButton = styled(FollowButton)`
+  padding: 2px 8px;
   width: 92px;
   height: 24px;
 `;

--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
@@ -113,11 +113,12 @@ export function SomeoneFollowedYou({
 }
 
 const StyledHStack = styled(HStack)`
+  flex-wrap: wrap;
+  row-gap: 10px;
   width: 100%;
 `;
 
 const StyledFollowButton = styled(FollowButton)`
-  padding: 2px 8px;
   width: 92px;
   height: 24px;
 `;

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList.tsx
@@ -72,29 +72,30 @@ export default function SharedFollowersList({ userRef }: Props) {
   const isMobile = useIsMobileWindowWidth();
   return (
     <StyledList fullscreen={isMobile} gap={24}>
-      <AutoSizer>
-        {({ width, height }) => (
-          <InfiniteLoader
-            isRowLoaded={isRowLoaded}
-            loadMoreRows={handleLoadMore}
-            rowCount={rowCount}
-          >
-            {({ onRowsRendered, registerChild }) => (
-              <List
-                ref={registerChild}
-                onRowsRendered={onRowsRendered}
-                rowRenderer={rowRenderer}
-                width={width}
-                height={height}
-                rowHeight={56}
-                rowCount={sharedFollowers.length}
-              />
-            )}
-          </InfiniteLoader>
-        )}
-      </AutoSizer>
-
-      <VStack></VStack>
+      <AutoSizerWrapper>
+        <AutoSizer >
+          {({ width, height }) => (
+            <InfiniteLoader
+              isRowLoaded={isRowLoaded}
+              loadMoreRows={handleLoadMore}
+              rowCount={rowCount}
+            >
+              {({ onRowsRendered, registerChild }) => (
+                <List
+                  ref={registerChild}
+                  onRowsRendered={onRowsRendered}
+                  rowRenderer={rowRenderer}
+                  width={width}
+                  height={height}
+                  rowHeight={56}
+                  rowCount={sharedFollowers.length}
+                />
+              )}
+            </InfiniteLoader>
+          )}
+        </AutoSizer>
+</AutoSizerWrapper>
+        <VStack></VStack>
     </StyledList>
   );
 }
@@ -103,7 +104,7 @@ const StyledList = styled(VStack)<{ fullscreen: boolean }>`
   width: 375px;
   max-width: 375px;
   margin: 4px;
-  height: ${({ fullscreen }) => (fullscreen ? '100%' : '640px')};
+  height: ${({ fullscreen }) => (fullscreen ? '100%' : '400px')};
 `;
 
 function SharedFollowersListRow({ userRef }: { userRef: SharedFollowersListRowFragment$key }) {
@@ -135,3 +136,8 @@ function SharedFollowersListRow({ userRef }: { userRef: SharedFollowersListRowFr
     />
   );
 }
+
+
+const AutoSizerWrapper = styled(VStack)`
+  height: 100%;
+`;

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList.tsx
@@ -93,7 +93,6 @@ export default function SharedFollowersList({ userRef }: Props) {
           </InfiniteLoader>
         )}
       </AutoSizer>
-      <VStack></VStack>
     </StyledList>
   );
 }

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList.tsx
@@ -72,30 +72,28 @@ export default function SharedFollowersList({ userRef }: Props) {
   const isMobile = useIsMobileWindowWidth();
   return (
     <StyledList fullscreen={isMobile} gap={24}>
-      <AutoSizerWrapper>
-        <AutoSizer >
-          {({ width, height }) => (
-            <InfiniteLoader
-              isRowLoaded={isRowLoaded}
-              loadMoreRows={handleLoadMore}
-              rowCount={rowCount}
-            >
-              {({ onRowsRendered, registerChild }) => (
-                <List
-                  ref={registerChild}
-                  onRowsRendered={onRowsRendered}
-                  rowRenderer={rowRenderer}
-                  width={width}
-                  height={height}
-                  rowHeight={56}
-                  rowCount={sharedFollowers.length}
-                />
-              )}
-            </InfiniteLoader>
-          )}
-        </AutoSizer>
-</AutoSizerWrapper>
-        <VStack></VStack>
+      <AutoSizer>
+        {({ width, height }) => (
+          <InfiniteLoader
+            isRowLoaded={isRowLoaded}
+            loadMoreRows={handleLoadMore}
+            rowCount={rowCount}
+          >
+            {({ onRowsRendered, registerChild }) => (
+              <List
+                ref={registerChild}
+                onRowsRendered={onRowsRendered}
+                rowRenderer={rowRenderer}
+                width={width}
+                height={height}
+                rowHeight={56}
+                rowCount={sharedFollowers.length}
+              />
+            )}
+          </InfiniteLoader>
+        )}
+      </AutoSizer>
+      <VStack></VStack>
     </StyledList>
   );
 }
@@ -136,8 +134,3 @@ function SharedFollowersListRow({ userRef }: { userRef: SharedFollowersListRowFr
     />
   );
 }
-
-
-const AutoSizerWrapper = styled(VStack)`
-  height: 100%;
-`;

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedInfoListRow.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedInfoListRow.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link';
 import { Route } from 'nextjs-routes';
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import styled from 'styled-components';
 
 import Markdown from '~/components/core/Markdown/Markdown';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import { BaseM, TitleDiatypeM } from '~/components/core/Text/Text';
+import { useModalActions } from '~/contexts/modal/ModalContext';
 import colors from '~/shared/theme/colors';
 
 type Props = {
@@ -17,6 +18,7 @@ type Props = {
 };
 
 export default function SharedInfoListRow({ title, subTitle, href, imageContent }: Props) {
+  const { hideModal } = useModalActions();
   const rowContent = useMemo(() => {
     return (
       <StyledHStack justify="space-between" align="center" gap={8}>
@@ -33,11 +35,13 @@ export default function SharedInfoListRow({ title, subTitle, href, imageContent 
     );
   }, [imageContent, subTitle, title]);
 
+  const onPressUserRow = useCallback(() => hideModal(), [hideModal]);
+
   if (href === null) {
-    return <StyledRowNonLink>{rowContent}</StyledRowNonLink>;
+    return <StyledRowNonLink onClick={onPressUserRow}>{rowContent}</StyledRowNonLink>;
   }
 
-  return <StyledRowLink href={href}>{rowContent}</StyledRowLink>;
+  return <StyledRowLink onClick={onPressUserRow} href={href}>{rowContent}</StyledRowLink>;
 }
 
 const StyledRowNonLink = styled.div`

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedInfoListRow.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedInfoListRow.tsx
@@ -35,14 +35,14 @@ export default function SharedInfoListRow({ title, subTitle, href, imageContent 
   }, [imageContent, subTitle, title]);
 
   const { hideModal } = useModalActions();
-  const handlePressUserRow = useCallback(() => hideModal(), [hideModal]);
+  const handlePressUserLink = useCallback(() => hideModal(), [hideModal]);
 
   if (href === null) {
-    return <StyledRowNonLink onClick={handlePressUserRow}>{rowContent}</StyledRowNonLink>;
+    return <StyledRowNonLink>{rowContent}</StyledRowNonLink>;
   }
 
   return (
-    <StyledRowLink onClick={handlePressUserRow} href={href}>
+    <StyledRowLink onClick={handlePressUserLink} href={href}>
       {rowContent}
     </StyledRowLink>
   );

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedInfoListRow.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedInfoListRow.tsx
@@ -18,7 +18,6 @@ type Props = {
 };
 
 export default function SharedInfoListRow({ title, subTitle, href, imageContent }: Props) {
-  const { hideModal } = useModalActions();
   const rowContent = useMemo(() => {
     return (
       <StyledHStack justify="space-between" align="center" gap={8}>
@@ -35,14 +34,15 @@ export default function SharedInfoListRow({ title, subTitle, href, imageContent 
     );
   }, [imageContent, subTitle, title]);
 
-  const onPressUserRow = useCallback(() => hideModal(), [hideModal]);
+  const { hideModal } = useModalActions();
+  const handlePressUserRow = useCallback(() => hideModal(), [hideModal]);
 
   if (href === null) {
-    return <StyledRowNonLink onClick={onPressUserRow}>{rowContent}</StyledRowNonLink>;
+    return <StyledRowNonLink onClick={handlePressUserRow}>{rowContent}</StyledRowNonLink>;
   }
 
   return (
-    <StyledRowLink onClick={onPressUserRow} href={href}>
+    <StyledRowLink onClick={handlePressUserRow} href={href}>
       {rowContent}
     </StyledRowLink>
   );

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedInfoListRow.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedInfoListRow.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { Route } from 'nextjs-routes';
-import { useMemo, useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 
 import Markdown from '~/components/core/Markdown/Markdown';
@@ -41,7 +41,11 @@ export default function SharedInfoListRow({ title, subTitle, href, imageContent 
     return <StyledRowNonLink onClick={onPressUserRow}>{rowContent}</StyledRowNonLink>;
   }
 
-  return <StyledRowLink onClick={onPressUserRow} href={href}>{rowContent}</StyledRowLink>;
+  return (
+    <StyledRowLink onClick={onPressUserRow} href={href}>
+      {rowContent}
+    </StyledRowLink>
+  );
 }
 
 const StyledRowNonLink = styled.div`


### PR DESCRIPTION
### Summary of Changes
modal should close upon clicking on a navigational element within it and the modal is height is reduced.

### Demo
Upon opening the modal and clicking a user, it now closes the modal in addition to rerouting to the new user profile page
![Screenshot 2023-08-31 at 1 05 49 PM](https://github.com/gallery-so/gallery/assets/49758803/37b62fe3-4566-421f-8af0-befb425f75b9)
![Screenshot 2023-08-31 at 1 05 58 PM](https://github.com/gallery-so/gallery/assets/49758803/e00ac205-bcc3-4c98-bb75-11302796e3ad)


### Edge Cases
Different shared user list lengths

### Testing Steps
Can test locally on branch and visit profile with shared followers.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
