### PR TITLE
[GAL-4112] Ensure "followed you" wraps to next line in web notifications

### DIFF
--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
@@ -86,7 +86,7 @@ export function SomeoneFollowedYou({
 
   return (
     <StyledHStack justify="space-between" align="center">
-      <HStack gap={4} align="center">
+      <StyledContainer  gap={4} align="center">
         {count > 1 ? (
           <BaseM>
             <strong>{count} collectors</strong>
@@ -106,16 +106,19 @@ export function SomeoneFollowedYou({
           </>
         )}
         <BaseM>followed you</BaseM>
-      </HStack>
+      </StyledContainer>
       {shouldShowFollowBackButton && <StyledFollowButton queryRef={query} userRef={lastFollower} />}
     </StyledHStack>
   );
 }
 
 const StyledHStack = styled(HStack)`
-  flex-wrap: wrap;
-  row-gap: 10px;
   width: 100%;
+`;
+
+const StyledContainer = styled(HStack)`
+  display: flex;
+  flex-wrap: wrap;
 `;
 
 const StyledFollowButton = styled(FollowButton)`

--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
@@ -96,18 +96,22 @@ export function SomeoneFollowedYou({
             {lastFollower ? (
               <HStack gap={8} align="center">
                 <ProfilePicture size="md" userRef={lastFollower} />
-                <HoverCardOnUsername userRef={lastFollower} onClick={onClose} />
+                <StyledContainer gap={4}>
+                  <HoverCardOnUsername userRef={lastFollower} onClick={onClose} />
+                  <BaseM>followed </BaseM>
+                  <BaseM>you</BaseM>
+</StyledContainer>
               </HStack>
             ) : (
               <BaseM>
                 <strong>Someone</strong>
+                followed you
               </BaseM>
             )}
           </>
         )}
-        <BaseM>followed you</BaseM>
-      </StyledContainer>
-      {shouldShowFollowBackButton && <StyledFollowButton queryRef={query} userRef={lastFollower} />}
+                </StyledContainer>
+                {shouldShowFollowBackButton && <StyledFollowButton queryRef={query} userRef={lastFollower} />}
     </StyledHStack>
   );
 }

--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
@@ -86,7 +86,7 @@ export function SomeoneFollowedYou({
 
   return (
     <StyledHStack justify="space-between" align="center">
-      <StyledContainer  gap={4} align="center">
+      <StyledContainer gap={4} align="center">
         {count > 1 ? (
           <BaseM>
             <strong>{count} collectors</strong>
@@ -100,18 +100,21 @@ export function SomeoneFollowedYou({
                   <HoverCardOnUsername userRef={lastFollower} onClick={onClose} />
                   <BaseM>followed </BaseM>
                   <BaseM>you</BaseM>
-</StyledContainer>
+                </StyledContainer>
               </HStack>
             ) : (
-              <BaseM>
-                <strong>Someone</strong>
-                followed you
-              </BaseM>
+              <HStack gap={4}>
+                <BaseM>
+                  <strong>Someone</strong>
+                </BaseM>
+
+                <BaseM>followed you</BaseM>
+              </HStack>
             )}
           </>
         )}
-                </StyledContainer>
-                {shouldShowFollowBackButton && <StyledFollowButton queryRef={query} userRef={lastFollower} />}
+      </StyledContainer>
+      {shouldShowFollowBackButton && <StyledFollowButton queryRef={query} userRef={lastFollower} />}
     </StyledHStack>
   );
 }

--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
@@ -103,11 +103,10 @@ export function SomeoneFollowedYou({
                 </StyledContainer>
               </HStack>
             ) : (
-                <BaseM>
-                  <strong>Someone </strong>
-                  followed you
-                </BaseM>
-
+              <BaseM>
+                <strong>Someone </strong>
+                followed you
+              </BaseM>
             )}
           </>
         )}

--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
@@ -103,13 +103,11 @@ export function SomeoneFollowedYou({
                 </StyledContainer>
               </HStack>
             ) : (
-              <HStack gap={4}>
                 <BaseM>
-                  <strong>Someone</strong>
+                  <strong>Someone </strong>
+                  followed you
                 </BaseM>
 
-                <BaseM>followed you</BaseM>
-              </HStack>
             )}
           </>
         )}

--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
@@ -85,7 +85,7 @@ export function SomeoneFollowedYou({
     count === 1 && lastFollower && (isInitiallyFollowingBack || isFollowingBack);
 
   return (
-    <StyledHStack justify="space-between" align="center">
+    <StyledHStack justify="space-between" align="center" gap={4}>
       <StyledContainer gap={4} align="center">
         {count > 1 ? (
           <BaseM>

--- a/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneFollowedYou.tsx
@@ -113,11 +113,12 @@ export function SomeoneFollowedYou({
 }
 
 const StyledHStack = styled(HStack)`
+  flex-wrap: wrap;
+  row-gap: 10px;
   width: 100%;
 `;
 
 const StyledFollowButton = styled(FollowButton)`
-  padding: 2px 8px;
   width: 92px;
   height: 24px;
 `;


### PR DESCRIPTION
### Summary of Changes
Wrap "followed you" button in 'userX followed you' notification if username is too long, and **no changes** if username is not too long

### Demo
| Before (should stay unchanged) | Before (issue) |
|--------|--------|
| ![Screenshot 2023-08-31 at 1 44 21 PM](https://github.com/gallery-so/gallery/assets/49758803/dc1abe21-caee-497d-8b66-f46e64f1fde2) | ![Screenshot 2023-08-31 at 3 13 01 PM](https://github.com/gallery-so/gallery/assets/49758803/6c002667-85c1-421b-93b2-720d92ce3b08) | 

| After (should stay unchanged) | After (issue resolved) |
|--------|--------|
| ![Screenshot 2023-08-31 at 2 48 50 PM](https://github.com/gallery-so/gallery/assets/49758803/17e7489f-cb54-4c3d-81ac-15bd6663da55) | ![Screenshot 2023-08-31 at 3 31 05 PM](https://github.com/gallery-so/gallery/assets/49758803/20a7a3ef-acaf-4b0a-b173-d005087969d3) |

### Edge Cases
Tested with different length usernames for same type notification
![Screenshot 2023-08-31 at 3 26 51 PM](https://github.com/gallery-so/gallery/assets/49758803/5d9a6a11-c18e-46dc-8c51-6b840fe4fc66)
![Screenshot 2023-08-31 at 3 29 56 PM](https://github.com/gallery-so/gallery/assets/49758803/8cb67fdc-dc1c-4e63-99b3-acb6c1e66b32)
![Screenshot 2023-08-31 at 3 34 19 PM](https://github.com/gallery-so/gallery/assets/49758803/bf834c4a-c0a7-4455-b847-232257bb2f35)
When `lastFollower` is null or undefined
![Screenshot 2023-08-31 at 3 17 31 PM](https://github.com/gallery-so/gallery/assets/49758803/83c05f59-735a-465a-929e-861f065c9c92)

### Testing Steps
Can test locally on branch

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
