### PR TITLE
Fix broken OS links, refactor

### DIFF
--- a/apps/mobile/src/screens/NftDetailScreen/NftAdditionalDetailsEth.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftAdditionalDetailsEth.tsx
@@ -7,7 +7,7 @@ import { graphql } from 'relay-runtime';
 import { NftAdditionalDetailsEthFragment$key } from '~/generated/NftAdditionalDetailsEthFragment.graphql';
 import colors from '~/shared/theme/colors';
 import { extractRelevantMetadataFromToken } from '~/shared/utils/extractRelevantMetadataFromToken';
-import { hexHandler } from '~/shared/utils/getOpenseaExternalUrl';
+import { hexToDec } from '~/shared/utils/hexToDec';
 
 import { LinkableAddress } from '../../components/LinkableAddress';
 import { DetailExternalLink, DetailLabelText, DetailSection, DetailValue } from './DetailSection';
@@ -67,7 +67,7 @@ export function NftAdditionalDetailsEth({ tokenRef }: NftAdditionalDetailsEthPro
           {tokenId && (
             <DetailSection>
               <DetailLabelText>TOKEN ID</DetailLabelText>
-              <DetailValue>{hexHandler(tokenId)}</DetailValue>
+              <DetailValue>{hexToDec(tokenId)}</DetailValue>
             </DetailSection>
           )}
 

--- a/apps/mobile/src/screens/NftDetailScreen/NftAdditionalDetailsEth.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftAdditionalDetailsEth.tsx
@@ -7,7 +7,6 @@ import { graphql } from 'relay-runtime';
 import { NftAdditionalDetailsEthFragment$key } from '~/generated/NftAdditionalDetailsEthFragment.graphql';
 import colors from '~/shared/theme/colors';
 import { extractRelevantMetadataFromToken } from '~/shared/utils/extractRelevantMetadataFromToken';
-import { hexToDec } from '~/shared/utils/hexToDec';
 
 import { LinkableAddress } from '../../components/LinkableAddress';
 import { DetailExternalLink, DetailLabelText, DetailSection, DetailValue } from './DetailSection';
@@ -67,7 +66,7 @@ export function NftAdditionalDetailsEth({ tokenRef }: NftAdditionalDetailsEthPro
           {tokenId && (
             <DetailSection>
               <DetailLabelText>TOKEN ID</DetailLabelText>
-              <DetailValue>{hexToDec(tokenId)}</DetailValue>
+              <DetailValue>{tokenId}</DetailValue>
             </DetailSection>
           )}
 

--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsEth.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsEth.tsx
@@ -5,7 +5,7 @@ import { BaseM, TitleXS } from '~/components/core/Text/Text';
 import { EnsOrAddress } from '~/components/EnsOrAddress';
 import { LinkableAddress } from '~/components/LinkableAddress';
 import { NftAdditionalDetailsEthFragment$key } from '~/generated/NftAdditionalDetailsEthFragment.graphql';
-import { hexHandler } from '~/shared/utils/getOpenseaExternalUrl';
+import { hexToDec } from '~/shared/utils/hexToDec';
 
 import NftDetailsExternalLinksEth from './NftDetailsExternalLinksEth';
 
@@ -56,7 +56,7 @@ export function NftAdditionalDetailsEth({ tokenRef }: NftAdditionaDetailsNonPOAP
       {tokenId && (
         <div>
           <TitleXS>Token ID</TitleXS>
-          <BaseM>{hexHandler(tokenId)}</BaseM>
+          <BaseM>{hexToDec(tokenId)}</BaseM>
         </div>
       )}
       <NftDetailsExternalLinksEth tokenRef={token} />

--- a/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsTezos.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetailsTezos.tsx
@@ -15,7 +15,7 @@ import { NftAdditionalDetailsTezosFragment$key } from '~/generated/NftAdditional
 import { RefreshIcon } from '~/icons/RefreshIcon';
 import { useRefreshMetadata } from '~/scenes/NftDetailPage/NftAdditionalDetails/useRefreshMetadata';
 import { extractRelevantMetadataFromToken } from '~/shared/utils/extractRelevantMetadataFromToken';
-import { hexHandler } from '~/shared/utils/getOpenseaExternalUrl';
+import { hexToDec } from '~/shared/utils/hexToDec';
 
 type NftAdditionaDetailsNonPOAPProps = {
   tokenRef: NftAdditionalDetailsTezosFragment$key;
@@ -76,7 +76,7 @@ export function NftAdditionalDetailsTezos({ tokenRef }: NftAdditionaDetailsNonPO
       {tokenId && (
         <div>
           <TitleXS>Token ID</TitleXS>
-          <BaseM>{hexHandler(tokenId)}</BaseM>
+          <BaseM>{hexToDec(tokenId)}</BaseM>
         </div>
       )}
 

--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -22,7 +22,7 @@ import { useBreakpoint, useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import { NftAdditionalDetails } from '~/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetails';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';
-import { getOpenseaExternalUrl } from '~/shared/utils/getOpenseaExternalUrl';
+import { extractRelevantMetadataFromToken } from '~/shared/utils/extractRelevantMetadataFromToken';
 import unescape from '~/shared/utils/unescape';
 import { getCommunityUrlForToken } from '~/utils/getCommunityUrlForToken';
 import isFeatureEnabled, { FeatureFlag } from '~/utils/graphql/isFeatureEnabled';
@@ -65,6 +65,7 @@ function NftDetailText({ tokenRef, authenticatedUserOwnsAsset, queryRef }: Props
         ...NftAdditionalDetailsFragment
         ...getCommunityUrlForTokenFragment
         ...PostComposerModalFragment
+        ...extractRelevantMetadataFromTokenFragment
       }
     `,
     tokenRef
@@ -90,27 +91,21 @@ function NftDetailText({ tokenRef, authenticatedUserOwnsAsset, queryRef }: Props
   const isMobile = useIsMobileWindowWidth();
   const horizontalLayout = breakpoint === size.desktop || breakpoint === size.tablet;
 
-  const openseaExternalUrl = useMemo(() => {
-    if (token.chain && token.contract?.contractAddress?.address && token.tokenId) {
-      getOpenseaExternalUrl(token.chain, token.contract.contractAddress.address, token.tokenId);
-    }
-
-    return '';
-  }, [token.chain, token.contract?.contractAddress?.address, token.tokenId]);
+  const { openseaUrl } = extractRelevantMetadataFromToken(token);
 
   const handleBuyNowClick = useCallback(() => {
     track('Buy Now Button Click', {
       username: token.owner?.username ? token.owner.username.toLowerCase() : undefined,
       contractAddress: token.contract?.contractAddress?.address,
       tokenId: token.tokenId,
-      externaUrl: openseaExternalUrl,
+      externaUrl: openseaUrl,
     });
   }, [
     track,
     token.owner?.username,
     token.contract?.contractAddress?.address,
     token.tokenId,
-    openseaExternalUrl,
+    openseaUrl,
   ]);
 
   const handleCreatorNameClick = useCallback(() => {
@@ -119,14 +114,14 @@ function NftDetailText({ tokenRef, authenticatedUserOwnsAsset, queryRef }: Props
       username: token.owner?.username ? token.owner.username.toLowerCase() : undefined,
       contractAddress: token.contract?.contractAddress?.address,
       tokenId: token.tokenId,
-      externaUrl: openseaExternalUrl,
+      externaUrl: openseaUrl,
     });
   }, [
     track,
     token.owner?.username,
     token.contract?.contractAddress?.address,
     token.tokenId,
-    openseaExternalUrl,
+    openseaUrl,
   ]);
 
   const handleCollectorNameClick = useCallback(() => {
@@ -134,14 +129,14 @@ function NftDetailText({ tokenRef, authenticatedUserOwnsAsset, queryRef }: Props
       username: token.owner?.username ? token.owner.username.toLowerCase() : undefined,
       contractAddress: token.contract?.contractAddress?.address,
       tokenId: token.tokenId,
-      externaUrl: openseaExternalUrl,
+      externaUrl: openseaUrl,
     });
   }, [
     track,
     token.owner?.username,
     token.contract?.contractAddress?.address,
     token.tokenId,
-    openseaExternalUrl,
+    openseaUrl,
   ]);
 
   const communityUrl = getCommunityUrlForToken(token);
@@ -242,7 +237,7 @@ function NftDetailText({ tokenRef, authenticatedUserOwnsAsset, queryRef }: Props
             {SHOW_BUY_NOW_BUTTON && (
               <VStack gap={24}>
                 <HorizontalBreak />
-                <StyledInteractiveLink href={openseaExternalUrl} onClick={handleBuyNowClick}>
+                <StyledInteractiveLink href={openseaUrl} onClick={handleBuyNowClick}>
                   <StyledButton>Buy Now</StyledButton>
                 </StyledInteractiveLink>
               </VStack>

--- a/packages/shared/src/utils/extractRelevantMetadataFromToken.ts
+++ b/packages/shared/src/utils/extractRelevantMetadataFromToken.ts
@@ -5,9 +5,13 @@ import { extractRelevantMetadataFromTokenFragment$key } from '~/generated/extrac
 import { isChainEvm } from './chains';
 import { extractMirrorXyzUrl } from './extractMirrorXyzUrl';
 import { DateFormatOption, getFormattedDate } from './getFormattedDate';
-import { getOpenseaExternalUrl, hexHandler } from './getOpenseaExternalUrl';
-import getProhibitionUrl from './getProhibitionUrl';
-import { getFxHashExternalUrl, getObjktExternalUrl } from './getTezosExternalUrl';
+import { getOpenseaExternalUrlDangerously } from './getOpenseaExternalUrl';
+import { getProhibitionUrlDangerously } from './getProhibitionUrl';
+import {
+  getFxHashExternalUrlDangerously,
+  getObjktExternalUrlDangerously,
+} from './getTezosExternalUrl';
+import { hexToDec } from './hexToDec';
 import processProjectUrl from './processProjectUrl';
 
 export function extractRelevantMetadataFromToken(
@@ -57,20 +61,20 @@ export function extractRelevantMetadataFromToken(
   };
 
   if (tokenId) {
-    result.tokenId = hexHandler(tokenId);
+    result.tokenId = hexToDec(tokenId);
   }
 
   if (contractAddress && tokenId) {
-    result.prohibitionUrl = getProhibitionUrl(contractAddress, result.tokenId);
-    result.fxhashUrl = getFxHashExternalUrl(contractAddress, result.tokenId);
-    result.objktUrl = getObjktExternalUrl(contractAddress, result.tokenId);
+    result.prohibitionUrl = getProhibitionUrlDangerously(contractAddress, tokenId);
+    result.fxhashUrl = getFxHashExternalUrlDangerously(contractAddress, tokenId);
+    result.objktUrl = getObjktExternalUrlDangerously(contractAddress, tokenId);
     if (
       chain &&
       // eslint-disable-next-line relay/no-future-added-value
       chain !== '%future added value' &&
       isChainEvm(chain)
     ) {
-      result.openseaUrl = getOpenseaExternalUrl(chain, contractAddress, result.tokenId);
+      result.openseaUrl = getOpenseaExternalUrlDangerously(chain, contractAddress, tokenId);
     }
   }
 

--- a/packages/shared/src/utils/getOpenseaExternalUrl.ts
+++ b/packages/shared/src/utils/getOpenseaExternalUrl.ts
@@ -1,24 +1,18 @@
+import { hexToDec } from './hexToDec';
+
 export const GALLERY_OS_ADDRESS = '0x8914496dc01efcc49a2fa340331fb90969b6f1d2';
 
-// The backend converts all token IDs to hexadecimals; here, we convert back
-// https://stackoverflow.com/a/53751162
-export const hexHandler = (str: string) => {
-  if (str.length % 2) {
-    str = '0' + str;
-  }
-
-  const bn = BigInt('0x' + str);
-  const d = bn.toString(10);
-  return d;
-};
-
-export const getOpenseaExternalUrl = (
+/**
+ * WARNING: you will rarely want to use this function directly;
+ * prefer to use `extractRelevantMetadataFromToken.ts`
+ */
+export const getOpenseaExternalUrlDangerously = (
   chainStr: string,
   contractAddress: string,
   tokenId: string
 ) => {
   const chain = chainStr.toLocaleLowerCase();
-  const hexTokenId = hexHandler(tokenId);
+  const hexTokenId = hexToDec(tokenId);
 
-  return `https://opensea.io/assets/${chain}/${contractAddress}/${hexTokenId}`;
+  return `https://opensea.io/assets/${chain}/${contractAddress}/${hexTokenId}?ref=${GALLERY_OS_ADDRESS}`;
 };

--- a/packages/shared/src/utils/getProhibitionUrl.ts
+++ b/packages/shared/src/utils/getProhibitionUrl.ts
@@ -1,10 +1,14 @@
-import { hexHandler } from './getOpenseaExternalUrl';
+import { hexToDec } from './hexToDec';
 
 const PROHIBITION_CONTRACT_ADDRESSES = new Set(['0x47a91457a3a1f700097199fd63c039c4784384ab']);
 
-export default function getProhibitionUrl(contractAddress: string, tokenId: string) {
+/**
+ * WARNING: you will rarely want to use this function directly;
+ * prefer to use `extractRelevantMetadataFromToken.ts`
+ */
+export function getProhibitionUrlDangerously(contractAddress: string, tokenId: string) {
   if (PROHIBITION_CONTRACT_ADDRESSES.has(contractAddress)) {
-    return `https://prohibition.art/token/${contractAddress}-${hexHandler(tokenId)}`;
+    return `https://prohibition.art/token/${contractAddress}-${hexToDec(tokenId)}`;
   }
   return '';
 }

--- a/packages/shared/src/utils/getTezosExternalUrl.ts
+++ b/packages/shared/src/utils/getTezosExternalUrl.ts
@@ -1,15 +1,25 @@
+import { hexToDec } from './hexToDec';
+
 // https://www.fxhash.xyz/doc/fxhash/integration-guide
 const GENTK_V1_CONTRACT_ADDRESS = 'KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE';
 const GENTK_V2_CONTRACT_ADDRESS = 'KT1U6EHmNxJTkvaWJ4ThczG4FSDaHC21ssvi';
 const fxHashContractAddresses = new Set([GENTK_V1_CONTRACT_ADDRESS, GENTK_V2_CONTRACT_ADDRESS]);
 
-export const getFxHashExternalUrl = (contractAddress: string, tokenId: string) => {
+/**
+ * WARNING: you will rarely want to use this function directly;
+ * prefer to use `extractRelevantMetadataFromToken.ts`
+ */
+export const getFxHashExternalUrlDangerously = (contractAddress: string, tokenId: string) => {
   if (fxHashContractAddresses.has(contractAddress)) {
-    return `https://www.fxhash.xyz/gentk/${tokenId}`;
+    return `https://www.fxhash.xyz/gentk/${hexToDec(tokenId)}`;
   }
   return '';
 };
 
-export const getObjktExternalUrl = (contractAddress: string, tokenId: string) => {
-  return `https://objkt.com/asset/${contractAddress}/${tokenId}`;
+/**
+ * WARNING: you will rarely want to use this function directly;
+ * prefer to use `extractRelevantMetadataFromToken.ts`
+ */
+export const getObjktExternalUrlDangerously = (contractAddress: string, tokenId: string) => {
+  return `https://objkt.com/asset/${contractAddress}/${hexToDec(tokenId)}`;
 };

--- a/packages/shared/src/utils/hexToDec.ts
+++ b/packages/shared/src/utils/hexToDec.ts
@@ -1,0 +1,11 @@
+// The backend converts all token IDs to hexadecimals; here, we convert back
+// https://stackoverflow.com/a/53751162
+export const hexToDec = (str: string) => {
+  if (str.length % 2) {
+    str = '0' + str;
+  }
+
+  const bn = BigInt('0x' + str);
+  const d = bn.toString(10);
+  return d;
+};


### PR DESCRIPTION
### Summary of Changes

Core problem: we store token IDs in hex, and convert it back to decimal on the client for display purposes. Given that we use token IDs in various ways, there were areas where we'd forget to convert it to decimal, or worse, run the conversion multiple times.

Solution:
- refactor all relevant areas to use `extractRelevantMetadataFromToken`. this is what we should use in 99% of cases, and will ensure the hexToDec conversion is applied once
- strongly encourage the usage of above exclusively by appending direct helper functions with `-Dangerously`

### Demo or Before/After Pics

Opening external links on various chains works

| Before | After |
|--------|--------|
| <img width="1343" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/56cf6a2a-d8af-4a23-873b-5b4652dc8f56"> | <img width="1203" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/aa07ee73-31e7-4238-a826-4b410cd3bb6f"> | 

### Edge Cases

- [x] Ensure mobile external links work as well


### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
