### PR TITLE
fix input color in check in form for darkmode

### DIFF
--- a/apps/mobile/src/components/MarfaCheckIn/CheckInEmailEntry.tsx
+++ b/apps/mobile/src/components/MarfaCheckIn/CheckInEmailEntry.tsx
@@ -140,7 +140,7 @@ export default function CheckInEmailEntry({
       <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
         Enter your email and we’ll let you know if you win an allowlist spot.
       </Typography>
-      <View className="dark:text-white p-4 my-4 bg-faint">
+      <View className="bg-faint dark:text-white dark:bg-black-700 dark:color-white p-4 my-4">
         <BottomSheetTextInput
           value={email}
           autoFocus


### PR DESCRIPTION
### Summary of Changes
Input color was wrong for email input in darkmode

### Demo or Before/After Pics
before
<img width="422" alt="CleanShot 2023-09-18 at 18 17 23@2x" src="https://github.com/gallery-so/gallery/assets/80802871/0cb25d9a-b3be-4434-95d5-0098f30a1ff0">

after
<img width="406" alt="CleanShot 2023-09-18 at 18 15 47@2x" src="https://github.com/gallery-so/gallery/assets/80802871/7cc89405-c3bf-4ff1-a6e4-5816e1b17709">


### Edge Cases
light mode still looks fine
<img width="388" alt="CleanShot 2023-09-18 at 18 18 40@2x" src="https://github.com/gallery-so/gallery/assets/80802871/c35e9571-70de-436a-a8e0-28d4be291c52">

### Testing Steps
open check in flow in dark mode

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
