### PR TITLE
Add Follow Back Button on mobile notifs

### DIFF
--- a/apps/mobile/src/components/Notification/Notifications/SomeoneFollowedYou.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/SomeoneFollowedYou.tsx
@@ -4,8 +4,8 @@ import { Text, View } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { FollowButton } from '~/components/FollowButton';
+import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { NotificationBottomSheetUserList } from '~/components/Notification/NotificationBottomSheetUserList';
 import { NotificationSkeleton } from '~/components/Notification/NotificationSkeleton';
 import { Typography } from '~/components/Typography';
@@ -116,15 +116,7 @@ export function SomeoneFollowedYou({ notificationRef, queryRef }: SomeoneFollowe
       responsibleUserRefs={followers}
       notificationRef={notification}
     >
-      <View
-        style={{
-          display: 'flex',
-          flexDirection: 'row', // Change this to 'row'
-          width: '100%',
-          justifyContent: 'space-between',
-          alignItems: 'center', // Align items vertically in the center
-        }}
-      >
+      <View className="flex flex-row w-full justify-between items-center">
         <Text style={shouldShowFollowBackButton ? { maxWidth: '70%' } : null}>
           <Typography
             font={{

--- a/apps/mobile/src/components/Notification/Notifications/SomeoneFollowedYou.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/SomeoneFollowedYou.tsx
@@ -117,7 +117,7 @@ export function SomeoneFollowedYou({ notificationRef, queryRef }: SomeoneFollowe
       notificationRef={notification}
     >
       <View className="flex flex-row w-full justify-between items-center">
-        <Text style={shouldShowFollowBackButton ? { maxWidth: '70%' } : null}>
+        <Text className={shouldShowFollowBackButton ? 'max-w-70' : ''}>
           <Typography
             font={{
               family: 'ABCDiatype',

--- a/apps/mobile/src/components/Notification/Notifications/SomeoneFollowedYou.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/SomeoneFollowedYou.tsx
@@ -125,7 +125,7 @@ export function SomeoneFollowedYou({ notificationRef, queryRef }: SomeoneFollowe
           alignItems: 'center', // Align items vertically in the center
         }}
       >
-        <Text style={{ maxWidth: '70%' }}>
+        <Text style={shouldShowFollowBackButton ? { maxWidth: '70%' } : null}>
           <Typography
             font={{
               family: 'ABCDiatype',
@@ -139,7 +139,7 @@ export function SomeoneFollowedYou({ notificationRef, queryRef }: SomeoneFollowe
               <>{lastFollower ? lastFollower.username : 'Someone'}</>
             )}
           </Typography>{' '}
-          followed you
+          <Typography font={{ family: 'ABCDiatype', weight: 'Regular' }}>followed you</Typography>
         </Text>
         {shouldShowFollowBackButton && <FollowButton queryRef={query} userRef={lastFollower} />}
       </View>


### PR DESCRIPTION
### Summary of Changes

Display the follow-back button on "user followed you" notification if you are not following the user back.

### Demo
| Before | After | After (Dark)|
|--------|--------|-------|
| <img width="457" alt="Screenshot 2023-09-15 at 5 30 26 AM" src="https://github.com/gallery-so/gallery/assets/49758803/d578edc2-bc61-480d-a16b-7e70927751d9"> | <img width="460" alt="Screenshot 2023-09-15 at 5 19 53 AM" src="https://github.com/gallery-so/gallery/assets/49758803/09668442-e5a8-4c33-8b52-0c3db6a3ebef"> | <img width="464" alt="Screenshot 2023-09-15 at 5 28 31 AM" src="https://github.com/gallery-so/gallery/assets/49758803/e1b810ae-5aab-43a5-a0bd-d84c86f75750"> |


When you already follow back the user
<img width="384" alt="Screenshot 2023-09-15 at 5 25 03 AM" src="https://github.com/gallery-so/gallery/assets/49758803/e0f0cb91-29d1-4392-9eae-942dc2336f1e">
### Edge Cases
Make sure it wraps when there's a super long username
<img width="383" alt="Screenshot 2023-09-15 at 5 19 29 AM" src="https://github.com/gallery-so/gallery/assets/49758803/f7891a3c-520a-4589-a699-9f61cb699d0d">
Will need to uhm improve this case not sure yet how
<img width="382" alt="Screenshot 2023-09-15 at 5 33 38 AM" src="https://github.com/gallery-so/gallery/assets/49758803/492c3ed3-d527-4962-aa8c-7143b2c9d212">
Also, the notification page component does not dismount when you click on another tab so the Follow Back button stays after you follow back and go to a different tab and come back. So will need to trigger a refresh or something
<img width="377" alt="Screenshot 2023-09-15 at 5 46 26 AM" src="https://github.com/gallery-so/gallery/assets/49758803/ea569a3e-252f-4aca-a875-0759c731ff2f">

### Testing Steps
Can test locally on branch

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
