### PR TITLE
fix unicode rendering in comment notification

### DIFF
--- a/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourPost.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourPost.tsx
@@ -10,6 +10,7 @@ import { SomeoneCommentedOnYourPostFragment$key } from '~/generated/SomeoneComme
 import { useReportError } from '~/shared/contexts/ErrorReportingContext';
 import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
 import colors from '~/shared/theme/colors';
+import unescape from '~/shared/utils/unescape';
 type Props = {
   notificationRef: SomeoneCommentedOnYourPostFragment$key;
   onClose: () => void;
@@ -70,7 +71,7 @@ export default function SomeoneCommentedOnYourPost({ notificationRef, onClose }:
               commented on your <strong>post</strong>
             </BaseM>
           </StyledTextWrapper>
-          <StyledCaption dangerouslySetInnerHTML={{ __html: comment.comment }}></StyledCaption>
+          <StyledCaption>{unescape(comment.comment)}</StyledCaption>
         </VStack>
       </HStack>
       {previewUrlSet?.urls.small && <StyledPostPreview src={previewUrlSet?.urls.small} />}

--- a/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourPost.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourPost.tsx
@@ -70,7 +70,7 @@ export default function SomeoneCommentedOnYourPost({ notificationRef, onClose }:
               commented on your <strong>post</strong>
             </BaseM>
           </StyledTextWrapper>
-          <StyledCaption>{comment.comment}</StyledCaption>
+          <StyledCaption dangerouslySetInnerHTML={{ __html: comment.comment }}></StyledCaption>
         </VStack>
       </HStack>
       {previewUrlSet?.urls.small && <StyledPostPreview src={previewUrlSet?.urls.small} />}


### PR DESCRIPTION
### Summary of Changes

The notification feed was rendering unicode characters in comments as strings. This PR adds dangerouslySetInnerHTML to the comment notification component to fix that issue.

### Demo or Before/After Pics

<img width="819" alt="Screenshot 2023-09-03 at 7 57 31 AM" src="https://github.com/gallery-so/gallery/assets/3245367/fd8b24cd-cf77-4eec-adba-53fada5ea5ef">

### Testing Steps

1. Click on notifications
2. Find a comment notification where the comment includes a special character

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
