### PR TITLE
[GAL-4387] Clear up provider after connect wallet

### DIFF
--- a/apps/mobile/src/contexts/ManageWalletContext.tsx
+++ b/apps/mobile/src/contexts/ManageWalletContext.tsx
@@ -99,6 +99,11 @@ const ManageWalletProvider = memo(({ children }: Props) => {
     bottomSheet.current?.dismiss();
   }, []);
 
+  const clearState = useCallback(() => {
+    setIsSigningIn(false);
+    provider?.disconnect();
+  }, [provider]);
+
   const handleSignMessage = useCallback(async () => {
     if (!web3Provider || !address || hasSigned.current) {
       return;
@@ -181,11 +186,12 @@ const ManageWalletProvider = memo(({ children }: Props) => {
     } catch (error) {
       provider?.disconnect();
     } finally {
-      setIsSigningIn(false);
+      clearState();
     }
   }, [
     address,
     addWallet,
+    clearState,
     createNonce,
     login,
     isSyncing,
@@ -200,9 +206,9 @@ const ManageWalletProvider = memo(({ children }: Props) => {
     if (isConnected && !hasSigned.current) {
       handleSignMessage();
     } else {
-      setIsSigningIn(false);
+      clearState();
     }
-  }, [isConnected, handleSignMessage]);
+  }, [clearState, isConnected, handleSignMessage]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
### Summary of Changes

Fix a bug where the wallet connect still ask for signature when re-open the apps. 

**Solution**
We cleared up the web3 provider after the user attempt to sign the signature message (success or failed)


### Edge Cases

1. Sign with with wallet connect -> Close app -> Re-open the app again 
2. Add wallet to existing user -> Close app -> Re-open the app again

### Testing Steps

1. Sign with with wallet connect -> Close app -> Re-open the app again 

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if mobile) I've tested the changes on both light and dark modes.
