### PR TITLE
show Trending instead of For You if signed out

### DIFF
--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/HomeNavbar/HomeNavbar.tsx
@@ -69,7 +69,7 @@ export function HomeNavbar({ queryRef }: Props) {
             href={route(curatedRoute)}
             onClick={handleTrendingClick}
           >
-            For You
+            {isLoggedIn ? 'For You' : 'Trending'}
           </NavbarLink>
 
           <NavbarLink


### PR DESCRIPTION
### Summary of Changes

We recently rename the Curated tab to Trending, but it doesn't make sense if you're signed out

So show Trending instead of For You if signed out 

### Demo or Before/After Pics

signed in on left, signed out on right
<img width="814" alt="CleanShot 2023-09-01 at 19 10 23@2x" src="https://github.com/gallery-so/gallery/assets/80802871/f0cbfedf-7477-4ce4-b583-6b20b834d250">



### Edge Cases
- signed in, signed out

### Testing Steps
Look at the home page while signed in and signed out

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
