### PR TITLE
[GAL-3843] Update web Nft Composer to display landscape and portrait images properly 

### DIFF
--- a/apps/web/src/components/NftSelector/NftSelectorPreviewAsset.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorPreviewAsset.tsx
@@ -29,15 +29,20 @@ export function NftSelectorPreviewAsset({
   const imageUrl = useGetSinglePreviewImage({ tokenRef: token, size: 'medium' }) ?? '';
 
   const { handleNftLoaded } = useNftRetry({ tokenId: token.dbid });
-  return resizeToSquare ? (
-    <StyledSquareImage isSelected={false} src={imageUrl} alt="token" onLoad={handleNftLoaded} />
-  ) : (
-    <StyledImage isSelected={false} src={imageUrl} alt="token" onLoad={handleNftLoaded} />
+  return (
+    <StyledImage
+      isSelected={false}
+      src={imageUrl}
+      alt="token"
+      onLoad={handleNftLoaded}
+      enforceSquareAspectRatio={resizeToSquare}
+    />
   );
 }
 
 type SelectedProps = {
   isSelected?: boolean;
+  enforceSquareAspectRatio: boolean;
 };
 
 const StyledImage = styled.img<SelectedProps>`
@@ -45,18 +50,14 @@ const StyledImage = styled.img<SelectedProps>`
   max-width: 100%;
   transition: opacity ${transitions.cubic};
   opacity: ${({ isSelected }) => (isSelected ? 0.5 : 1)};
-
   object-fit: cover;
-`;
 
-const StyledSquareImage = styled.img<SelectedProps>`
-  max-height: 100%;
-  max-width: 100%;
-  transition: opacity ${transitions.cubic};
-  opacity: ${({ isSelected }) => (isSelected ? 0.5 : 1)};
-
-  height: auto;
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  object-fit: cover;
+  ${({ enforceSquareAspectRatio }) =>
+    enforceSquareAspectRatio
+      ? `
+    height: auto;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    `
+      : undefined}
 `;

--- a/apps/web/src/components/NftSelector/NftSelectorPreviewAsset.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorPreviewAsset.tsx
@@ -29,13 +29,11 @@ export function NftSelectorPreviewAsset({
   const imageUrl = useGetSinglePreviewImage({ tokenRef: token, size: 'medium' }) ?? '';
 
   const { handleNftLoaded } = useNftRetry({ tokenId: token.dbid });
-  if (resizeToSquare) {
-    return (
-      <StyledSquareImage isSelected={false} src={imageUrl} alt="token" onLoad={handleNftLoaded} />
-    );
-  } else {
-    return <StyledImage isSelected={false} src={imageUrl} alt="token" onLoad={handleNftLoaded} />;
-  }
+  return resizeToSquare ? (
+    <StyledSquareImage isSelected={false} src={imageUrl} alt="token" onLoad={handleNftLoaded} />
+  ) : (
+    <StyledImage isSelected={false} src={imageUrl} alt="token" onLoad={handleNftLoaded} />
+  );
 }
 
 type SelectedProps = {

--- a/apps/web/src/components/NftSelector/NftSelectorPreviewAsset.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorPreviewAsset.tsx
@@ -9,9 +9,13 @@ import transitions from '../core/transitions';
 
 type NftSelectorPreviewAssetProps = {
   tokenRef: NftSelectorPreviewAssetFragment$key;
+  resizeToSquare?: boolean;
 };
 
-export function NftSelectorPreviewAsset({ tokenRef }: NftSelectorPreviewAssetProps) {
+export function NftSelectorPreviewAsset({
+  tokenRef,
+  resizeToSquare = true,
+}: NftSelectorPreviewAssetProps) {
   const token = useFragment(
     graphql`
       fragment NftSelectorPreviewAssetFragment on Token {
@@ -25,8 +29,13 @@ export function NftSelectorPreviewAsset({ tokenRef }: NftSelectorPreviewAssetPro
   const imageUrl = useGetSinglePreviewImage({ tokenRef: token, size: 'medium' }) ?? '';
 
   const { handleNftLoaded } = useNftRetry({ tokenId: token.dbid });
-
-  return <StyledImage isSelected={false} src={imageUrl} alt="token" onLoad={handleNftLoaded} />;
+  if (resizeToSquare) {
+    return (
+      <StyledSquareImage isSelected={false} src={imageUrl} alt="token" onLoad={handleNftLoaded} />
+    );
+  } else {
+    return <StyledImage isSelected={false} src={imageUrl} alt="token" onLoad={handleNftLoaded} />;
+  }
 }
 
 type SelectedProps = {
@@ -34,6 +43,15 @@ type SelectedProps = {
 };
 
 const StyledImage = styled.img<SelectedProps>`
+  max-height: 100%;
+  max-width: 100%;
+  transition: opacity ${transitions.cubic};
+  opacity: ${({ isSelected }) => (isSelected ? 0.5 : 1)};
+
+  object-fit: cover;
+`;
+
+const StyledSquareImage = styled.img<SelectedProps>`
   max-height: 100%;
   max-width: 100%;
   transition: opacity ${transitions.cubic};

--- a/apps/web/src/components/NftSelector/NftSelectorPreviewAsset.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorPreviewAsset.tsx
@@ -9,12 +9,12 @@ import transitions from '../core/transitions';
 
 type NftSelectorPreviewAssetProps = {
   tokenRef: NftSelectorPreviewAssetFragment$key;
-  resizeToSquare?: boolean;
+  enforceSquareAspectRatio?: boolean;
 };
 
 export function NftSelectorPreviewAsset({
   tokenRef,
-  resizeToSquare = true,
+  enforceSquareAspectRatio = true,
 }: NftSelectorPreviewAssetProps) {
   const token = useFragment(
     graphql`
@@ -35,7 +35,7 @@ export function NftSelectorPreviewAsset({
       src={imageUrl}
       alt="token"
       onLoad={handleNftLoaded}
-      enforceSquareAspectRatio={resizeToSquare}
+      enforceSquareAspectRatio={enforceSquareAspectRatio}
     />
   );
 }

--- a/apps/web/src/components/Posts/PostComposer.tsx
+++ b/apps/web/src/components/Posts/PostComposer.tsx
@@ -20,7 +20,7 @@ import { Button } from '../core/Button/Button';
 import IconContainer from '../core/IconContainer';
 import { HStack, VStack } from '../core/Spacer/Stack';
 import { TitleS } from '../core/Text/Text';
-import { TextAreaWithCharCount } from '../core/TextArea/TextArea';
+import { AutoResizingTextAreaWithCharCount } from '../core/TextArea/TextArea';
 import PostComposerNft from './PostComposerNft';
 
 type Props = {
@@ -147,7 +147,7 @@ export default function PostComposer({ onBackClick, tokenId }: Props) {
         <ContentContainer>
           <PostComposerNft tokenRef={token} />
           <VStack grow>
-            <TextAreaWithCharCount
+            <AutoResizingTextAreaWithCharCount
               defaultValue={caption}
               placeholder={`Say something about ${inputPlaceholderTokenName}`}
               currentCharCount={caption.length}
@@ -160,7 +160,7 @@ export default function PostComposer({ onBackClick, tokenId }: Props) {
           </VStack>
         </ContentContainer>
       </VStack>
-      <HStack justify={generalError ? 'space-between' : 'flex-end'} align="flex-end">
+      <StyledHStack justify={generalError ? 'space-between' : 'flex-end'} align="flex-end">
         {generalError && (
           <StyledWrapper>
             <AlertTriangleIcon color={colors.red} />
@@ -174,7 +174,7 @@ export default function PostComposer({ onBackClick, tokenId }: Props) {
         >
           POST
         </Button>
-      </HStack>
+      </StyledHStack>
     </StyledPostComposer>
   );
 }
@@ -186,6 +186,10 @@ const StyledPostComposer = styled(VStack)`
   @media only screen and ${breakpoints.tablet} {
     padding: 0;
   }
+`;
+
+const StyledHStack = styled(HStack)`
+  padding-top: 16px;
 `;
 
 const StyledHeader = styled(HStack)`

--- a/apps/web/src/components/Posts/PostComposerAsset.tsx
+++ b/apps/web/src/components/Posts/PostComposerAsset.tsx
@@ -26,13 +26,16 @@ export default function PostComposerAsset({ tokenRef }: Props) {
   return (
     <StyledPostComposerAsset>
       <NftFailureBoundary tokenId={token.dbid}>
-        <NftSelectorPreviewAsset tokenRef={token} />
+        <NftSelectorPreviewAsset tokenRef={token} resizeToSquare={false} />
       </NftFailureBoundary>
     </StyledPostComposerAsset>
   );
 }
 
 const StyledPostComposerAsset = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 100%;
   height: 100%;
   min-width: 100%;

--- a/apps/web/src/components/Posts/PostComposerAsset.tsx
+++ b/apps/web/src/components/Posts/PostComposerAsset.tsx
@@ -40,11 +40,4 @@ const StyledPostComposerAsset = styled.div`
   height: 100%;
   min-width: 100%;
   min-height: 100%;
-
-  @media only screen and ${breakpoints.tablet} {
-    width: 180px;
-    height: 180px;
-    min-width: 180px;
-    min-height: 180px;
-  }
 `;

--- a/apps/web/src/components/Posts/PostComposerAsset.tsx
+++ b/apps/web/src/components/Posts/PostComposerAsset.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 import { PostComposerAssetFragment$key } from '~/generated/PostComposerAssetFragment.graphql';
 
-import breakpoints from '../core/breakpoints';
 import { NftFailureBoundary } from '../NftFailureFallback/NftFailureBoundary';
 import { NftSelectorPreviewAsset } from '../NftSelector/NftSelectorPreviewAsset';
 
@@ -26,7 +25,7 @@ export default function PostComposerAsset({ tokenRef }: Props) {
   return (
     <StyledPostComposerAsset>
       <NftFailureBoundary tokenId={token.dbid}>
-        <NftSelectorPreviewAsset tokenRef={token} resizeToSquare={false} />
+        <NftSelectorPreviewAsset tokenRef={token} enforceSquareAspectRatio={false} />
       </NftFailureBoundary>
     </StyledPostComposerAsset>
   );

--- a/apps/web/src/components/Posts/PostComposerModal.tsx
+++ b/apps/web/src/components/Posts/PostComposerModal.tsx
@@ -101,7 +101,7 @@ const StyledPostComposerModal = styled.div`
   height: 100%;
   @media only screen and ${breakpoints.tablet} {
     min-width: 562px;
-    min-height: 344px;
+    min-height: 274px;
   }
 `;
 


### PR DESCRIPTION
### Summary of Changes
Update web Nft Composer to display landscape and portrait images properly while keeping the images elsewhere unchanged

### Demo or Before/After Pics

| Before                                     | After                                      | 
| ------------------------------------------ | ------------------------------------------ |  
|  <img width="766" alt="Screenshot 2023-10-02 at 1 23 32 PM" src="https://github.com/gallery-so/gallery/assets/49758803/c04e4f96-3167-4788-98cf-3ea70998f06a"> | <img width="706" alt="Screenshot 2023-10-15 at 8 50 36 AM" src="https://github.com/gallery-so/gallery/assets/49758803/c9b0a85b-33b9-4296-903a-55041853d9be"> |

## Some more cases

| After                                     | After 2                                     | 
| ------------------------------------------ | ------------------------------------------ |  
| <img width="699" alt="Screenshot 2023-10-16 at 3 38 42 AM" src="https://github.com/gallery-so/gallery/assets/49758803/6d571b23-614a-4e8b-b752-19e6d3dbdab2"> | <img width="687" alt="Screenshot 2023-10-15 at 8 45 44 AM" src="https://github.com/gallery-so/gallery/assets/49758803/d015f093-8ee8-4b30-acc0-64f46d6cd2c1"> | 

## Other improvement
textarea grows with text size
| Before                                     | After                                      | 
| ------------------------------------------ | ------------------------------------------ |  
| <img width="713" alt="Screenshot 2023-10-15 at 9 07 39 AM" src="https://github.com/gallery-so/gallery/assets/49758803/9ef5dfd3-19cb-4878-9635-cb761f6fcadd"> | <img width="664" alt="Screenshot 2023-10-15 at 9 01 44 AM" src="https://github.com/gallery-so/gallery/assets/49758803/0062d14b-dca6-4b22-b484-24a060f77b87"> |



### Edge Cases
Tested different media type nfts

### Testing Steps
Can test locally on branch

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
