### PR TITLE
Refactor web post composer for getting previews

### DIFF
--- a/apps/web/src/components/NftSelector/NftSelectorToken.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorToken.tsx
@@ -2,15 +2,13 @@ import { useCallback } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
-import { ContentIsLoadedEvent } from '~/contexts/shimmer/ShimmerContext';
 import { NftSelectorTokenFragment$key } from '~/generated/NftSelectorTokenFragment.graphql';
 import { useNftRetry } from '~/hooks/useNftRetry';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
-import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 
 import { NftFailureBoundary } from '../NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '../NftFailureFallback/NftFailureFallback';
-import { NftSelectorPreviewAsset, RawNftSelectorPreviewAsset } from './RawNftSelectorPreviewAsset';
+import { NftSelectorPreviewAsset } from './RawNftSelectorPreviewAsset';
 
 type Props = {
   tokenRef: NftSelectorTokenFragment$key;
@@ -22,17 +20,6 @@ export function NftSelectorToken({ tokenRef, onSelectToken, isInGroup = false }:
     graphql`
       fragment NftSelectorTokenFragment on Token {
         dbid
-        media {
-          ... on Media {
-            fallbackMedia {
-              mediaURL
-            }
-          }
-
-          ... on SyncingMedia {
-            __typename
-          }
-        }
         ...RawNftSelectorPreviewAssetFragment
       }
     `,
@@ -43,20 +30,6 @@ export function NftSelectorToken({ tokenRef, onSelectToken, isInGroup = false }:
 
   const { handleNftLoaded, handleNftError, retryKey, refreshMetadata, refreshingMetadata } =
     useNftRetry({ tokenId: token.dbid });
-
-  const handleError = useCallback<ContentIsLoadedEvent>(
-    (event) => {
-      handleNftError(event);
-    },
-    [handleNftError]
-  );
-
-  const handleLoad = useCallback<ContentIsLoadedEvent>(
-    (event) => {
-      handleNftLoaded(event);
-    },
-    [handleNftLoaded]
-  );
 
   const handleClick = useCallback(() => {
     if (isInGroup) {
@@ -80,24 +53,10 @@ export function NftSelectorToken({ tokenRef, onSelectToken, isInGroup = false }:
           />
         </StyledNftFailureFallbackWrapper>
       }
-      onError={handleError}
+      onError={handleNftError}
     >
-      <ReportingErrorBoundary
-        fallback={
-          <div>
-            <RawNftSelectorPreviewAsset
-              type="image"
-              isSelected={false}
-              src={token.media?.fallbackMedia?.mediaURL}
-              onLoad={handleLoad}
-            />
-            <StyledOutline onClick={handleClick} />
-          </div>
-        }
-      >
-        <NftSelectorPreviewAsset tokenRef={token} onLoad={handleLoad} />
-        <StyledOutline onClick={handleClick} />
-      </ReportingErrorBoundary>
+      <NftSelectorPreviewAsset tokenRef={token} onLoad={handleNftLoaded} />
+      <StyledOutline onClick={handleClick} />
     </NftFailureBoundary>
   );
 }

--- a/apps/web/src/components/NftSelector/NftSelectorTokenPreview.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorTokenPreview.tsx
@@ -14,34 +14,42 @@ import { NftSelectorToken } from './NftSelectorToken';
 type Props = {
   group: NftSelectorCollectionGroup;
   onSelectToken: (tokenId: string) => void;
-  onSelectGroup?: (collection: NftSelectorContractType) => void;
+  onSelectContract?: (collection: NftSelectorContractType) => void;
+  hasSelectedContract: boolean;
 };
 
-export function NftSelectorTokenPreview({ group, onSelectToken, onSelectGroup = noop }: Props) {
+const NftSelectorTokenCollection = ({ title }: { title: string }) => {
+  return (
+    <StyledNftSelectorTokenCollection>
+      <BaseM>{title}</BaseM>
+    </StyledNftSelectorTokenCollection>
+  );
+};
+
+export function NftSelectorTokenPreview({
+  group,
+  onSelectToken,
+  onSelectContract = noop,
+  hasSelectedContract,
+}: Props) {
   const tokens = group.tokens;
 
-  const handleSelectGroup = useCallback(() => {
+  const handleSelectContract = useCallback(() => {
     const collection = {
       title: group.title,
       address: group.address,
     };
 
-    onSelectGroup(collection);
-  }, [group.address, group.title, onSelectGroup]);
-
-  const NftSelectorTokenCollection = () => {
-    return (
-      <StyledNftSelectorTokenCollection>
-        <BaseM>{group.title}</BaseM>
-      </StyledNftSelectorTokenCollection>
-    );
-  };
+    onSelectContract(collection);
+  }, [group.address, group.title, onSelectContract]);
 
   if (tokens.length === 1) {
     return (
       <StyledNftSelectorTokensContainer>
         {tokens[0] && <NftSelectorToken tokenRef={tokens[0]} onSelectToken={onSelectToken} />}
-        <NftSelectorTokenCollection />
+        <NftSelectorTokenCollection
+          title={hasSelectedContract ? tokens[0]?.name ?? group.title : group.title}
+        />
       </StyledNftSelectorTokensContainer>
     );
   }
@@ -50,7 +58,7 @@ export function NftSelectorTokenPreview({ group, onSelectToken, onSelectGroup = 
   const remainingTokens = tokens.length - showTokens.length;
 
   return (
-    <StyledNftSelectorTokensContainer isGrouped onClick={handleSelectGroup}>
+    <StyledNftSelectorTokensContainer isGrouped onClick={handleSelectContract}>
       {showTokens.map((token) => (
         <NftSelectorToken
           key={token.dbid}
@@ -64,7 +72,7 @@ export function NftSelectorTokenPreview({ group, onSelectToken, onSelectGroup = 
           <BaseM>+ {remainingTokens}</BaseM>
         </StyledRemainingTokens>
       )}
-      <NftSelectorTokenCollection />
+      <NftSelectorTokenCollection title={group.title} />
     </StyledNftSelectorTokensContainer>
   );
 }

--- a/apps/web/src/components/NftSelector/NftSelectorView.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorView.tsx
@@ -138,15 +138,16 @@ export function NftSelectorView({
               <NftSelectorTokenPreview
                 key={index}
                 group={column}
-                onSelectGroup={onSelectContract}
                 onSelectToken={onSelectToken}
+                onSelectContract={onSelectContract}
+                hasSelectedContract={Boolean(selectedContractAddress)}
               />
             );
           })}
         </StyledNftSelectorViewContainer>
       );
     },
-    [onSelectContract, onSelectToken, rows]
+    [onSelectContract, onSelectToken, rows, selectedContractAddress]
   );
 
   if (!rows.length && !hasSearchKeyword) {

--- a/apps/web/src/components/NftSelector/groupNftSelectorCollectionsByAddress.ts
+++ b/apps/web/src/components/NftSelector/groupNftSelectorCollectionsByAddress.ts
@@ -28,6 +28,7 @@ export function groupNftSelectorCollectionsByAddress({
           # dbid is used by NftSelectorTokenPreview.tsx
           # eslint-disable-next-line relay/unused-fields
           dbid
+          name
           chain
           isSpamByProvider
           isSpamByUser

--- a/apps/web/src/components/Posts/PostComposerAsset.tsx
+++ b/apps/web/src/components/Posts/PostComposerAsset.tsx
@@ -3,15 +3,11 @@ import styled from 'styled-components';
 
 import { PostComposerAssetFragment$key } from '~/generated/PostComposerAssetFragment.graphql';
 import { useNftRetry } from '~/hooks/useNftRetry';
-import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 
 import breakpoints from '../core/breakpoints';
 import { NftFailureBoundary } from '../NftFailureFallback/NftFailureBoundary';
 import { NftFailureFallback } from '../NftFailureFallback/NftFailureFallback';
-import {
-  NftSelectorPreviewAsset,
-  RawNftSelectorPreviewAsset,
-} from '../NftSelector/RawNftSelectorPreviewAsset';
+import { NftSelectorPreviewAsset } from '../NftSelector/RawNftSelectorPreviewAsset';
 
 type Props = {
   tokenRef: PostComposerAssetFragment$key;
@@ -23,17 +19,6 @@ export default function PostComposerAsset({ tokenRef }: Props) {
       fragment PostComposerAssetFragment on Token {
         __typename
         dbid
-        media {
-          ... on Media {
-            fallbackMedia {
-              mediaURL
-            }
-          }
-
-          ... on SyncingMedia {
-            __typename
-          }
-        }
         ...RawNftSelectorPreviewAssetFragment
       }
     `,
@@ -42,37 +27,24 @@ export default function PostComposerAsset({ tokenRef }: Props) {
 
   const { handleNftLoaded, handleNftError, retryKey, refreshMetadata, refreshingMetadata } =
     useNftRetry({ tokenId: token.dbid });
+
   return (
     <StyledPostComposerAsset>
       <NftFailureBoundary
         key={retryKey}
         tokenId={token.dbid}
         fallback={
-          <div>
-            <NftFailureFallback
-              size="medium"
-              tokenId={token.dbid}
-              onRetry={refreshMetadata}
-              refreshing={refreshingMetadata}
-            />
-          </div>
+          // TODO: update FailureFallback or FailureBoundary to handle "Loading..."
+          <NftFailureFallback
+            size="medium"
+            tokenId={token.dbid}
+            onRetry={refreshMetadata}
+            refreshing={refreshingMetadata}
+          />
         }
         onError={handleNftError}
       >
-        <ReportingErrorBoundary
-          fallback={
-            <div>
-              <RawNftSelectorPreviewAsset
-                type="image"
-                isSelected={false}
-                src={token.media?.fallbackMedia?.mediaURL}
-                onLoad={handleNftLoaded}
-              />
-            </div>
-          }
-        >
-          <NftSelectorPreviewAsset tokenRef={token} onLoad={handleNftLoaded} />
-        </ReportingErrorBoundary>
+        <NftSelectorPreviewAsset tokenRef={token} onLoad={handleNftLoaded} />
       </NftFailureBoundary>
     </StyledPostComposerAsset>
   );


### PR DESCRIPTION
### Summary of Changes

Branch of #1885 targeting Web Post Composer

- migrated usages of `getVideoOrImageUrlForNftPreview` in Web Post Composer
- noticed we were doubling up on error boundaries which we should avoid doing (explained in video)
- improved display of token titles when within a grouped

### Demo or Before/After Pics

https://www.loom.com/share/c1363eadaa814e1f9589c72b31718cda?sid=4e82c367-c9a3-4656-9891-946afa5275e5

Before
<img width="865" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/a069e16d-d69c-4586-8204-7839e3e205c1">

After
<img width="870" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/9cb3791e-5b0f-4955-955e-b2f78b1fdaf0">


### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
