### PR TITLE
[GAL-4227] truncate string in hover card

### DIFF
--- a/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
@@ -138,6 +138,13 @@ export function HoverCardCommunityInner({
     return null;
   }
 
+  const formatEthAddress = (e: string) => {
+    return e.slice(0, 4) + '...' + e.slice(-4);
+  };
+
+  // check if name is eth address and truncate
+  const hasAddress = Boolean(community.name.startsWith('0x') && community.name.length > 20);
+
   const hasDescription = Boolean(community.description);
   return (
     <VStack gap={6}>
@@ -145,9 +152,11 @@ export function HoverCardCommunityInner({
         <StyledLink href={communityProfileLink}>
           <CommunityProfilePicture communityRef={community} size={64} />
         </StyledLink>
-        <VStack gap={2}>
+        <Section gap={2}>
           <StyledLink href={communityProfileLink}>
-            <StyledCardTitle>{community.name}</StyledCardTitle>
+            <StyledCardTitle>
+              {hasAddress ? formatEthAddress(community.name) : community.name}
+            </StyledCardTitle>
           </StyledLink>
           {community.description && (
             <StyledCardDescription>
@@ -156,7 +165,7 @@ export function HoverCardCommunityInner({
               </BaseM>
             </StyledCardDescription>
           )}
-        </VStack>
+        </Section>
       </HStack>
       <HStack align="center" gap={4}>
         <ProfilePictureStack usersRef={owners} total={totalOwners} />
@@ -175,16 +184,20 @@ const StyledLink = styled(Link)`
   min-width: 0;
 `;
 
+const Section = styled(VStack)`
+  max-width: 250px;
+`;
+
 const StyledCardTitle = styled(TitleM)`
   font-style: normal;
   text-overflow: ellipsis;
   overflow: hidden;
+  white-space: nowrap;
 `;
 
 const StyledCardDescription = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 250px;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
@@ -14,7 +14,7 @@ import { HoverCardCommunityInnerQuery } from '~/generated/HoverCardCommunityInne
 import { ErrorWithSentryMetadata } from '~/shared/errors/ErrorWithSentryMetadata';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
-import { isValidEthereumAddress, truncateEthAddress } from '~/shared/utils/wallet';
+import { isValidEthereumAddress, truncateAddress } from '~/shared/utils/wallet';
 
 import CommunityProfilePicture from '../ProfilePicture/CommunityProfilePicture';
 import { ProfilePictureStack } from '../ProfilePicture/ProfilePictureStack';
@@ -150,7 +150,7 @@ export function HoverCardCommunityInner({
           <StyledLink href={communityProfileLink}>
             <StyledCardTitle>
               {isValidEthereumAddress(community.name)
-                ? truncateEthAddress(community.name)
+                ? truncateAddress(community.name)
                 : community.name}
             </StyledCardTitle>
           </StyledLink>

--- a/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardCommunityInner.tsx
@@ -14,6 +14,7 @@ import { HoverCardCommunityInnerQuery } from '~/generated/HoverCardCommunityInne
 import { ErrorWithSentryMetadata } from '~/shared/errors/ErrorWithSentryMetadata';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
+import { isValidEthereumAddress, truncateEthAddress } from '~/shared/utils/wallet';
 
 import CommunityProfilePicture from '../ProfilePicture/CommunityProfilePicture';
 import { ProfilePictureStack } from '../ProfilePicture/ProfilePictureStack';
@@ -138,13 +139,6 @@ export function HoverCardCommunityInner({
     return null;
   }
 
-  const formatEthAddress = (e: string) => {
-    return e.slice(0, 4) + '...' + e.slice(-4);
-  };
-
-  // check if name is eth address and truncate
-  const hasAddress = Boolean(community.name.startsWith('0x') && community.name.length > 20);
-
   const hasDescription = Boolean(community.description);
   return (
     <VStack gap={6}>
@@ -155,7 +149,9 @@ export function HoverCardCommunityInner({
         <Section gap={2}>
           <StyledLink href={communityProfileLink}>
             <StyledCardTitle>
-              {hasAddress ? formatEthAddress(community.name) : community.name}
+              {isValidEthereumAddress(community.name)
+                ? truncateEthAddress(community.name)
+                : community.name}
             </StyledCardTitle>
           </StyledLink>
           {community.description && (

--- a/apps/web/src/components/HoverCard/HoverCardOnUsername.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardOnUsername.tsx
@@ -157,7 +157,7 @@ const StyledCardContainer = styled.div`
   width: 375px;
   min-height: 128px;
   max-width: calc(100vw - ${pageGutter.mobile * 2}px);
-  display: grid;
+  display: flex;
   gap: 8px;
   background-color: ${colors.white};
 

--- a/apps/web/src/components/HoverCard/HoverCardUsernameInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardUsernameInner.tsx
@@ -93,7 +93,7 @@ export function HoverCardUsernameInner({ preloadedQuery }: Props) {
   return (
     <Section gap={4}>
       <StyledCardHeaderContainer gap={8}>
-        <StyledCardHeader align="center" justify="space-between">
+        <StyledCardHeader gap={2} align="center" justify="space-between">
           <StyledUsernameAndBadge align="center" gap={4}>
             <StyledLink href={userProfileLink}>
               <HStack align="center" gap={4}>
@@ -136,7 +136,6 @@ const Section = styled(VStack)`
 
 const StyledCardHeader = styled(HStack)`
   display: flex;
-  gap: 2px;
   min-width: 0;
   // enforce height on container since the follow button causes additional height
   height: 24px;

--- a/apps/web/src/components/HoverCard/HoverCardUsernameInner.tsx
+++ b/apps/web/src/components/HoverCard/HoverCardUsernameInner.tsx
@@ -91,7 +91,7 @@ export function HoverCardUsernameInner({ preloadedQuery }: Props) {
   const displayName = handleCustomDisplayName(user.username);
 
   return (
-    <VStack gap={4}>
+    <Section gap={4}>
       <StyledCardHeaderContainer gap={8}>
         <StyledCardHeader align="center" justify="space-between">
           <StyledUsernameAndBadge align="center" gap={4}>
@@ -126,13 +126,17 @@ export function HoverCardUsernameInner({ preloadedQuery }: Props) {
         )}
       </StyledCardHeaderContainer>
       {isLoggedIn && !isOwnProfile && <UserSharedInfo userRef={user} />}
-    </VStack>
+    </Section>
   );
 }
 
+const Section = styled(VStack)`
+  width: 100%;
+`;
+
 const StyledCardHeader = styled(HStack)`
   display: flex;
-
+  gap: 2px;
   min-width: 0;
   // enforce height on container since the follow button causes additional height
   height: 24px;

--- a/packages/shared/src/utils/regex.ts
+++ b/packages/shared/src/utils/regex.ts
@@ -16,3 +16,6 @@ export const BREAK_LINES = /(\r\n|\n|\r|\\\n)/gm;
 
 // check https in URL
 export const HTTPS_URL = /^https?:\/\//i;
+
+// check if ethereum address
+export const ETH_ADDRESS = /^0x[a-fA-F0-9]{40}$/;

--- a/packages/shared/src/utils/wallet.ts
+++ b/packages/shared/src/utils/wallet.ts
@@ -5,6 +5,8 @@ import { walletGetExternalAddressLinkFragment$key } from '~/generated/walletGetE
 import { walletTruncateAddressFragment$key } from '~/generated/walletTruncateAddressFragment.graphql';
 import { walletTruncateUniversalUsernameFragment$key } from '~/generated/walletTruncateUniversalUsernameFragment.graphql';
 
+import { ETH_ADDRESS } from './regex';
+
 const overrides: Record<string, string> = {
   METAMASK: 'MetaMask',
   WALLETCONNECT: 'WalletConnect',
@@ -109,4 +111,13 @@ export function getExternalAddressLink(chainAddressRef: walletGetExternalAddress
   }
 
   return null;
+}
+
+export function truncateEthAddress(e: string) {
+  return e.slice(0, 4) + '...' + e.slice(-4);
+}
+
+export function isValidEthereumAddress(address: string): boolean {
+  const pattern = ETH_ADDRESS;
+  return pattern.test(address);
 }

--- a/packages/shared/src/utils/wallet.ts
+++ b/packages/shared/src/utils/wallet.ts
@@ -113,10 +113,6 @@ export function getExternalAddressLink(chainAddressRef: walletGetExternalAddress
   return null;
 }
 
-export function truncateEthAddress(e: string) {
-  return e.slice(0, 4) + '...' + e.slice(-4);
-}
-
 export function isValidEthereumAddress(address: string): boolean {
   const pattern = ETH_ADDRESS;
   return pattern.test(address);


### PR DESCRIPTION
### Summary of Changes

Truncate long strings in community hover cards and check for user hover cards.

### Before
![image](https://github.com/gallery-so/gallery/assets/144851666/3a049509-553c-464e-bccf-6fd3c2927765)

### After
<img width="434" alt="Screenshot 2023-09-14 at 2 22 29 AM" src="https://github.com/gallery-so/gallery/assets/144851666/cc862b9f-971c-4711-9e0f-02204438c966">
<img width="447" alt="Screenshot 2023-09-14 at 2 21 37 AM" src="https://github.com/gallery-so/gallery/assets/144851666/10129b95-40e0-4061-a827-4043c0175614">
<img width="447" alt="Screenshot 2023-09-14 at 2 22 11 AM" src="https://github.com/gallery-so/gallery/assets/144851666/99c10602-6c37-497d-ad56-0235f87054ea">


### Testing Steps

Try with ETH addresses and long user names

