### PR TITLE
Share-to-Gallery on Web

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -112,6 +112,11 @@ const nextConfig = {
         destination: 'https://gallery-so.notion.site/Careers-e8d78dea54834630928f075f4a4ccdba',
         permanent: false,
       },
+      {
+        source: '/~/compose',
+        destination: '/home?composer=true',
+        permanent: false,
+      },
       process.env.MAINTENANCE_MODE === '1'
         ? // Redirect all non-maintenance routes to /maintenance.
           // Also ignore /icons so that assets properly load on that page.

--- a/apps/web/src/components/NftSelector/NftSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelector.tsx
@@ -2,6 +2,7 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 import styled from 'styled-components';
 
+import { usePostComposerContext } from '~/contexts/postComposer/PostComposerContext';
 import { NftSelectorQuery } from '~/generated/NftSelectorQuery.graphql';
 import { NftSelectorViewerFragment$key } from '~/generated/NftSelectorViewerFragment.graphql';
 import useSyncTokens from '~/hooks/api/tokens/useSyncTokens';
@@ -9,23 +10,18 @@ import { ChevronLeftIcon } from '~/icons/ChevronLeftIcon';
 import { RefreshIcon } from '~/icons/RefreshIcon';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
-import { Chain } from '~/shared/utils/chains';
 import { doesUserOwnWalletFromChainFamily } from '~/utils/doesUserOwnWalletFromChainFamily';
 
 import IconContainer from '../core/IconContainer';
 import { HStack, VStack } from '../core/Spacer/Stack';
 import { BaseM } from '../core/Text/Text';
 import isRefreshDisabledForUser from '../GalleryEditor/PiecesSidebar/isRefreshDisabledForUser';
-import { TokenFilterType } from '../GalleryEditor/PiecesSidebar/SidebarViewSelector';
 import useTokenSearchResults from '../GalleryEditor/PiecesSidebar/useTokenSearchResults';
 import { NewTooltip } from '../Tooltip/NewTooltip';
 import { useTooltipHover } from '../Tooltip/useTooltipHover';
 import { NftSelectorCollectionGroup } from './groupNftSelectorCollectionsByAddress';
 import { NftSelectorFilterNetwork } from './NftSelectorFilter/NftSelectorFilterNetwork';
-import {
-  NftSelectorFilterSort,
-  NftSelectorSortView,
-} from './NftSelectorFilter/NftSelectorFilterSort';
+import { NftSelectorFilterSort } from './NftSelectorFilter/NftSelectorFilterSort';
 import { NftSelectorViewSelector } from './NftSelectorFilter/NftSelectorViewSelector';
 import { NftSelectorLoadingView } from './NftSelectorLoadingView';
 import { NftSelectorSearchBar } from './NftSelectorSearchBar';
@@ -110,9 +106,8 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
     rawTokensToDisplay: tokens,
   });
 
-  const [selectedView, setSelectedView] = useState<TokenFilterType>('Collected');
-  const [selectedSortView, setSelectedSortView] = useState<NftSelectorSortView>('Recently added');
-  const [selectedNetworkView, setSelectedNetworkView] = useState<Chain>('Ethereum');
+  const { filterType, setFilterType, sortType, setSortType, network, setNetwork } =
+    usePostComposerContext();
 
   const [selectedContract, setSelectedContract] = useState<NftSelectorContractType>(
     preSelectedContract || null
@@ -133,17 +128,17 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
         return true;
       }
 
-      if (token.chain !== selectedNetworkView) {
+      if (token.chain !== network) {
         return false;
       }
 
       // Early return created tokens as we don't need to filter out spam
-      if (selectedView === 'Created') {
+      if (filterType === 'Created') {
         return token.ownerIsCreator;
       }
 
       // Filter out created tokens in Collected view...
-      if (selectedView === 'Collected') {
+      if (filterType === 'Collected') {
         if (!token.ownerIsHolder) {
           return false;
         }
@@ -151,7 +146,7 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
 
       // ...but incorporate with spam filtering logic for Collected view
       const isSpam = token.isSpamByUser !== null ? token.isSpamByUser : token.isSpamByProvider;
-      if (selectedView === 'Hidden') {
+      if (filterType === 'Hidden') {
         return isSpam;
       }
 
@@ -159,15 +154,15 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
     });
 
     // Sort tokens
-    if (selectedSortView === 'Recently added') {
+    if (sortType === 'Recently added') {
       filteredTokens.sort((a, b) => {
         return new Date(b.creationTime).getTime() - new Date(a.creationTime).getTime();
       });
-    } else if (selectedSortView === 'Oldest') {
+    } else if (sortType === 'Oldest') {
       filteredTokens.sort((a, b) => {
         return new Date(a.creationTime).getTime() - new Date(b.creationTime).getTime();
       });
-    } else if (selectedSortView === 'Alphabetical') {
+    } else if (sortType === 'Alphabetical') {
       filteredTokens.sort((a, b) => {
         const contractA = a.contract?.name?.toLocaleLowerCase();
         const contractB = b.contract?.name?.toLocaleLowerCase();
@@ -188,12 +183,9 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
     }
 
     return filteredTokens;
-  }, [isSearching, selectedNetworkView, selectedSortView, selectedView, tokenSearchResults]);
+  }, [filterType, isSearching, network, sortType, tokenSearchResults]);
 
-  const ownsWalletFromSelectedChainFamily = doesUserOwnWalletFromChainFamily(
-    selectedNetworkView,
-    query
-  );
+  const ownsWalletFromSelectedChainFamily = doesUserOwnWalletFromChainFamily(network, query);
 
   const track = useTrack();
   const isRefreshDisabledAtUserLevel = isRefreshDisabledForUser(viewer?.user?.dbid ?? '');
@@ -207,12 +199,12 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
 
     track('NFT Selector: Clicked Refresh');
 
-    if (selectedView === 'Hidden') {
+    if (filterType === 'Hidden') {
       return;
     }
 
-    await syncTokens({ type: selectedView, chain: selectedNetworkView });
-  }, [refreshDisabled, track, selectedView, syncTokens, selectedNetworkView]);
+    await syncTokens({ type: filterType, chain: network });
+  }, [refreshDisabled, track, filterType, syncTokens, network]);
 
   const { floating, reference, getFloatingProps, getReferenceProps, floatingStyle } =
     useTooltipHover({
@@ -227,7 +219,7 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
 
     // we only want to consider auto-syncing tokens if selectedNetworkView changes, so limit dependencies
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNetworkView]);
+  }, [network]);
 
   return (
     <StyledNftSelectorModal>
@@ -255,27 +247,22 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
           <StyledHeaderContainer justify="space-between" align="center">
             <StyledTitleText>{selectedContract?.title}</StyledTitleText>
 
-            <NftSelectorFilterSort
-              selectedView={selectedSortView}
-              onSelectedViewChange={setSelectedSortView}
-            />
+            <NftSelectorFilterSort selectedView={sortType} onSelectedViewChange={setSortType} />
           </StyledHeaderContainer>
         ) : (
           <DropdownsContainer gap={4} align="center" disabled={isSearching}>
             <NftSelectorViewSelector
               isSearching={isSearching}
-              selectedView={selectedView}
-              onSelectedViewChange={setSelectedView}
+              selectedView={filterType}
+              onSelectedViewChange={setFilterType}
+              selectedNetwork={network}
             />
-            <NftSelectorFilterSort
-              selectedView={selectedSortView}
-              onSelectedViewChange={setSelectedSortView}
-            />
+            <NftSelectorFilterSort selectedView={sortType} onSelectedViewChange={setSortType} />
             <NftSelectorFilterNetwork
               isSearching={isSearching}
-              selectedMode={selectedView}
-              selectedNetwork={selectedNetworkView}
-              onSelectedViewChange={setSelectedNetworkView}
+              selectedMode={filterType}
+              selectedNetwork={network}
+              onSelectedViewChange={setNetwork}
               queryRef={query}
             />
 
@@ -307,7 +294,7 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
           tokenRefs={tokensToDisplay}
           selectedContractAddress={selectedContract?.address ?? null}
           onSelectContract={setSelectedContract}
-          selectedNetworkView={selectedNetworkView}
+          selectedNetworkView={network}
           hasSearchKeyword={isSearching}
           handleRefresh={handleRefresh}
           onSelectToken={onSelectToken}

--- a/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorViewSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorViewSelector.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import DoubleArrowsIcon from '~/icons/DoubleArrowsIcon';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';
+import { Chain, chains } from '~/shared/utils/chains';
 
 import { Dropdown } from '../../core/Dropdown/Dropdown';
 import { DropdownItem } from '../../core/Dropdown/DropdownItem';
@@ -17,12 +18,14 @@ type NftSelectorViewSelectorProps = {
   isSearching: boolean;
   selectedView: TokenFilterType;
   onSelectedViewChange: (selectedView: TokenFilterType) => void;
+  selectedNetwork: Chain;
 };
 
 export function NftSelectorViewSelector({
   isSearching,
   selectedView,
   onSelectedViewChange,
+  selectedNetwork,
 }: NftSelectorViewSelectorProps) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -36,6 +39,13 @@ export function NftSelectorViewSelector({
     },
     [track, onSelectedViewChange]
   );
+
+  const isCreatorSupportEnabledForChain = useMemo(() => {
+    const selectedChain = chains.find((chain) => chain.name === selectedNetwork);
+    return selectedChain?.hasCreatorSupport;
+  }, [selectedNetwork]);
+
+  console.log({ isCreatorSupportEnabledForChain });
 
   return (
     <Container>
@@ -53,7 +63,10 @@ export function NftSelectorViewSelector({
           <DropdownItem onClick={() => onSelectView('Collected')}>
             <BaseM>Collected</BaseM>
           </DropdownItem>
-          <DropdownItem onClick={() => onSelectView('Created')}>
+          <DropdownItem
+            onClick={() => onSelectView('Created')}
+            disabled={!isCreatorSupportEnabledForChain}
+          >
             <BaseM>Created</BaseM>
           </DropdownItem>
         </DropdownSection>

--- a/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorViewSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorViewSelector.tsx
@@ -45,8 +45,6 @@ export function NftSelectorViewSelector({
     return selectedChain?.hasCreatorSupport;
   }, [selectedNetwork]);
 
-  console.log({ isCreatorSupportEnabledForChain });
-
   return (
     <Container>
       <Selector

--- a/apps/web/src/contexts/postComposer/PostComposerContext.tsx
+++ b/apps/web/src/contexts/postComposer/PostComposerContext.tsx
@@ -42,17 +42,16 @@ type Props = { children: ReactNode };
 
 const PostComposerProvider = memo(({ children }: Props) => {
   const {
-    /* eslint-disable @typescript-eslint/no-unused-vars */
     query: {
       composer,
       // required fields
-      tokenId, // TODO: actually use this fallback
-      contractAddress, // TODO: auto-select contract
+      // tokenId, // TODO: actually use this fallback
+      // contractAddress, // TODO: auto-select contract.
       chain,
       // optional fields
-      collection_title: collectionTitle, // TODO: actually use this fallback
-      token_title: tokenTitle, // TODO: actually use this fallback
-      image_url: imageUrl, // TODO: actually use this fallback
+      // collection_title: collectionTitle, // TODO: actually use this fallback
+      // token_title: tokenTitle, // TODO: actually use this fallback
+      // image_url: imageUrl, // TODO: actually use this fallback
       caption: caption,
     },
   } = useRouter();

--- a/apps/web/src/contexts/postComposer/PostComposerContext.tsx
+++ b/apps/web/src/contexts/postComposer/PostComposerContext.tsx
@@ -86,6 +86,33 @@ const PostComposerProvider = memo(({ children }: Props) => {
     }
   }, [chain, composer, isMobile]);
 
+  /**
+   * TODO: we want to run autosync for certain chains when a user selects them from the dropdown.
+   * however, there are a couple issues:
+   * 1) the autosync will run *every* time the user selects a chain. so if they're quickly switching
+   *    back and forth between many chains, we'll be firing a lot of syncs. solution: just trigger it
+   *    once globally per chain for that session.
+   * 2) while syncing, the entire modal goes into a loading state. this is problematic if the user
+   *    has many ETH NFTs, selects ETH, and the modal looks blocked / loading for 30 seconds.
+   *    solution: need a "background" syncing mode that doesn't block the UI
+   */
+  // const { syncTokens } = useSyncTokens();
+  // useEffect(
+  //   function handleAutoSync() {
+  //     const chainMetadata = chains.find((c) => c.name === network);
+  //     if (chainMetadata?.shouldAutoRefresh && filterType === 'Collected') {
+  //       syncTokens({
+  //         type: filterType,
+  //         chain: network,
+  //       });
+  //     }
+  //   },
+  //   // not passing in `syncTokens` because the function is unstable and gets
+  //   // redefined when new tokens are fetched
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  //   [filterType, network]
+  // );
+
   const value = useMemo(
     () => ({
       caption: _caption,

--- a/apps/web/src/contexts/postComposer/PostComposerContext.tsx
+++ b/apps/web/src/contexts/postComposer/PostComposerContext.tsx
@@ -11,10 +11,20 @@ import {
   useState,
 } from 'react';
 
+import { TokenFilterType } from '~/components/GalleryEditor/PiecesSidebar/SidebarViewSelector';
+import { NftSelectorSortView } from '~/components/NftSelector/NftSelectorFilter/NftSelectorFilterSort';
+import { Chain } from '~/shared/utils/chains';
+
 type PostComposerState = {
   caption: string;
   setCaption: (s: string) => void;
   captionRef: MutableRefObject<string>;
+  filterType: TokenFilterType;
+  setFilterType: (s: TokenFilterType) => void;
+  sortType: NftSelectorSortView;
+  setSortType: (s: NftSelectorSortView) => void;
+  network: Chain;
+  setNetwork: (s: Chain) => void;
 };
 
 const PostComposerContext = createContext<PostComposerState | undefined>(undefined);
@@ -52,13 +62,23 @@ const PostComposerProvider = memo(({ children }: Props) => {
     captionRef.current = caption;
   }, [caption]);
 
+  const [filterType, setFilterType] = useState<TokenFilterType>('Collected');
+  const [sortType, setSortType] = useState<NftSelectorSortView>('Recently added');
+  const [network, setNetwork] = useState<Chain>('Ethereum');
+
   const value = useMemo(
     () => ({
       caption,
       setCaption,
       captionRef,
+      filterType,
+      setFilterType,
+      sortType,
+      setSortType,
+      network,
+      setNetwork,
     }),
-    [caption]
+    [caption, filterType, network, sortType]
   );
 
   return <PostComposerContext.Provider value={value}>{children}</PostComposerContext.Provider>;

--- a/packages/shared/src/utils/chains.ts
+++ b/packages/shared/src/utils/chains.ts
@@ -87,5 +87,5 @@ export function isChainEvm(chain: Chain) {
 }
 
 export function isSupportedChain(chain: string): chain is Chain {
-  return Boolean(chains.find((c) => c.name === chain));
+  return Boolean(chains.find((c) => c.name.toLowerCase() === chain.toLowerCase()));
 }

--- a/packages/shared/src/utils/chains.ts
+++ b/packages/shared/src/utils/chains.ts
@@ -77,3 +77,7 @@ export const chainsMap = keyBy(chains, 'name') as Record<Chain, ChainMetadata>;
 export function isChainEvm(chain: Chain) {
   return chainsMap[chain].baseChain === 'Ethereum';
 }
+
+export function isSupportedChain(chain: string): chain is Chain {
+  return Boolean(chains.find((c) => c.name === chain));
+}

--- a/packages/shared/src/utils/chains.ts
+++ b/packages/shared/src/utils/chains.ts
@@ -8,6 +8,7 @@ export const chains = [
     baseChain: 'Ethereum',
     hasCreatorSupport: true,
     isEnabled: true,
+    shouldAutoRefresh: false,
   },
   {
     name: 'Tezos',
@@ -16,6 +17,7 @@ export const chains = [
     baseChain: 'Tezos',
     hasCreatorSupport: false,
     isEnabled: true,
+    shouldAutoRefresh: false,
   },
   {
     name: 'Polygon',
@@ -24,6 +26,7 @@ export const chains = [
     baseChain: 'Ethereum',
     hasCreatorSupport: false,
     isEnabled: true,
+    shouldAutoRefresh: false,
   },
   {
     name: 'Arbitrum',
@@ -32,6 +35,7 @@ export const chains = [
     baseChain: 'Ethereum',
     hasCreatorSupport: false,
     isEnabled: true,
+    shouldAutoRefresh: true,
   },
   {
     name: 'Zora',
@@ -40,6 +44,7 @@ export const chains = [
     baseChain: 'Ethereum',
     hasCreatorSupport: false,
     isEnabled: true,
+    shouldAutoRefresh: true,
   },
   {
     name: 'Base',
@@ -48,6 +53,7 @@ export const chains = [
     baseChain: 'Ethereum',
     hasCreatorSupport: false,
     isEnabled: true,
+    shouldAutoRefresh: true,
   },
   {
     name: 'Optimism',
@@ -56,6 +62,7 @@ export const chains = [
     baseChain: 'Ethereum',
     hasCreatorSupport: false,
     isEnabled: true,
+    shouldAutoRefresh: true,
   },
   {
     name: 'POAP',
@@ -64,6 +71,7 @@ export const chains = [
     baseChain: 'Ethereum',
     hasCreatorSupport: false,
     isEnabled: true,
+    shouldAutoRefresh: true,
   },
 ] as const;
 


### PR DESCRIPTION
### Summary of Changes

Full walkthrough of code changes with demo: https://www.loom.com/share/e0967092a7104f128c3d8c727d2f0101?sid=c81819b8-91f3-4cd4-aa7f-96a25aaca331

v0 share-to-gallery implementation on web.

**Example redirect**

start: `http://localhost:3000/~/compose?tokenId=98&contractAddress=0xE480a895DE49B49e37A8f0a8bD7e07FC9844CDb9&chain=Arbitrum&collection_title=Dots&token_title=Dots+%2398&caption=I+just+minted+Dots+%2398+by+wutsit2u+on+Prohibition`

end: `http://localhost:3000/home?tokenId=98&contractAddress=0xE480a895DE49B49e37A8f0a8bD7e07FC9844CDb9&chain=Arbitrum&collection_title=Dots&token_title=Dots%20%2398&caption=I%20just%20minted%20Dots%20%2398%20by%20wutsit2u%20on%20Prohibition&composer=true`

If Logged In:
- automatically opens post modal with arbitrum selected (upon ensuring they've supplied `chain=arbitrum`)
- will be required to manually refresh their arbitrum tokens until minted one appears

If Logged Out:
- prompt auth modal
- will be required to manually post afterwards

**Additional Changes**
- lifted more pieces of post composer state up to global context, allowing pre-selected networks and filter types to be maintained across modal instances
- ensure `Created` tab isn't supported for non-mainnet chains

**NOT supported in this PR; will be provided in upcoming versions**
- jumping straight to the post composer step with relevant token selected (because the token may not be in our DB yet)
- verifying and auto-syncing provided token ID + contract address to user
- edge case where authenticated user may not have a wallet hooked up to gallery (e.g. signed up with email only). the user will be required to hook up their minting wallet.
- allowing logged out users to optimistically create a post

### Edge Cases

- [x] handled discrepancy in chain casing (e.g. arbitrum vs Arbitrum)

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
