### PR TITLE
get correct first page for collection page posts, and also load more …

### DIFF
--- a/apps/mobile/src/components/Community/CommunityTabsHeader.tsx
+++ b/apps/mobile/src/components/Community/CommunityTabsHeader.tsx
@@ -16,7 +16,7 @@ export function CommunityTabsHeader({ selectedRoute, onRouteChange, communityRef
   const community = useFragment(
     graphql`
       fragment CommunityTabsHeaderFragment on Community {
-        posts(first: $postLast, after: $postBefore) {
+        posts(last: $postLast, before: $postBefore) {
           pageInfo {
             total
           }

--- a/apps/mobile/src/components/Community/Tabs/CommunityViewPostsTab.tsx
+++ b/apps/mobile/src/components/Community/Tabs/CommunityViewPostsTab.tsx
@@ -18,6 +18,7 @@ import { Typography } from '~/components/Typography';
 import { CommunityViewPostsTabFragment$key } from '~/generated/CommunityViewPostsTabFragment.graphql';
 import { CommunityViewPostsTabQueryFragment$key } from '~/generated/CommunityViewPostsTabQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
+import { POSTS_PER_PAGE } from '~/screens/CommunityScreen/CommunityScreen';
 
 import { CommunityPostBottomSheet } from '../CommunityPostBottomSheet';
 
@@ -27,7 +28,11 @@ type Props = {
 };
 
 export function CommunityViewPostsTab({ communityRef, queryRef }: Props) {
-  const { data: community } = usePaginationFragment(
+  const {
+    data: community,
+    hasPrevious,
+    loadPrevious,
+  } = usePaginationFragment(
     graphql`
       fragment CommunityViewPostsTabFragment on Community
       @refetchable(queryName: "CommunityViewPostsTabFragmentPaginationQuery") {
@@ -36,7 +41,7 @@ export function CommunityViewPostsTab({ communityRef, queryRef }: Props) {
         contractAddress {
           address
         }
-        posts(first: $postLast, after: $postBefore)
+        posts(last: $postLast, before: $postBefore)
           @connection(key: "CommunityViewPostsTabFragment_posts") {
           edges {
             node {
@@ -133,6 +138,12 @@ export function CommunityViewPostsTab({ communityRef, queryRef }: Props) {
     });
   }, [isMemberOfCommunity, navigation, community?.contractAddress?.address]);
 
+  const loadMore = useCallback(() => {
+    if (hasPrevious) {
+      loadPrevious(POSTS_PER_PAGE);
+    }
+  }, [hasPrevious, loadPrevious]);
+
   if (totalPosts === 0) {
     return (
       <View className="flex-1 pt-16 justify-center">
@@ -177,6 +188,7 @@ export function CommunityViewPostsTab({ communityRef, queryRef }: Props) {
         estimatedItemSize={400}
         data={items}
         renderItem={renderItem}
+        onEndReached={loadMore}
       />
     </View>
   );

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewActivityTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewActivityTab.tsx
@@ -13,13 +13,18 @@ import { FeedVirtualizedRow } from '~/components/Feed/FeedVirtualizedRow';
 import { useFailedEventTracker } from '~/components/Feed/useFailedEventTracker';
 import { useListContentStyle } from '~/components/ProfileView/Tabs/useListContentStyle';
 import { ProfileViewActivityTabFragment$key } from '~/generated/ProfileViewActivityTabFragment.graphql';
+import { ACTIVITY_FEED_ITEMS_PER_PAGE } from '~/screens/ProfileScreen/ProfileScreen';
 
 type ProfileViewActivityTabProps = {
   queryRef: ProfileViewActivityTabFragment$key;
 };
 
 export function ProfileViewActivityTab({ queryRef }: ProfileViewActivityTabProps) {
-  const { data: query } = usePaginationFragment(
+  const {
+    data: query,
+    hasPrevious,
+    loadPrevious,
+  } = usePaginationFragment(
     graphql`
       fragment ProfileViewActivityTabFragment on Query
       @refetchable(queryName: "ProfileViewActivityTabFragmentPaginationQuery") {
@@ -85,10 +90,21 @@ export function ProfileViewActivityTab({ queryRef }: ProfileViewActivityTabProps
   );
 
   const contentContainerStyle = useListContentStyle();
+  const loadMore = useCallback(() => {
+    if (hasPrevious) {
+      loadPrevious(ACTIVITY_FEED_ITEMS_PER_PAGE);
+    }
+  }, [hasPrevious, loadPrevious]);
 
   return (
     <View style={contentContainerStyle}>
-      <Tabs.FlashList ref={ref} data={items} renderItem={renderItem} estimatedItemSize={400} />
+      <Tabs.FlashList
+        ref={ref}
+        data={items}
+        renderItem={renderItem}
+        estimatedItemSize={400}
+        onEndReached={loadMore}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/screens/CommunityScreen/CommunityScreen.tsx
+++ b/apps/mobile/src/screens/CommunityScreen/CommunityScreen.tsx
@@ -19,6 +19,8 @@ type CommunityScreenInnerProps = {
   contractAddress: string;
 };
 
+export const POSTS_PER_PAGE = 24;
+
 function CommunityScreenInner({ chain, contractAddress }: CommunityScreenInnerProps) {
   const communityQuery = useLazyLoadQuery<CommunityScreenInitializeQuery>(
     graphql`
@@ -61,7 +63,7 @@ function CommunityScreenInner({ chain, contractAddress }: CommunityScreenInnerPr
       },
       listOwnersFirst: 200,
       onlyGalleryUsers: true,
-      postLast: 24,
+      postLast: POSTS_PER_PAGE,
       communityID: communityQuery.community.dbid ?? '',
     },
     { fetchPolicy: 'store-or-network', UNSTABLE_renderPolicy: 'partial' }

--- a/apps/mobile/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -16,6 +16,8 @@ import { MainTabStackNavigatorParamList } from '~/navigation/types';
 
 import { useRefreshHandle } from '../../hooks/useRefreshHandle';
 
+export const ACTIVITY_FEED_ITEMS_PER_PAGE = 24;
+
 function ProfileScreenInner() {
   const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'Profile'>>();
 
@@ -36,7 +38,7 @@ function ProfileScreenInner() {
     `,
     {
       username: route.params.username,
-      feedLast: 24,
+      feedLast: ACTIVITY_FEED_ITEMS_PER_PAGE,
       sharedCommunitiesFirst: SHARED_COMMUNITIES_PER_PAGE,
       sharedFollowersFirst: SHARED_FOLLOWERS_PER_PAGE,
       includePosts: true,


### PR DESCRIPTION
### Summary of Changes
get correct first page for collection page posts, and also load more at end of page.

we were getting the last page instead of the first, so we never showed the newest posts on a collection page. we also weren't fetching more pages upon scrolling to the bottom of the list.

noticed we also weren't loading more on the Profile Page activity tab, so added that here as well.

### Demo or Before/After Pics
Before 
![CleanShot 2023-09-27 at 11 23 28](https://github.com/gallery-so/gallery/assets/80802871/22d26508-85a9-45ae-8e54-2fbc2405aec1)



After (shows newest)
![CleanShot 2023-09-27 at 11 22 04](https://github.com/gallery-so/gallery/assets/80802871/c1f211ea-b681-4065-96e9-e8f4f9fec3fb)



Load more: collection screen

https://github.com/gallery-so/gallery/assets/80802871/5c4d6b54-81b1-4e58-a548-2f2c79a16594



Load more: activity tab

https://github.com/gallery-so/gallery/assets/80802871/d5a9ba23-48b8-433c-8b2c-f4e9d8b6a837


### Edge Cases


### Testing Steps
- go to Prohibition collection page, which has more than 1 page of posts
- you should see a new post at the top (should match web)
- if you scroll down, more posts should appear.

- you should also be able to observe this load behavior on the activity tab.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
