### PR TITLE
rename Curated to For You

### DIFF
--- a/apps/mobile/src/navigation/FeedTabNavigator/TabBar.tsx
+++ b/apps/mobile/src/navigation/FeedTabNavigator/TabBar.tsx
@@ -15,6 +15,10 @@ type TabItemProps = {
   route: NavigationRoute;
 };
 
+const TabNameOverrides: Record<string, string> = {
+  Curated: 'For You',
+};
+
 function TabItem({ navigation, route, activeRoute }: TabItemProps) {
   const isFocused = activeRoute === route.name;
 
@@ -46,7 +50,7 @@ function TabItem({ navigation, route, activeRoute }: TabItemProps) {
         }`}
         font={{ family: 'ABCDiatype', weight: 'Medium' }}
       >
-        {route.name}
+        {TabNameOverrides[route.name] ?? route.name}
       </Typography>
     </GalleryTouchableOpacity>
   );

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
@@ -69,7 +69,7 @@ export function HomeNavbar({ queryRef }: Props) {
             href={route(curatedRoute)}
             onClick={handleTrendingClick}
           >
-            Curated
+            For You
           </NavbarLink>
 
           <NavbarLink


### PR DESCRIPTION
### Summary of Changes

Rename Curated to For You based on user feedback.
Since we're still testing the name change, I decided to keep this a surface level change and only change the user facing copy instead of changing the naming in all of the code. It's possible that we get additional feedback and change the label again.


### Demo or Before/After Pics
Before
![CleanShot 2023-09-01 at 12 29 46](https://github.com/gallery-so/gallery/assets/80802871/9e416806-71f1-4a7c-aad4-dd7df788ed03)
![CleanShot 2023-09-01 at 12 29 42](https://github.com/gallery-so/gallery/assets/80802871/33ac575b-8ef0-4e39-a95a-5d62764c2e24)




After 
![CleanShot 2023-09-01 at 12 27 04](https://github.com/gallery-so/gallery/assets/80802871/a9559332-ee23-4550-ae9d-92885418aa89)
![CleanShot 2023-09-01 at 12 27 08](https://github.com/gallery-so/gallery/assets/80802871/d883f7a9-c9c6-4bba-8a39-62dda8414c2c)



### Edge Cases
Make sure routing, etc still works. functionality should not be affected 

### Testing Steps
Go to to feed on webs and mobile and verify copy change and no functional regressions.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
