### PR TITLE
[GAL-4314] Dismiss keyboard after commenting on mobile

### DIFF
--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import { View } from 'react-native';
+import { Keyboard } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 import { useEventComment } from 'src/hooks/useEventComment';
@@ -63,6 +64,9 @@ export function CommentsBottomSheet({ bottomSheetRef, feedId, type }: CommentsBo
         postComment({
           feedId,
           value,
+          onSuccess: () => {
+            Keyboard.dismiss();
+          },
         });
         return;
       }
@@ -70,6 +74,9 @@ export function CommentsBottomSheet({ bottomSheetRef, feedId, type }: CommentsBo
       submitComment({
         feedEventId: feedId,
         value,
+        onSuccess: () => {
+          Keyboard.dismiss();
+        },
       });
     },
     [feedId, type, submitComment, postComment]


### PR DESCRIPTION
### Summary of Changes
Dismiss keyboard after commenting on post or feed event on mobile

### Demo or Before/After 

https://github.com/gallery-so/gallery/assets/49758803/7f89419e-37c8-462f-b706-2bc22a9261fd



### Edge Cases
tested commenting on both post and feed events

### Testing Steps
can test locally on branch by making a comment

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
