### PR TITLE
[GAL-4310] [GAL-4312] Pull-to-refresh on community page / Fix cut-off bio

### DIFF
--- a/apps/mobile/src/components/Community/CommunityView.tsx
+++ b/apps/mobile/src/components/Community/CommunityView.tsx
@@ -78,7 +78,7 @@ export function CommunityView({ queryRef }: Props) {
     });
   }, [community.chain, community.contractAddress?.address]);
 
-  const Header = useCallback(() => {
+  const TabBar = useCallback(() => {
     return (
       <CommunityTabsHeader
         communityRef={community}
@@ -110,7 +110,7 @@ export function CommunityView({ queryRef }: Props) {
       </View>
 
       <View className="flex-grow">
-        <GalleryTabsContainer Header={Header} ref={containerRef} initialTabName={selectedRoute}>
+        <GalleryTabsContainer TabBar={TabBar} ref={containerRef} initialTabName={selectedRoute}>
           <Tabs.Tab name="Posts">
             <CommunityViewPostsTab communityRef={community} queryRef={query} />
           </Tabs.Tab>

--- a/apps/mobile/src/components/GalleryTabs/GalleryTabsContainer.tsx
+++ b/apps/mobile/src/components/GalleryTabs/GalleryTabsContainer.tsx
@@ -11,7 +11,8 @@ import colors from '~/shared/theme/colors';
 type GalleryTabsContainerProps = {
   children: TabReactElement<string> | TabReactElement<string>[];
   initialTabName?: string;
-  Header: () => JSX.Element;
+  TabBar?: () => JSX.Element;
+  Header?: () => JSX.Element;
 };
 
 type GalleryTabsContainerType = CollapsibleRef<string>;
@@ -20,7 +21,7 @@ const GalleryTabsContainer: React.FC<GalleryTabsContainerProps> = (
   props,
   ref: ForwardedRef<GalleryTabsContainerType>
 ) => {
-  const { children, Header, initialTabName } = props;
+  const { children, TabBar, Header, initialTabName } = props;
   const { colorScheme } = useColorScheme();
 
   const containerRef = useRef<GalleryTabsContainerType | null>(null);
@@ -48,8 +49,8 @@ const GalleryTabsContainer: React.FC<GalleryTabsContainerProps> = (
           borderBottomColor: 'transparent',
           backgroundColor: colorScheme === 'light' ? colors.white : colors.black['900'],
         }}
-        renderTabBar={Empty}
-        renderHeader={Header}
+        renderTabBar={TabBar || Empty}
+        renderHeader={Header || Empty}
       >
         {children}
       </Tabs.Container>


### PR DESCRIPTION
### Summary of Changes

- Add pull to refresh on collection screen
- Fix overlap community header

### Demo 

**Add pull to refresh on collection screen**


https://github.com/gallery-so/gallery/assets/4480258/ce54b27d-08f1-44ac-b85f-ceba9d08c7d9



**Fix overlap on community header**

| Before | After |
|--------|--------|
| <img width="512" alt="CleanShot 2023-09-26 at 12 20 10@2x" src="https://github.com/gallery-so/gallery/assets/4480258/cd054c8a-293f-4880-8412-60dabbfcef8b"> | <img width="529" alt="CleanShot 2023-09-26 at 12 19 38@2x" src="https://github.com/gallery-so/gallery/assets/4480258/904ae950-bba4-4149-8870-97cefcb29344"> | 


### Edge Cases

1. Check any community screen
2. Check profile screen to make sure there is no regression

### Testing Steps

1. Open any community screen

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if mobile) I've tested the changes on both light and dark modes.
