### PR TITLE
Lazy Load NftSelector & PostComposer

### DIFF
--- a/apps/web/src/components/NftSelector/NftSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelector.tsx
@@ -92,6 +92,7 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
             ...NftSelectorViewFragment
 
             # Needed for when we select a token, we want to have this already in the cache
+            # eslint-disable-next-line relay/must-colocate-fragment-spreads
             ...PostComposerTokenFragment
           }
         }

--- a/apps/web/src/components/NftSelector/NftSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelector.tsx
@@ -71,6 +71,8 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
           dbid
 
           tokens(ownershipFilter: [Creator, Holder]) {
+            __typename
+
             dbid
             name
             chain
@@ -88,6 +90,9 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
 
             ...useTokenSearchResultsFragment
             ...NftSelectorViewFragment
+
+            # Needed for when we select a token, we want to have this already in the cache
+            ...PostComposerTokenFragment
           }
         }
       }

--- a/apps/web/src/components/NftSelector/useNftSelector.tsx
+++ b/apps/web/src/components/NftSelector/useNftSelector.tsx
@@ -1,65 +1,26 @@
 import { useCallback } from 'react';
-import { useFragment } from 'react-relay';
-import { graphql } from 'relay-runtime';
 
 import { useModalActions } from '~/contexts/modal/ModalContext';
-import { useNftSelectorFragment$key } from '~/generated/useNftSelectorFragment.graphql';
-import { useNftSelectorQueryFragment$key } from '~/generated/useNftSelectorQueryFragment.graphql';
-import { removeNullValues } from '~/shared/relay/removeNullValues';
 
 import { NftSelector } from './NftSelector';
 import useUpdateProfileImage from './useUpdateProfileImage';
 
 type Props = {
-  tokensRef: useNftSelectorFragment$key;
-  queryRef: useNftSelectorQueryFragment$key;
   onSelectToken: (tokenId: string) => void;
   headerText: string;
 };
 
-export default function useNftSelector({ tokensRef, queryRef, onSelectToken, headerText }: Props) {
-  const tokens = useFragment(
-    graphql`
-      fragment useNftSelectorFragment on Token @relay(plural: true) {
-        ...NftSelectorFragment
-      }
-    `,
-    tokensRef
-  );
-
-  const query = useFragment(
-    graphql`
-      fragment useNftSelectorQueryFragment on Query {
-        ...NftSelectorQueryFragment
-      }
-    `,
-    queryRef
-  );
-
-  const nonNullTokens = removeNullValues(tokens ?? []);
-
+export default function useNftSelector({ onSelectToken, headerText }: Props) {
   const { showModal } = useModalActions();
 
   return useCallback(() => {
     showModal({
-      content: (
-        <NftSelector
-          tokensRef={nonNullTokens}
-          queryRef={query}
-          onSelectToken={onSelectToken}
-          headerText={headerText}
-        />
-      ),
+      content: <NftSelector onSelectToken={onSelectToken} headerText={headerText} />,
     });
-  }, [headerText, nonNullTokens, onSelectToken, query, showModal]);
+  }, [headerText, onSelectToken, showModal]);
 }
 
-type RefProps = {
-  tokensRef: useNftSelectorFragment$key;
-  queryRef: useNftSelectorQueryFragment$key;
-};
-
-export function useNftSelectorForProfilePicture({ tokensRef, queryRef }: RefProps) {
+export function useNftSelectorForProfilePicture() {
   const { setProfileImage } = useUpdateProfileImage();
   const { hideModal } = useModalActions();
 
@@ -72,8 +33,6 @@ export function useNftSelectorForProfilePicture({ tokensRef, queryRef }: RefProp
   );
 
   return useNftSelector({
-    tokensRef: tokensRef,
-    queryRef: queryRef,
     onSelectToken: handleSelectToken,
     headerText: 'Select profile picture',
   });

--- a/apps/web/src/components/Notifications/notifications/NewTokens.tsx
+++ b/apps/web/src/components/Notifications/notifications/NewTokens.tsx
@@ -31,7 +31,6 @@ export function NewTokens({ notificationRef, onClose }: Props) {
             __typename
             dbid
             name
-            ...PostComposerModalFragment
             ...NewTokensTokenPreviewFragment
           }
         }
@@ -54,7 +53,7 @@ export function NewTokens({ notificationRef, onClose }: Props) {
   const handleCreatePostClick = useCallback(() => {
     track('NFT Detail: Clicked Create Post');
     showModal({
-      content: <PostComposerModal tokenRef={token} />,
+      content: <PostComposerModal tokenId={token.dbid} />,
       headerVariant: 'thicc',
       isFullPage: isMobile,
     });

--- a/apps/web/src/components/Posts/PostComposer.tsx
+++ b/apps/web/src/components/Posts/PostComposer.tsx
@@ -42,8 +42,7 @@ export default function PostComposer({ onBackClick, tokenId }: Props) {
         }
       }
     `,
-    { tokenId },
-    { fetchPolicy: 'store-only' }
+    { tokenId }
   );
 
   if (query.tokenById?.__typename !== 'Token') {

--- a/apps/web/src/components/Posts/PostComposerModal.tsx
+++ b/apps/web/src/components/Posts/PostComposerModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
@@ -6,9 +6,6 @@ import ErrorBoundary from '~/contexts/boundary/ErrorBoundary';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { usePostComposerContext } from '~/contexts/postComposer/PostComposerContext';
 import { PostComposerModalFragment$key } from '~/generated/PostComposerModalFragment.graphql';
-import { PostComposerModalWithSelectorFragment$key } from '~/generated/PostComposerModalWithSelectorFragment.graphql';
-import { PostComposerModalWithSelectorQueryFragment$key } from '~/generated/PostComposerModalWithSelectorQueryFragment.graphql';
-import { removeNullValues } from '~/shared/relay/removeNullValues';
 
 import breakpoints from '../core/breakpoints';
 import { Button } from '../core/Button/Button';
@@ -19,48 +16,12 @@ import DiscardPostConfirmation from './DiscardPostConfirmation';
 import PostComposer from './PostComposer';
 
 type Props = {
-  viewerRef: PostComposerModalWithSelectorFragment$key;
-  queryRef: PostComposerModalWithSelectorQueryFragment$key;
   preSelectedContract?: NftSelectorContractType;
 };
 
 // Modal with multiple steps: the NFT Selector -> then Post Composer
-export function PostComposerModalWithSelector({ viewerRef, queryRef, preSelectedContract }: Props) {
-  const viewer = useFragment(
-    graphql`
-      fragment PostComposerModalWithSelectorFragment on Viewer {
-        user {
-          tokens(ownershipFilter: [Creator, Holder]) {
-            dbid
-            ...NftSelectorFragment
-            ...PostComposerFragment
-          }
-        }
-      }
-    `,
-    viewerRef
-  );
-
-  const tokens = useMemo(() => {
-    return removeNullValues(viewer?.user?.tokens) ?? [];
-  }, [viewer]);
-
-  const query = useFragment(
-    graphql`
-      fragment PostComposerModalWithSelectorQueryFragment on Query {
-        ...NftSelectorQueryFragment
-      }
-    `,
-    queryRef
-  );
-
-  const nonNullTokens = removeNullValues(tokens ?? []);
-
+export function PostComposerModalWithSelector({ preSelectedContract }: Props) {
   const [selectedTokenId, setSelectedTokenId] = useState<string | null>(null);
-
-  const selectedToken = useMemo(() => {
-    return tokens.find((token) => token.dbid === selectedTokenId);
-  }, [selectedTokenId, tokens]);
 
   const onSelectToken = useCallback((tokenId: string) => {
     setSelectedTokenId(tokenId);
@@ -97,6 +58,8 @@ export function PostComposerModalWithSelector({ viewerRef, queryRef, preSelected
     });
   }, [captionRef, showModal, returnUserToSelectorStep, setCaption]);
 
+  const selectedToken = null;
+
   return (
     <StyledPostComposerModal>
       <ErrorBoundary fallback={<PostComposerErrorScreen />}>
@@ -104,8 +67,6 @@ export function PostComposerModalWithSelector({ viewerRef, queryRef, preSelected
           <PostComposer onBackClick={onBackClick} tokenRef={selectedToken} />
         ) : (
           <NftSelector
-            tokensRef={nonNullTokens}
-            queryRef={query}
             onSelectToken={onSelectToken}
             headerText={'Select item to post'}
             preSelectedContract={preSelectedContract}

--- a/apps/web/src/components/Posts/PostComposerModal.tsx
+++ b/apps/web/src/components/Posts/PostComposerModal.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useState } from 'react';
-import { graphql, useFragment } from 'react-relay';
+import { Suspense, useCallback, useState } from 'react';
 import styled from 'styled-components';
 
+import { NftSelectorLoadingView } from '~/components/NftSelector/NftSelectorLoadingView';
 import ErrorBoundary from '~/contexts/boundary/ErrorBoundary';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { usePostComposerContext } from '~/contexts/postComposer/PostComposerContext';
-import { PostComposerModalFragment$key } from '~/generated/PostComposerModalFragment.graphql';
 
 import breakpoints from '../core/breakpoints';
 import { Button } from '../core/Button/Button';
@@ -58,13 +57,14 @@ export function PostComposerModalWithSelector({ preSelectedContract }: Props) {
     });
   }, [captionRef, showModal, returnUserToSelectorStep, setCaption]);
 
-  const selectedToken = null;
-
   return (
     <StyledPostComposerModal>
       <ErrorBoundary fallback={<PostComposerErrorScreen />}>
-        {selectedToken ? (
-          <PostComposer onBackClick={onBackClick} tokenRef={selectedToken} />
+        {selectedTokenId ? (
+          // Just in case the PostComposer's token isn't already in the cache, we'll have a fallback
+          <Suspense fallback={<NftSelectorLoadingView />}>
+            <PostComposer onBackClick={onBackClick} tokenId={selectedTokenId} />
+          </Suspense>
         ) : (
           <NftSelector
             onSelectToken={onSelectToken}
@@ -78,23 +78,15 @@ export function PostComposerModalWithSelector({ preSelectedContract }: Props) {
 }
 
 type PostComposerModalProps = {
-  tokenRef: PostComposerModalFragment$key;
+  tokenId: string;
 };
 
 // Modal with a single step, the Post Composer.
-export function PostComposerModal({ tokenRef }: PostComposerModalProps) {
-  const token = useFragment(
-    graphql`
-      fragment PostComposerModalFragment on Token {
-        ...PostComposerFragment
-      }
-    `,
-    tokenRef
-  );
+export function PostComposerModal({ tokenId }: PostComposerModalProps) {
   return (
     <StyledPostComposerModal>
       <ErrorBoundary fallback={<PostComposerErrorScreen />}>
-        <PostComposer tokenRef={token} />
+        <PostComposer tokenId={tokenId} />
       </ErrorBoundary>
     </StyledPostComposerModal>
   );

--- a/apps/web/src/components/Profile/EditUserInfoForm.tsx
+++ b/apps/web/src/components/Profile/EditUserInfoForm.tsx
@@ -9,7 +9,6 @@ import { TextAreaWithCharCount } from '~/components/core/TextArea/TextArea';
 import { EditUserInfoFormFragment$key } from '~/generated/EditUserInfoFormFragment.graphql';
 import { EditUserInfoFormQueryFragment$key } from '~/generated/EditUserInfoFormQueryFragment.graphql';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
-import { removeNullValues } from '~/shared/relay/removeNullValues';
 import unescape from '~/shared/utils/unescape';
 
 import { useNftSelectorForProfilePicture } from '../NftSelector/useNftSelector';
@@ -53,11 +52,6 @@ function UserInfoForm({
         profileImage {
           __typename
         }
-
-        tokens(ownershipFilter: [Creator, Holder]) {
-          ...ProfilePictureDropdownFragment
-          ...useNftSelectorFragment
-        }
       }
     `,
     userRef
@@ -67,7 +61,6 @@ function UserInfoForm({
     graphql`
       fragment EditUserInfoFormQueryFragment on Query {
         ...ProfilePictureDropdownQueryFragment
-        ...useNftSelectorQueryFragment
       }
     `,
     queryRef
@@ -76,8 +69,7 @@ function UserInfoForm({
   const [showPfpDropdown, setShowPfpDropdown] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const tokens = removeNullValues(user.tokens) ?? [];
-  const showNftSelector = useNftSelectorForProfilePicture({ tokensRef: tokens, queryRef: query });
+  const showNftSelector = useNftSelectorForProfilePicture();
   const track = useTrack();
 
   const handleEditPfp = useCallback(() => {
@@ -157,7 +149,6 @@ function UserInfoForm({
             <ProfilePictureDropdown
               open={showPfpDropdown}
               onClose={handleClosePfpDropdown}
-              tokensRef={tokens}
               queryRef={query}
             />
           </StyledProfilePictureContainer>

--- a/apps/web/src/components/Profile/ProfilePictureDropdown.tsx
+++ b/apps/web/src/components/Profile/ProfilePictureDropdown.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
-import { ProfilePictureDropdownFragment$key } from '~/generated/ProfilePictureDropdownFragment.graphql';
 import { ProfilePictureDropdownQueryFragment$key } from '~/generated/ProfilePictureDropdownQueryFragment.graphql';
 import { AllGalleriesIcon } from '~/icons/AllGalleriesIcon';
 import { TrashIconNew } from '~/icons/TrashIconNew';
@@ -20,20 +19,10 @@ import useUpdateProfileImage from '../NftSelector/useUpdateProfileImage';
 type Props = {
   open: boolean;
   onClose: () => void;
-  tokensRef: ProfilePictureDropdownFragment$key;
   queryRef: ProfilePictureDropdownQueryFragment$key;
 };
 
-export function ProfilePictureDropdown({ open, onClose, tokensRef, queryRef }: Props) {
-  const tokens = useFragment(
-    graphql`
-      fragment ProfilePictureDropdownFragment on Token @relay(plural: true) {
-        ...useNftSelectorFragment
-      }
-    `,
-    tokensRef
-  );
-
+export function ProfilePictureDropdown({ open, onClose, queryRef }: Props) {
   const query = useFragment(
     graphql`
       fragment ProfilePictureDropdownQueryFragment on Query {
@@ -70,13 +59,12 @@ export function ProfilePictureDropdown({ open, onClose, tokensRef, queryRef }: P
             }
           }
         }
-        ...useNftSelectorQueryFragment
       }
     `,
     queryRef
   );
 
-  const showNftSelector = useNftSelectorForProfilePicture({ tokensRef: tokens, queryRef: query });
+  const showNftSelector = useNftSelectorForProfilePicture();
   const { setProfileImage, removeProfileImage } = useUpdateProfileImage();
   const track = useTrack();
 

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
@@ -45,7 +45,6 @@ export function StandardSidebar({ queryRef }: Props) {
         viewer {
           ... on Viewer {
             __typename
-            ...PostComposerModalWithSelectorFragment
             user {
               username
               ...SidebarPfpFragment
@@ -64,7 +63,6 @@ export function StandardSidebar({ queryRef }: Props) {
         ...SettingsFragment
         ...useExperienceFragment
         ...useAnnouncementFragment
-        ...PostComposerModalWithSelectorQueryFragment
         ...isFeatureEnabledFragment
       }
     `,

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
@@ -195,7 +195,7 @@ export function StandardSidebar({ queryRef }: Props) {
       },
     });
     track('Sidebar Create Post Click');
-  }, [hideDrawer, isLoggedIn, showModal, query, isMobile, track, captionRef, setCaption]);
+  }, [hideDrawer, isLoggedIn, showModal, isMobile, track, captionRef, setCaption]);
 
   const handleSearchClick = useCallback(() => {
     track('Sidebar Search Click');

--- a/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalSidebar/StandardSidebar.tsx
@@ -168,7 +168,7 @@ export function StandardSidebar({ queryRef }: Props) {
 
     showModal({
       id: 'post-composer',
-      content: <PostComposerModalWithSelector viewerRef={query?.viewer} queryRef={query} />,
+      content: <PostComposerModalWithSelector />,
       headerVariant: 'thicc',
       isFullPage: isMobile,
       onCloseOverride: (onClose: () => void) => {

--- a/apps/web/src/contexts/relay/RelayProvider.tsx
+++ b/apps/web/src/contexts/relay/RelayProvider.tsx
@@ -4,6 +4,7 @@ import RelayModernEnvironment from 'relay-runtime/lib/store/RelayModernEnvironme
 import { RecordMap } from 'relay-runtime/lib/store/RelayStoreTypes';
 
 import { relayFetchFunction, relaySubscribeFunction } from '~/contexts/relay/network';
+import { createMissingFieldHandlers } from '~/shared/relay/missingFieldHandlers';
 
 export const serializeRelayEnvironment = (environment: Environment) =>
   environment.getStore().getSource().toJSON();
@@ -16,6 +17,7 @@ export const createServerSideRelayEnvironment = (): Environment =>
 
 export const createRelayEnvironmentFromRecords = (records?: RecordMap): Environment =>
   new RelayModernEnvironment({
+    missingFieldHandlers: createMissingFieldHandlers(),
     store: new Store(new RecordSource(records ?? {})),
     network: Network.create(relayFetchFunction, relaySubscribeFunction),
   });

--- a/apps/web/src/hooks/api/tokens/useSyncTokens.ts
+++ b/apps/web/src/hooks/api/tokens/useSyncTokens.ts
@@ -32,8 +32,7 @@ export default function useSyncTokens() {
               # This should be sufficient to capture all the things
               # we want to refresh. Don't @me when this fails.
               ...GalleryEditorViewerFragment
-              # Refresh tokens for post composer
-              ...PostComposerModalWithSelectorFragment
+              # Refresh tokens for post composer TODO TERENCE FIGURE THIS OUT
 
               ... on Viewer {
                 user {
@@ -66,7 +65,7 @@ export default function useSyncTokens() {
               # we want to refresh. Don't @me when this fails.
               ...GalleryEditorViewerFragment
               # Refresh tokens for post composer
-              ...PostComposerModalWithSelectorFragment
+              #              ...PostComposerModalWithSelectorFragment TODO TERENCE FIGURE THIS OUT
               ... on Viewer {
                 user {
                   tokens(ownershipFilter: [Creator, Holder]) {

--- a/apps/web/src/hooks/api/tokens/useSyncTokens.ts
+++ b/apps/web/src/hooks/api/tokens/useSyncTokens.ts
@@ -32,7 +32,8 @@ export default function useSyncTokens() {
               # This should be sufficient to capture all the things
               # we want to refresh. Don't @me when this fails.
               ...GalleryEditorViewerFragment
-              # Refresh tokens for post composer TODO TERENCE FIGURE THIS OUT
+              # Refresh tokens for post composer
+              ...NftSelectorViewerFragment
 
               ... on Viewer {
                 user {
@@ -65,7 +66,8 @@ export default function useSyncTokens() {
               # we want to refresh. Don't @me when this fails.
               ...GalleryEditorViewerFragment
               # Refresh tokens for post composer
-              #              ...PostComposerModalWithSelectorFragment TODO TERENCE FIGURE THIS OUT
+              ...NftSelectorViewerFragment
+
               ... on Viewer {
                 user {
                   tokens(ownershipFilter: [Creator, Holder]) {

--- a/apps/web/src/scenes/CommunityPage/CommunityPageMetadata.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageMetadata.tsx
@@ -65,11 +65,7 @@ export default function CommunityPageMetadata({ communityRef, queryRef }: Props)
       fragment CommunityPageMetadataQueryFragment on Query {
         viewer {
           __typename
-          ... on Viewer {
-            ...PostComposerModalWithSelectorFragment
-          }
         }
-        ...PostComposerModalWithSelectorQueryFragment
         ...isFeatureEnabledFragment
       }
     `,
@@ -114,8 +110,6 @@ export default function CommunityPageMetadata({ communityRef, queryRef }: Props)
     showModal({
       content: (
         <PostComposerModalWithSelector
-          viewerRef={query?.viewer}
-          queryRef={query}
           preSelectedContract={{
             title: community.name ?? '',
             address: community.contractAddress?.address ?? '', // ok to proceed to post composer even if contractAddress is missing (unlikely). user will just be prompted to select a token

--- a/apps/web/src/scenes/CommunityPage/CommunityPagePostsTab.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPagePostsTab.tsx
@@ -67,11 +67,9 @@ export default function CommunityPagePostsTab({ communityRef, queryRef }: Props)
         viewer {
           ... on Viewer {
             __typename
-            ...PostComposerModalWithSelectorFragment
           }
         }
         ...FeedListFragment
-        ...PostComposerModalWithSelectorQueryFragment
       }
     `,
     queryRef
@@ -94,8 +92,6 @@ export default function CommunityPagePostsTab({ communityRef, queryRef }: Props)
     showModal({
       content: (
         <PostComposerModalWithSelector
-          viewerRef={query?.viewer}
-          queryRef={query}
           preSelectedContract={{
             title: community.name ?? '',
             address: community.contractAddress?.address ?? '', // ok to proceed to post composer even if contractAddress is missing (unlikely). user will just be prompted to select a token

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.test.tsx
@@ -89,15 +89,6 @@ const UnknownMediaResponse: NftDetailAssetTestQueryQuery = {
         __typename: 'UnknownMedia',
         fallbackMedia: null,
         contentRenderURL: 'bad url here',
-        previewURLs: {
-          small: 'http://someurl.com',
-          medium: 'http://someurl.com',
-          large: 'http://someurl.com',
-        },
-      },
-      community: {
-        __typename: 'Community',
-        id: 'Community:testCommunityId',
       },
       contract: {
         __typename: 'Contract',

--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -43,6 +43,7 @@ function NftDetailText({ tokenRef, authenticatedUserOwnsAsset, queryRef }: Props
   const token = useFragment(
     graphql`
       fragment NftDetailTextFragment on Token {
+        dbid
         name
         chain
         description
@@ -64,7 +65,6 @@ function NftDetailText({ tokenRef, authenticatedUserOwnsAsset, queryRef }: Props
 
         ...NftAdditionalDetailsFragment
         ...getCommunityUrlForTokenFragment
-        ...PostComposerModalFragment
         ...extractRelevantMetadataFromTokenFragment
       }
     `,
@@ -159,7 +159,7 @@ function NftDetailText({ tokenRef, authenticatedUserOwnsAsset, queryRef }: Props
   const handleCreatePostClick = useCallback(() => {
     track('NFT Detail: Clicked Create Post');
     showModal({
-      content: <PostComposerModal tokenRef={token} />,
+      content: <PostComposerModal tokenId={token.dbid} />,
       headerVariant: 'thicc',
       isFullPage: isMobile,
     });

--- a/packages/shared/src/relay/missingFieldHandlers.ts
+++ b/packages/shared/src/relay/missingFieldHandlers.ts
@@ -19,6 +19,10 @@ export function createMissingFieldHandlers(): MissingFieldHandler[] {
         return `Collection:${args.id}`;
       }
 
+      if (field.name === 'tokenById') {
+        return `Token:${args.id}`;
+      }
+
       return undefined;
     },
   };


### PR DESCRIPTION
### Summary of Changes

The goal of this PR is to stop eagerly loading a user's entire list of tokens. For now we can push the loading of tokens down to the modal that needs it and show a nice fallback state while we wait. 

**This is still super slow for users with large # of tokens. In the future we should come up w/ a plan to paginate tokens**.

### Demo or Before/After Pics


https://github.com/gallery-so/gallery/assets/6754223/6634ff1f-87a8-4e88-85a7-4c3132e4c3ff



### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
