### PR TITLE
GAL-4320 only admire on double tap

### DIFF
--- a/apps/mobile/src/components/Feed/FeedListItem.tsx
+++ b/apps/mobile/src/components/Feed/FeedListItem.tsx
@@ -56,7 +56,7 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
     queryRef: query,
   });
 
-  const onAdmire = useCallback(() => {
+  const handleAdmire = useCallback(() => {
     if (!hasViewerAdmiredEvent) {
       toggleAdmire();
     }
@@ -70,7 +70,7 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
     if (event.eventData.__typename === 'GalleryUpdatedFeedEventData') {
       return (
         <GalleryUpdatedFeedEvent
-          onAdmire={onAdmire}
+          onAdmire={handleAdmire}
           eventId={eventId}
           eventDataRef={event.eventData}
         />
@@ -80,7 +80,7 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
     return (
       <View className="overflow-hidden">
         <NonRecursiveFeedListItem
-          onAdmire={onAdmire}
+          onAdmire={handleAdmire}
           eventId={eventId}
           slideIndex={0}
           eventCount={1}
@@ -88,7 +88,7 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
         />
       </View>
     );
-  }, [event.eventData, eventId, onAdmire]);
+  }, [event.eventData, eventId, handleAdmire]);
 
   return <View>{inner}</View>;
 }

--- a/apps/mobile/src/components/Feed/FeedListItem.tsx
+++ b/apps/mobile/src/components/Feed/FeedListItem.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
@@ -51,10 +51,16 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
     throw new ErrorWithSentryMetadata('Missing eventData on feed event', {});
   }
 
-  const { toggleAdmire } = useToggleAdmire({
+  const { hasViewerAdmiredEvent, toggleAdmire } = useToggleAdmire({
     eventRef: event,
     queryRef: query,
   });
+
+  const onAdmire = useCallback(() => {
+    if (!hasViewerAdmiredEvent) {
+      toggleAdmire();
+    }
+  }, [hasViewerAdmiredEvent, toggleAdmire]);
 
   const inner = useMemo(() => {
     if (!event?.eventData) {
@@ -64,7 +70,7 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
     if (event.eventData.__typename === 'GalleryUpdatedFeedEventData') {
       return (
         <GalleryUpdatedFeedEvent
-          onAdmire={toggleAdmire}
+          onAdmire={onAdmire}
           eventId={eventId}
           eventDataRef={event.eventData}
         />
@@ -74,7 +80,7 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
     return (
       <View className="overflow-hidden">
         <NonRecursiveFeedListItem
-          onAdmire={toggleAdmire}
+          onAdmire={onAdmire}
           eventId={eventId}
           slideIndex={0}
           eventCount={1}
@@ -82,7 +88,7 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
         />
       </View>
     );
-  }, [event.eventData, eventId, toggleAdmire]);
+  }, [event.eventData, eventId, onAdmire]);
 
   return <View>{inner}</View>;
 }

--- a/apps/mobile/src/components/Feed/Posts/PostListItem.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostListItem.tsx
@@ -40,6 +40,9 @@ export function PostListItem({ feedPostRef, queryRef }: Props) {
           ...useGetPreviewImagesSingleFragment
           ...UniversalNftPreviewWithBoundaryFragment
         }
+        viewerAdmire {
+          __typename
+        }
         ...useTogglePostAdmireFragment
       }
     `,
@@ -101,7 +104,9 @@ export function PostListItem({ feedPostRef, queryRef }: Props) {
       clearTimeout(singleTapTimeoutRef.current);
       singleTapTimeoutRef.current = null;
 
-      toggleAdmire();
+      if (feedPost.viewerAdmire?.__typename !== 'Admire') {
+        toggleAdmire();
+      }
     } else {
       singleTapTimeoutRef.current = setTimeout(() => {
         singleTapTimeoutRef.current = null;
@@ -111,7 +116,7 @@ export function PostListItem({ feedPostRef, queryRef }: Props) {
         });
       }, DOUBLE_TAP_WINDOW);
     }
-  }, [firstToken.dbid, navigation, imageUrl, toggleAdmire]);
+  }, [feedPost.viewerAdmire?.__typename, toggleAdmire, navigation, imageUrl, firstToken.dbid]);
 
   return (
     <View className="flex flex-1 flex-col pt-1" style={{ width: dimensions.width }}>

--- a/apps/mobile/src/components/Feed/Posts/PostListItem.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostListItem.tsx
@@ -40,9 +40,7 @@ export function PostListItem({ feedPostRef, queryRef }: Props) {
           ...useGetPreviewImagesSingleFragment
           ...UniversalNftPreviewWithBoundaryFragment
         }
-        viewerAdmire {
-          __typename
-        }
+
         ...useTogglePostAdmireFragment
       }
     `,
@@ -63,7 +61,7 @@ export function PostListItem({ feedPostRef, queryRef }: Props) {
 
   const singleTapTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { toggleAdmire } = useTogglePostAdmire({
+  const { hasViewerAdmiredEvent, toggleAdmire } = useTogglePostAdmire({
     postRef: feedPost,
     queryRef: query,
   });
@@ -104,7 +102,7 @@ export function PostListItem({ feedPostRef, queryRef }: Props) {
       clearTimeout(singleTapTimeoutRef.current);
       singleTapTimeoutRef.current = null;
 
-      if (feedPost.viewerAdmire?.__typename !== 'Admire') {
+      if (!hasViewerAdmiredEvent) {
         toggleAdmire();
       }
     } else {
@@ -116,7 +114,7 @@ export function PostListItem({ feedPostRef, queryRef }: Props) {
         });
       }, DOUBLE_TAP_WINDOW);
     }
-  }, [feedPost.viewerAdmire?.__typename, toggleAdmire, navigation, imageUrl, firstToken.dbid]);
+  }, [hasViewerAdmiredEvent, toggleAdmire, navigation, imageUrl, firstToken.dbid]);
 
   return (
     <View className="flex flex-1 flex-col pt-1" style={{ width: dimensions.width }}>

--- a/apps/web/src/components/NftSelector/NftSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelector.tsx
@@ -12,6 +12,7 @@ import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import { doesUserOwnWalletFromChainFamily } from '~/utils/doesUserOwnWalletFromChainFamily';
 
+import breakpoints from '../core/breakpoints';
 import IconContainer from '../core/IconContainer';
 import { HStack, VStack } from '../core/Spacer/Stack';
 import { BaseM } from '../core/Text/Text';
@@ -305,19 +306,35 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
 }
 
 const StyledNftSelectorModal = styled(VStack)`
-  width: 880px;
   max-height: 100%;
   min-height: 250px;
+  width: 100%;
+  padding: 16px;
+
+  @media only screen and ${breakpoints.desktop} {
+    width: 880px;
+    padding: 0;
+  }
 `;
 
 const StyledTitle = styled.div`
-  padding: 16px 0;
+  padding-bottom: 16px;
+
+  @media only screen and ${breakpoints.desktop} {
+    padding: 16px 0;
+  }
 `;
 const StyledTitleText = styled(BaseM)`
   font-weight: 700;
 `;
-const StyledActionContainer = styled(HStack)`
+const StyledActionContainer = styled(VStack)`
   padding-bottom: 8px;
+  gap: 8px;
+
+  @media only screen and ${breakpoints.desktop} {
+    flex-direction: row;
+    gap: 16px;
+  }
 `;
 
 const StyledHeaderContainer = styled(HStack)`
@@ -327,4 +344,9 @@ const StyledHeaderContainer = styled(HStack)`
 const DropdownsContainer = styled(HStack)<{ disabled: boolean }>`
   opacity: ${({ disabled }) => (disabled ? 0.35 : 1)};
   pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
+
+  flex-wrap: wrap;
+  @media only screen and ${breakpoints.desktop} {
+    flex-wrap: unset;
+  }
 `;


### PR DESCRIPTION
### Summary of Changes
Double Tapping on a post or feed event currently toggles an admire.
Instead, make it so it only admires, not unadmire. this is in line with what users are used to.

### Demo or Before/After Pics
Posts:


https://github.com/gallery-so/gallery/assets/80802871/ebf83ce7-5727-400e-b552-53227987b112



Feed Events

https://github.com/gallery-so/gallery/assets/80802871/7d6c19d5-52c3-417a-8fcf-4e8495f4eb4a




### Edge Cases
- Post/FeedEvent that you haven't admired
- Post/FeedEvent that you have admired
- admire via pressing the icon, then try to double tap
- double tap, then try to unadmire via the icon, etc

### Testing Steps
try to admire/unadmire posts or FeedEvents by double tapping 

### Checklist
double tap posts a bunch of times and try to admire/unadmire

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
