### PR TITLE
GAL-4177: fix content overflow on community hover card

### DIFF
--- a/apps/web/src/components/Feed/Posts/PostHeader.tsx
+++ b/apps/web/src/components/Feed/Posts/PostHeader.tsx
@@ -3,12 +3,13 @@ import { graphql, useFragment } from 'react-relay';
 
 import Markdown from '~/components/core/Markdown/Markdown';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM } from '~/components/core/Text/Text';
+import { BaseM, TitleDiatypeM } from '~/components/core/Text/Text';
 import HoverCardOnUsername from '~/components/HoverCard/HoverCardOnUsername';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { PostHeaderFragment$key } from '~/generated/PostHeaderFragment.graphql';
 import { PostHeaderQueryFragment$key } from '~/generated/PostHeaderQueryFragment.graphql';
 import { getTimeSince } from '~/shared/utils/time';
+import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 
 import { StyledTime } from '../Events/EventStyles';
 import PostDropdown from './PostDropdown';
@@ -26,6 +27,7 @@ export default function PostHeader({ postRef, queryRef }: Props) {
         caption
         author @required(action: THROW) {
           ... on GalleryUser {
+            username
             ...ProfilePictureFragment
             ...HoverCardOnUsernameFragment
           }
@@ -46,17 +48,19 @@ export default function PostHeader({ postRef, queryRef }: Props) {
     queryRef
   );
 
+  const displayName = handleCustomDisplayName(post.author?.username ?? '');
+
   return (
     <VStack gap={6}>
       <HStack justify="space-between">
-        <HStack align="center" gap={6}>
-          <HoverCardOnUsername userRef={post.author}>
+        <HoverCardOnUsername userRef={post.author}>
+          <HStack align="center" gap={6}>
             <ProfilePicture userRef={post.author} size="md" />
-          </HoverCardOnUsername>
-          <VStack>
-            <HoverCardOnUsername userRef={post.author} />
-          </VStack>
-        </HStack>
+            <VStack>
+              <TitleDiatypeM>{displayName}</TitleDiatypeM>
+            </VStack>
+          </HStack>
+        </HoverCardOnUsername>
         <HStack align="center" gap={4}>
           <StyledTime>{getTimeSince(post.creationTime)}</StyledTime>
           <PostDropdown postRef={post} queryRef={query} />

--- a/apps/web/src/components/Feed/Posts/PostHeader.tsx
+++ b/apps/web/src/components/Feed/Posts/PostHeader.tsx
@@ -50,7 +50,9 @@ export default function PostHeader({ postRef, queryRef }: Props) {
     <VStack gap={6}>
       <HStack justify="space-between">
         <HStack align="center" gap={6}>
-          <ProfilePicture userRef={post.author} size="md" />
+          <HoverCardOnUsername userRef={post.author}>
+            <ProfilePicture userRef={post.author} size="md" />
+          </HoverCardOnUsername>
           <VStack>
             <HoverCardOnUsername userRef={post.author} />
           </VStack>

--- a/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
@@ -176,9 +176,6 @@ const StyledLink = styled(Link)`
 `;
 
 const StyledCardTitle = styled(TitleM)`
-  font-size: 18px;
-  font-weight: 700;
-  line-height: 24px;
   font-style: normal;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
@@ -136,7 +136,9 @@ export function HoverCardCommunityInner({
   return (
     <VStack gap={6}>
       <HStack gap={8} align={`${hasDescription ? '' : 'center'}`}>
-        <CommunityProfilePicture communityRef={community} size={64} />
+        <StyledLink href={communityProfileLink}>
+          <CommunityProfilePicture communityRef={community} size={64} />
+        </StyledLink>
         <VStack gap={2}>
           <StyledLink href={communityProfileLink}>
             <StyledCardTitle>{community.name}</StyledCardTitle>

--- a/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
@@ -104,7 +104,13 @@ export function HoverCardCommunityInner({
     ));
 
     if (totalOwners > 3) {
-      result.push(<StyledBaseS>{totalOwners - 2} others</StyledBaseS>);
+      result.push(
+        <>
+          <StyledBaseS>{totalOwners - 2}</StyledBaseS>
+          <StyledBaseS>&nbsp;</StyledBaseS>
+          <StyledBaseS>others</StyledBaseS>
+        </>
+      );
     }
 
     // Add punctuation: "," and "and"

--- a/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
@@ -136,7 +136,7 @@ export function HoverCardCommunityInner({
   return (
     <VStack gap={6}>
       <HStack gap={8} align={`${hasDescription ? '' : 'center'}`}>
-        <CommunityProfilePicture communityRef={community} size="xxl" />
+        <CommunityProfilePicture communityRef={community} size={64} />
         <VStack gap={2}>
           <StyledLink href={communityProfileLink}>
             <StyledCardTitle>{community.name}</StyledCardTitle>

--- a/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
@@ -14,7 +14,6 @@ import { HoverCardCommunityInnerQuery } from '~/generated/HoverCardCommunityInne
 import { ErrorWithSentryMetadata } from '~/shared/errors/ErrorWithSentryMetadata';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
-import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 
 import CommunityProfilePicture from '../ProfilePicture/CommunityProfilePicture';
 import { ProfilePictureStack } from '../ProfilePicture/ProfilePictureStack';
@@ -133,15 +132,14 @@ export function HoverCardCommunityInner({
     return null;
   }
 
-  const displayName = handleCustomDisplayName(community?.name as string);
-
+  const hasDescription = Boolean(community.description);
   return (
-    <VStack gap={8}>
-      <HStack align="center" gap={8}>
-        <CommunityProfilePicture communityRef={community} size="lg" />
-        <VStack gap={4}>
+    <VStack gap={6}>
+      <HStack gap={8} align={`${hasDescription ? '' : 'center'}`}>
+        <CommunityProfilePicture communityRef={community} size="xxl" />
+        <VStack gap={2}>
           <StyledLink href={communityProfileLink}>
-            <StyledCardTitle>{displayName}</StyledCardTitle>
+            <StyledCardTitle>{community.name}</StyledCardTitle>
           </StyledLink>
           {community.description && (
             <StyledCardDescription>
@@ -154,7 +152,7 @@ export function HoverCardCommunityInner({
       </HStack>
       <HStack align="center" gap={4}>
         <ProfilePictureStack usersRef={owners} total={totalOwners} />
-        <HStack wrap="wrap">
+        <HStack align="center" wrap="wrap">
           <StyledBaseS>Owned by&nbsp;</StyledBaseS>
           {content}
         </HStack>
@@ -170,15 +168,18 @@ const StyledLink = styled(Link)`
 `;
 
 const StyledCardTitle = styled(TitleM)`
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 24px;
   font-style: normal;
   text-overflow: ellipsis;
-  white-space: nowrap;
   overflow: hidden;
 `;
 
 const StyledCardDescription = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 250px;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/apps/web/src/components/HoverCard/HoverCardOnCommunity.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardOnCommunity.tsx
@@ -169,7 +169,6 @@ export default function HoverCardOnCommunity({ children, onClick = noop, communi
 const StyledCardContainer = styled.div`
   border: 1px solid ${colors.black['800']};
   padding: 16px;
-  width: 375px;
   max-width: calc(100vw - ${pageGutter.mobile * 2}px);
   display: grid;
   gap: 8px;

--- a/apps/web/src/components/HoverCard/HoverCardOnCommunity.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardOnCommunity.tsx
@@ -35,7 +35,8 @@ import colors from '~/shared/theme/colors';
 import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 import noop from '~/utils/noop';
 
-import breakpoints, { pageGutter } from '../core/breakpoints';
+import breakpoints from '../core/breakpoints';
+import { SelfCenteredSpinner } from '../core/Spinner/Spinner';
 
 const HOVER_POPUP_DELAY = 100;
 
@@ -151,7 +152,7 @@ export default function HoverCardOnCommunity({ children, onClick = noop, communi
                 exit={{ opacity: 0, y: 0 }}
               >
                 <StyledCardContainer>
-                  <Suspense fallback={null}>
+                  <Suspense fallback={<SelfCenteredSpinner />}>
                     <HoverCardCommunityInner
                       preloadedCommunityQuery={preloadedHoverCardCommunityQuery}
                     />
@@ -169,7 +170,8 @@ export default function HoverCardOnCommunity({ children, onClick = noop, communi
 const StyledCardContainer = styled.div`
   border: 1px solid ${colors.black['800']};
   padding: 16px;
-  max-width: calc(100vw - ${pageGutter.mobile * 2}px);
+  width: 360px;
+  min-height: 128px;
   display: grid;
   gap: 8px;
   background-color: ${colors.white};

--- a/apps/web/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -37,6 +37,7 @@ import handleCustomDisplayName from '~/utils/handleCustomDisplayName';
 import noop from '~/utils/noop';
 
 import breakpoints, { pageGutter } from '../core/breakpoints';
+import { SelfCenteredSpinner } from '../core/Spinner/Spinner';
 
 const HOVER_POPUP_DELAY = 100;
 
@@ -137,7 +138,7 @@ export default function HoverCardOnUsername({ children, userRef, onClick = noop 
                 exit={{ opacity: 0, y: 0 }}
               >
                 <StyledCardContainer>
-                  <Suspense fallback={null}>
+                  <Suspense fallback={<SelfCenteredSpinner />}>
                     <HoverCardUsernameInner preloadedQuery={preloadedHoverCardQuery} />
                   </Suspense>
                 </StyledCardContainer>
@@ -154,6 +155,7 @@ const StyledCardContainer = styled.div`
   border: 1px solid ${colors.black['800']};
   padding: 16px;
   width: 375px;
+  min-height: 128px;
   max-width: calc(100vw - ${pageGutter.mobile * 2}px);
   display: grid;
   gap: 8px;

--- a/apps/web/src/components/HoverCard/HoverCardUsernameInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardUsernameInner.tsx
@@ -139,7 +139,8 @@ const StyledCardHeader = styled(HStack)`
 `;
 
 const StyledCardHeaderContainer = styled(VStack)`
-  padding: 12px 0;
+  padding-top: 6px;
+  padding-bottom: 12px;
 `;
 
 const StyledLink = styled(Link)`

--- a/apps/web/src/components/ProfilePicture/RawProfilePicture.tsx
+++ b/apps/web/src/components/ProfilePicture/RawProfilePicture.tsx
@@ -24,7 +24,7 @@ const fontSizeMapping: { [size in Size]: number } = {
   xxl: 48,
 };
 
-type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | number;
 
 export type RawProfilePictureProps = {
   size: Size;
@@ -56,9 +56,9 @@ export function RawProfilePicture({
   inheritBorderColor,
   ...rest
 }: RawProfilePictureProps) {
-  const widthAndHeight = sizeMapping[size];
+  const widthAndHeight = typeof size === 'number' ? size : sizeMapping[size];
 
-  let fontSize: number | null = fontSizeMapping[size];
+  let fontSize: number | null = typeof size === 'number' ? size / 1.75 : fontSizeMapping[size];
   if (hasInset) {
     fontSize -= 2;
   }

--- a/apps/web/src/components/core/Spinner/Spinner.tsx
+++ b/apps/web/src/components/core/Spinner/Spinner.tsx
@@ -17,3 +17,17 @@ export const Spinner = styled.span`
 
   animation: ${spin} 1s linear infinite;
 `;
+
+export const SelfCenteredSpinner = () => {
+  return (
+    <CenteringContainer>
+      <Spinner />
+    </CenteringContainer>
+  );
+};
+
+const CenteringContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;


### PR DESCRIPTION
### Summary of Changes

fix content overflow on community hover card, and implement some new design changes suggested by Fraser

### Demo or Before/After Pics

**Before:**
![image](https://github.com/gallery-so/gallery/assets/26466468/ea6bbc65-acf7-48a8-9366-ff4b4d1ffd21)

**After:**
<img width="527" alt="CleanShot 2023-09-02 at 01 46 50@2x" src="https://github.com/gallery-so/gallery/assets/26466468/aa754f7a-782f-4d84-8197-a3604030c314">
<img width="541" alt="CleanShot 2023-09-02 at 01 45 19@2x" src="https://github.com/gallery-so/gallery/assets/26466468/bcb1ab3c-c598-40b5-869e-2f8e316062c3">
<img width="527" alt="CleanShot 2023-09-02 at 01 46 08@2x" src="https://github.com/gallery-so/gallery/assets/26466468/05c2b77b-a97c-4316-af3a-7a2ee88d9c71">


### Edge Cases

So there's an edge case here, `-webkit-line-clamp` works well with regular text content but may struggle with long URLs or single continuous strings of characters because it doesn't have natural breakpoints to determine where to truncate.. that's way the NFTs that have some mint urls in their description which are a little long, the content seems to overflow outside the hover card.. See the screenshot below:
<img width="557" alt="CleanShot 2023-09-02 at 03 48 14@2x" src="https://github.com/gallery-so/gallery/assets/26466468/fa6176a6-262f-490f-8c80-c204abb48da9">

So I tried the `word-break: break-all;`: This property allows long strings to break at any character, ensuring that they stay within their container.. this works fine but again this will affect readability of regular text. So I set a `max-width` to the description container. And this seems have solved the issue.. I tested it with a lot of NFTs that's in our feed and it works as expected.. here's a screenshot:
<img width="542" alt="CleanShot 2023-09-02 at 03 50 08@2x" src="https://github.com/gallery-so/gallery/assets/26466468/1d8374d0-ae97-44b3-b199-da5df622c2a5">

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
