### PR TITLE
Cache the video on load

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -27,6 +27,7 @@
     "expo-dev-client": "~2.1.5",
     "expo-dev-menu": "^2.1.4",
     "expo-device": "~5.2.1",
+    "expo-file-system": "~15.2.2",
     "expo-font": "~11.1.1",
     "expo-linking": "^4.0.1",
     "expo-notifications": "^0.18.1",

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -29,6 +29,7 @@ import SyncTokensProvider from './contexts/SyncTokensContext';
 import ToastProvider from './contexts/ToastContext';
 import { TokenStateManagerProvider } from './contexts/TokenStateManagerContext';
 import { magic } from './magic';
+import { useCacheIntroVideo } from './screens/Onboarding/useCacheIntroVideo';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -58,6 +59,7 @@ export default function App() {
 
   const [colorSchemeLoaded, setColorSchemeLoaded] = useState(false);
   const { setColorScheme, colorScheme } = useColorScheme();
+  const { introVideoLoaded } = useCacheIntroVideo();
 
   useEffect(
     function loadInitialColorSchemeFromAsyncStorage() {
@@ -116,7 +118,7 @@ export default function App() {
     [colorSchemeLoaded, fontsLoaded]
   );
 
-  if (!fontsLoaded || !colorSchemeLoaded) {
+  if (!fontsLoaded || !colorSchemeLoaded || !introVideoLoaded) {
     return null;
   }
 

--- a/apps/mobile/src/screens/Onboarding/OnboardingVideoScreen.tsx
+++ b/apps/mobile/src/screens/Onboarding/OnboardingVideoScreen.tsx
@@ -10,11 +10,14 @@ import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { Typography } from '~/components/Typography';
 import { LoginStackNavigatorProp } from '~/navigation/types';
 
+import { useCacheIntroVideo } from './useCacheIntroVideo';
+
 export const SEEN_ONBOARDING_VIDEO_STORAGE_KEY = 'hasSeenOnboardingVideo';
 
 export function OnboardingVideoScreen() {
   const { top } = useSafeAreaInsets();
   const navigation = useNavigation<LoginStackNavigatorProp>();
+  const { uri } = useCacheIntroVideo();
 
   const handleRedirectToLandingScreen = useCallback(() => {
     AsyncStorage.setItem(SEEN_ONBOARDING_VIDEO_STORAGE_KEY, 'true');
@@ -44,22 +47,24 @@ export function OnboardingVideoScreen() {
 
         <ChevronRightIcon />
       </View>
-      <Video
-        style={{
-          width: '100%',
-          height: '100%',
-        }}
-        shouldPlay
-        resizeMode={ResizeMode.COVER}
-        source={{
-          uri: 'https://storage.googleapis.com/gallery-prod-325303.appspot.com/mobile_onboarding_animation.mp4',
-        }}
-        onPlaybackStatusUpdate={(status) => {
-          if (status.isLoaded && status.didJustFinish) {
-            handleRedirectToLandingScreen();
-          }
-        }}
-      />
+      {uri && (
+        <Video
+          style={{
+            width: '100%',
+            height: '100%',
+          }}
+          shouldPlay
+          resizeMode={ResizeMode.COVER}
+          source={{
+            uri,
+          }}
+          onPlaybackStatusUpdate={(status) => {
+            if (status.isLoaded && status.didJustFinish) {
+              handleRedirectToLandingScreen();
+            }
+          }}
+        />
+      )}
     </View>
   );
 }

--- a/apps/mobile/src/screens/Onboarding/useCacheIntroVideo.ts
+++ b/apps/mobile/src/screens/Onboarding/useCacheIntroVideo.ts
@@ -1,0 +1,51 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as FileSystem from 'expo-file-system';
+import { useEffect, useState } from 'react';
+
+const CACHE_FOLDER = FileSystem.cacheDirectory + 'video/';
+const VIDEO_NAME = 'onboarding_video.mp4';
+const VIDEO_URI =
+  'https://storage.googleapis.com/gallery-prod-325303.appspot.com/mobile_onboarding_animation.mp4';
+
+export const INTRO_VIDEO_STORAGE_KEY = 'introVideoLoaded';
+
+export function useCacheIntroVideo() {
+  const [introVideoLoaded, setIntroVideoLoaded] = useState(false);
+  const [uri, setUri] = useState<string | null>(null);
+
+  const cacheVideo = async () => {
+    const videoCache = CACHE_FOLDER + VIDEO_NAME;
+
+    // Ensure the folder exists
+    await FileSystem.makeDirectoryAsync(CACHE_FOLDER, { intermediates: true });
+
+    // Download and cache the video
+    try {
+      const { uri } = await FileSystem.downloadAsync(VIDEO_URI, videoCache);
+      setUri(uri);
+      AsyncStorage.setItem(INTRO_VIDEO_STORAGE_KEY, uri);
+    } catch (error) {
+      // If there was an error, fallback to the network URI
+      setUri(VIDEO_URI);
+    } finally {
+      setIntroVideoLoaded(true);
+    }
+  };
+
+  // Only cache the video if it hasn't been cached before
+  useEffect(() => {
+    AsyncStorage.getItem(INTRO_VIDEO_STORAGE_KEY).then((value) => {
+      if (value) {
+        setUri(value);
+        setIntroVideoLoaded(true);
+      } else {
+        cacheVideo();
+      }
+    });
+  }, []);
+
+  return {
+    introVideoLoaded,
+    uri: uri,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -26072,6 +26072,7 @@ __metadata:
     expo-dev-client: ~2.1.5
     expo-dev-menu: ^2.1.4
     expo-device: ~5.2.1
+    expo-file-system: ~15.2.2
     expo-font: ~11.1.1
     expo-linking: ^4.0.1
     expo-notifications: ^0.18.1


### PR DESCRIPTION
### Summary of Changes


The idea:

1. Download the video when the user in the splash screen (same as phase when we setup our color scheme and font)
2. Store it inside the user device cache folder
3. Save the path inside the local storage
4. We just load the video from the local storage path

### Demo or Before/After Pics


https://github.com/gallery-so/gallery/assets/4480258/7c934240-ef0c-4b8c-8624-da7be048ea33



### Edge Cases

1. Test open the app with clear cache + local storage
2. Reopen the app and check whether are we downloading the video again

### Testing Steps

**Before**
1. Clear the local storage through expo debugger
2. Run with this command `yarn workspace mobile expo start --clear` to fresh start the app with clear cache

**Steps**
1. Enter with secret gesture
2. You should see the intro video instantly

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if mobile) I've tested the changes on both light and dark modes.
