### PR TITLE
[GAL-4299] Comments not landing on certain activity from mobile app

### DIFF
--- a/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -26,6 +26,9 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
       fragment FeedEventSocializeSectionFragment on FeedEvent {
         dbid
         eventData {
+          ... on GalleryUpdatedFeedEventData {
+            __typename
+          }
           ... on UserFollowedUsersFeedEventData {
             __typename
           }
@@ -90,6 +93,7 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
     return comments;
   }, [event.comments?.edges]);
 
+  const eventDataType = event.eventData?.__typename === 'GalleryUpdatedFeedEventData' ? 'FeedEvent' : 'Post';
   const totalComments = event.comments?.pageInfo?.total ?? 0;
   const isEmptyComments = totalComments === 0;
 
@@ -118,6 +122,7 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
   if (event.eventData?.__typename === 'UserFollowedUsersFeedEventData') {
     return <View className="pb-6" />;
   }
+
 
   return (
     <>
@@ -157,7 +162,7 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
         )}
       </View>
       <CommentsBottomSheet
-        type="Post"
+        type={eventDataType}
         feedId={event.dbid}
         bottomSheetRef={commentsBottomSheetRef}
       />


### PR DESCRIPTION
### Summary of Changes
Basically change a spot where it was hardcoded to show comments for only posts

### Demo
check the slack thread here for before:
| After 1 | After 2 |
|--------|--------|
| <img width="462" alt="Screenshot 2023-09-15 at 6 31 49 AM" src="https://github.com/gallery-so/gallery/assets/49758803/a74d84a9-8491-4966-9f68-a5fea19f4dbf"> | <img width="454" alt="Screenshot 2023-09-15 at 6 31 55 AM" src="https://github.com/gallery-so/gallery/assets/49758803/f7519206-e06b-4695-802f-13bb94068bad"> | 

### Edge Cases
No real cases considered

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
