### PR TITLE
[GAL-4135] Long Contract name spills over in web nft selector

### DIFF
--- a/apps/web/src/components/NftSelector/NftSelectorTokenPreview.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorTokenPreview.tsx
@@ -21,7 +21,7 @@ type Props = {
 const NftSelectorTokenCollection = ({ title }: { title: string }) => {
   return (
     <StyledNftSelectorTokenCollection>
-      <BaseM>{title}</BaseM>
+      <StyledBaseM>{title}</StyledBaseM>
     </StyledNftSelectorTokenCollection>
   );
 };
@@ -82,6 +82,17 @@ export function NftSelectorTokenPreview({
     </StyledNftSelectorTokensContainer>
   );
 }
+
+const StyledBaseM = styled(BaseM)`
+  word-wrap: break-word;
+  word-break: break-all;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
 
 const StyledNftSelectorTokenCollection = styled.div`
   position: absolute;


### PR DESCRIPTION
### Summary of Changes

contract name is truncated to fit in the parent container so that the label fits inside the nft.

### Demo or Before/After Pics
| Before | After | After |
|--------|--------|--------|
| <img width="317" alt="Screenshot 2023-09-10 at 3 30 19 AM" src="https://github.com/gallery-so/gallery/assets/49758803/408e8fd5-e504-4475-b278-74793dccc18f"> | <img width="312" alt="Screenshot 2023-09-11 at 9 58 01 AM" src="https://github.com/gallery-so/gallery/assets/49758803/bba726ac-c93e-48e4-a9df-24afe39a5497"> | <img width="332" alt="Screenshot 2023-09-10 at 3 18 12 AM" src="https://github.com/gallery-so/gallery/assets/49758803/f0c76a24-4546-46c8-b742-d0eb2af4ef73"> | 

### Edge Cases
No specific cases tested

### Testing Steps
Can test locally on branch

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
