### PR TITLE
GAL-4169 rename Activity tab to Posts

### DIFF
--- a/apps/mobile/src/components/ProfileView/ProfileView.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileView.tsx
@@ -83,10 +83,8 @@ export function ProfileView({ queryRef, shouldShowBackButton }: ProfileViewProps
         <View className="flex flex-row items-center justify-between pt-4">
           <View className="flex flex-row">
             <ConnectedProfilePicture queryRef={query} />
-
             <ProfileViewUsername queryRef={query} />
           </View>
-
           <EditProfileButton queryRef={query} />
         </View>
       </View>
@@ -96,17 +94,14 @@ export function ProfileView({ queryRef, shouldShowBackButton }: ProfileViewProps
           <Tabs.Tab name="Featured">
             <ProfileViewFeaturedTab queryRef={query} />
           </Tabs.Tab>
-
           <Tabs.Tab name="Galleries">
             <ProfileViewGalleriesTab queryRef={query} />
           </Tabs.Tab>
-
+          <Tabs.Tab name="Posts">
+            <ProfileViewActivityTab queryRef={query} />
+          </Tabs.Tab>
           <Tabs.Tab name="Followers">
             <ProfileViewFollowersTab queryRef={query} />
-          </Tabs.Tab>
-
-          <Tabs.Tab name="Activity">
-            <ProfileViewActivityTab queryRef={query} />
           </Tabs.Tab>
         </GalleryTabsContainer>
       </View>

--- a/apps/mobile/src/components/ProfileView/ProfileViewHeader.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewHeader.tsx
@@ -90,11 +90,11 @@ export function ProfileViewHeader({ queryRef, selectedRoute, onRouteChange }: Pr
         counter: totalGalleries,
       },
       {
-        name: 'Followers',
-        counter: totalFollowers,
+        name: 'Posts',
       },
       {
-        name: 'Activity',
+        name: 'Followers',
+        counter: totalFollowers,
       },
     ];
   }, [totalGalleries, totalFollowers]);

--- a/apps/web/pages/[username]/posts.tsx
+++ b/apps/web/pages/[username]/posts.tsx
@@ -6,7 +6,7 @@ import { ITEMS_PER_PAGE, MAX_PIECES_DISPLAYED_PER_FEED_EVENT } from '~/component
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/CommentsModal/CommentsModal';
 import { GalleryNavbar } from '~/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavbar';
 import { StandardSidebar } from '~/contexts/globalLayout/GlobalSidebar/StandardSidebar';
-import { activityQuery } from '~/generated/activityQuery.graphql';
+import { postsQuery } from '~/generated/postsQuery.graphql';
 import { MetaTagProps } from '~/pages/_app';
 import GalleryRoute from '~/scenes/_Router/GalleryRoute';
 import UserActivityPage from '~/scenes/UserActivityPage/UserActivityPage';
@@ -16,8 +16,8 @@ import GalleryViewEmitter from '~/shared/components/GalleryViewEmitter';
 import { PreloadQueryArgs } from '~/types/PageComponentPreloadQuery';
 import { openGraphMetaTags } from '~/utils/openGraphMetaTags';
 
-const activityQueryNode = graphql`
-  query activityQuery(
+const postsQueryNode = graphql`
+  query postsQuery(
     $username: String!
     $interactionsFirst: Int!
     $interactionsAfter: String
@@ -41,11 +41,11 @@ const NON_EXISTENT_FEED_EVENT_ID = 'some-non-existent-feed-event-id';
 
 type UserActivityProps = MetaTagProps & {
   username: string;
-  preloadedQuery: PreloadedQuery<activityQuery>;
+  preloadedQuery: PreloadedQuery<postsQuery>;
 };
 
 export default function UserFeed({ username, preloadedQuery }: UserActivityProps) {
-  const query = usePreloadedQuery<activityQuery>(activityQueryNode, preloadedQuery);
+  const query = usePreloadedQuery<postsQuery>(postsQueryNode, preloadedQuery);
 
   return (
     <GalleryRoute
@@ -63,9 +63,9 @@ export default function UserFeed({ username, preloadedQuery }: UserActivityProps
 
 UserFeed.preloadQuery = ({ relayEnvironment, query }: PreloadQueryArgs) => {
   if (query.username && typeof query.username === 'string' && !Array.isArray(query.eventId)) {
-    return loadQuery<activityQuery>(
+    return loadQuery<postsQuery>(
       relayEnvironment,
-      activityQueryNode,
+      postsQueryNode,
       {
         topEventId: query.eventId ?? NON_EXISTENT_FEED_EVENT_ID,
         username: query.username,

--- a/apps/web/src/components/Notifications/Notification.tsx
+++ b/apps/web/src/components/Notifications/Notification.tsx
@@ -142,7 +142,7 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
         showCaret: false,
         handleClick: function navigateToUserActivityWithFeedEventAtTop() {
           if (username && eventId) {
-            push({ pathname: '/[username]/activity', query: { username, eventId } });
+            push({ pathname: '/[username]/posts', query: { username, eventId } });
           }
           hideDrawer();
         },

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavLinks.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavLinks.tsx
@@ -44,7 +44,7 @@ export function GalleryNavLinks({ username, queryRef }: Props) {
   const featuredRoute: Route = { pathname: '/[username]', query: { username } };
   const galleriesRoute: Route = { pathname: '/[username]/galleries', query: { username } };
   const followersRoute: Route = { pathname: '/[username]/followers', query: { username } };
-  const activityRoute: Route = { pathname: '/[username]/activity', query: { username } };
+  const postsRoute: Route = { pathname: '/[username]/posts', query: { username } };
 
   return (
     <HStack gap={8}>
@@ -71,10 +71,10 @@ export function GalleryNavLinks({ username, queryRef }: Props) {
 
       <NavbarLink
         // @ts-expect-error We're not using the legacy Link
-        href={route(activityRoute)}
-        active={pathname === activityRoute.pathname}
+        href={route(postsRoute)}
+        active={pathname === postsRoute.pathname}
       >
-        Activity
+        Posts
       </NavbarLink>
 
       <NavbarLink

--- a/apps/web/src/scenes/UserActivityPage/UserActivityFeed.tsx
+++ b/apps/web/src/scenes/UserActivityPage/UserActivityFeed.tsx
@@ -89,7 +89,7 @@ function UserActivityFeed({ userRef, queryRef }: Props) {
     return (
       <EmptyState
         title={"It's quiet in here"}
-        description="This user doesn't seem to have any activity yet."
+        description="This user doesn't seem to have any posts yet."
       />
     );
   }


### PR DESCRIPTION
### Summary of Changes
Rename the Activity tab on user profiles to Posts, on web and mobile

### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="347" alt="CleanShot 2023-10-02 at 19 37 20@2x" src="https://github.com/gallery-so/gallery/assets/80802871/31678295-e43c-42aa-9f6a-d1e6801911c7"> | <img width="436" alt="CleanShot 2023-10-02 at 19 24 56@2x" src="https://github.com/gallery-so/gallery/assets/80802871/386d35da-5860-4c7d-8a48-66c5ae7ef3b9">|
|<img width="360" alt="CleanShot 2023-10-02 at 19 38 16@2x" src="https://github.com/gallery-so/gallery/assets/80802871/eaf1e3ce-0cba-41a1-b980-7127c0bdb8fb">|<img width="374" alt="CleanShot 2023-10-02 at 19 25 14@2x" src="https://github.com/gallery-so/gallery/assets/80802871/f878fcd8-659e-42b2-9f7c-016886f6cd75">|

### Edge Cases
Deep link of [username]/posts -> mobile app. I found this doesn't work on main, so [made a ticket to address separately](https://linear.app/galleryso/issue/GAL-4410/deep-link-fails-for-user-profile-sub-routes-galleries-posts-followers)


### Testing Steps
Open a user profile on web and mobile and confirm the tab now says Posts

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
