### PR TITLE
[GAl-4437] Address spacing in NFT detail view on mobile

### DIFF
--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -158,7 +158,7 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
 
   return (
     <ScrollView>
-      <View className="flex flex-col space-y-6 px-4 pb-4">
+      <View className="flex flex-col space-y-3 px-4 pb-4">
         <View className="flex flex-col space-y-3">
           <View className="flex flex-row justify-between">
             <TokenViewEmitter
@@ -185,7 +185,7 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
           </View>
         </View>
 
-        <View className="flex flex-col space-y-4">
+        <View className="flex flex-col space-y-2 pt-3">
           <Typography
             className="text-2xl"
             font={{ family: 'GTAlpina', weight: 'StandardLight', italic: true }}

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -217,7 +217,7 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
 
         <View className="flex-row">
           {token.owner && (
-            <View className="w-1/2">
+            <View className="w-1/2 gap-y-1">
               <Typography
                 className="text-xs text-shadow dark:text-metal"
                 font={{ family: 'ABCDiatype', weight: 'Medium' }}

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -174,7 +174,7 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
             />
           </View>
 
-          <View className="w-full mb-2">
+          <View className="w-full mb-3">
             <TokenFailureBoundary tokenRef={token} variant="large">
               <NftDetailAssetCacheSwapper
                 cachedPreviewAssetUrl={route.params.cachedPreviewAssetUrl}

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -174,7 +174,7 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
             />
           </View>
 
-          <View className="w-full">
+          <View className="w-full mb-2">
             <TokenFailureBoundary tokenRef={token} variant="large">
               <NftDetailAssetCacheSwapper
                 cachedPreviewAssetUrl={route.params.cachedPreviewAssetUrl}
@@ -185,7 +185,7 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
           </View>
         </View>
 
-        <View className="flex flex-col space-y-2 pt-3">
+        <View className="flex flex-col space-y-2">
           <Typography
             className="text-2xl"
             font={{ family: 'GTAlpina', weight: 'StandardLight', italic: true }}


### PR DESCRIPTION
### Summary of Changes
Match nft detail page styling from [design here](https://www.figma.com/file/joBcmzJpAoCuQK0Tz093YI/Global-Product-Design-%5BWIP%5D?type=design&node-id=1-3&mode=design&t=JCJWSmSNJfsvBFzN-0)

### Demo or Before/After Pics

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="447" alt="Screenshot 2023-10-10 at 4 26 47 AM" src="https://github.com/gallery-so/gallery/assets/49758803/bf4289f9-bd11-410b-aca1-68a7bc7eb307"> | <img width="450" alt="Screenshot 2023-10-10 at 4 28 46 AM" src="https://github.com/gallery-so/gallery/assets/49758803/42451efb-d287-4b82-83f6-7f32fcf02dbe"> |


### After 2
<img width="300" alt="Screenshot 2023-10-10 at 4 25 11 AM" src="https://github.com/gallery-so/gallery/assets/49758803/b9e20723-24a0-48d9-98ad-d896f17c7fc8">

### Edge Cases
List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
