### PR TITLE
[GAL-4298] Share button in "..." menu copies wrong url [mobile]

### DIFF
--- a/apps/mobile/src/components/Feed/Posts/PostBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostBottomSheet.tsx
@@ -3,8 +3,8 @@ import { useNavigation } from '@react-navigation/native';
 import clsx from 'clsx';
 import { ForwardedRef, forwardRef, useCallback, useMemo, useRef } from 'react';
 import { View } from 'react-native';
+import { Share } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
-import { shareUniversalToken } from 'src/utils/shareToken';
 
 import {
   GalleryBottomSheetModal,
@@ -40,13 +40,13 @@ function PostBottomSheet(
     graphql`
       fragment PostBottomSheetFragment on Post {
         __typename
+        dbid
         author {
           username
         }
         tokens {
           dbid
           ...getVideoOrImageUrlForNftPreviewFragment
-          ...shareTokenUniversalFragment
         }
         ...DeletePostBottomSheetFragment
       }
@@ -144,8 +144,9 @@ function PostBottomSheet(
   }, [cachedPreviewAssetUrl, navigation, token.dbid]);
 
   const handleShare = useCallback(() => {
-    shareUniversalToken(token);
-  }, [token]);
+    const url = `https://gallery.so/post/${post.dbid}`;
+    Share.share({ url });
+  }, [post.dbid]);
 
   const inner = useMemo(() => {
     if (isOwnPost) {


### PR DESCRIPTION
### Summary of Changes
Copies the correct URL to Post on mobile from "..." menu of a post

### Demo or Before/After Pics
| After | After | After pasting copied link |
|--------|--------|--------|
| <img width="449" alt="Screenshot 2023-09-20 at 4 09 40 AM" src="https://github.com/gallery-so/gallery/assets/49758803/7fdb67a3-c405-46c0-9f26-9d2f20eb2db1"> | <img width="452" alt="Screenshot 2023-09-20 at 4 09 45 AM" src="https://github.com/gallery-so/gallery/assets/49758803/e9994b16-30f5-49d9-830a-aa6213bb6a1e"> | <img width="448" alt="Screenshot 2023-09-20 at 4 09 53 AM" src="https://github.com/gallery-so/gallery/assets/49758803/a01a762b-f181-4f6c-8aaa-29475409fcb2"> | 


### Edge Cases
No specific cases considered

### Testing Steps
Can test locally on branch

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
