### PR TITLE
add Posts feature page and required cms components

### DIFF
--- a/apps/web/pages/features/posts.tsx
+++ b/apps/web/pages/features/posts.tsx
@@ -1,0 +1,57 @@
+import GalleryRoute from '~/scenes/_Router/GalleryRoute';
+import { CmsTypes } from '~/scenes/ContentPages/cms_types';
+import PostsFeaturePage from '~/scenes/ContentPages/PostsFeaturePage';
+import { fetchSanityContent } from '~/utils/sanity';
+
+type Props = {
+  pageContent: CmsTypes.FeaturePage;
+};
+
+export default function PostsFeatureRoute({ pageContent }: Props) {
+  return <GalleryRoute element={<PostsFeaturePage pageContent={pageContent} />} navbar={false} />;
+}
+
+export const getServerSideProps = async () => {
+  const query = `
+  *[ _type == "featurePage" && id == "posts" ]{
+    ...,
+    "featureHighlights": featureHighlights[]->{
+      heading,
+      orientation,
+      body,
+      externalLink,
+      media{
+        mediaType,
+        image{
+          asset->{
+            url
+          },
+          alt
+        },
+        video{
+          asset->{
+            url
+          }
+        }
+      }
+    },
+    "faqModule": faqModule->{
+      title,
+      faqs
+    },
+    "splashImage": {
+      "asset": splashImage.asset->{
+        url
+      },
+      alt
+    }
+  } | order(date desc)
+`;
+  const content = await fetchSanityContent(query);
+
+  return {
+    props: {
+      pageContent: content[0],
+    },
+  };
+};

--- a/apps/web/src/scenes/ContentPages/ContentModules/Faq.tsx
+++ b/apps/web/src/scenes/ContentPages/ContentModules/Faq.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from 'react';
+import { animated, useSpring } from 'react-spring';
+import styled from 'styled-components';
+
+import breakpoints from '~/components/core/breakpoints';
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+import { TitleDiatypeL } from '~/components/core/Text/Text';
+import colors from '~/shared/theme/colors';
+
+import { CmsTypes } from '../cms_types';
+
+type FaqPairProps = {
+  content: CmsTypes.Faq;
+  isOpen: boolean;
+  onClick: () => void;
+};
+
+function FaqPair({ content, isOpen, onClick }: FaqPairProps) {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [contentHeight, setContentHeight] = useState(0);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setContentHeight(contentRef.current.scrollHeight);
+    }
+  }, [content]);
+
+  const toggleExpansion = useSpring({
+    opacity: isOpen ? 1 : 0,
+    height: isOpen ? `${contentHeight}px` : '0px',
+    config: { duration: 200, easing: (t) => t },
+  });
+
+  const rotatePlusIcon = useSpring({
+    transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+    config: { duration: 200, easing: (t) => t },
+  });
+
+  const togglePlusIconOpacity = useSpring({
+    opacity: isOpen ? 0 : 1,
+    config: { duration: 200, easing: (t) => t },
+  });
+
+  return (
+    <StyledFaqPair isOpen={isOpen} onClick={onClick} justify="space-between">
+      <VStack>
+        <div>
+          <StyledQuestionText>{content.question}</StyledQuestionText>
+        </div>
+        <AnimatedAnswerContainer style={toggleExpansion} ref={contentRef}>
+          <StyledAnswerText>{content.answer}</StyledAnswerText>
+        </AnimatedAnswerContainer>
+      </VStack>
+      <Button style={rotatePlusIcon}>
+        <HorizontalLine />
+        <VerticalLine style={togglePlusIconOpacity} />
+      </Button>
+    </StyledFaqPair>
+  );
+}
+
+const AnimatedAnswerContainer = styled(animated.div)`
+  overflow: hidden;
+  box-sizing: border-box;
+`;
+
+const Line = styled(animated.div)`
+  position: absolute;
+  background-color: black;
+  left: 50%;
+  transform: translateX(-50%);
+`;
+
+const HorizontalLine = styled(Line)`
+  width: 100%;
+  height: 1px;
+  top: 50%;
+`;
+
+const VerticalLine = styled(Line)`
+  width: 1px;
+  height: 100%;
+  top: 0;
+`;
+
+const Button = styled(animated.div)`
+  margin-top: 8px;
+  position: relative;
+  width: 12px;
+  min-width: 12px;
+  height: 12px;
+  cursor: pointer;
+`;
+
+const StyledFaqPair = styled(HStack)<{ isOpen: boolean }>`
+  background-color: ${({ isOpen }) => (isOpen ? colors.offWhite : 'none')};
+  cursor: pointer;
+  transition: background-color 0.3s ease-in-out;
+  padding: 8px 16px;
+`;
+
+const StyledQuestionText = styled(TitleDiatypeL)`
+  font-weight: 400;
+
+  @media only screen and ${breakpoints.desktop} {
+    font-size: 20px;
+    line-height: 32px;
+  }
+`;
+
+const StyledAnswerText = styled(TitleDiatypeL)`
+  padding: 8px 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+`;
+
+type Props = {
+  content: CmsTypes.FaqModule;
+};
+
+export default function Faq({ content }: Props) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const handleClick = (index: number) => {
+    setOpenIndex(openIndex === index ? null : index);
+  };
+
+  return (
+    <StyledSection gap={64} justify="center">
+      <StyledContainer gap={16}>
+        <StyledTitle>Frequently asked questions</StyledTitle>
+        <VStack>
+          {content.faqs.map((faq, index) => (
+            <FaqPair
+              key={index}
+              content={faq}
+              isOpen={index === openIndex}
+              onClick={() => handleClick(index)}
+            />
+          ))}
+        </VStack>
+      </StyledContainer>
+    </StyledSection>
+  );
+}
+
+const StyledSection = styled(HStack)`
+  background-color: ${colors.faint};
+  width: 100%;
+  padding: 48px 32px;
+
+  @media only screen and ${breakpoints.desktop} {
+    padding: 72px 0;
+  }
+`;
+
+const StyledContainer = styled(VStack)`
+  @media only screen and ${breakpoints.desktop} {
+    width: 943px;
+    flex-direction: row;
+  }
+`;
+
+const StyledTitle = styled(TitleDiatypeL)`
+  font-weight: 400;
+  font-size: 24px;
+  line-height: 28px;
+
+  @media only screen and ${breakpoints.desktop} {
+    font-size: 36px;
+    line-height: 42px;
+  }
+`;

--- a/apps/web/src/scenes/ContentPages/ContentModules/Faq.tsx
+++ b/apps/web/src/scenes/ContentPages/ContentModules/Faq.tsx
@@ -15,6 +15,7 @@ type FaqPairProps = {
   onClick: () => void;
 };
 
+// A pair of question + answer for the FAQ section
 function FaqPair({ content, isOpen, onClick }: FaqPairProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [contentHeight, setContentHeight] = useState(0);
@@ -119,11 +120,12 @@ type Props = {
   content: CmsTypes.FaqModule;
 };
 
+// The FAQ section which contains a list of FaqPairs.
 export default function Faq({ content }: Props) {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   const handleClick = (index: number) => {
-    setOpenIndex(openIndex === index ? null : index);
+    setOpenIndex(index);
   };
 
   return (

--- a/apps/web/src/scenes/ContentPages/ContentModules/Faq.tsx
+++ b/apps/web/src/scenes/ContentPages/ContentModules/Faq.tsx
@@ -125,7 +125,7 @@ export default function Faq({ content }: Props) {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   const handleClick = (index: number) => {
-    setOpenIndex(index);
+    setOpenIndex(openIndex === index ? null : index);
   };
 
   return (
@@ -151,6 +151,7 @@ const StyledSection = styled(HStack)`
   background-color: ${colors.faint};
   width: 100%;
   padding: 48px 32px;
+  margin-bottom: 96px;
 
   @media only screen and ${breakpoints.desktop} {
     padding: 72px 0;

--- a/apps/web/src/scenes/ContentPages/ContentModules/FeatureHighlight.tsx
+++ b/apps/web/src/scenes/ContentPages/ContentModules/FeatureHighlight.tsx
@@ -13,7 +13,7 @@ type FeatureHighlightBulletsProps = {
 
 function FeatureHighlightBullets({ bullets }: FeatureHighlightBulletsProps) {
   const textList = useMemo(
-    () => bullets.map((bullet) => bullet.children[0] && bullet.children[0].text),
+    () => bullets.map((bullet) => bullet.children[0] && bullet.children[0]?.text),
     [bullets]
   );
   return (

--- a/apps/web/src/scenes/ContentPages/ContentModules/FeatureHighlight.tsx
+++ b/apps/web/src/scenes/ContentPages/ContentModules/FeatureHighlight.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import breakpoints from '~/components/core/breakpoints';
 import { VStack } from '~/components/core/Spacer/Stack';
 import { TitleCondensed, TitleDiatypeL } from '~/components/core/Text/Text';
+import colors from '~/shared/theme/colors';
 
 import { CmsTypes } from '../cms_types';
 
@@ -18,16 +19,20 @@ function FeatureHighlightBullets({ bullets }: FeatureHighlightBulletsProps) {
   );
   return (
     <VStack>
-      <ul>
+      <StyledList>
         {textList.map((text, index) => (
           <li key={index}>
-            <StyldText>{text}</StyldText>
+            <StyledText>{text}</StyledText>
           </li>
         ))}
-      </ul>
+      </StyledList>
     </VStack>
   );
 }
+
+const StyledList = styled.ul`
+  padding-left: 24px;
+`;
 
 type FeatureHighlightMediaProps = {
   media: CmsTypes.FeatureHighlight['media'];
@@ -52,10 +57,10 @@ type Props = {
 export default function FeatureHighlight({ content }: Props) {
   return (
     <StyledHighlight gap={24} orientation={content.orientation}>
-      <StyledSection align="flex-start">
+      <StyledTextSection align="flex-start">
         <StyledTitle>{content.heading}</StyledTitle>
         <FeatureHighlightBullets bullets={content.body} />
-      </StyledSection>
+      </StyledTextSection>
       {content.media && (
         <StyledMedia>
           <FeatureHighlightMedia media={content.media} />
@@ -78,21 +83,17 @@ const StyledHighlight = styled(VStack)<{ orientation: string }>`
 
 const StyledTitle = styled(TitleCondensed)`
   font-size: 48px;
+  text-align: start;
   @media only screen and ${breakpoints.desktop} {
     font-size: 64px;
   }
 `;
 
-const StyledSection = styled(VStack)`
+const StyledTextSection = styled(VStack)`
   align-items: flex-start;
 
   @media only screen and ${breakpoints.tablet} {
-    align-items: center;
     max-width: 480px;
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    align-items: flex-start;
   }
 `;
 
@@ -101,6 +102,7 @@ const StyledMedia = styled.div`
   min-height: 326px;
   max-width: 326px;
   max-height: 326px;
+  background-color: ${colors.faint};
 
   @media only screen and ${breakpoints.desktop} {
     min-width: 500px;
@@ -118,7 +120,7 @@ const StyledImage = styled.img`
   height: 100%;
 `;
 
-const StyldText = styled(TitleDiatypeL)`
+const StyledText = styled(TitleDiatypeL)`
   font-weight: 400;
   font-size: 16px;
   line-height: 20px;

--- a/apps/web/src/scenes/ContentPages/ContentModules/FeatureHighlight.tsx
+++ b/apps/web/src/scenes/ContentPages/ContentModules/FeatureHighlight.tsx
@@ -1,0 +1,129 @@
+import { useMemo } from 'react';
+import styled from 'styled-components';
+
+import breakpoints from '~/components/core/breakpoints';
+import { VStack } from '~/components/core/Spacer/Stack';
+import { TitleCondensed, TitleDiatypeL } from '~/components/core/Text/Text';
+
+import { CmsTypes } from '../cms_types';
+
+type FeatureHighlightBulletsProps = {
+  bullets: CmsTypes.FeatureHighlight['body'];
+};
+
+function FeatureHighlightBullets({ bullets }: FeatureHighlightBulletsProps) {
+  const textList = useMemo(
+    () => bullets.map((bullet) => bullet.children[0] && bullet.children[0].text),
+    [bullets]
+  );
+  return (
+    <VStack>
+      <ul>
+        {textList.map((text, index) => (
+          <li key={index}>
+            <StyldText>{text}</StyldText>
+          </li>
+        ))}
+      </ul>
+    </VStack>
+  );
+}
+
+type FeatureHighlightMediaProps = {
+  media: CmsTypes.FeatureHighlight['media'];
+};
+
+function FeatureHighlightMedia({ media }: FeatureHighlightMediaProps) {
+  if (media.video) {
+    return <StyledVideo autoPlay loop muted src={media?.video.asset.url} />;
+  }
+
+  if (media.image) {
+    return <StyledImage src={media.image.asset.url} />;
+  }
+
+  return null;
+}
+
+type Props = {
+  content: CmsTypes.FeatureHighlight;
+};
+
+export default function FeatureHighlight({ content }: Props) {
+  return (
+    <StyledHighlight gap={24} orientation={content.orientation}>
+      <StyledSection align="flex-start">
+        <StyledTitle>{content.heading}</StyledTitle>
+        <FeatureHighlightBullets bullets={content.body} />
+      </StyledSection>
+      {content.media && (
+        <StyledMedia>
+          <FeatureHighlightMedia media={content.media} />
+        </StyledMedia>
+      )}
+    </StyledHighlight>
+  );
+}
+
+const StyledHighlight = styled(VStack)<{ orientation: string }>`
+  align-items: center;
+  margin: 0 32px;
+
+  @media only screen and ${breakpoints.desktop} {
+    flex-direction: ${({ orientation }) => (orientation === 'right' ? 'row-reverse' : 'row')};
+    gap: 0 32px;
+    margin: 0;
+  }
+`;
+
+const StyledTitle = styled(TitleCondensed)`
+  font-size: 48px;
+  @media only screen and ${breakpoints.desktop} {
+    font-size: 64px;
+  }
+`;
+
+const StyledSection = styled(VStack)`
+  align-items: flex-start;
+
+  @media only screen and ${breakpoints.tablet} {
+    align-items: center;
+    max-width: 480px;
+  }
+
+  @media only screen and ${breakpoints.desktop} {
+    align-items: flex-start;
+  }
+`;
+
+const StyledMedia = styled.div`
+  min-width: 326px;
+  min-height: 326px;
+  max-width: 326px;
+  max-height: 326px;
+
+  @media only screen and ${breakpoints.desktop} {
+    min-width: 500px;
+    min-height: 500px;
+    max-width: 500px;
+    max-height: 500px;
+  }
+`;
+const StyledVideo = styled.video`
+  width: 100%;
+  height: 100%;
+`;
+const StyledImage = styled.img`
+  width: 100%;
+  height: 100%;
+`;
+
+const StyldText = styled(TitleDiatypeL)`
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 20px;
+  @media only screen and ${breakpoints.desktop} {
+    font-size: 20px;
+    line-height: 28px;
+  }
+`;

--- a/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
+++ b/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
@@ -145,6 +145,10 @@ const GetStartedButton = styled(ButtonLink)`
   text-transform: initial;
   padding: 8px 32px;
   width: fit-content;
+
+  &:hover {
+    opacity: 0.8;
+  }
 `;
 
 const StyledSplashImage = styled.img`

--- a/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
+++ b/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
@@ -80,7 +80,6 @@ const StyledPage = styled(VStack)`
   align-items: flex-start;
   min-height: 100vh;
   margin-top: 32px;
-  background-color: ${colors.offWhite};
 
   @media only screen and ${breakpoints.desktop} {
     align-items: center;

--- a/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
+++ b/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
@@ -1,0 +1,160 @@
+import Head from 'next/head';
+import { useCallback } from 'react';
+import styled from 'styled-components';
+
+import breakpoints, { pageGutter } from '~/components/core/breakpoints';
+import { ButtonLink } from '~/components/core/Button/Button';
+import Markdown from '~/components/core/Markdown/Markdown';
+import { VStack } from '~/components/core/Spacer/Stack';
+import { TitleCondensed, TitleDiatypeL } from '~/components/core/Text/Text';
+import { useTrack } from '~/shared/contexts/AnalyticsContext';
+import colors from '~/shared/theme/colors';
+
+import { CmsTypes } from './cms_types';
+import Faq from './ContentModules/Faq';
+import FeatureHighlight from './ContentModules/FeatureHighlight';
+
+type Props = {
+  pageContent: CmsTypes.FeaturePage;
+};
+
+export default function PostsFeaturePage({ pageContent }: Props) {
+  const track = useTrack();
+  const handleGetStartedClick = useCallback(() => {
+    track('Posts Feature Page: Clicked Get Started');
+  }, [track]);
+
+  return (
+    <>
+      <Head>
+        <title>Gallery | Posts</title>
+      </Head>
+      <StyledPage gap={96}>
+        <StyledContent align="center" gap={96}>
+          <StyledIntro gap={48} align="center">
+            <VStack gap={32}>
+              <VStack>
+                <StyledHeading>Introducing</StyledHeading>
+                <StyledHeading>
+                  <strong>Posts</strong>
+                </StyledHeading>
+              </VStack>
+              <StyledSubheading>{pageContent.introText}</StyledSubheading>
+            </VStack>
+            <GetStartedButton
+              href={{ pathname: '/auth' }}
+              onClick={handleGetStartedClick}
+              data-testid="sign-in-button"
+            >
+              <TitleDiatypeL color={colors.white}>Get Started</TitleDiatypeL>
+            </GetStartedButton>
+          </StyledIntro>
+          <StyledSplashImage src={pageContent.splashImage.asset.url} />
+          <VStack gap={96}>
+            {pageContent.featureHighlights.map((highlight) => (
+              <FeatureHighlight key={highlight.heading} content={highlight} />
+            ))}
+          </VStack>
+          <VStack align="center" gap={32}>
+            {pageContent.externalLink && (
+              <StyledSubheading>
+                <Markdown text={pageContent.externalLink} />
+              </StyledSubheading>
+            )}
+            <GetStartedButton
+              href={{ pathname: '/auth' }}
+              onClick={handleGetStartedClick}
+              data-testid="sign-in-button"
+            >
+              <TitleDiatypeL color={colors.white}>Get Started</TitleDiatypeL>
+            </GetStartedButton>
+          </VStack>
+        </StyledContent>
+        <Faq content={pageContent.faqModule} />
+      </StyledPage>
+    </>
+  );
+}
+
+const StyledPage = styled(VStack)`
+  align-items: flex-start;
+  min-height: 100vh;
+  margin-top: 32px;
+  background-color: ${colors.offWhite};
+
+  @media only screen and ${breakpoints.desktop} {
+    align-items: center;
+  }
+`;
+
+const StyledContent = styled(VStack)`
+  width: 100%;
+  @media only screen and ${breakpoints.desktop} {
+    width: 1080px;
+    margin: 80px ${pageGutter.mobile}px 0;
+  }
+`;
+
+const StyledIntro = styled(VStack)`
+  margin: 0 32px;
+`;
+
+const StyledHeading = styled(TitleCondensed)`
+  font-size: 72px;
+  line-height: 56px;
+  width: 100%;
+
+  font-weight: 400;
+
+  strong {
+    font-style: italic;
+    font-weight: 400;
+  }
+
+  @media only screen and ${breakpoints.desktop} {
+    font-size: 128px;
+    line-height: 96px;
+    width: 500px;
+  }
+`;
+
+const StyledSubheading = styled(TitleDiatypeL)`
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 400;
+  text-align: center;
+
+  a {
+    font-size: 16px;
+  }
+
+  @media only screen and ${breakpoints.tablet} {
+    max-width: 326px;
+  }
+
+  @media only screen and ${breakpoints.desktop} {
+    font-size: 24px;
+    line-height: 32px;
+    max-width: 500px;
+    a {
+      font-size: 24px;
+    }
+  }
+`;
+
+const GetStartedButton = styled(ButtonLink)`
+  text-transform: initial;
+  padding: 8px 32px;
+  width: fit-content;
+`;
+
+const StyledSplashImage = styled.img`
+  width: 100%;
+
+  @media only screen and ${breakpoints.tablet} {
+    max-width: 480px;
+  }
+  @media only screen and ${breakpoints.desktop} {
+    max-width: 720px;
+  }
+`;

--- a/apps/web/src/scenes/ContentPages/cms_types.ts
+++ b/apps/web/src/scenes/ContentPages/cms_types.ts
@@ -1,3 +1,5 @@
+// Types that represent the content models in our CMS. These should be manually updated whenever we update the CMS model schema.
+
 interface Block {
   _type: 'block';
   style: string;

--- a/apps/web/src/scenes/ContentPages/cms_types.ts
+++ b/apps/web/src/scenes/ContentPages/cms_types.ts
@@ -1,0 +1,62 @@
+interface Block {
+  _type: 'block';
+  style: string;
+  list: string;
+  children: { _key: string; _type: 'span'; text: string; marks: string[] }[];
+}
+
+interface Image {
+  _type: 'image';
+  asset: {
+    url: string;
+  };
+  alt: string;
+}
+
+interface Media {
+  _type: 'media';
+  mediaType: 'image' | 'video';
+  image: Image;
+  video: Video;
+  alt: string;
+}
+
+interface Video {
+  _type: 'video';
+  asset: {
+    url: string;
+  };
+}
+
+export namespace CmsTypes {
+  export interface Faq {
+    _type: 'faq';
+    question: string;
+    answer: string;
+  }
+
+  export interface FaqModule {
+    _type: 'faqModule';
+    title: string;
+    faqs: Faq[];
+  }
+
+  export interface FeatureHighlight {
+    _type: 'featureHighlight';
+    heading: string;
+    body: Block[];
+    media: Media;
+    orientation: 'left' | 'right';
+  }
+
+  export interface FeaturePage {
+    _type: 'featurePage';
+    id: string;
+    title: string;
+    introText: string;
+    splashImage: Image;
+    featureHighlights: FeatureHighlight[];
+    faqModule: FaqModule;
+    externalLink: string;
+  }
+}


### PR DESCRIPTION
### Summary of Changes
This PR adds a Feature Page to introduce posts. it can be found at /features/posts.
The content is provided via our CMS, and rendered using new components that match the CMS content models.


### Demo or Before/After Pics
![CleanShot 2023-10-13 at 13 37 10](https://github.com/gallery-so/gallery/assets/80802871/aa3f8704-ecdf-4282-ab2d-357cf455fbc8)

![CleanShot 2023-10-13 at 13 37 06](https://github.com/gallery-so/gallery/assets/80802871/94e982cb-5d3a-4de6-9af1-b5fb4fe39d8e)

![CleanShot 2023-10-13 at 13 36 56](https://github.com/gallery-so/gallery/assets/80802871/7c3c5807-da30-48d9-9707-07c2887ab5b4)

![CleanShot 2023-10-13 at 13 36 59](https://github.com/gallery-so/gallery/assets/80802871/5294cd3f-fd42-48b2-9ed0-c8439ddd691b)


### Edge Cases
- mobile responsive

### Testing Steps
- go to /features/posts

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
