### PR TITLE
Fix composer regression, useClearURLQueryParams

### DIFF
--- a/apps/web/src/components/Posts/PostComposerModal.tsx
+++ b/apps/web/src/components/Posts/PostComposerModal.tsx
@@ -5,6 +5,7 @@ import { NftSelectorLoadingView } from '~/components/NftSelector/NftSelectorLoad
 import ErrorBoundary from '~/contexts/boundary/ErrorBoundary';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { usePostComposerContext } from '~/contexts/postComposer/PostComposerContext';
+import { useClearURLQueryParams } from '~/utils/useClearURLQueryParams';
 
 import breakpoints from '../core/breakpoints';
 import { Button } from '../core/Button/Button';
@@ -29,6 +30,8 @@ export function PostComposerModalWithSelector({ preSelectedContract }: Props) {
   const returnUserToSelectorStep = useCallback(() => {
     setSelectedTokenId(null);
   }, []);
+
+  useClearURLQueryParams('composer');
 
   const { showModal } = useModalActions();
 
@@ -83,6 +86,7 @@ type PostComposerModalProps = {
 
 // Modal with a single step, the Post Composer.
 export function PostComposerModal({ tokenId }: PostComposerModalProps) {
+  useClearURLQueryParams('composer');
   return (
     <StyledPostComposerModal>
       <ErrorBoundary fallback={<PostComposerErrorScreen />}>

--- a/apps/web/src/components/Settings/Settings.tsx
+++ b/apps/web/src/components/Settings/Settings.tsx
@@ -1,5 +1,4 @@
-import { useRouter } from 'next/router';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
@@ -10,6 +9,7 @@ import DrawerHeader from '~/contexts/globalLayout/GlobalSidebar/DrawerHeader';
 import { SettingsFragment$key } from '~/generated/SettingsFragment.graphql';
 import { useLogout } from '~/hooks/useLogout';
 import colors from '~/shared/theme/colors';
+import { useClearURLQueryParams } from '~/utils/useClearURLQueryParams';
 
 import ManageAuthSection from './ManageAccountsSection/ManageAccountsSection';
 import ManageEmailSection from './ManageEmailSection/ManageEmailSection';
@@ -34,16 +34,7 @@ function Settings({ queryRef }: Props) {
     queryRef
   );
 
-  // drop settings param from URL once modal has been opened
-  const { pathname, query: urlQuery, replace } = useRouter();
-  useEffect(() => {
-    const params = new URLSearchParams(urlQuery as Record<string, string>);
-    if (params.has('settings')) {
-      params.delete('settings');
-      // @ts-expect-error we're simply replacing the current page with the same path
-      replace({ pathname, query: params.toString() }, undefined, { shallow: true });
-    }
-  }, [pathname, replace, urlQuery]);
+  useClearURLQueryParams('settings');
 
   const logout = useLogout();
 

--- a/apps/web/src/utils/useClearURLQueryParams.ts
+++ b/apps/web/src/utils/useClearURLQueryParams.ts
@@ -1,0 +1,25 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+// clears a given parameter(s) from the URL.
+//
+// this is useful when wanting to ensure an action only occurs once;
+// e.g. `settings=true` opens the settings sidebar, and we want to
+// prevent any extraneous effects from opening it again.
+//
+// the user won't notice any weird behavior or redirects as their
+// position will simply be replaced.
+export function useClearURLQueryParams(param: string | string[]) {
+  const { pathname, query: urlQuery, replace } = useRouter();
+  useEffect(() => {
+    const params = new URLSearchParams(urlQuery as Record<string, string>);
+    const paramsToClear = typeof param === 'string' ? [param] : param;
+    for (const p of paramsToClear) {
+      if (params.has(p)) {
+        params.delete(p);
+      }
+    }
+    // @ts-expect-error we're simply replacing the current page with the same path
+    replace({ pathname, query: params.toString() }, undefined, { shallow: true });
+  }, [param, pathname, replace, urlQuery]);
+}


### PR DESCRIPTION
### Summary of Changes

- Fixes a regression where the composer would continue to open after you closed it, triggered another element (e.g. sidebar notifications), then closed the sidebar. This would occur because the URL query params would continue to feature `composer=true`
- Introduce a new utility, `useClearURLQueryParams`, to help prevent this

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
