### PR TITLE
Disable post live rendering on mobile web

### DIFF
--- a/apps/web/src/components/Feed/Posts/PostNftPreview.tsx
+++ b/apps/web/src/components/Feed/Posts/PostNftPreview.tsx
@@ -8,7 +8,10 @@ import { StyledImageWithLoading } from '~/components/LoadingAsset/ImageWithLoadi
 import NftPreview from '~/components/NftPreview/NftPreview';
 import ShimmerProvider from '~/contexts/shimmer/ShimmerContext';
 import { PostNftPreviewFragment$key } from '~/generated/PostNftPreviewFragment.graphql';
-import useWindowSize, { useBreakpoint } from '~/hooks/useWindowSize';
+import useWindowSize, {
+  useBreakpoint,
+  useIsMobileOrMobileLargeWindowWidth,
+} from '~/hooks/useWindowSize';
 import { StyledVideo } from '~/scenes/NftDetailPage/NftDetailVideo';
 
 import { getFeedTokenDimensions } from '../dimensions';
@@ -42,10 +45,17 @@ export default function PostNftPreview({ tokenRef, onNftLoad }: Props) {
     });
   }, [breakpoint, width]);
 
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
+
   return (
     <StyledPostNftPreview>
       <ShimmerProvider>
-        <NftPreview tokenRef={token} previewSize={tokenSize} shouldLiveRender onLoad={onNftLoad} />
+        <NftPreview
+          tokenRef={token}
+          previewSize={tokenSize}
+          shouldLiveRender={!isMobile}
+          onLoad={onNftLoad}
+        />
       </ShimmerProvider>
     </StyledPostNftPreview>
   );


### PR DESCRIPTION
### Summary of Changes

Live rendering posts on mobile web drag down performance significantly

### Checklist

- Posts no longer live render on mobile width
- Posts continue to live render on non-mobile width

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
