### PR TITLE
[GAL-4196] Add navigation in mobile comments modal

### DIFF
--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
@@ -1,11 +1,14 @@
 import { View } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
+import { useNavigation } from '@react-navigation/native';
 
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { Typography } from '~/components/Typography';
+import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { CommentsBottomSheetLineFragment$key } from '~/generated/CommentsBottomSheetLineFragment.graphql';
 import { getTimeSince } from '~/shared/utils/time';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
 
 type CommentLineProps = {
   commentRef: CommentsBottomSheetLineFragment$key;
@@ -29,9 +32,22 @@ export function CommentsBottomSheetLine({ commentRef }: CommentLineProps) {
   );
 
   const timeAgo = getTimeSince(comment.creationTime);
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
+
+  function handleUserPress() {
+    const username = comment?.commenter?.username;
+    if (username) {
+      navigation.push('Profile', { username: username, hideBackButton: false });
+    }
+  }
 
   return (
-    <View className="flex flex-row space-x-2 px-2">
+    <GalleryTouchableOpacity
+      className="flex flex-row space-x-2 px-2"
+      onPress={handleUserPress}
+      eventElementId={'CommentsBottomSheetLine Single User'}
+      eventName={'CommentsBottomSheetLine Single User'}
+    >
       {comment.commenter && (
         <View className="mt-1">
           <ProfilePicture userRef={comment.commenter} size="sm" />
@@ -55,6 +71,6 @@ export function CommentsBottomSheetLine({ commentRef }: CommentLineProps) {
           </Typography>
         </View>
       </View>
-    </View>
+    </GalleryTouchableOpacity>
   );
 }

--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
@@ -40,7 +40,7 @@ export function CommentsBottomSheetLine({ commentRef }: CommentLineProps) {
     if (username) {
       navigation.push('Profile', { username: username, hideBackButton: false });
     }
-  }, [comment?.commenter?.username, navigation])
+  }, [comment?.commenter?.username, navigation]);
 
   return (
     <GalleryTouchableOpacity

--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
@@ -1,14 +1,14 @@
+import { useNavigation } from '@react-navigation/native';
 import { View } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
-import { useNavigation } from '@react-navigation/native';
 
+import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { Typography } from '~/components/Typography';
-import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { CommentsBottomSheetLineFragment$key } from '~/generated/CommentsBottomSheetLineFragment.graphql';
-import { getTimeSince } from '~/shared/utils/time';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
+import { getTimeSince } from '~/shared/utils/time';
 
 type CommentLineProps = {
   commentRef: CommentsBottomSheetLineFragment$key;

--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
@@ -1,4 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
+import { useCallback } from 'react';
 import { View } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
@@ -34,12 +35,12 @@ export function CommentsBottomSheetLine({ commentRef }: CommentLineProps) {
   const timeAgo = getTimeSince(comment.creationTime);
   const navigation = useNavigation<MainTabStackNavigatorProp>();
 
-  function handleUserPress() {
+  const handleUserPress = useCallback(() => {
     const username = comment?.commenter?.username;
     if (username) {
       navigation.push('Profile', { username: username, hideBackButton: false });
     }
-  }
+  }, [comment?.commenter?.username, navigation])
 
   return (
     <GalleryTouchableOpacity


### PR DESCRIPTION
### Summary of Changes
Currently, from comments modal on mobile you can't navigate to user profile by clicking on user's pfp, username or comment. This pr adds that functionality 

### After
https://github.com/gallery-so/gallery/assets/49758803/b236aecc-0caf-45bb-afbf-554dd729c4d3

### Edge Cases
Hmm not sure just tested with a bunch of user comments



### Testing Steps
Can test locally on branch

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
