### PR TITLE
[GAl-4435] NFT Detail Page share link on mobile is wrong url

### DIFF
--- a/apps/mobile/src/utils/shareToken.ts
+++ b/apps/mobile/src/utils/shareToken.ts
@@ -52,7 +52,7 @@ export async function shareUniversalToken(tokenRef: shareTokenUniversalFragment$
   );
 
   if (token.owner?.username) {
-    const url = `https://gallery.so/token/${token.dbid}`;
+    const url = `https://gallery.so/${token.owner.username}/token/${token.dbid}`;
 
     Share.share({ url });
   }


### PR DESCRIPTION
### Summary of Changes
updates the share URL to use token owner's username

### Demo or Before/After Pics

| After                                     | After  2                                    |After   3                                   |
| ------------------------------------------ | ------------------------------------------ | ------------------------------------------ |
| <img width="439" alt="Screenshot 2023-10-04 at 8 12 41 PM" src="https://github.com/gallery-so/gallery/assets/49758803/75c4e284-8c81-40ee-8ff8-9606f144449f"> | <img width="449" alt="Screenshot 2023-10-04 at 8 12 48 PM" src="https://github.com/gallery-so/gallery/assets/49758803/57a2f610-ac28-4d7e-afad-c6f5b850ce50"> | <img width="450" alt="Screenshot 2023-10-04 at 8 13 02 PM" src="https://github.com/gallery-so/gallery/assets/49758803/1f5b6855-c32d-44bd-b0ba-f82d217ddea6"> |



### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
