### PR TITLE
Fix regression on search onClick

### DIFF
--- a/apps/mobile/src/components/Search/Community/CommunitySearchResult.tsx
+++ b/apps/mobile/src/components/Search/Community/CommunitySearchResult.tsx
@@ -6,7 +6,6 @@ import { MentionType } from 'src/hooks/useMentionableMessage';
 import { CommunityProfilePicture } from '~/components/ProfilePicture/CommunityProfilePicture';
 import { CommunitySearchResultFragment$key } from '~/generated/CommunitySearchResultFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
-import { noop } from '~/shared/utils/noop';
 
 import { SearchResult } from '../SearchResult';
 
@@ -14,7 +13,7 @@ type Props = {
   communityRef: CommunitySearchResultFragment$key;
   onSelect?: (item: MentionType) => void;
 };
-export function CommunitySearchResult({ communityRef, onSelect = noop }: Props) {
+export function CommunitySearchResult({ communityRef, onSelect }: Props) {
   const community = useFragment(
     graphql`
       fragment CommunitySearchResultFragment on Community {

--- a/apps/mobile/src/components/Search/SearchResults.tsx
+++ b/apps/mobile/src/components/Search/SearchResults.tsx
@@ -8,7 +8,6 @@ import { CommunitySearchResultFragment$key } from '~/generated/CommunitySearchRe
 import { GallerySearchResultFragment$key } from '~/generated/GallerySearchResultFragment.graphql';
 import { SearchResultsQuery } from '~/generated/SearchResultsQuery.graphql';
 import { UserSearchResultFragment$key } from '~/generated/UserSearchResultFragment.graphql';
-import { noop } from '~/shared/utils/noop';
 
 import { Typography } from '../Typography';
 import { CommunitySearchResult } from './Community/CommunitySearchResult';
@@ -54,7 +53,7 @@ export function SearchResults({
   keyword,
   onChangeFilter,
   blurInputFocus,
-  onSelect = noop,
+  onSelect,
   onlyShowTopResults = false,
   isMentionSearch = false,
 }: Props) {

--- a/apps/mobile/src/components/Search/User/UserSearchResult.tsx
+++ b/apps/mobile/src/components/Search/User/UserSearchResult.tsx
@@ -6,7 +6,6 @@ import { MentionType } from 'src/hooks/useMentionableMessage';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { UserSearchResultFragment$key } from '~/generated/UserSearchResultFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
-import { noop } from '~/shared/utils/noop';
 
 import { SearchResult } from '../SearchResult';
 
@@ -15,7 +14,7 @@ type Props = {
   onSelect?: (item: MentionType) => void;
 };
 
-export function UserSearchResult({ userRef, onSelect = noop }: Props) {
+export function UserSearchResult({ userRef, onSelect }: Props) {
   const user = useFragment(
     graphql`
       fragment UserSearchResultFragment on GalleryUser {


### PR DESCRIPTION
### Summary of Changes

Fix the regression from mentions PR that the search result can't be pressed.

### Demo or Before/After Pics

**Search**


https://github.com/gallery-so/gallery/assets/4480258/84bd80b9-5663-4b17-98b5-74e4981aacbf


**Mentions**


https://github.com/gallery-so/gallery/assets/4480258/66dc646c-f05e-452a-9dde-b5a74f965a62



### Edge Cases

1. Search any user/community/galleries
2. Mention user or gallery in comment/post

### Testing Steps

1. Search anything in search screen
2. You should be able to browse around

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if mobile) I've tested the changes on both light and dark modes.
