### PR TITLE
Clean up Nft Detail Screen

### DIFF
--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailScreenInner.tsx
@@ -1,43 +1,13 @@
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import { useColorScheme } from 'nativewind';
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { useCallback } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
-import FastImage from 'react-native-fast-image';
 import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import { BackButton } from '~/components/BackButton';
-import { TokenFailureBoundary } from '~/components/Boundaries/TokenFailureBoundary/TokenFailureBoundary';
-import { Button } from '~/components/Button';
-import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
-import { Pill } from '~/components/Pill';
-import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { NftDetailScreenInnerQuery } from '~/generated/NftDetailScreenInnerQuery.graphql';
-import { PostIcon } from '~/navigation/MainTabNavigator/PostIcon';
-import { MainTabStackNavigatorParamList, MainTabStackNavigatorProp } from '~/navigation/types';
-import { NftDetailAssetCacheSwapper } from '~/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetCacheSwapper';
-import TokenViewEmitter from '~/shared/components/TokenViewEmitter';
-import { useTrack } from '~/shared/contexts/AnalyticsContext';
-import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
-import colors from '~/shared/theme/colors';
+import { MainTabStackNavigatorParamList } from '~/navigation/types';
 
-import { IconContainer } from '../../components/IconContainer';
-import { InteractiveLink } from '../../components/InteractiveLink';
-import { Markdown } from '../../components/Markdown';
-import { Typography } from '../../components/Typography';
-import { PoapIcon } from '../../icons/PoapIcon';
-import { ShareIcon } from '../../icons/ShareIcon';
 import { shareToken } from '../../utils/shareToken';
-import { NftAdditionalDetails } from './NftAdditionalDetails';
-import { NftDetailAsset } from './NftDetailAsset/NftDetailAsset';
-
-const markdownStyles = StyleSheet.create({
-  body: {
-    fontSize: 14,
-  },
-});
-
-const ENABLED_CREATOR = false;
+import { NftDetailSection } from './NftDetailSection';
 
 export function NftDetailScreenInner() {
   const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'NftDetail'>>();
@@ -56,36 +26,11 @@ export function NftDetailScreenInner() {
         tokenById(id: $tokenId) {
           ... on Token {
             __typename
-            dbid
-            name
-            chain
-            tokenId
-            description
-
-            contract {
-              name
-              badgeURL
-              contractAddress {
-                address
-                chain
-              }
-            }
-            ownerIsCreator
-            owner {
-              id
-              username
-              ...ProfilePictureFragment
-            }
-
-            ...NftAdditionalDetailsFragment
-            ...NftDetailAssetFragment
+            ...shareTokenFragment
           }
-
-          ...shareTokenFragment
-          ...TokenFailureBoundaryFragment
         }
 
-        ...useLoggedInUserIdFragment
+        ...NftDetailSectionQueryFragment
       }
     `,
     {
@@ -107,199 +52,15 @@ export function NftDetailScreenInner() {
     // { tokenId: '2O1TnqK7sbhbdlAeQwLFkxo8T9i' }
   );
 
-  const { colorScheme } = useColorScheme();
-
   const token = query.tokenById;
-
-  const loggedInUserId = useLoggedInUserId(query);
 
   if (token?.__typename !== 'Token') {
     throw new Error("We couldn't find that token. Something went wrong and we're looking into it.");
   }
 
-  const isTokenOwner = loggedInUserId === token.owner?.id;
-
-  const track = useTrack();
-
-  const navigation = useNavigation<MainTabStackNavigatorProp>();
-
   const handleShare = useCallback(() => {
     shareToken(token, query.collectionTokenById?.collection ?? null);
   }, [query.collectionTokenById, token]);
 
-  const handleOpenCommunityScreen = useCallback(() => {
-    const contractAddress = token.contract?.contractAddress;
-    const { address, chain } = contractAddress ?? {};
-    if (!address || !chain) return;
-    navigation.push('Community', {
-      contractAddress: address,
-      chain,
-    });
-  }, [navigation, token.contract?.contractAddress]);
-
-  const handleUsernamePress = useCallback(() => {
-    if (token.owner?.username) {
-      track('NFT Detail Collector Name Clicked', {
-        username: token.owner.username,
-        contractAddress: token.contract?.contractAddress?.address,
-        tokenId: token.tokenId,
-      });
-      navigation.push('Profile', { username: token.owner.username });
-    }
-  }, [
-    navigation,
-    track,
-    token.owner?.username,
-    token.contract?.contractAddress?.address,
-    token.tokenId,
-  ]);
-
-  const handleCreatePost = useCallback(() => {
-    if (!token.dbid) return;
-
-    navigation.navigate('PostComposer', {
-      tokenId: token.dbid,
-    });
-  }, [navigation, token.dbid]);
-
-  // const handleCreatorPress = useCallback(() => {
-  //   if (token.creator?.username) {
-  //     track('NFT Detail Creator Name Clicked', {
-  //       username: token.creator.username,
-  //       contractAddress: token.contract?.contractAddress?.address,
-  //       tokenId: token.tokenId,
-  //     });
-  //     navigation.push('Profile', { username: token.creator.username });
-  //   }
-  // }, [navigation, track, token.creator?.username]);
-
-  return (
-    <ScrollView>
-      <View className="flex flex-col space-y-6 px-4 pb-4">
-        <View className="flex flex-col space-y-3">
-          <View className="flex flex-row justify-between">
-            <TokenViewEmitter
-              collectionID={route.params.collectionId ?? ''}
-              tokenID={route.params.tokenId}
-            />
-            <BackButton />
-            <IconContainer
-              eventElementId="NFT Detail Share Icon"
-              eventName="NFT Detail Share Icon Clicked"
-              icon={<ShareIcon />}
-              onPress={handleShare}
-            />
-          </View>
-
-          <View className="w-full">
-            <TokenFailureBoundary tokenRef={token} variant="large">
-              <NftDetailAssetCacheSwapper
-                cachedPreviewAssetUrl={route.params.cachedPreviewAssetUrl}
-              >
-                <NftDetailAsset tokenRef={token} />
-              </NftDetailAssetCacheSwapper>
-            </TokenFailureBoundary>
-          </View>
-        </View>
-
-        <View className="flex flex-col space-y-4">
-          <Typography
-            className="text-2xl"
-            font={{ family: 'GTAlpina', weight: 'StandardLight', italic: true }}
-          >
-            {token.name}
-          </Typography>
-
-          {token.contract?.name ? (
-            <GalleryTouchableOpacity
-              eventElementId="NFT Detail Contract Name Pill"
-              eventName="NFT Detail Contract Name Pill Clicked"
-            >
-              <Pill className="flex flex-row space-x-1 self-start">
-                {token.chain === 'POAP' && <PoapIcon className="h-6 w-6" />}
-                {token.contract?.badgeURL && (
-                  <FastImage className="h-6 w-6" source={{ uri: token.contract.badgeURL }} />
-                )}
-                <GalleryTouchableOpacity
-                  onPress={handleOpenCommunityScreen}
-                  eventElementId="Community Pill"
-                  eventName="Community Pill Clicked"
-                >
-                  <Typography numberOfLines={1} font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-                    {token.contract.name}
-                  </Typography>
-                </GalleryTouchableOpacity>
-              </Pill>
-            </GalleryTouchableOpacity>
-          ) : null}
-        </View>
-
-        <View className="flex-row">
-          {token.owner && (
-            <View className="w-1/2">
-              <Typography
-                className="text-xs text-shadow dark:text-metal"
-                font={{ family: 'ABCDiatype', weight: 'Medium' }}
-              >
-                {token.ownerIsCreator ? 'CREATOR' : 'OWNER'}
-              </Typography>
-
-              <GalleryTouchableOpacity
-                className="flex flex-row items-center space-x-1"
-                onPress={handleUsernamePress}
-                eventElementId="NFT Detail Token Owner Username"
-                eventName="NFT Detail Token Owner Username"
-              >
-                {token.owner.username && <ProfilePicture userRef={token.owner} size="xs" />}
-
-                <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-                  {token.owner.username}
-                </Typography>
-              </GalleryTouchableOpacity>
-            </View>
-          )}
-          {ENABLED_CREATOR && (
-            <View className="w-1/2">
-              <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-                CREATOR
-              </Typography>
-
-              <InteractiveLink onPress={handleUsernamePress} type="NFT Detail Token Creator">
-                riley.eth
-              </InteractiveLink>
-              <InteractiveLink onPress={handleUsernamePress} type="NFT Detail Token Creator">
-                riley.eth
-              </InteractiveLink>
-            </View>
-          )}
-        </View>
-
-        {token.description && (
-          <View>
-            <Markdown style={markdownStyles}>{token.description}</Markdown>
-          </View>
-        )}
-
-        {isTokenOwner && (
-          <Button
-            icon={
-              <PostIcon
-                width={24}
-                strokeWidth={1.5}
-                color={colorScheme === 'dark' ? colors.black['800'] : colors.white}
-              />
-            }
-            eventElementId={null}
-            eventName={null}
-            onPress={handleCreatePost}
-            text="create post"
-          />
-        )}
-
-        <View className="flex-1">
-          <NftAdditionalDetails tokenRef={token} />
-        </View>
-      </View>
-    </ScrollView>
-  );
+  return <NftDetailSection onShare={handleShare} queryRef={query} />;
 }

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -1,0 +1,284 @@
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { useColorScheme } from 'nativewind';
+import { useCallback } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import FastImage from 'react-native-fast-image';
+import Markdown from 'react-native-markdown-display';
+import { graphql, useFragment } from 'react-relay';
+import { PoapIcon } from 'src/icons/PoapIcon';
+import { ShareIcon } from 'src/icons/ShareIcon';
+
+import { BackButton } from '~/components/BackButton';
+import { TokenFailureBoundary } from '~/components/Boundaries/TokenFailureBoundary/TokenFailureBoundary';
+import { Button } from '~/components/Button';
+import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
+import { IconContainer } from '~/components/IconContainer';
+import { InteractiveLink } from '~/components/InteractiveLink';
+import { Pill } from '~/components/Pill';
+import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
+import { Typography } from '~/components/Typography';
+import { NftDetailSectionQueryFragment$key } from '~/generated/NftDetailSectionQueryFragment.graphql';
+import { PostIcon } from '~/navigation/MainTabNavigator/PostIcon';
+import { MainTabStackNavigatorParamList, MainTabStackNavigatorProp } from '~/navigation/types';
+import TokenViewEmitter from '~/shared/components/TokenViewEmitter';
+import { useTrack } from '~/shared/contexts/AnalyticsContext';
+import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
+import colors from '~/shared/theme/colors';
+
+import { NftAdditionalDetails } from './NftAdditionalDetails';
+import { NftDetailAsset } from './NftDetailAsset/NftDetailAsset';
+import { NftDetailAssetCacheSwapper } from './NftDetailAsset/NftDetailAssetCacheSwapper';
+
+type Props = {
+  onShare: () => void;
+  queryRef: NftDetailSectionQueryFragment$key;
+};
+
+const ENABLED_CREATOR = false;
+
+const markdownStyle = StyleSheet.create({
+  body: {
+    fontSize: 14,
+  },
+  heading1: {
+    fontSize: 14,
+  },
+  hr: {
+    height: 15,
+    backgroundColor: 'transparent',
+  },
+});
+
+export function NftDetailSection({ onShare, queryRef }: Props) {
+  const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'NftDetail'>>();
+
+  const query = useFragment(
+    graphql`
+      fragment NftDetailSectionQueryFragment on Query {
+        tokenById(id: $tokenId) {
+          ... on Token {
+            __typename
+            dbid
+            name
+            chain
+            tokenId
+            description
+
+            contract {
+              name
+              badgeURL
+              contractAddress {
+                address
+                chain
+              }
+            }
+            ownerIsCreator
+            owner {
+              id
+              username
+              ...ProfilePictureFragment
+            }
+
+            ...NftAdditionalDetailsFragment
+            ...NftDetailAssetFragment
+            ...TokenFailureBoundaryFragment
+          }
+        }
+        ...useLoggedInUserIdFragment
+      }
+    `,
+    queryRef
+  );
+
+  const { colorScheme } = useColorScheme();
+
+  const token = query.tokenById;
+
+  const loggedInUserId = useLoggedInUserId(query);
+
+  if (token?.__typename !== 'Token') {
+    throw new Error("We couldn't find that token. Something went wrong and we're looking into it.");
+  }
+
+  const isTokenOwner = loggedInUserId === token.owner?.id;
+
+  const track = useTrack();
+
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
+
+  const handleOpenCommunityScreen = useCallback(() => {
+    const contractAddress = token.contract?.contractAddress;
+    const { address, chain } = contractAddress ?? {};
+    if (!address || !chain) return;
+    navigation.push('Community', {
+      contractAddress: address,
+      chain,
+    });
+  }, [navigation, token.contract?.contractAddress]);
+
+  const handleUsernamePress = useCallback(() => {
+    if (token.owner?.username) {
+      track('NFT Detail Collector Name Clicked', {
+        username: token.owner.username,
+        contractAddress: token.contract?.contractAddress?.address,
+        tokenId: token.tokenId,
+      });
+      navigation.push('Profile', { username: token.owner.username });
+    }
+  }, [
+    navigation,
+    track,
+    token.owner?.username,
+    token.contract?.contractAddress?.address,
+    token.tokenId,
+  ]);
+
+  const handleCreatePost = useCallback(() => {
+    if (!token.dbid) return;
+
+    navigation.navigate('PostComposer', {
+      tokenId: token.dbid,
+    });
+  }, [navigation, token.dbid]);
+
+  // const handleCreatorPress = useCallback(() => {
+  //   if (token.creator?.username) {
+  //     track('NFT Detail Creator Name Clicked', {
+  //       username: token.creator.username,
+  //       contractAddress: token.contract?.contractAddress?.address,
+  //       tokenId: token.tokenId,
+  //     });
+  //     navigation.push('Profile', { username: token.creator.username });
+  //   }
+  // }, [navigation, track, token.creator?.username]);
+
+  return (
+    <ScrollView>
+      <View className="flex flex-col space-y-6 px-4 pb-4">
+        <View className="flex flex-col space-y-3">
+          <View className="flex flex-row justify-between">
+            <TokenViewEmitter
+              collectionID={route.params.collectionId ?? ''}
+              tokenID={route.params.tokenId}
+            />
+            <BackButton />
+            <IconContainer
+              eventElementId="NFT Detail Share Icon"
+              eventName="NFT Detail Share Icon Clicked"
+              icon={<ShareIcon />}
+              onPress={onShare}
+            />
+          </View>
+
+          <View className="w-full">
+            <TokenFailureBoundary tokenRef={token} variant="large">
+              <NftDetailAssetCacheSwapper
+                cachedPreviewAssetUrl={route.params.cachedPreviewAssetUrl}
+              >
+                <NftDetailAsset tokenRef={token} />
+              </NftDetailAssetCacheSwapper>
+            </TokenFailureBoundary>
+          </View>
+        </View>
+
+        <View className="flex flex-col space-y-4">
+          <Typography
+            className="text-2xl"
+            font={{ family: 'GTAlpina', weight: 'StandardLight', italic: true }}
+          >
+            {token.name}
+          </Typography>
+
+          {token.contract?.name ? (
+            <GalleryTouchableOpacity
+              eventElementId="NFT Detail Contract Name Pill"
+              eventName="NFT Detail Contract Name Pill Clicked"
+            >
+              <Pill className="flex flex-row space-x-1 self-start">
+                {token.chain === 'POAP' && <PoapIcon className="h-6 w-6" />}
+                {token.contract?.badgeURL && (
+                  <FastImage className="h-6 w-6" source={{ uri: token.contract.badgeURL }} />
+                )}
+                <GalleryTouchableOpacity
+                  onPress={handleOpenCommunityScreen}
+                  eventElementId="Community Pill"
+                  eventName="Community Pill Clicked"
+                >
+                  <Typography numberOfLines={1} font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+                    {token.contract.name}
+                  </Typography>
+                </GalleryTouchableOpacity>
+              </Pill>
+            </GalleryTouchableOpacity>
+          ) : null}
+        </View>
+
+        <View className="flex-row">
+          {token.owner && (
+            <View className="w-1/2">
+              <Typography
+                className="text-xs text-shadow dark:text-metal"
+                font={{ family: 'ABCDiatype', weight: 'Medium' }}
+              >
+                {token.ownerIsCreator ? 'CREATOR' : 'OWNER'}
+              </Typography>
+
+              <GalleryTouchableOpacity
+                className="flex flex-row items-center space-x-1"
+                onPress={handleUsernamePress}
+                eventElementId="NFT Detail Token Owner Username"
+                eventName="NFT Detail Token Owner Username"
+              >
+                {token.owner.username && <ProfilePicture userRef={token.owner} size="xs" />}
+
+                <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+                  {token.owner.username}
+                </Typography>
+              </GalleryTouchableOpacity>
+            </View>
+          )}
+          {ENABLED_CREATOR && (
+            <View className="w-1/2">
+              <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+                CREATOR
+              </Typography>
+
+              <InteractiveLink onPress={handleUsernamePress} type="NFT Detail Token Creator">
+                riley.eth
+              </InteractiveLink>
+              <InteractiveLink onPress={handleUsernamePress} type="NFT Detail Token Creator">
+                riley.eth
+              </InteractiveLink>
+            </View>
+          )}
+        </View>
+
+        {token.description && (
+          <View>
+            <Markdown style={markdownStyle}>{token.description}</Markdown>
+          </View>
+        )}
+
+        {isTokenOwner && (
+          <Button
+            icon={
+              <PostIcon
+                width={24}
+                strokeWidth={1.5}
+                color={colorScheme === 'dark' ? colors.black['800'] : colors.white}
+              />
+            }
+            eventElementId={null}
+            eventName={null}
+            onPress={handleCreatePost}
+            text="create post"
+          />
+        )}
+
+        <View className="flex-1">
+          <NftAdditionalDetails tokenRef={token} />
+        </View>
+      </View>
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/screens/NftDetailScreen/UniversalNftDetailScreenInner.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/UniversalNftDetailScreenInner.tsx
@@ -1,38 +1,13 @@
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { useCallback } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
-import FastImage from 'react-native-fast-image';
 import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
-import { ShareIcon } from 'src/icons/ShareIcon';
 import { shareUniversalToken } from 'src/utils/shareToken';
 
-import { BackButton } from '~/components/BackButton';
-import { TokenFailureBoundary } from '~/components/Boundaries/TokenFailureBoundary/TokenFailureBoundary';
-import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
-import { IconContainer } from '~/components/IconContainer';
-import { Pill } from '~/components/Pill';
 import { UniversalNftDetailScreenInnerQuery } from '~/generated/UniversalNftDetailScreenInnerQuery.graphql';
-import { MainTabStackNavigatorParamList, MainTabStackNavigatorProp } from '~/navigation/types';
-import { NftDetailAssetCacheSwapper } from '~/screens/NftDetailScreen/NftDetailAsset/NftDetailAssetCacheSwapper';
-import { useTrack } from '~/shared/contexts/AnalyticsContext';
+import { MainTabStackNavigatorParamList } from '~/navigation/types';
 
-import { InteractiveLink } from '../../components/InteractiveLink';
-import { Markdown } from '../../components/Markdown';
-import { Typography } from '../../components/Typography';
-import { PoapIcon } from '../../icons/PoapIcon';
-import { NftAdditionalDetails } from './NftAdditionalDetails';
-import { NftDetailAsset } from './NftDetailAsset/NftDetailAsset';
-
-const markdownStyles = StyleSheet.create({
-  body: {
-    fontSize: 14,
-  },
-});
-
-const ENABLED_CREATOR = false;
-
-// TODO: Refactor this to merge with existing NftDetailScreen
+import { NftDetailSection } from './NftDetailSection';
 
 export function UniversalNftDetailScreenInner() {
   const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'NftDetail'>>();
@@ -43,30 +18,10 @@ export function UniversalNftDetailScreenInner() {
         tokenById(id: $tokenId) {
           ... on Token {
             __typename
-            name
-            chain
-            tokenId
-            description
-
-            contract {
-              name
-              badgeURL
-              contractAddress {
-                address
-                chain
-              }
-            }
-            ownerIsCreator
-            owner {
-              username
-            }
-
-            ...NftAdditionalDetailsFragment
-            ...NftDetailAssetFragment
             ...shareTokenUniversalFragment
-            ...TokenFailureBoundaryFragment
           }
         }
+        ...NftDetailSectionQueryFragment
       }
     `,
     {
@@ -80,136 +35,9 @@ export function UniversalNftDetailScreenInner() {
     throw new Error("We couldn't find that token. Something went wrong and we're looking into it.");
   }
 
-  const track = useTrack();
-
-  const navigation = useNavigation<MainTabStackNavigatorProp>();
-
-  const handleOpenCommunityScreen = useCallback(() => {
-    const contractAddress = token.contract?.contractAddress;
-    const { address, chain } = contractAddress ?? {};
-    if (!address || !chain) return;
-    navigation.push('Community', {
-      contractAddress: address,
-      chain,
-    });
-  }, [navigation, token.contract?.contractAddress]);
-
-  const handleUsernamePress = useCallback(() => {
-    if (token.owner?.username) {
-      track('NFT Detail Collector Name Clicked', {
-        username: token.owner.username,
-        contractAddress: token.contract?.contractAddress?.address,
-        tokenId: token.tokenId,
-      });
-      navigation.push('Profile', { username: token.owner.username });
-    }
-  }, [
-    navigation,
-    track,
-    token.owner?.username,
-    token.contract?.contractAddress?.address,
-    token.tokenId,
-  ]);
-
   const handleShare = useCallback(() => {
     shareUniversalToken(token);
   }, [token]);
 
-  return (
-    <ScrollView>
-      <View className="flex flex-col space-y-6 px-4 pb-4">
-        <View className="flex flex-col space-y-3">
-          <View className="flex flex-row justify-between">
-            <BackButton />
-            <IconContainer
-              eventElementId="NFT Detail Share Icon"
-              eventName="NFT Detail Share Icon Clicked"
-              icon={<ShareIcon />}
-              onPress={handleShare}
-            />
-          </View>
-
-          <View className="w-full">
-            <TokenFailureBoundary tokenRef={token} variant="large">
-              <NftDetailAssetCacheSwapper
-                cachedPreviewAssetUrl={route.params.cachedPreviewAssetUrl}
-              >
-                <NftDetailAsset tokenRef={token} />
-              </NftDetailAssetCacheSwapper>
-            </TokenFailureBoundary>
-          </View>
-        </View>
-
-        <View className="flex flex-col space-y-4">
-          <Typography
-            className="text-2xl"
-            font={{ family: 'GTAlpina', weight: 'StandardLight', italic: true }}
-          >
-            {token.name}
-          </Typography>
-
-          {token.contract?.name ? (
-            <GalleryTouchableOpacity
-              eventElementId="NFT Detail Contract Name Pill"
-              eventName="NFT Detail Contract Name Pill Clicked"
-            >
-              <Pill className="flex flex-row space-x-1 self-start">
-                {token.chain === 'POAP' && <PoapIcon className="h-6 w-6" />}
-                {token.contract?.badgeURL && (
-                  <FastImage className="h-6 w-6" source={{ uri: token.contract.badgeURL }} />
-                )}
-                <GalleryTouchableOpacity
-                  onPress={handleOpenCommunityScreen}
-                  eventElementId="Community Pill"
-                  eventName="Community Pill Clicked"
-                >
-                  <Typography numberOfLines={1} font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-                    {token.contract.name}
-                  </Typography>
-                </GalleryTouchableOpacity>
-              </Pill>
-            </GalleryTouchableOpacity>
-          ) : null}
-        </View>
-
-        <View className="flex-row">
-          {token.owner && (
-            <View className="w-1/2">
-              <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-                {token.ownerIsCreator ? 'CREATOR' : 'OWNER'}
-              </Typography>
-
-              <InteractiveLink onPress={handleUsernamePress} type="NFT Detail Token Owner Username">
-                {token.owner.username}
-              </InteractiveLink>
-            </View>
-          )}
-          {ENABLED_CREATOR && (
-            <View className="w-1/2">
-              <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-                CREATOR
-              </Typography>
-
-              <InteractiveLink onPress={handleUsernamePress} type="NFT Detail Token Creator">
-                riley.eth
-              </InteractiveLink>
-              <InteractiveLink onPress={handleUsernamePress} type="NFT Detail Token Creator">
-                riley.eth
-              </InteractiveLink>
-            </View>
-          )}
-        </View>
-
-        {token.description && (
-          <View>
-            <Markdown style={markdownStyles}>{token.description}</Markdown>
-          </View>
-        )}
-
-        <View className="flex-1">
-          <NftAdditionalDetails tokenRef={token} />
-        </View>
-      </View>
-    </ScrollView>
-  );
+  return <NftDetailSection onShare={handleShare} queryRef={query} />;
 }


### PR DESCRIPTION
### Summary of Changes

Previously, we have the issue the `NftDetailScreen` doesnt support if the `token` didn't have any `collection` . So, we decided to duplicate our `NftDetailScreen` and named it `UniversalNftDetailScreen`. 

This PR should clean up a bit that we used the same component for both screen

### Demo

Throw some UI polish on NFT description

| Before | After |
|--------|--------|
|<img width="389" alt="CleanShot 2023-09-29 at 18 00 37@2x" src="https://github.com/gallery-so/gallery/assets/4480258/ba38b5b8-a75e-4d83-a7b8-bd37072744dc"> |<img width="382" alt="CleanShot 2023-09-29 at 18 00 15@2x" src="https://github.com/gallery-so/gallery/assets/4480258/e7442fe9-2598-46a1-989f-1d5310c76e23"> | 


### Edge Cases

1. View a token from feed (universal token screen)
2. View a token from gallery (normal token screen + collection)
3. Ensure the share button in the universal screen is correct
4. Ensure the share button in the token screen is correct 


### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if mobile) I've tested the changes on both light and dark modes.
