### PR TITLE
[GAL-4259] include isBetaTester in events

### DIFF
--- a/apps/mobile/src/contexts/MobileAnalyticsProvider.tsx
+++ b/apps/mobile/src/contexts/MobileAnalyticsProvider.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from 'react';
 import { env } from '~/env/runtime';
 import AnalyticsProvider, {
   IdentifyFunction,
+  RegisterSuperPropertiesFunction,
   TrackFunction,
 } from '~/shared/contexts/AnalyticsContext';
 
@@ -29,9 +30,17 @@ const identify: IdentifyFunction = (userId) => {
   instance?.identify(userId);
 };
 
+const registerSuperProperties: RegisterSuperPropertiesFunction = (eventProps) => {
+  instance?.registerSuperProperties(eventProps);
+};
+
 export function MobileAnalyticsProvider({ children }: PropsWithChildren) {
   return (
-    <AnalyticsProvider track={track} identify={identify}>
+    <AnalyticsProvider
+      track={track}
+      identify={identify}
+      registerSuperProperties={registerSuperProperties}
+    >
       {children}
     </AnalyticsProvider>
   );

--- a/apps/web/src/contexts/analytics/WebAnalyticsProvider.tsx
+++ b/apps/web/src/contexts/analytics/WebAnalyticsProvider.tsx
@@ -4,6 +4,7 @@ import { memo, ReactNode } from 'react';
 
 import AnalyticsProvider, {
   IdentifyFunction,
+  RegisterSuperPropertiesFunction,
   TrackFunction,
 } from '~/shared/contexts/AnalyticsContext';
 
@@ -41,11 +42,26 @@ export const _identify: IdentifyFunction = (userId) => {
   }
 };
 
+export const _registerSuperProperties: RegisterSuperPropertiesFunction = (eventProps) => {
+  if (!mixpanelEnabled) return;
+
+  try {
+    mixpanel.register(eventProps);
+  } catch (error: unknown) {
+    // mixpanel errors shouldn't disrupt app
+    captureException(error);
+  }
+};
+
 type Props = { children: ReactNode };
 
 const WebAnalyticsProvider = memo(({ children }: Props) => {
   return (
-    <AnalyticsProvider track={_track} identify={_identify}>
+    <AnalyticsProvider
+      track={_track}
+      identify={_identify}
+      registerSuperProperties={_registerSuperProperties}
+    >
       {children}
     </AnalyticsProvider>
   );


### PR DESCRIPTION
### Summary of Changes
Include in events whether or not a user is a beta tester.
there are two methods: including the flag in every event, and setting the flag on the user profile.
there are pros and cons to each method, so we'll start by doing both to minimize gaps or incomplete data. we can evaluate if one turns out to be more reliable or accurate. for example, one difference is user role state - we may add or remove Beta Tester roles in the future, and including it in every event maintains historical context because you can see more directly whether a user was a beta tester at the time the event was triggered. 



### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots. You can type `/table` to quickly come up with a before/after table.

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
