### PR TITLE
GAL-4394 vertically center search result if no second line

### DIFF
--- a/apps/mobile/src/components/Search/SearchResult.tsx
+++ b/apps/mobile/src/components/Search/SearchResult.tsx
@@ -74,11 +74,13 @@ export function SearchResult({ title, description, variant, profilePicture, ...p
         <View>
           <Markdown style={markdownStyles}>{highlightedName}</Markdown>
         </View>
-        <View>
-          <Markdown style={markdownStyles} numberOfLines={1}>
-            {highlightedDescription}
-          </Markdown>
-        </View>
+        {highlightedDescription && (
+          <View>
+            <Markdown style={markdownStyles} numberOfLines={1}>
+              {highlightedDescription}
+            </Markdown>
+          </View>
+        )}
       </View>
     </GalleryTouchableOpacity>
   );


### PR DESCRIPTION
### Summary of Changes

If there's no second line in the search result like a bio, the text should still remain vertically aligned against the PFP.




### Demo or Before/After Pics

Before

![CleanShot 2023-09-27 at 17 19 42](https://github.com/gallery-so/gallery/assets/80802871/3014027e-8e07-4952-887e-9017277840fc)



AFter

![CleanShot 2023-09-27 at 17 19 33](https://github.com/gallery-so/gallery/assets/80802871/f722b6f6-b324-4a82-81e3-eab6f71cd63c)



### Edge Cases
- has username + bio
- has username, no bio
- same for galleries, and communities

### Testing Steps
- search for something and verify 
- 
### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
