### PR TITLE
Deprecate sorting sidebar tokens by errored IDs

### DIFF
--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarList/SidebarList.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarList/SidebarList.tsx
@@ -35,8 +35,6 @@ type Props = {
   selectedView: TokenFilterType;
   shouldUseCollectionGrouping: boolean;
   onToggleExpanded(address: string): void;
-  handleTokenRenderError: (id: string) => void;
-  handleTokenRenderSuccess: (id: string) => void;
   setSpamPreferenceForCollection: SetSpamFn;
 };
 
@@ -44,8 +42,6 @@ export function SidebarList({
   rows,
   selectedView,
   onToggleExpanded,
-  handleTokenRenderError,
-  handleTokenRenderSuccess,
   shouldUseCollectionGrouping,
   setSpamPreferenceForCollection,
 }: Props) {
@@ -89,27 +85,13 @@ export function SidebarList({
                 tokenRef
               );
 
-              return (
-                <SidebarNftIcon
-                  key={token.dbid}
-                  tokenRef={token}
-                  handleTokenRenderError={handleTokenRenderError}
-                  handleTokenRenderSuccess={handleTokenRenderSuccess}
-                />
-              );
+              return <SidebarNftIcon key={token.dbid} tokenRef={token} />;
             })}
           </Selection>
         );
       }
     },
-    [
-      handleTokenRenderError,
-      handleTokenRenderSuccess,
-      onToggleExpanded,
-      rows,
-      selectedView,
-      setSpamPreferenceForCollection,
-    ]
+    [onToggleExpanded, rows, selectedView, setSpamPreferenceForCollection]
   );
 
   const rowHeightCalculator = useCallback(

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarNftIcon.tsx
@@ -22,15 +22,9 @@ import { getBackgroundColorOverrideForContract } from '~/utils/token';
 
 type SidebarNftIconProps = {
   tokenRef: SidebarNftIconFragment$key;
-  handleTokenRenderError: (id: string) => void;
-  handleTokenRenderSuccess: (id: string) => void;
 };
 
-function SidebarNftIcon({
-  tokenRef,
-  handleTokenRenderError,
-  handleTokenRenderSuccess,
-}: SidebarNftIconProps) {
+function SidebarNftIcon({ tokenRef }: SidebarNftIconProps) {
   const token = useFragment(
     graphql`
       fragment SidebarNftIconFragment on Token {
@@ -93,17 +87,15 @@ function SidebarNftIcon({
   const handleError = useCallback<ContentIsLoadedEvent>(
     (event) => {
       handleNftError(event);
-      handleTokenRenderError(token.dbid);
     },
-    [handleNftError, handleTokenRenderError, token.dbid]
+    [handleNftError]
   );
 
   const handleLoad = useCallback<ContentIsLoadedEvent>(
     (event) => {
       handleNftLoaded(event);
-      handleTokenRenderSuccess(token.dbid);
     },
-    [handleNftLoaded, handleTokenRenderSuccess, token.dbid]
+    [handleNftLoaded]
   );
 
   const relayEnvironment = useRelayEnvironment();

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarTokens.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarTokens.tsx
@@ -105,24 +105,7 @@ export const SidebarTokens = ({
     [tokens, setSpamPreference]
   );
 
-  const [erroredTokenIds, setErroredTokenIds] = useState<Set<string>>(new Set());
   const [collapsedCollections, setCollapsedCollections] = useState<Set<string>>(new Set());
-
-  const handleMarkErroredTokenId = useCallback((id: string) => {
-    setErroredTokenIds((prev) => {
-      const next = new Set(prev);
-      next.add(id);
-      return next;
-    });
-  }, []);
-
-  const handleMarkSuccessTokenId = useCallback((id: string) => {
-    setErroredTokenIds((prev) => {
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
-    });
-  }, []);
 
   const handleToggleExpanded = useCallback((address: string) => {
     setCollapsedCollections((previous) => {
@@ -151,21 +134,14 @@ export const SidebarTokens = ({
 
       return createVirtualizedRowsFromGroups({
         groups,
-        erroredTokenIds,
         collapsedCollections,
       });
     } else {
       return createVirtualizedRowsFromTokens({
         filteredTokensBySelectedWallet,
-        erroredTokenIds,
       });
     }
-  }, [
-    collapsedCollections,
-    erroredTokenIds,
-    shouldUseCollectionGrouping,
-    filteredTokensBySelectedWallet,
-  ]);
+  }, [collapsedCollections, shouldUseCollectionGrouping, filteredTokensBySelectedWallet]);
 
   useEffect(
     function resetCollapsedSectionsWhileSearching() {
@@ -208,8 +184,6 @@ export const SidebarTokens = ({
       rows={rows}
       selectedView={selectedView}
       onToggleExpanded={handleToggleExpanded}
-      handleTokenRenderError={handleMarkErroredTokenId}
-      handleTokenRenderSuccess={handleMarkSuccessTokenId}
       shouldUseCollectionGrouping={shouldUseCollectionGrouping}
       setSpamPreferenceForCollection={setSpamPreferenceForCollection}
     />

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/createVirtualizedRowsFromGroups.ts
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/createVirtualizedRowsFromGroups.ts
@@ -1,49 +1,35 @@
 import { CollectionGroup } from '~/components/GalleryEditor/PiecesSidebar/groupCollectionsByAddress';
 import { VirtualizedRow } from '~/components/GalleryEditor/PiecesSidebar/SidebarList/SidebarList';
-import { SidebarListTokenFragment$key } from '~/generated/SidebarListTokenFragment.graphql';
 import { SidebarTokensFragment$data } from '~/generated/SidebarTokensFragment.graphql';
 
 type createVirtualizedRowsFromGroupsArgs = {
   groups: CollectionGroup[];
-  erroredTokenIds: Set<string>;
   collapsedCollections: Set<string>;
 };
 
 export function createVirtualizedRowsFromGroups({
   groups,
-  erroredTokenIds,
   collapsedCollections,
 }: createVirtualizedRowsFromGroupsArgs): VirtualizedRow[] {
   const rows: VirtualizedRow[] = [];
 
   for (const group of groups) {
-    const tokensSortedByErrored: SidebarListTokenFragment$key[] = [...group.tokens].sort((a, b) => {
-      const aIsErrored = erroredTokenIds.has(a.dbid);
-      const bIsErrored = erroredTokenIds.has(b.dbid);
-
-      if (aIsErrored === bIsErrored) {
-        return 0;
-      } else if (aIsErrored) {
-        return 1;
-      } else {
-        return -1;
-      }
-    });
+    const { title, address, tokens } = group;
 
     // Default to expanded
-    const expanded = !collapsedCollections.has(group.address);
+    const expanded = !collapsedCollections.has(address);
 
     rows.push({
       type: 'collection-title',
       expanded,
-      address: group.address,
-      title: group.title,
-      count: group.tokens.length,
+      address: address,
+      title: title,
+      count: tokens.length,
     });
 
     const COLUMNS_PER_ROW = 3;
-    for (let i = 0; i < tokensSortedByErrored.length; i += COLUMNS_PER_ROW) {
-      const rowTokens = tokensSortedByErrored.slice(i, i + COLUMNS_PER_ROW);
+    for (let i = 0; i < tokens.length; i += COLUMNS_PER_ROW) {
+      const rowTokens = tokens.slice(i, i + COLUMNS_PER_ROW);
 
       rows.push({
         type: 'tokens',
@@ -58,34 +44,18 @@ export function createVirtualizedRowsFromGroups({
 
 type createVirtualizedRowsFromTokensArgs = {
   filteredTokensBySelectedWallet: SidebarTokensFragment$data;
-  erroredTokenIds: Set<string>;
 };
 
 export function createVirtualizedRowsFromTokens({
   filteredTokensBySelectedWallet,
-  erroredTokenIds,
 }: createVirtualizedRowsFromTokensArgs): VirtualizedRow[] {
   const rows: VirtualizedRow[] = [];
 
   const tokens = filteredTokensBySelectedWallet ?? [];
 
-  const tokensSortedByErrored = [...tokens].sort((a, b) => {
-    const aIsErrored = erroredTokenIds.has(a.id);
-
-    const bIsErrored = erroredTokenIds.has(b.id);
-
-    if (aIsErrored === bIsErrored) {
-      return 0;
-    } else if (aIsErrored) {
-      return 1;
-    } else {
-      return -1;
-    }
-  });
-
   const COLUMNS_PER_ROW = 3;
-  for (let i = 0; i < tokensSortedByErrored.length; i += COLUMNS_PER_ROW) {
-    const rowTokens = tokensSortedByErrored.slice(i, i + COLUMNS_PER_ROW);
+  for (let i = 0; i < tokens.length; i += COLUMNS_PER_ROW) {
+    const rowTokens = tokens.slice(i, i + COLUMNS_PER_ROW);
 
     rows.push({
       type: 'tokens',


### PR DESCRIPTION
### Summary of Changes

Historically, we wanted to push errored token IDs to the bottom of the list in the user's sidebar. But this is less necessary at this point since we group tokens by contract address, and it frees up a lot of complex business logic.

### Demo or Before/After Pics

| Before | After |
|--------|--------|
| <img width="245" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/9ac28155-c3ae-47d9-81f0-e1332430c0a4"> | <img width="225" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/5941f4f6-7916-4c8d-b58f-d32265746489"> |

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.

