### PR TITLE
Web Instrumentation: Dropdowns

### DIFF
--- a/apps/web/src/components/Feed/Posts/PostDropdown.tsx
+++ b/apps/web/src/components/Feed/Posts/PostDropdown.tsx
@@ -5,14 +5,13 @@ import CopyToClipboard from '~/components/CopyToClipboard/CopyToClipboard';
 import { DropdownItem } from '~/components/core/Dropdown/DropdownItem';
 import { DropdownSection } from '~/components/core/Dropdown/DropdownSection';
 import SettingsDropdown from '~/components/core/Dropdown/SettingsDropdown';
-import { BaseM } from '~/components/core/Text/Text';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { PostDropdownFragment$key } from '~/generated/PostDropdownFragment.graphql';
 import { PostDropdownQueryFragment$key } from '~/generated/PostDropdownQueryFragment.graphql';
 import LinkToFullPageNftDetailModal from '~/scenes/NftDetailPage/LinkToFullPageNftDetailModal';
 import { contexts } from '~/shared/analytics/constants';
-import colors from '~/shared/theme/colors';
 import { getBaseUrl } from '~/utils/getBaseUrl';
+import noop from '~/utils/noop';
 
 import DeletePostConfirmation from './DeletePostConfirmation';
 
@@ -89,9 +88,7 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
       <SettingsDropdown iconVariant="default">
         <DropdownSection>
           <CopyToClipboard textToCopy={postUrl}>
-            <DropdownItem>
-              <BaseM>Share</BaseM>
-            </DropdownItem>
+            <DropdownItem name="Feed Post" eventContext={contexts.Posts} label="Share" />
           </CopyToClipboard>
           {token && (
             <LinkToFullPageNftDetailModal
@@ -99,14 +96,20 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
               tokenId={token?.dbid}
               eventContext={contexts.Posts}
             >
-              <DropdownItem>
-                <BaseM>View Item Detail</BaseM>
-              </DropdownItem>
+              <DropdownItem
+                name="Feed Post"
+                eventContext={contexts.Posts}
+                label="View Item Detail"
+              />
             </LinkToFullPageNftDetailModal>
           )}
-          <DropdownItem onClick={handleDeletePostClick}>
-            <BaseM color={colors.error}>Delete</BaseM>
-          </DropdownItem>
+          <DropdownItem
+            onClick={handleDeletePostClick}
+            name="Feed Post"
+            eventContext={contexts.Posts}
+            label="Delete"
+            variant="error"
+          />
         </DropdownSection>
       </SettingsDropdown>
     );
@@ -116,9 +119,12 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
     <SettingsDropdown iconVariant="default">
       <DropdownSection>
         <CopyToClipboard textToCopy={postUrl}>
-          <DropdownItem onClick={() => {}}>
-            <BaseM>Share</BaseM>
-          </DropdownItem>
+          <DropdownItem
+            onClick={noop}
+            name="Feed Post"
+            eventContext={contexts.Posts}
+            label="Share"
+          />
         </CopyToClipboard>
         {/* Follow up: GAL-3862 */}
         {/* <DropdownItem onClick={handleFollowClick}>
@@ -130,9 +136,7 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
             tokenId={token?.dbid}
             eventContext={contexts.Posts}
           >
-            <DropdownItem>
-              <BaseM>View Item Detail</BaseM>
-            </DropdownItem>
+            <DropdownItem name="Feed Post" eventContext={contexts.Posts} label="View Item Detail" />
           </LinkToFullPageNftDetailModal>
         )}
       </DropdownSection>

--- a/apps/web/src/components/Feed/Posts/PostDropdown.tsx
+++ b/apps/web/src/components/Feed/Posts/PostDropdown.tsx
@@ -108,7 +108,7 @@ export default function PostDropdown({ postRef, queryRef }: Props) {
             name="Feed Post"
             eventContext={contexts.Posts}
             label="Delete"
-            variant="error"
+            variant="delete"
           />
         </DropdownSection>
       </SettingsDropdown>

--- a/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionListItem.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionListItem.tsx
@@ -159,7 +159,7 @@ export function CollectionListItem({ collectionId, queryRef }: CollectionListIte
                 name="Collection List Item"
                 eventContext={contexts.Editor}
                 label="Delete"
-                variant="error"
+                variant="delete"
               />
             </DropdownSection>
           </SettingsDropdown>

--- a/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionListItem.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionListItem.tsx
@@ -8,7 +8,6 @@ import { DropdownSection } from '~/components/core/Dropdown/DropdownSection';
 import SettingsDropdown from '~/components/core/Dropdown/SettingsDropdown';
 import IconContainer from '~/components/core/IconContainer';
 import { HStack } from '~/components/core/Spacer/Stack';
-import { BaseM } from '~/components/core/Text/Text';
 import { TitleXS } from '~/components/core/Text/Text';
 import { useGalleryEditorContext } from '~/components/GalleryEditor/GalleryEditorContext';
 import { NewTooltip } from '~/components/Tooltip/NewTooltip';
@@ -16,6 +15,7 @@ import { useTooltipHover } from '~/components/Tooltip/useTooltipHover';
 import { CollectionListItemQueryFragment$key } from '~/generated/CollectionListItemQueryFragment.graphql';
 import HideIcon from '~/icons/HideIcon';
 import ShowIcon from '~/icons/ShowIcon';
+import { contexts } from '~/shared/analytics/constants';
 import { ErrorWithSentryMetadata } from '~/shared/errors/ErrorWithSentryMetadata';
 import colors from '~/shared/theme/colors';
 import unescape from '~/shared/utils/unescape';
@@ -142,15 +142,25 @@ export function CollectionListItem({ collectionId, queryRef }: CollectionListIte
           />
           <SettingsDropdown size="sm" iconVariant="stacked" disableHoverPadding>
             <DropdownSection>
-              <DropdownItem onClick={handleEdit}>
-                <BaseM>Edit Name & Description</BaseM>
-              </DropdownItem>
-              <DropdownItem onClick={handleMoveCollectionModal}>
-                <BaseM>Move To...</BaseM>
-              </DropdownItem>
-              <DropdownItem onClick={handleDelete}>
-                <BaseM color={colors.error}>Delete</BaseM>
-              </DropdownItem>
+              <DropdownItem
+                onClick={handleEdit}
+                name="Collection List Item"
+                eventContext={contexts.Editor}
+                label="Edit Name & Description"
+              />
+              <DropdownItem
+                onClick={handleMoveCollectionModal}
+                name="Collection List Item"
+                eventContext={contexts.Editor}
+                label="Move To..."
+              />
+              <DropdownItem
+                onClick={handleDelete}
+                name="Collection List Item"
+                eventContext={contexts.Editor}
+                label="Delete"
+                variant="error"
+              />
             </DropdownSection>
           </SettingsDropdown>
         </CollectionListItemActionsContainer>

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarChainDropdown.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarChainDropdown.tsx
@@ -11,6 +11,7 @@ import { HStack } from '~/components/core/Spacer/Stack';
 import { BaseM } from '~/components/core/Text/Text';
 import { SidebarChainDropdownFragment$key } from '~/generated/SidebarChainDropdownFragment.graphql';
 import DoubleArrowsIcon from '~/icons/DoubleArrowsIcon';
+import { contexts } from '~/shared/analytics/constants';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { ChainMetadata, chains } from '~/shared/utils/chains';
 import isAdminRole from '~/utils/graphql/isAdminRole';
@@ -90,6 +91,9 @@ export default function SidebarChainDropdown({
                   handleSelectChain(chain);
                 }}
                 disabled={isChainDisabled}
+                name="Sidebar Chain"
+                eventContext={contexts.Editor}
+                eventSelection={chain.name}
               >
                 <HStack align="center" gap={6}>
                   <Image src={chain.icon} width={16} height={16} alt={chain.name} />

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarViewSelector.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarViewSelector.tsx
@@ -8,6 +8,7 @@ import IconContainer from '~/components/core/IconContainer';
 import { HStack } from '~/components/core/Spacer/Stack';
 import { BaseM } from '~/components/core/Text/Text';
 import DoubleArrowsIcon from '~/icons/DoubleArrowsIcon';
+import { contexts } from '~/shared/analytics/constants';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 
 export type TokenFilterType = 'Collected' | 'Created' | 'Hidden';
@@ -48,15 +49,24 @@ export function SidebarViewSelector({
         onClose={() => setIsDropdownOpen(false)}
       >
         <DropdownSection>
-          <DropdownItem onClick={() => onSelectView('Collected')}>
-            <BaseM>Collected</BaseM>
-          </DropdownItem>
-          <DropdownItem onClick={() => onSelectView('Created')}>
-            <BaseM>Created</BaseM>
-          </DropdownItem>
-          <DropdownItem onClick={() => onSelectView('Hidden')}>
-            <BaseM>Hidden</BaseM>
-          </DropdownItem>
+          <DropdownItem
+            onClick={() => onSelectView('Collected')}
+            name="Token Type"
+            eventContext={contexts.Editor}
+            label="Collected"
+          />
+          <DropdownItem
+            onClick={() => onSelectView('Created')}
+            name="Token Type"
+            eventContext={contexts.Editor}
+            label="Created"
+          />
+          <DropdownItem
+            onClick={() => onSelectView('Hidden')}
+            name="Token Type"
+            eventContext={contexts.Editor}
+            label="Hidden"
+          />
         </DropdownSection>
       </StyledDropdown>
     </Container>

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarWalletSelector.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarWalletSelector.tsx
@@ -12,6 +12,7 @@ import { OnConnectWalletSuccessFn } from '~/components/WalletSelector/multichain
 import { SidebarWalletSelectorFragment$key } from '~/generated/SidebarWalletSelectorFragment.graphql';
 import useAddWalletModal from '~/hooks/useAddWalletModal';
 import DoubleArrowsIcon from '~/icons/DoubleArrowsIcon';
+import { contexts } from '~/shared/analytics/constants';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import { ChainMetadata } from '~/shared/utils/chains';
@@ -110,13 +111,20 @@ export default function SidebarWalletSelector({
         onClose={() => setIsDropdownOpen(false)}
       >
         <DropdownSection>
-          <DropdownItem onClick={() => handleSelectWallet('All')}>
-            <BaseM>All</BaseM>
-          </DropdownItem>
+          <DropdownItem
+            onClick={() => handleSelectWallet('All')}
+            name="Select Wallet"
+            eventContext={contexts.Editor}
+            label="All"
+          />
           {userWalletsOnSelectedNetwork.map((wallet, index) => (
-            <DropdownItem key={index} onClick={() => handleSelectWallet(wallet)}>
-              <BaseM>{truncateWalletAddress(wallet)}</BaseM>
-            </DropdownItem>
+            <DropdownItem
+              key={index}
+              onClick={() => handleSelectWallet(wallet)}
+              name="Select Wallet"
+              eventContext={contexts.Editor}
+              label={truncateWalletAddress(wallet)}
+            />
           ))}
           {!addWalletDisabled && (
             <DropdownItem
@@ -124,9 +132,10 @@ export default function SidebarWalletSelector({
                 handleSubmit();
                 handleSelectWallet('All');
               }}
-            >
-              <BaseM>ADD WALLET</BaseM>
-            </DropdownItem>
+              name="Select Wallet"
+              eventContext={contexts.Editor}
+              label="Add Wallet"
+            />
           )}
         </DropdownSection>
       </StyledDropdown>

--- a/apps/web/src/components/MultiGallery/Gallery.tsx
+++ b/apps/web/src/components/MultiGallery/Gallery.tsx
@@ -345,7 +345,7 @@ export default function Gallery({
                           name="Manage Gallery"
                           eventContext={contexts.Editor}
                           label="Delete"
-                          variant="error"
+                          variant="delete"
                         />
                       </DropdownSection>
                     </SettingsDropdown>

--- a/apps/web/src/components/MultiGallery/Gallery.tsx
+++ b/apps/web/src/components/MultiGallery/Gallery.tsx
@@ -14,6 +14,7 @@ import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import ArrowDownIcon from '~/icons/ArrowDownIcon';
 import ArrowUpIcon from '~/icons/ArrowUpIcon';
 import DragHandleIcon from '~/icons/DragHandleIcon';
+import { contexts } from '~/shared/analytics/constants';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
 import colors from '~/shared/theme/colors';
@@ -308,26 +309,44 @@ export default function Gallery({
                   <HStack>
                     <SettingsDropdown iconVariant="stacked">
                       <DropdownSection>
-                        <DropdownItem onClick={handleEditGalleryName}>
-                          <BaseM>Edit Name & Description</BaseM>
-                        </DropdownItem>
+                        <DropdownItem
+                          onClick={handleEditGalleryName}
+                          name="Manage Gallery"
+                          eventContext={contexts.Editor}
+                          label="Edit Name & Description"
+                        />
                         {hidden ? (
-                          <DropdownItem onClick={handleUpdateGalleryHidden}>UNHIDE</DropdownItem>
+                          <DropdownItem
+                            onClick={handleUpdateGalleryHidden}
+                            name="Manage Gallery"
+                            eventContext={contexts.Editor}
+                            label="Unhide"
+                          />
                         ) : (
                           <>
                             {!isFeatured && (
-                              <DropdownItem onClick={handleSetFeaturedGallery}>
-                                <BaseM>Feature on Profile</BaseM>
-                              </DropdownItem>
+                              <DropdownItem
+                                onClick={handleSetFeaturedGallery}
+                                name="Manage Gallery"
+                                eventContext={contexts.Editor}
+                                label="Feature on Profile"
+                              />
                             )}
-                            <DropdownItem onClick={handleUpdateGalleryHidden}>
-                              <BaseM>Hide</BaseM>
-                            </DropdownItem>
+                            <DropdownItem
+                              onClick={handleUpdateGalleryHidden}
+                              name="Manage Gallery"
+                              eventContext={contexts.Editor}
+                              label="Hide"
+                            />
                           </>
                         )}
-                        <DropdownItem onClick={handleDeleteGallery}>
-                          <BaseM color={colors.error}>Delete</BaseM>
-                        </DropdownItem>
+                        <DropdownItem
+                          onClick={handleDeleteGallery}
+                          name="Manage Gallery"
+                          eventContext={contexts.Editor}
+                          label="Delete"
+                          variant="error"
+                        />
                       </DropdownSection>
                     </SettingsDropdown>
                   </HStack>

--- a/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorFilterNetwork.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorFilterNetwork.tsx
@@ -7,6 +7,7 @@ import { BaseM } from '~/components/core/Text/Text';
 import { TokenFilterType } from '~/components/GalleryEditor/PiecesSidebar/SidebarViewSelector';
 import { NftSelectorFilterNetworkFragment$key } from '~/generated/NftSelectorFilterNetworkFragment.graphql';
 import DoubleArrowsIcon from '~/icons/DoubleArrowsIcon';
+import { contexts } from '~/shared/analytics/constants';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';
 import { Chain, ChainMetadata, chains } from '~/shared/utils/chains';
@@ -107,6 +108,9 @@ export function NftSelectorFilterNetwork({
                   onSelectChain(chain);
                 }}
                 disabled={isChainDisabled}
+                name="NFT Selector Filter Network"
+                eventContext={contexts.Posts}
+                eventSelection={chain.name}
               >
                 <NetworkDropdownByNetwork chain={chain} />
               </DropdownItem>

--- a/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorFilterSort.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorFilterSort.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 import DoubleArrowsIcon from '~/icons/DoubleArrowsIcon';
+import { contexts } from '~/shared/analytics/constants';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';
 
@@ -44,15 +45,24 @@ export function NftSelectorFilterSort({
       </Selector>
       <Dropdown position="right" active={isDropdownOpen} onClose={() => setIsDropdownOpen(false)}>
         <DropdownSection>
-          <DropdownItem onClick={() => onSelectView('Recently added')}>
-            <BaseM>Recently added</BaseM>
-          </DropdownItem>
-          <DropdownItem onClick={() => onSelectView('Oldest')}>
-            <BaseM>Oldest</BaseM>
-          </DropdownItem>
-          <DropdownItem onClick={() => onSelectView('Alphabetical')}>
-            <BaseM>Alphabetical</BaseM>
-          </DropdownItem>
+          <DropdownItem
+            onClick={() => onSelectView('Recently added')}
+            name="NFT Selector Filter Sort"
+            eventContext={contexts.Posts}
+            label="Recently added"
+          />
+          <DropdownItem
+            onClick={() => onSelectView('Oldest')}
+            name="NFT Selector Filter Sort"
+            eventContext={contexts.Posts}
+            label="Oldest"
+          />
+          <DropdownItem
+            onClick={() => onSelectView('Alphabetical')}
+            name="NFT Selector Filter Sort"
+            eventContext={contexts.Posts}
+            label="Alphabetical"
+          />
         </DropdownSection>
       </Dropdown>
     </Container>

--- a/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorViewSelector.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorViewSelector.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import DoubleArrowsIcon from '~/icons/DoubleArrowsIcon';
+import { contexts } from '~/shared/analytics/constants';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';
 import { Chain, chains } from '~/shared/utils/chains';
@@ -58,15 +59,19 @@ export function NftSelectorViewSelector({
       </Selector>
       <Dropdown position="right" active={isDropdownOpen} onClose={() => setIsDropdownOpen(false)}>
         <DropdownSection>
-          <DropdownItem onClick={() => onSelectView('Collected')}>
-            <BaseM>Collected</BaseM>
-          </DropdownItem>
+          <DropdownItem
+            onClick={() => onSelectView('Collected')}
+            name="NFT Selector Filter Type"
+            eventContext={contexts.Posts}
+            label="Collected"
+          />
           <DropdownItem
             onClick={() => onSelectView('Created')}
             disabled={!isCreatorSupportEnabledForChain}
-          >
-            <BaseM>Created</BaseM>
-          </DropdownItem>
+            name="NFT Selector Filter Type"
+            eventContext={contexts.Posts}
+            label="Created"
+          />
         </DropdownSection>
       </Dropdown>
     </Container>

--- a/apps/web/src/components/Profile/EditUserInfoForm.tsx
+++ b/apps/web/src/components/Profile/EditUserInfoForm.tsx
@@ -32,7 +32,7 @@ type Props = {
 
 export const BIO_MAX_CHAR_COUNT = 600;
 
-function UserInfoForm({
+function EditUserInfoForm({
   className,
   onSubmit,
   username,
@@ -145,7 +145,7 @@ function UserInfoForm({
       <HStack gap={16} align="center">
         {!mode && (
           <StyledProfilePictureContainer onClick={handleOpenPfpDropdown}>
-            <ProfilePicture userRef={user} size="xl" isEditable hasInset />
+            <ProfilePicture userRef={user} size="xl" isEditable hasInset clickDisabled />
             <ProfilePictureDropdown
               open={showPfpDropdown}
               onClose={handleClosePfpDropdown}
@@ -196,4 +196,4 @@ const StyledProfilePictureContainer = styled.div`
   position: relative;
 `;
 
-export default UserInfoForm;
+export default EditUserInfoForm;

--- a/apps/web/src/components/Profile/ProfilePictureDropdown.tsx
+++ b/apps/web/src/components/Profile/ProfilePictureDropdown.tsx
@@ -138,7 +138,7 @@ export function ProfilePictureDropdown({ open, onClose, queryRef }: Props) {
             name="Profile Picture"
             eventContext={contexts.PFP}
             label="Remove current profile picture"
-            variant="error"
+            variant="delete"
           />
         )}
       </DropdownSection>

--- a/apps/web/src/components/Profile/ProfilePictureDropdown.tsx
+++ b/apps/web/src/components/Profile/ProfilePictureDropdown.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { ProfilePictureDropdownQueryFragment$key } from '~/generated/ProfilePictureDropdownQueryFragment.graphql';
 import { AllGalleriesIcon } from '~/icons/AllGalleriesIcon';
-import { TrashIconNew } from '~/icons/TrashIconNew';
+import { contexts } from '~/shared/analytics/constants';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';
 
@@ -108,7 +108,11 @@ export function ProfilePictureDropdown({ open, onClose, queryRef }: Props) {
   return (
     <Dropdown position="left" active={open} onClose={onClose}>
       <DropdownSection>
-        <StyledDropdownItem onClick={handleSetEnsProfilePicture}>
+        <StyledDropdownItem
+          onClick={handleSetEnsProfilePicture}
+          name="Profile Picture"
+          eventContext={contexts.PFP}
+        >
           <StyledDropdownItemContainer gap={8}>
             {ensProfileImage ? (
               <StyledEnsImage src={ensProfileImage} />
@@ -118,19 +122,24 @@ export function ProfilePictureDropdown({ open, onClose, queryRef }: Props) {
             <BaseS>Use ENS Avatar</BaseS>
           </StyledDropdownItemContainer>
         </StyledDropdownItem>
-        <StyledDropdownItem onClick={handleShowNftSelector}>
+        <StyledDropdownItem
+          onClick={handleShowNftSelector}
+          name="Profile Picture"
+          eventContext={contexts.PFP}
+        >
           <StyledDropdownItemContainer gap={8}>
             <AllGalleriesIcon color={colors.black[800]} />
             <BaseS>Choose from collection</BaseS>
           </StyledDropdownItemContainer>
         </StyledDropdownItem>
         {user.profileImage && (
-          <StyledDropdownItem onClick={handleRemoveProfileImage}>
-            <StyledDropdownItemContainer gap={8}>
-              <TrashIconNew color="#E12E16" />
-              <StyledRemoveText>Remove current profile picture</StyledRemoveText>
-            </StyledDropdownItemContainer>
-          </StyledDropdownItem>
+          <StyledDropdownItem
+            onClick={handleRemoveProfileImage}
+            name="Profile Picture"
+            eventContext={contexts.PFP}
+            label="Remove current profile picture"
+            variant="error"
+          />
         )}
       </DropdownSection>
     </Dropdown>

--- a/apps/web/src/components/core/Dropdown/DropdownItem.tsx
+++ b/apps/web/src/components/core/Dropdown/DropdownItem.tsx
@@ -14,7 +14,7 @@ export type DropdownEventProps = {
   eventSelection?: string;
   // if provided, will render a label using default styling
   label?: string;
-  variant?: 'default' | 'error';
+  variant?: 'default' | 'delete';
 } & Omit<GalleryElementTrackingProps, 'eventElementId' | 'eventName'>;
 
 type DropdownItemProps = {
@@ -58,8 +58,8 @@ export function DropdownItem({
     return (
       <StyledDropdownItem disabled={disabled} onClick={handleClick}>
         <HStack gap={4} align="center">
-          {variant === 'error' ? <TrashIconNew color={colors.error} /> : null}
-          <BaseM color={variant === 'error' ? colors.error : undefined}>{label}</BaseM>
+          {variant === 'delete' ? <TrashIconNew color={colors.error} /> : null}
+          <BaseM color={variant === 'delete' ? colors.error : undefined}>{label}</BaseM>
         </HStack>
       </StyledDropdownItem>
     );

--- a/apps/web/src/components/core/Dropdown/DropdownItem.tsx
+++ b/apps/web/src/components/core/Dropdown/DropdownItem.tsx
@@ -1,8 +1,78 @@
+import { ComponentProps, MouseEventHandler, useCallback } from 'react';
 import styled from 'styled-components';
 
+import { TrashIconNew } from '~/icons/TrashIconNew';
+import { GalleryElementTrackingProps, useTrack } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';
 
-export const DropdownItem = styled.div<{ disabled?: boolean }>`
+import { HStack } from '../Spacer/Stack';
+import { BaseM } from '../Text/Text';
+
+export type DropdownEventProps = {
+  // used for event tracking
+  name: string;
+  eventSelection?: string;
+  // if provided, will render a label using default styling
+  label?: string;
+  variant?: 'default' | 'error';
+} & Omit<GalleryElementTrackingProps, 'eventElementId' | 'eventName'>;
+
+type DropdownItemProps = {
+  disabled?: boolean;
+} & ComponentProps<'div'> &
+  DropdownEventProps;
+
+export function DropdownItem({
+  disabled,
+  onClick,
+  label,
+  variant = 'default',
+  name,
+  eventContext,
+  eventFlow,
+  eventSelection,
+  properties,
+  children,
+}: DropdownItemProps) {
+  const track = useTrack();
+
+  const handleClick = useCallback<MouseEventHandler<HTMLDivElement>>(
+    (event) => {
+      event.stopPropagation();
+
+      track('Dropdown Item Click', {
+        id: `${name} Dropdown Item`,
+        name: `${name} Dropdown Item Click`,
+        context: eventContext,
+        flow: eventFlow,
+        selection: label || eventSelection,
+        ...properties,
+      });
+
+      onClick?.(event);
+    },
+    [track, name, eventContext, eventFlow, label, eventSelection, properties, onClick]
+  );
+
+  if (label) {
+    return (
+      <StyledDropdownItem disabled={disabled} onClick={handleClick}>
+        <HStack gap={4} align="center">
+          {variant === 'error' ? <TrashIconNew color={colors.error} /> : null}
+          <BaseM color={variant === 'error' ? colors.error : undefined}>{label}</BaseM>
+        </HStack>
+      </StyledDropdownItem>
+    );
+  }
+
+  return (
+    <StyledDropdownItem disabled={disabled} onClick={handleClick}>
+      {children}
+    </StyledDropdownItem>
+  );
+}
+
+const StyledDropdownItem = styled.div<{ disabled?: boolean }>`
   padding: 8px;
 
   font-family: 'Helvetica Neue';

--- a/apps/web/src/components/core/Dropdown/DropdownLink.tsx
+++ b/apps/web/src/components/core/Dropdown/DropdownLink.tsx
@@ -1,22 +1,73 @@
 import { Route } from 'nextjs-routes';
-import { ReactNode } from 'react';
+import { MouseEventHandler, ReactNode, useCallback } from 'react';
 import styled from 'styled-components';
 
+import { TrashIconNew } from '~/icons/TrashIconNew';
+import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';
 
 import GalleryLink from '../GalleryLink/GalleryLink';
+import { HStack } from '../Spacer/Stack';
+import { BaseM } from '../Text/Text';
+import { DropdownEventProps } from './DropdownItem';
 
-type DropdownLinkProps = { href: Route; children: ReactNode; onClick?: () => void };
+type DropdownLinkProps = {
+  href: Route;
+  children?: ReactNode;
+  onClick?: () => void;
+} & DropdownEventProps;
 
-export function DropdownLink({ href, children, onClick }: DropdownLinkProps) {
+export function DropdownLink({
+  href,
+  children,
+  onClick,
+  label,
+  variant = 'default',
+  name,
+  eventContext,
+  eventFlow,
+  eventSelection,
+  properties,
+}: DropdownLinkProps) {
+  const track = useTrack();
+
+  const handleClick = useCallback<MouseEventHandler<HTMLAnchorElement>>(
+    (event) => {
+      event.stopPropagation();
+
+      track('Dropdown Item Click', {
+        id: `${name} Dropdown Item`,
+        name: `${name} Dropdown Item Click`,
+        context: eventContext,
+        flow: eventFlow,
+        selection: eventSelection,
+        ...properties,
+      });
+
+      onClick?.();
+    },
+    [track, name, eventContext, eventFlow, eventSelection, properties, onClick]
+  );
+
+  if (label) {
+    return (
+      <StyledGalleryLink onClick={handleClick}>
+        <HStack gap={4} align="center">
+          {variant === 'error' ? <TrashIconNew color={colors.error} /> : null}
+          <BaseM color={variant === 'error' ? colors.error : undefined}>{label}</BaseM>
+        </HStack>
+      </StyledGalleryLink>
+    );
+  }
+
   return (
-    <StyledDropdownItem to={href} onClick={onClick}>
+    <StyledGalleryLink to={href} onClick={handleClick}>
       {children}
-    </StyledDropdownItem>
+    </StyledGalleryLink>
   );
 }
 
-const StyledDropdownItem = styled(GalleryLink)`
+const StyledGalleryLink = styled(GalleryLink)`
   padding: 8px;
 
   font-family: 'Helvetica Neue';

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionRightContent.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionRightContent.tsx
@@ -17,6 +17,7 @@ import { CollectionRightContentFragment$key } from '~/generated/CollectionRightC
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import EditUserInfoModal from '~/scenes/UserGalleryPage/EditUserInfoModal';
 import LinkButton from '~/scenes/UserGalleryPage/LinkButton';
+import { contexts } from '~/shared/analytics/constants';
 
 import { SignUpButton } from '../SignUpButton';
 
@@ -118,9 +119,19 @@ export function CollectionRightContent({
       <Dropdown active={showDropdown} onClose={handleCloseDropdown} position="right">
         <DropdownSection>
           {editCollectionUrl && (
-            <DropdownLink href={editCollectionUrl}>EDIT COLLECTION</DropdownLink>
+            <DropdownLink
+              href={editCollectionUrl}
+              name="Collection Nav"
+              eventContext={contexts.UserCollection}
+              label="Edit Collection"
+            />
           )}
-          <DropdownItem onClick={handleNameAndBioClick}>NAME & BIO</DropdownItem>
+          <DropdownItem
+            onClick={handleNameAndBioClick}
+            name="Collection Nav"
+            eventContext={contexts.UserCollection}
+            label="Name & Bio"
+          />
         </DropdownSection>
       </Dropdown>
     );
@@ -159,4 +170,5 @@ export function CollectionRightContent({
 
 const EditLinkWrapper = styled.div`
   position: relative;
+  cursor: pointer;
 `;

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryRightContent.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryRightContent.tsx
@@ -161,8 +161,20 @@ export function GalleryRightContent({ queryRef, galleryRef, username }: GalleryR
     return (
       <Dropdown active={showDropdown} onClose={handleCloseDropdown} position="right">
         <DropdownSection>
-          {editGalleryUrl && <DropdownLink href={editGalleryUrl}>EDIT GALLERY</DropdownLink>}
-          <DropdownItem onClick={handleNameAndBioClick}>NAME & BIO</DropdownItem>
+          {editGalleryUrl && (
+            <DropdownLink
+              href={editGalleryUrl}
+              name="Gallery Nav"
+              eventContext={contexts.UserGallery}
+              label="Edit Gallery"
+            />
+          )}
+          <DropdownItem
+            onClick={handleNameAndBioClick}
+            name="Gallery Nav"
+            eventContext={contexts.UserGallery}
+            label="Name & Bio"
+          />
         </DropdownSection>
       </Dropdown>
     );
@@ -223,4 +235,5 @@ export function GalleryRightContent({ queryRef, galleryRef, username }: GalleryR
 
 const EditLinkWrapper = styled.div`
   position: relative;
+  cursor: pointer;
 `;

--- a/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
+++ b/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
@@ -21,7 +21,6 @@ import useUpdateCollectionInfo from '~/hooks/api/collections/useUpdateCollection
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import MobileLayoutToggle from '~/scenes/UserGalleryPage/MobileLayoutToggle';
 import { contexts } from '~/shared/analytics/constants';
-import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import unescape from '~/shared/utils/unescape';
 
 import GalleryTitleBreadcrumb from '../UserGalleryPage/GalleryTitleBreadcrumb';
@@ -89,8 +88,6 @@ function CollectionGalleryHeader({
     () => (collection.collectorsNote ? unescape(collection.collectorsNote || '') : null),
     [collection.collectorsNote]
   );
-
-  const track = useTrack();
 
   const {
     dbid: collectionId,
@@ -189,9 +186,12 @@ function CollectionGalleryHeader({
               {/* On mobile, we show these options in the navbar, not in header */}
               <SettingsDropdown iconVariant="default">
                 <DropdownSection>
-                  <DropdownItem onClick={handleEditNameClick}>
-                    <BaseM>Edit Name & Description</BaseM>
-                  </DropdownItem>
+                  <DropdownItem
+                    onClick={handleEditNameClick}
+                    name="Manage Collection"
+                    eventContext={contexts.UserCollection}
+                    label="Edit Name & Description"
+                  />
 
                   {!shouldDisplayMobileLayoutToggle && (
                     <DropdownLink
@@ -199,12 +199,10 @@ function CollectionGalleryHeader({
                         pathname: '/gallery/[galleryId]/edit',
                         query: { galleryId, collectionId },
                       }}
-                      onClick={() => {
-                        track('Update existing collection');
-                      }}
-                    >
-                      <BaseM>Edit Collection</BaseM>
-                    </DropdownLink>
+                      name="Manage Collection"
+                      eventContext={contexts.UserCollection}
+                      label="Edit Collection"
+                    />
                   )}
                 </DropdownSection>
               </SettingsDropdown>

--- a/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -25,7 +25,6 @@ import { UserGalleryCollectionQueryFragment$key } from '~/generated/UserGalleryC
 import useUpdateCollectionInfo from '~/hooks/api/collections/useUpdateCollectionInfo';
 import useResizeObserver from '~/hooks/useResizeObserver';
 import { contexts } from '~/shared/analytics/constants';
-import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
 import unescape from '~/shared/utils/unescape';
 import { getBaseUrl } from '~/utils/getBaseUrl';
@@ -97,8 +96,6 @@ function UserGalleryCollection({
   };
   const collectionUrl = route(collectionUrlPath);
 
-  const track = useTrack();
-
   // Get height of this component
   const componentRef = useRef<HTMLDivElement>(null);
   const { height: collectionElHeight } = useResizeObserver(componentRef);
@@ -153,23 +150,29 @@ function UserGalleryCollection({
               <DropdownSection>
                 {showEditActions && (
                   <>
-                    <DropdownItem onClick={handleEditNameClick}>
-                      <BaseM>Edit Name & Description</BaseM>
-                    </DropdownItem>
+                    <DropdownItem
+                      onClick={handleEditNameClick}
+                      name="Manage Collection"
+                      eventContext={contexts.UserGallery}
+                      label="Edit Name & Collection"
+                    />
                     <DropdownLink
                       href={{
                         pathname: '/gallery/[galleryId]/edit',
                         query: { galleryId, collectionId },
                       }}
-                      onClick={() => track('Update existing collection button clicked')}
-                    >
-                      <BaseM>Edit Collection</BaseM>
-                    </DropdownLink>
+                      name="Manage Collection"
+                      eventContext={contexts.UserGallery}
+                      label="Edit Collection"
+                    />
                   </>
                 )}
-                <DropdownLink href={collectionUrlPath}>
-                  <BaseM>View Collection</BaseM>
-                </DropdownLink>
+                <DropdownLink
+                  href={collectionUrlPath}
+                  name="Manage Collection"
+                  eventContext={contexts.UserGallery}
+                  label="View Collection"
+                />
               </DropdownSection>
             </SettingsDropdown>
           </StyledOptionsContainer>
@@ -177,7 +180,7 @@ function UserGalleryCollection({
         {unescapedCollectorsNote && (
           <>
             <StyledCollectorsNote>
-              <Markdown text={unescapedCollectorsNote} eventContext={contexts.UserCollection} />
+              <Markdown text={unescapedCollectorsNote} eventContext={contexts.UserGallery} />
             </StyledCollectorsNote>
           </>
         )}

--- a/apps/web/src/scenes/UserGalleryPage/UserNameAndDescriptionHeader.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserNameAndDescriptionHeader.tsx
@@ -108,7 +108,7 @@ export function UserNameAndDescriptionHeader({ userRef, queryRef }: Props) {
       <Container gap={4}>
         <HStack align="center" gap={4}>
           <HStack gap={8} align="center">
-            <ProfilePicture userRef={user} size="md" />
+            <ProfilePicture userRef={user} size="md" clickDisabled />
             <StyledUsername>{displayName}</StyledUsername>
           </HStack>
 

--- a/packages/shared/src/analytics/constants.ts
+++ b/packages/shared/src/analytics/constants.ts
@@ -25,6 +25,7 @@ export const contexts = {
   Changelog: 'Changelog',
   Error: 'Error',
   Maintenance: 'Maintenance',
+  PFP: 'PFP',
 } as const;
 
 export type AnalyticsEventContextType = keyof typeof contexts;


### PR DESCRIPTION
### Summary of Changes

- QoL update to simply supply a `label` to `DropdownItem` or `DropdownLink` instead of specifying a `BaseM`, with 
- QoL update to automatically add the trash icon when variant `delete` is set
- add `clickDisabled` prop for PFPs to prevent unnecessary redirects and click takeovers when clicking an element that happens to feature a PFP (e.g. trying to edit your PFP by clicking on it when you're on your own profile)

