### PR TITLE
GAL-4161 refactor how comments are rendered to solve wrapping

### DIFF
--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
@@ -1,19 +1,19 @@
 import { useNavigation } from '@react-navigation/native';
 import { useCallback, useRef, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import { WarningLinkBottomSheet } from '~/components/Feed/Posts/WarningLinkBottomSheet';
 import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
-import { Markdown } from '~/components/Markdown';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { Typography } from '~/components/Typography';
 import { CommentsBottomSheetLineFragment$key } from '~/generated/CommentsBottomSheetLineFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { replaceUrlsWithMarkdownFormat } from '~/shared/utils/replaceUrlsWithMarkdownFormat';
 import { getTimeSince } from '~/shared/utils/time';
+
+import ProcessedCommentText from '../Socialize/ProcessedCommentText';
 
 type CommentLineProps = {
   commentRef: CommentsBottomSheetLineFragment$key;
@@ -39,22 +39,16 @@ export function CommentsBottomSheetLine({ commentRef }: CommentLineProps) {
   const timeAgo = getTimeSince(comment.creationTime);
   const navigation = useNavigation<MainTabStackNavigatorProp>();
 
-  const [redirectUrl, setRedirectUrl] = useState('');
-  const captionWithMarkdownLinks = replaceUrlsWithMarkdownFormat(comment.comment ?? '');
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const handleLinkPress = useCallback((url: string) => {
-    bottomSheetRef.current?.present();
-    setRedirectUrl(url);
-  }, []);
-
   const handleUserPress = useCallback(() => {
     const username = comment?.commenter?.username;
     if (username) {
       navigation.push('Profile', { username: username, hideBackButton: false });
     }
   }, [comment?.commenter?.username, navigation]);
+
+  if (!comment.comment) {
+    return null;
+  }
 
   return (
     <GalleryTouchableOpacity
@@ -80,18 +74,10 @@ export function CommentsBottomSheetLine({ commentRef }: CommentLineProps) {
             {timeAgo}
           </Typography>
         </View>
-        <View className="flex">
-          <Markdown onBypassLinkPress={handleLinkPress} style={markdownStyles}>
-            {captionWithMarkdownLinks}
-          </Markdown>
-          <WarningLinkBottomSheet redirectUrl={redirectUrl} ref={bottomSheetRef} />
-        </View>
+        {/* <View className="flex"> */}
+        <ProcessedCommentText comment={comment.comment} />
+        {/* </View> */}
       </View>
     </GalleryTouchableOpacity>
   );
 }
-const markdownStyles = StyleSheet.create({
-  body: {
-    fontSize: 14,
-  },
-});

--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
@@ -1,16 +1,14 @@
 import { useNavigation } from '@react-navigation/native';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback } from 'react';
 import { View } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { Typography } from '~/components/Typography';
 import { CommentsBottomSheetLineFragment$key } from '~/generated/CommentsBottomSheetLineFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
-import { replaceUrlsWithMarkdownFormat } from '~/shared/utils/replaceUrlsWithMarkdownFormat';
 import { getTimeSince } from '~/shared/utils/time';
 
 import ProcessedCommentText from '../Socialize/ProcessedCommentText';
@@ -74,9 +72,7 @@ export function CommentsBottomSheetLine({ commentRef }: CommentLineProps) {
             {timeAgo}
           </Typography>
         </View>
-        {/* <View className="flex"> */}
         <ProcessedCommentText comment={comment.comment} />
-        {/* </View> */}
       </View>
     </GalleryTouchableOpacity>
   );

--- a/apps/mobile/src/components/Feed/Posts/FeedPostSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Posts/FeedPostSocializeSection.tsx
@@ -4,15 +4,14 @@ import { graphql, useFragment } from 'react-relay';
 import { useTogglePostAdmire } from 'src/hooks/useTogglePostAdmire';
 
 import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
-import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
-import { Typography } from '~/components/Typography';
 import { FeedPostSocializeSectionFragment$key } from '~/generated/FeedPostSocializeSectionFragment.graphql';
 import { FeedPostSocializeSectionQueryFragment$key } from '~/generated/FeedPostSocializeSectionQueryFragment.graphql';
 
 import { CommentsBottomSheet } from '../CommentsBottomSheet/CommentsBottomSheet';
 import { AdmireButton } from '../Socialize/AdmireButton';
+import { Admires } from '../Socialize/Admires';
 import { CommentButton } from '../Socialize/CommentButton';
-import { Interactions } from '../Socialize/Interactions';
+import Comments from '../Socialize/Comments';
 
 type Props = {
   feedPostRef: FeedPostSocializeSectionFragment$key;
@@ -35,7 +34,7 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef }: Props) {
           edges {
             node {
               dbid
-              ...InteractionsAdmiresFragment
+              ...AdmiresFragment
             }
           }
         }
@@ -48,7 +47,7 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef }: Props) {
           }
           edges {
             node {
-              ...InteractionsCommentsFragment
+              ...CommentsFragment
             }
           }
         }
@@ -86,7 +85,6 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef }: Props) {
   }, [post.comments?.edges]);
 
   const totalComments = post.comments?.pageInfo?.total ?? 0;
-  const isEmptyComments = totalComments === 0;
 
   const nonNullAdmires = useMemo(() => {
     const admires = [];
@@ -114,12 +112,10 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef }: Props) {
       <View className="px-3 pb-8 pt-2">
         <View className="flex flex-row justify-between">
           <View className="flex-1 pr-4 pt-1">
-            <Interactions
+            <Admires
               type="Post"
               feedId={post.dbid}
-              commentRefs={nonNullComments}
               admireRefs={nonNullAdmires}
-              totalComments={totalComments}
               totalAdmires={totalAdmires}
               onAdmirePress={toggleAdmire}
               openCommentBottomSheet={handleOpenCommentBottomSheet}
@@ -131,20 +127,11 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef }: Props) {
             <CommentButton openCommentBottomSheet={handleOpenCommentBottomSheet} />
           </View>
         </View>
-        {isEmptyComments && (
-          <GalleryTouchableOpacity
-            onPress={handleOpenCommentBottomSheet}
-            eventElementId={null}
-            eventName={null}
-          >
-            <Typography
-              font={{ family: 'ABCDiatype', weight: 'Regular' }}
-              className="text-sm text-shadow"
-            >
-              Add a comment
-            </Typography>
-          </GalleryTouchableOpacity>
-        )}
+        <Comments
+          commentRefs={nonNullComments}
+          totalComments={totalComments}
+          onCommentPress={handleOpenCommentBottomSheet}
+        />
       </View>
       <CommentsBottomSheet type="Post" feedId={post.dbid} bottomSheetRef={commentsBottomSheetRef} />
     </>

--- a/apps/mobile/src/components/Feed/Socialize/AdmireButton.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/AdmireButton.tsx
@@ -15,7 +15,7 @@ export function AdmireButton({ isAdmired, onPress, style }: Props) {
   return (
     <GalleryTouchableOpacity
       onPress={onPress}
-      className="flex justify-center align-center w-8 h-8 pt-0.5"
+      className="flex w-8 h-8 pt-0.5"
       style={style}
       eventElementId="Admire Button"
       eventName="Admire Button Clicked"

--- a/apps/mobile/src/components/Feed/Socialize/Admires.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/Admires.tsx
@@ -6,51 +6,23 @@ import { AdmireBottomSheet } from '~/components/Feed/AdmireBottomSheet/AdmireBot
 import { AdmireLine } from '~/components/Feed/Socialize/AdmireLine';
 import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { ProfilePictureBubblesWithCount } from '~/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers';
-import { InteractionsAdmiresFragment$key } from '~/generated/InteractionsAdmiresFragment.graphql';
-import { InteractionsCommentsFragment$key } from '~/generated/InteractionsCommentsFragment.graphql';
+import { AdmiresFragment$key } from '~/generated/AdmiresFragment.graphql';
 
 import { FeedItemTypes } from '../createVirtualizedFeedEventItems';
-import { CommentLine } from './CommentLine';
-import { RemainingCommentCount } from './RemainingCommentCount';
-
-const PREVIEW_COMMENT_COUNT = 1;
 
 type Props = {
   type: FeedItemTypes;
   feedId: string;
-  admireRefs: InteractionsAdmiresFragment$key;
-  commentRefs: InteractionsCommentsFragment$key;
+  admireRefs: AdmiresFragment$key;
   totalAdmires: number;
-  totalComments: number;
-
   onAdmirePress: () => void;
   openCommentBottomSheet: () => void;
 };
 
-export function Interactions({
-  type,
-  feedId,
-  admireRefs,
-  commentRefs,
-  totalAdmires,
-  totalComments,
-  onAdmirePress,
-  openCommentBottomSheet,
-}: Props) {
-  const comments = useFragment(
-    graphql`
-      fragment InteractionsCommentsFragment on Comment @relay(plural: true) {
-        dbid
-        ...CommentLineFragment
-      }
-    `,
-    commentRefs
-  );
-
+export function Admires({ type, feedId, admireRefs, totalAdmires, onAdmirePress }: Props) {
   const admires = useFragment(
     graphql`
-      fragment InteractionsAdmiresFragment on Admire @relay(plural: true) {
-        dbid
+      fragment AdmiresFragment on Admire @relay(plural: true) {
         admirer {
           ...AdmireLineFragment
           ...ProfileViewSharedFollowersBubblesFragment
@@ -74,8 +46,6 @@ export function Interactions({
     return users;
   }, [admires]);
 
-  const previewComments = comments.slice(-PREVIEW_COMMENT_COUNT);
-
   const admiresBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
   return (
@@ -97,22 +67,6 @@ export function Interactions({
           totalAdmires={totalAdmires}
           onAdmirePress={onAdmirePress}
         />
-      </View>
-
-      <View className="flex flex-col space-y-1">
-        {previewComments.map((comment) => {
-          return (
-            <CommentLine
-              key={comment.dbid}
-              commentRef={comment}
-              onCommentPress={openCommentBottomSheet}
-            />
-          );
-        })}
-
-        {totalComments > 1 && (
-          <RemainingCommentCount totalCount={totalComments} onPress={openCommentBottomSheet} />
-        )}
       </View>
 
       <AdmireBottomSheet type={type} feedId={feedId} bottomSheetRef={admiresBottomSheetRef} />

--- a/apps/mobile/src/components/Feed/Socialize/CommentButton.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentButton.tsx
@@ -13,7 +13,7 @@ export function CommentButton({ style, openCommentBottomSheet }: Props) {
   return (
     <GalleryTouchableOpacity
       onPress={openCommentBottomSheet}
-      className="flex justify-center items-center w-[32] h-[32] pt-1 "
+      className="flex justify-center items-center w-[32] h-[30] pt-1"
       style={style}
       eventElementId="Toggle Comment Box"
       eventName="Toggle Comment Box Clicked"

--- a/apps/mobile/src/components/Feed/Socialize/CommentLine.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentLine.tsx
@@ -1,14 +1,11 @@
-import { useCallback, useRef, useState } from 'react';
-import { StyleSheet, View, ViewProps } from 'react-native';
+import { Text, View, ViewProps } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
-import { WarningLinkBottomSheet } from '~/components/Feed/Posts/WarningLinkBottomSheet';
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
-import { Markdown } from '~/components/Markdown';
 import { UsernameDisplay } from '~/components/UsernameDisplay';
 import { CommentLineFragment$key } from '~/generated/CommentLineFragment.graphql';
-import { replaceUrlsWithMarkdownFormat } from '~/shared/utils/replaceUrlsWithMarkdownFormat';
+
+import ProcessedCommentText from './ProcessedCommentText';
 
 type Props = {
   commentRef: CommentLineFragment$key;
@@ -28,38 +25,25 @@ export function CommentLine({ commentRef, style, onCommentPress }: Props) {
     `,
     commentRef
   );
-  const [redirectUrl, setRedirectUrl] = useState('');
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-  const captionWithMarkdownLinks = replaceUrlsWithMarkdownFormat(comment.comment ?? '');
-
-  const handleLinkPress = useCallback((url: string) => {
-    bottomSheetRef.current?.present();
-    setRedirectUrl(url);
-  }, []);
 
   return (
     <View className="flex flex-row space-x-1" style={style}>
-      <UsernameDisplay userRef={comment.commenter} size="sm" />
       <GalleryTouchableOpacity
         onPress={onCommentPress}
         eventElementId={null}
         eventName={null}
         className="flex flex-row wrap"
       >
-        <Markdown onBypassLinkPress={handleLinkPress} style={markdownStyles}>
-          {captionWithMarkdownLinks}
-        </Markdown>
-        <WarningLinkBottomSheet redirectUrl={redirectUrl} ref={bottomSheetRef} />
+        <Text numberOfLines={2}>
+          <UsernameDisplay
+            userRef={comment.commenter}
+            size="sm"
+            // className="border border-black mr-1"
+            style={{ marginRight: 4 }}
+          />{' '}
+          <ProcessedCommentText comment={comment.comment} />
+        </Text>
       </GalleryTouchableOpacity>
     </View>
   );
 }
-
-const markdownStyles = StyleSheet.create({
-  body: {
-    fontSize: 14,
-  },
-  paragraph: {
-    marginBottom: 0,
-  },
-});

--- a/apps/mobile/src/components/Feed/Socialize/CommentLine.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/CommentLine.tsx
@@ -35,12 +35,7 @@ export function CommentLine({ commentRef, style, onCommentPress }: Props) {
         className="flex flex-row wrap"
       >
         <Text numberOfLines={2}>
-          <UsernameDisplay
-            userRef={comment.commenter}
-            size="sm"
-            // className="border border-black mr-1"
-            style={{ marginRight: 4 }}
-          />{' '}
+          <UsernameDisplay userRef={comment.commenter} size="sm" style={{ marginRight: 4 }} />{' '}
           <ProcessedCommentText comment={comment.comment} />
         </Text>
       </GalleryTouchableOpacity>

--- a/apps/mobile/src/components/Feed/Socialize/Comments.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/Comments.tsx
@@ -7,6 +7,7 @@ import { CommentsFragment$key } from '~/generated/CommentsFragment.graphql';
 
 import { CommentLine } from './CommentLine';
 import { RemainingCommentCount } from './RemainingCommentCount';
+import { useMemo } from 'react';
 
 type Props = {
   commentRefs: CommentsFragment$key;
@@ -25,7 +26,7 @@ export default function Comments({ commentRefs, totalComments, onCommentPress }:
     commentRefs
   );
 
-  const previewComments = comments.slice(-1);
+  const previewComments = useMemo(() => comments.slice(-1), [comments]);
 
   return (
     <View className="flex flex-col space-y-1">

--- a/apps/mobile/src/components/Feed/Socialize/Comments.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/Comments.tsx
@@ -1,0 +1,53 @@
+import { View } from 'react-native';
+import { graphql, useFragment } from 'react-relay';
+
+import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
+import { Typography } from '~/components/Typography';
+import { CommentsFragment$key } from '~/generated/CommentsFragment.graphql';
+
+import { CommentLine } from './CommentLine';
+import { RemainingCommentCount } from './RemainingCommentCount';
+
+type Props = {
+  commentRefs: CommentsFragment$key;
+  totalComments: number;
+  onCommentPress: () => void;
+};
+
+export default function Comments({ commentRefs, totalComments, onCommentPress }: Props) {
+  const comments = useFragment(
+    graphql`
+      fragment CommentsFragment on Comment @relay(plural: true) {
+        dbid
+        ...CommentLineFragment
+      }
+    `,
+    commentRefs
+  );
+
+  const previewComments = comments.slice(-1);
+
+  return (
+    <View className="flex flex-col space-y-1">
+      {previewComments.map((comment) => {
+        return (
+          <CommentLine key={comment.dbid} commentRef={comment} onCommentPress={onCommentPress} />
+        );
+      })}
+
+      {totalComments > 1 && (
+        <RemainingCommentCount totalCount={totalComments} onPress={onCommentPress} />
+      )}
+      {totalComments === 0 && (
+        <GalleryTouchableOpacity onPress={onCommentPress} eventElementId={null} eventName={null}>
+          <Typography
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
+            className="text-sm text-shadow"
+          >
+            Add a comment
+          </Typography>
+        </GalleryTouchableOpacity>
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -4,15 +4,14 @@ import { graphql, useFragment } from 'react-relay';
 import { useToggleAdmire } from 'src/hooks/useToggleAdmire';
 
 import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
-import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
-import { Typography } from '~/components/Typography';
 import { FeedEventSocializeSectionFragment$key } from '~/generated/FeedEventSocializeSectionFragment.graphql';
 import { FeedEventSocializeSectionQueryFragment$key } from '~/generated/FeedEventSocializeSectionQueryFragment.graphql';
 
 import { CommentsBottomSheet } from '../CommentsBottomSheet/CommentsBottomSheet';
 import { AdmireButton } from './AdmireButton';
+import { Admires } from './Admires';
 import { CommentButton } from './CommentButton';
-import { Interactions } from './Interactions';
+import Comments from './Comments';
 
 type Props = {
   feedEventRef: FeedEventSocializeSectionFragment$key;
@@ -40,7 +39,7 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
           edges {
             node {
               dbid
-              ...InteractionsAdmiresFragment
+              ...AdmiresFragment
             }
           }
         }
@@ -53,7 +52,7 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
           }
           edges {
             node {
-              ...InteractionsCommentsFragment
+              ...CommentsFragment
             }
           }
         }
@@ -91,7 +90,6 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
   }, [event.comments?.edges]);
 
   const totalComments = event.comments?.pageInfo?.total ?? 0;
-  const isEmptyComments = totalComments === 0;
 
   const nonNullAdmires = useMemo(() => {
     const admires = [];
@@ -124,12 +122,10 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
       <View className="px-3 pb-8 pt-5">
         <View className="flex flex-row justify-between">
           <View className="flex-1 pr-4 pt-1">
-            <Interactions
+            <Admires
               type="FeedEvent"
               feedId={event.dbid}
-              commentRefs={nonNullComments}
               admireRefs={nonNullAdmires}
-              totalComments={totalComments}
               totalAdmires={totalAdmires}
               onAdmirePress={toggleAdmire}
               openCommentBottomSheet={handleOpenCommentBottomSheet}
@@ -141,20 +137,11 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
             <CommentButton openCommentBottomSheet={handleOpenCommentBottomSheet} />
           </View>
         </View>
-        {isEmptyComments && (
-          <GalleryTouchableOpacity
-            onPress={handleOpenCommentBottomSheet}
-            eventElementId={null}
-            eventName={null}
-          >
-            <Typography
-              font={{ family: 'ABCDiatype', weight: 'Regular' }}
-              className="text-sm text-shadow"
-            >
-              Add a comment
-            </Typography>
-          </GalleryTouchableOpacity>
-        )}
+        <Comments
+          commentRefs={nonNullComments}
+          totalComments={totalComments}
+          onCommentPress={handleOpenCommentBottomSheet}
+        />
       </View>
       <CommentsBottomSheet
         type="FeedEvent"

--- a/apps/mobile/src/components/Feed/Socialize/ProcessedCommentText.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/ProcessedCommentText.tsx
@@ -50,14 +50,12 @@ export default function ProcessedCommentText({ comment }: CommentProps) {
   }, [comment]);
 
   return (
-    <>
-      <Typography
-        className="text-sm"
-        font={{ family: 'ABCDiatype', weight: 'Regular' }}
-        style={{ fontSize: 14, lineHeight: 18, paddingVertical: 2 }}
-      >
-        {processedText}
-      </Typography>
-    </>
+    <Typography
+      className="text-sm"
+      font={{ family: 'ABCDiatype', weight: 'Regular' }}
+      style={{ fontSize: 14, lineHeight: 18, paddingVertical: 2 }}
+    >
+      {processedText}
+    </Typography>
   );
 }

--- a/apps/mobile/src/components/Feed/Socialize/ProcessedCommentText.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/ProcessedCommentText.tsx
@@ -1,0 +1,63 @@
+import { ReactNode, useCallback, useMemo, useRef } from 'react';
+import { Text } from 'react-native';
+
+import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
+import { Typography } from '~/components/Typography';
+import { VALID_URL } from '~/shared/utils/regex';
+
+import { WarningLinkBottomSheet } from '../Posts/WarningLinkBottomSheet';
+
+type LinkProps = {
+  url: string;
+};
+
+const LinkComponent = ({ url }: LinkProps) => {
+  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const handleLinkPress = useCallback(() => {
+    bottomSheetRef.current?.present();
+  }, []);
+
+  return (
+    <>
+      <Text className="text-shadow" onPress={handleLinkPress}>
+        {url}
+      </Text>
+      <WarningLinkBottomSheet redirectUrl={url} ref={bottomSheetRef} />
+    </>
+  );
+};
+
+type CommentProps = {
+  comment: string;
+};
+
+// Makes a raw comment value display-ready by converting urls to link components
+export default function ProcessedCommentText({ comment }: CommentProps) {
+  const processedText = useMemo(() => {
+    const chunks = comment.split(VALID_URL);
+    const urls = comment.match(VALID_URL);
+
+    const result: ReactNode[] = [];
+
+    chunks.forEach((chunk, index) => {
+      result.push(<Text key={`text-${index}`}>{chunk}</Text>);
+      if (urls && urls[index]) {
+        result.push(<LinkComponent key={`link-${index}`} url={urls[index] ?? ''} />);
+      }
+    });
+
+    return result;
+  }, [comment]);
+
+  return (
+    <>
+      <Typography
+        className="text-sm"
+        font={{ family: 'ABCDiatype', weight: 'Regular' }}
+        style={{ fontSize: 14, lineHeight: 18, paddingVertical: 2 }}
+      >
+        {processedText}
+      </Typography>
+    </>
+  );
+}

--- a/apps/mobile/src/components/UsernameDisplay.tsx
+++ b/apps/mobile/src/components/UsernameDisplay.tsx
@@ -12,10 +12,9 @@ type Props = {
   userRef: UsernameDisplayFragment$key;
   style?: GalleryTouchableOpacityProps['style'];
   size?: 'xs' | 'sm';
-  text?: string;
 };
 
-export function UsernameDisplay({ userRef, style, size = 'xs', text }: Props) {
+export function UsernameDisplay({ userRef, style, size = 'xs' }: Props) {
   const user = useFragment(
     graphql`
       fragment UsernameDisplayFragment on GalleryUser {
@@ -42,7 +41,7 @@ export function UsernameDisplay({ userRef, style, size = 'xs', text }: Props) {
       eventName="Username Interaction Clicked"
     >
       <Typography className={`text-${size}`} font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-        {text ? text : user.username}
+        {user.username}
       </Typography>
     </GalleryTouchableOpacity>
   );


### PR DESCRIPTION
### Summary of Changes

This PR refactors how comments are rendered. Previously we used the Markdown to display the comment with links.

Problem:
For comments specifically, (vs other text like the Post caption), we don’t need to support markdown. Instead we only need to support links and mentions. The Markdown component introduce unnecessary complexity and rigidity because it handles a lot of other cases that we don't need to for displaying comments. Specifically, the Markdown component prevented us from being able to wrap the comment under the username in the preview.

Solution
This PR adds a new `ProcessedCommentText` that we'll now use instead of `Markdown` to render comments. This component will parse the raw comment for any urls and display them as tappable links. In the future, this can be updated to also detect Mentions.

I also changed the layout of the "Socialize" section where we display admires and comments, so that the comment line has space to take the full screen width. 


### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
|<img width="399" alt="CleanShot 2023-10-04 at 18 34 44@2x" src="https://github.com/gallery-so/gallery/assets/80802871/6dced5e7-ef0a-4b14-a73a-d70ad6523b72">|<img width="395" alt="CleanShot 2023-10-05 at 13 25 07@2x" src="https://github.com/gallery-so/gallery/assets/80802871/8c7f477b-5a8e-4bf9-bf0e-c9ae81837e27">|


### Edge Cases
- short comments, long comments that wrap
- should look good on both the Comment Preview on the feed, as well as comment list in bottom sheet


### Testing Steps
Enter a long comment that wraps 

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
