### PR TITLE
GAL-4301 handle error in nft selector grid

### DIFF
--- a/apps/mobile/src/components/NftPreview/NftPreviewErrorFallback.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreviewErrorFallback.tsx
@@ -4,7 +4,7 @@ import { ErrorIcon } from '../../icons/ErrorIcon';
 
 export function NftPreviewErrorFallback() {
   return (
-    <View className="w-full h-full bg-offWhite dark:bg-black-800 flex items-center justify-center">
+    <View className="w-full h-full bg-porcelain dark:bg-black-800 flex items-center justify-center">
       <ErrorIcon />
     </View>
   );

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerGrid.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerGrid.tsx
@@ -10,6 +10,7 @@ import { graphql } from 'relay-runtime';
 import { GallerySkeleton } from '~/components/GallerySkeleton';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { NftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
+import { NftPreviewErrorFallback } from '~/components/NftPreview/NftPreviewErrorFallback';
 import { Typography } from '~/components/Typography';
 import { NftSelectorPickerGridFragment$key } from '~/generated/NftSelectorPickerGridFragment.graphql';
 import { NftSelectorPickerGridOneOrManyFragment$key } from '~/generated/NftSelectorPickerGridOneOrManyFragment.graphql';
@@ -28,6 +29,7 @@ import {
   NftSelectorSortView,
 } from '~/screens/NftSelectorScreen/NftSelectorFilterBottomSheet';
 import { NftSelectorPickerSingularAsset } from '~/screens/NftSelectorScreen/NftSelectorPickerSingularAsset';
+import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 import getVideoOrImageUrlForNftPreview from '~/shared/relay/getVideoOrImageUrlForNftPreview';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 
@@ -327,7 +329,9 @@ function TokenGrid({ tokenRefs, contractAddress, screen, style }: TokenGridProps
               {row.tokens.map((tokenUrl) => {
                 return (
                   <View key={tokenUrl} className="flex-1 aspect-square">
-                    <TokenGridSinglePreview tokenUrl={tokenUrl} />
+                    <ReportingErrorBoundary fallback={<NftPreviewErrorFallback />}>
+                      <TokenGridSinglePreview tokenUrl={tokenUrl} />
+                    </ReportingErrorBoundary>
                   </View>
                 );
               })}

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerSingularAsset.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerSingularAsset.tsx
@@ -1,7 +1,7 @@
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { ResizeMode } from 'expo-av';
 import { useCallback, useState } from 'react';
-import { ActivityIndicator, View, ViewProps, Text } from 'react-native';
+import { ActivityIndicator, View, ViewProps } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerSingularAsset.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerSingularAsset.tsx
@@ -1,7 +1,7 @@
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { ResizeMode } from 'expo-av';
 import { useCallback, useState } from 'react';
-import { ActivityIndicator, View, ViewProps } from 'react-native';
+import { ActivityIndicator, View, ViewProps, Text } from 'react-native';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
@@ -81,7 +81,13 @@ export function NftSelectorPickerSingularAsset({
   }
 
   return (
-    <ReportingErrorBoundary fallback={<NftPreviewErrorFallback />}>
+    <ReportingErrorBoundary
+      fallback={
+        <View style={style} className="flex-1 aspect-square relative">
+          <NftPreviewErrorFallback />
+        </View>
+      }
+    >
       <GalleryTouchableOpacity
         style={style}
         disabled={isSettingProfileImage}


### PR DESCRIPTION
### Summary of Changes
An unhandled error while rendering items in the grid view (which we display for collections you own multiple tokens of) in the nft selector caused the app to crash for some users.

this pr adds a ReportingErrorBoundary around the offending component and improves styling for an existing error fallback component.



### Demo or Before/After Pics
before: app crashed

https://github.com/gallery-so/gallery/assets/80802871/b8da6399-a95a-4973-b421-8718e93c0f4c


After: app doesn't crash
https://github.com/gallery-so/gallery/assets/80802871/fdc09d99-cd74-42ac-8e0f-ad91505c83d3


Before: error grid fallback looks bad
![CleanShot 2023-09-15 at 18 48 45](https://github.com/gallery-so/gallery/assets/80802871/09887758-2161-42f8-a2b8-a075b2d16877)


After: error grid looks good
![CleanShot 2023-09-15 at 18 42 14](https://github.com/gallery-so/gallery/assets/80802871/4e63d26b-6645-4fb9-9629-f2e0972fd855)

### Edge Cases
na, this is the edge case

### Testing Steps
test as user `Mitchell` and confirm the nft selector doesn't crash

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
