### PR TITLE
add props to enable auto play on ios

### DIFF
--- a/apps/web/src/scenes/ContentPages/ContentModules/FeatureHighlight.tsx
+++ b/apps/web/src/scenes/ContentPages/ContentModules/FeatureHighlight.tsx
@@ -40,7 +40,7 @@ type FeatureHighlightMediaProps = {
 
 function FeatureHighlightMedia({ media }: FeatureHighlightMediaProps) {
   if (media.video) {
-    return <StyledVideo autoPlay loop muted src={media?.video.asset.url} />;
+    return <StyledVideo autoPlay loop muted playsInline src={media?.video.asset.url} />;
   }
 
   if (media.image) {


### PR DESCRIPTION
### Summary of Changes
add props to enable auto play on iOS

note - 2 of the videos still don't play, we suspect its because they were rendered with a slightly different codec from the one that works. will resolve by rendering new files

### Demo or Before/After Pics

before
https://github.com/gallery-so/gallery/assets/80802871/8af417c8-5f95-4a8a-a163-80b160f41a53


after
https://github.com/gallery-so/gallery/assets/80802871/525c7a45-8875-4b11-897a-106f3bd2789f



### Edge Cases


### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
