### PR TITLE
add simple hash to obfuscate event param

### DIFF
--- a/apps/mobile/src/components/DeepLinkRegistrar.tsx
+++ b/apps/mobile/src/components/DeepLinkRegistrar.tsx
@@ -2,10 +2,13 @@ import { useNavigation } from '@react-navigation/native';
 import { useEffect } from 'react';
 import { Linking } from 'react-native';
 import { fetchQuery, graphql, useRelayEnvironment } from 'react-relay';
+import { simpleHash } from 'src/utils/hashString';
 
 import { DeepLinkRegistrarAuthCheckQuery } from '~/generated/DeepLinkRegistrarAuthCheckQuery.graphql';
 import { RootStackNavigatorProp } from '~/navigation/types';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
+
+const MARFA_EVENT_HASH = -1082633448;
 
 export function DeepLinkRegistrar() {
   const relayEnvironment = useRelayEnvironment();
@@ -40,16 +43,20 @@ export function DeepLinkRegistrar() {
       const parsedUrl = new URL(url);
 
       /**
-       * /mobile?marfa=true
+       * Marfa Event Check In
        */
-      if (parsedUrl.pathname === '/mobile' && parsedUrl.searchParams.get('event') === 'marfa') {
-        navigation.navigate('MainTabs', {
-          screen: 'HomeTab',
-          params: {
-            screen: 'Home',
-            params: { screen: 'Curated', params: { showMarfaCheckIn: true } },
-          },
-        });
+      if (parsedUrl.pathname === '/mobile' && parsedUrl.searchParams.get('event')) {
+        const hashedEventParam = await simpleHash(parsedUrl.searchParams.get('event') ?? '');
+        if (hashedEventParam === MARFA_EVENT_HASH) {
+          navigation.navigate('MainTabs', {
+            screen: 'HomeTab',
+            params: {
+              screen: 'Home',
+              params: { screen: 'Curated', params: { showMarfaCheckIn: true } },
+            },
+          });
+          return;
+        }
         return;
       }
 

--- a/apps/mobile/src/utils/hashString.tsx
+++ b/apps/mobile/src/utils/hashString.tsx
@@ -1,0 +1,12 @@
+// theres no native sha256 available for react-native and the current use case (obfuscating event url param) doesnt necessitate a proper secure hash, so use a very simple "hash" instead
+export async function simpleHash(input: string) {
+  let hash = 0,
+    chr;
+  if (input.length === 0) return hash;
+  for (let i = 0; i < input.length; i++) {
+    chr = input.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash;
+}


### PR DESCRIPTION
### Summary of Changes
For Marfa a specific url shared at the event will trigger the Check In flow. we previously had all the pieces of the url hardcoded so someone outside the event could figure out the url.
wanted to add a simple hash so that the url isn't obviously hardcoded. 



### Demo or Before/After Pics
recording in slack

### Edge Cases

List any common edge cases that you have considered and tested.
- correct url triggers check in flow,
- incorrect url opens regular home landing page, and doesn't crash app 


### Testing Steps
follow url shared in slack

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
