### PR TITLE
GAL-4384 remove sticky header from feed

### DIFF
--- a/apps/mobile/src/components/Feed/FeedList.tsx
+++ b/apps/mobile/src/components/Feed/FeedList.tsx
@@ -57,7 +57,7 @@ export function FeedList({
   const { failedEvents, markEventAsFailure } = useFailedEventTracker();
   const ref = useRef<FlashList<FeedListItemType> | null>(null);
 
-  const { items, stickyIndices } = useMemo(() => {
+  const { items } = useMemo(() => {
     return createVirtualizedFeedEventItems({
       itemRefs: posts,
       failedEvents,
@@ -98,7 +98,6 @@ export function FeedList({
       estimatedItemSize={300}
       renderItem={renderItem}
       scrollEventThrottle={100}
-      stickyHeaderIndices={stickyIndices}
       getItemType={(item) => item.kind}
       keyExtractor={(item) => item.key}
       refreshControl={<GalleryRefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}

--- a/apps/mobile/src/components/Feed/createVirtualizedFeedEventItems.ts
+++ b/apps/mobile/src/components/Feed/createVirtualizedFeedEventItems.ts
@@ -118,10 +118,7 @@ export type createVirtualizedItemsFromFeedEventsArgs = {
 
 type createVirtualizedItemsFromFeedEventsReturnType = {
   items: FeedListItemType[];
-  stickyIndices: number[];
 };
-
-const STICKY_EVENT_ITEM_TYPES = new Set(['feed-item-header', 'post-item-header']);
 
 export function createVirtualizedFeedEventItems({
   failedEvents,
@@ -353,12 +350,5 @@ export function createVirtualizedFeedEventItems({
     }
   }
 
-  const stickyIndices: number[] = [];
-  items.forEach((item, index) => {
-    if (STICKY_EVENT_ITEM_TYPES.has(item.kind)) {
-      stickyIndices.push(index);
-    }
-  });
-
-  return { items, stickyIndices };
+  return { items };
 }

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewActivityTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewActivityTab.tsx
@@ -57,7 +57,7 @@ export function ProfileViewActivityTab({ queryRef }: ProfileViewActivityTabProps
   events.reverse();
 
   const ref = useRef<FlashList<FeedListItemType> | null>(null);
-  const { items, stickyIndices } = createVirtualizedFeedEventItems({
+  const { items } = createVirtualizedFeedEventItems({
     itemRefs: events,
     listRef: ref,
     failedEvents,
@@ -88,13 +88,7 @@ export function ProfileViewActivityTab({ queryRef }: ProfileViewActivityTabProps
 
   return (
     <View style={contentContainerStyle}>
-      <Tabs.FlashList
-        ref={ref}
-        data={items}
-        renderItem={renderItem}
-        estimatedItemSize={400}
-        stickyHeaderIndices={stickyIndices}
-      />
+      <Tabs.FlashList ref={ref} data={items} renderItem={renderItem} estimatedItemSize={400} />
     </View>
   );
 }

--- a/apps/web/src/components/NftSelector/NftSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelector.tsx
@@ -12,6 +12,7 @@ import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import { doesUserOwnWalletFromChainFamily } from '~/utils/doesUserOwnWalletFromChainFamily';
 
+import breakpoints from '../core/breakpoints';
 import IconContainer from '../core/IconContainer';
 import { HStack, VStack } from '../core/Spacer/Stack';
 import { BaseM } from '../core/Text/Text';
@@ -305,19 +306,35 @@ function NftSelectorInner({ onSelectToken, headerText, preSelectedContract }: Pr
 }
 
 const StyledNftSelectorModal = styled(VStack)`
-  width: 880px;
   max-height: 100%;
   min-height: 250px;
+  width: 100%;
+  padding: 16px;
+
+  @media only screen and ${breakpoints.desktop} {
+    width: 880px;
+    padding: 0;
+  }
 `;
 
 const StyledTitle = styled.div`
-  padding: 16px 0;
+  padding-bottom: 16px;
+
+  @media only screen and ${breakpoints.desktop} {
+    padding: 16px 0;
+  }
 `;
 const StyledTitleText = styled(BaseM)`
   font-weight: 700;
 `;
-const StyledActionContainer = styled(HStack)`
+const StyledActionContainer = styled(VStack)`
   padding-bottom: 8px;
+  gap: 8px;
+
+  @media only screen and ${breakpoints.desktop} {
+    flex-direction: row;
+    gap: 16px;
+  }
 `;
 
 const StyledHeaderContainer = styled(HStack)`
@@ -327,4 +344,9 @@ const StyledHeaderContainer = styled(HStack)`
 const DropdownsContainer = styled(HStack)<{ disabled: boolean }>`
   opacity: ${({ disabled }) => (disabled ? 0.35 : 1)};
   pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
+
+  flex-wrap: wrap;
+  @media only screen and ${breakpoints.desktop} {
+    flex-wrap: unset;
+  }
 `;


### PR DESCRIPTION
### Summary of Changes
Remove sticky header from items on the feed.
We are keeping the sticky header for other screens like the Gallery and Collection screens. this only affects the username header for Posts and Feed Events.

### Demo or Before/After Pics

https://github.com/gallery-so/gallery/assets/80802871/4144824a-140d-4cba-9765-6ceea5b6e9b9


### Edge Cases
Gallery and Collection screens should still have the sticky header where they used to be.

### Testing Steps
Scroll on the Feed and User Activity Feed, and verify that the username header on Posts and Feed Events are no longer sticky and scroll with the screen.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
