### PR TITLE
show global modal for posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ Hit up a member of the core team!
 - `moon run web:typecheck` for checking type validity
 - `moon run web:synpress-run` to run e2e tests
 - `moon run web:synpress-open` to open cypress
+- `yarn fetch-schema` to update graphql schema with latest dev version

--- a/README.md
+++ b/README.md
@@ -74,4 +74,5 @@ Hit up a member of the core team!
 - `moon run web:typecheck` for checking type validity
 - `moon run web:synpress-run` to run e2e tests
 - `moon run web:synpress-open` to open cypress
-- `yarn fetch-schema` to update graphql schema with latest dev version
+- `yarn fetch-schema` to pull graphql schema from production
+- `yarn fetch-schema-dev` to pull graphql schema from development

--- a/apps/web/pages/features/posts.tsx
+++ b/apps/web/pages/features/posts.tsx
@@ -11,43 +11,44 @@ export default function PostsFeatureRoute({ pageContent }: Props) {
   return <GalleryRoute element={<PostsFeaturePage pageContent={pageContent} />} navbar={false} />;
 }
 
-export const getServerSideProps = async () => {
-  const query = `
-  *[ _type == "featurePage" && id == "posts" ]{
-    ...,
-    "featureHighlights": featureHighlights[]->{
-      heading,
-      orientation,
-      body,
-      externalLink,
-      media{
-        mediaType,
-        image{
-          asset->{
-            url
-          },
-          alt
+export const featurePostsPageContentQuery = `
+*[ _type == "featurePage" && id == "posts" ]{
+  ...,
+  "featureHighlights": featureHighlights[]->{
+    heading,
+    orientation,
+    body,
+    externalLink,
+    media{
+      mediaType,
+      image{
+        asset->{
+          url
         },
-        video{
-          asset->{
-            url
-          }
+        alt
+      },
+      video{
+        asset->{
+          url
         }
       }
-    },
-    "faqModule": faqModule->{
-      title,
-      faqs
-    },
-    "splashImage": {
-      "asset": splashImage.asset->{
-        url
-      },
-      alt
     }
-  } | order(date desc)
+  },
+  "faqModule": faqModule->{
+    title,
+    faqs
+  },
+  "splashImage": {
+    "asset": splashImage.asset->{
+      url
+    },
+    alt
+  }
+} | order(date desc)
 `;
-  const content = await fetchSanityContent(query);
+
+export const getServerSideProps = async () => {
+  const content = await fetchSanityContent(featurePostsPageContentQuery);
 
   return {
     props: {

--- a/apps/web/src/contexts/globalLayout/GlobalLayoutContext.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalLayoutContext.tsx
@@ -31,8 +31,8 @@ import { PreloadQueryArgs } from '~/types/PageComponentPreloadQuery';
 import isTouchscreenDevice from '~/utils/isTouchscreenDevice';
 
 import { FEATURED_COLLECTION_IDS } from './GlobalAnnouncementPopover/GlobalAnnouncementPopover';
+import useGlobalAnnouncementPopover from './GlobalAnnouncementPopover/useGlobalAnnouncementPopover';
 import MobileBetaUpsell from './GlobalBanner/MobileBetaUpsell';
-// import useGlobalAnnouncementPopover from './GlobalAnnouncementPopover/useGlobalAnnouncementPopover';
 import GlobalSidebar, { GLOBAL_SIDEBAR_DESKTOP_WIDTH } from './GlobalSidebar/GlobalSidebar';
 import {
   FADE_TRANSITION_TIME_MS,
@@ -84,7 +84,7 @@ const GlobalLayoutContextQueryNode = graphql`
   query GlobalLayoutContextQuery {
     ...GlobalLayoutContextNavbarFragment
     # Keeping this around for the next time we want to use it
-    # ...useGlobalAnnouncementPopoverFragment
+    ...useGlobalAnnouncementPopoverFragment
   }
 `;
 
@@ -233,7 +233,7 @@ const GlobalLayoutContextProvider = memo(({ children, preloadedQuery }: Props) =
   );
 
   // Keeping this around for the next time we want to use it
-  // useGlobalAnnouncementPopover({ queryRef: query, authRequired: false, dismissVariant: 'global' });
+  useGlobalAnnouncementPopover({ queryRef: query, authRequired: false, dismissVariant: 'global' });
 
   const locationKey = useStabilizedRouteTransitionKey();
 

--- a/apps/web/src/contexts/modal/AnimatedModal.tsx
+++ b/apps/web/src/contexts/modal/AnimatedModal.tsx
@@ -8,6 +8,7 @@ import transitions, {
   ANIMATED_COMPONENT_TRANSITION_MS,
   ANIMATED_COMPONENT_TRANSLATION_PIXELS_LARGE,
 } from '~/components/core/transitions';
+import ErrorBoundary from '~/contexts/boundary/ErrorBoundary';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import { DecoratedCloseIcon } from '~/icons/CloseIcon';
 import colors from '~/shared/theme/colors';
@@ -106,7 +107,9 @@ function AnimatedModal({
                 )}
               </StyledModalActions>
             </StyledHeader>
-            <StyledContent padding={padding}>{content}</StyledContent>
+            <ErrorBoundary>
+              <StyledContent padding={padding}>{content}</StyledContent>
+            </ErrorBoundary>
           </StyledContainer>
         </_ToggleTranslate>
       </StyledModal>

--- a/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
+++ b/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
@@ -24,58 +24,64 @@ export default function PostsFeaturePage({ pageContent }: Props) {
       <Head>
         <title>Gallery | Posts</title>
       </Head>
-      <StyledPage gap={96}>
-        <StyledContent align="center" gap={96}>
-          <StyledIntro gap={48} align="center">
-            <VStack gap={32}>
-              <VStack>
-                <StyledHeading>Introducing</StyledHeading>
-                <StyledHeading>
-                  <strong>Posts</strong>
-                </StyledHeading>
-              </VStack>
-              <StyledSubheading>{pageContent.introText}</StyledSubheading>
-            </VStack>
-            <GalleryLink
-              to={{ pathname: '/auth' }}
-              eventElementId="Posts Feature Page: Get Started"
-              eventName="Posts Feature Page: Get Started Click"
-              eventContext={contexts.Posts}
-              eventFlow={flows['Posts Beta Announcement']}
-            >
-              <GetStartedButton eventElementId={null} eventName={null} eventContext={null}>
-                <TitleDiatypeL color={colors.white}>Get Started</TitleDiatypeL>
-              </GetStartedButton>
-            </GalleryLink>
-          </StyledIntro>
-          <StyledSplashImage src={pageContent.splashImage.asset.url} />
-          <VStack gap={96}>
-            {pageContent.featureHighlights.map((highlight) => (
-              <FeatureHighlight key={highlight.heading} content={highlight} />
-            ))}
-          </VStack>
-          <VStack align="center" gap={32}>
-            {pageContent.externalLink && (
-              <StyledSubheading>
-                <Markdown text={pageContent.externalLink} eventContext={contexts.Posts} />
-              </StyledSubheading>
-            )}
-            <GalleryLink
-              to={{ pathname: '/auth' }}
-              eventElementId="Posts Feature Page: Get Started"
-              eventName="Posts Feature Page: Get Started Click"
-              eventContext={contexts.Posts}
-              eventFlow={flows['Posts Beta Announcement']}
-            >
-              <GetStartedButton eventElementId={null} eventName={null} eventContext={null}>
-                <TitleDiatypeL color={colors.white}>Get Started</TitleDiatypeL>
-              </GetStartedButton>
-            </GalleryLink>
-          </VStack>
-        </StyledContent>
-        <Faq content={pageContent.faqModule} />
-      </StyledPage>
+      <PostsFeaturePageContent pageContent={pageContent} />
     </>
+  );
+}
+
+export function PostsFeaturePageContent({ pageContent }: Props) {
+  return (
+    <StyledPage gap={96}>
+      <StyledContent align="center" gap={96}>
+        <StyledIntro gap={48} align="center">
+          <VStack gap={32}>
+            <VStack>
+              <StyledHeading>Introducing</StyledHeading>
+              <StyledHeading>
+                <strong>Posts</strong>
+              </StyledHeading>
+            </VStack>
+            <StyledSubheading>{pageContent.introText}</StyledSubheading>
+          </VStack>
+          <GalleryLink
+            to={{ pathname: '/auth' }}
+            eventElementId="Posts Feature Page: Get Started"
+            eventName="Posts Feature Page: Get Started Click"
+            eventContext={contexts.Posts}
+            eventFlow={flows['Posts Beta Announcement']}
+          >
+            <GetStartedButton eventElementId={null} eventName={null} eventContext={null}>
+              <TitleDiatypeL color={colors.white}>Get Started</TitleDiatypeL>
+            </GetStartedButton>
+          </GalleryLink>
+        </StyledIntro>
+        <StyledSplashImage src={pageContent.splashImage?.asset.url} />
+        <VStack gap={96}>
+          {pageContent.featureHighlights?.map((highlight) => (
+            <FeatureHighlight key={highlight.heading} content={highlight} />
+          ))}
+        </VStack>
+        <VStack align="center" gap={32}>
+          {pageContent.externalLink && (
+            <StyledSubheading>
+              <Markdown text={pageContent.externalLink} eventContext={contexts.Posts} />
+            </StyledSubheading>
+          )}
+          <GalleryLink
+            to={{ pathname: '/auth' }}
+            eventElementId="Posts Feature Page: Get Started"
+            eventName="Posts Feature Page: Get Started Click"
+            eventContext={contexts.Posts}
+            eventFlow={flows['Posts Beta Announcement']}
+          >
+            <GetStartedButton eventElementId={null} eventName={null} eventContext={null}>
+              <TitleDiatypeL color={colors.white}>Get Started</TitleDiatypeL>
+            </GetStartedButton>
+          </GalleryLink>
+        </VStack>
+      </StyledContent>
+      <Faq content={pageContent.faqModule} />
+    </StyledPage>
   );
 }
 

--- a/apps/web/tests/graphql/mockGlobalLayoutQuery.ts
+++ b/apps/web/tests/graphql/mockGlobalLayoutQuery.ts
@@ -13,8 +13,9 @@ export function mockGlobalLayoutQuery() {
       user: {
         __typename: 'GalleryUser',
         id: GALLERY_USER_ID,
-        // @ts-expect-error not sure what the issue is
         username: 'Test Gallery User',
+        // @ts-expect-error not sure what the issue is
+        userExperiences: [],
         wallets: [],
         roles: ['ADMIN'],
         primaryWallet: {

--- a/schema.graphql
+++ b/schema.graphql
@@ -2144,7 +2144,6 @@ enum UserExperienceType {
   PostsBetaAnnouncement
 }
 
-
 type UserFollowedUsersFeedEventData implements FeedEventData {
   eventTime: Time
   owner: GalleryUser

--- a/schema.graphql
+++ b/schema.graphql
@@ -2141,7 +2141,9 @@ enum UserExperienceType {
   MobileBetaUpsell
   UpsellMintMemento5
   UpsellBanner
+  PostsBetaAnnouncement
 }
+
 
 type UserFollowedUsersFeedEventData implements FeedEventData {
   eventTime: Time


### PR DESCRIPTION
### Summary of Changes
Show global modal for posts

expected behavior 
- should be controlled by an experience flag
- should not be shown to signed out users
- should look the same as /features/posts page

I also added an error boundary to the animated modal content, so that the error fallback screen is displayed within the modal instead of taking over the full page, which allows the user to close the modal. Otherwise, if there's an error in this global modal it blocks the whole user experience.

### Demo or Before/After Pics
desktop
![CleanShot 2023-10-17 at 21 21 27](https://github.com/gallery-so/gallery/assets/80802871/de284e03-6b9a-4985-874e-6d0f10b0dba9)


mobile
![CleanShot 2023-10-17 at 21 21 37](https://github.com/gallery-so/gallery/assets/80802871/08a286d7-9bb0-4abb-8149-0d8ae847349c)


not shown for signed out users
![CleanShot 2023-10-17 at 21 18 40](https://github.com/gallery-so/gallery/assets/80802871/13bdddb3-cedb-4b75-a6d9-78ae45995f95)

Error boundary
![CleanShot 2023-10-17 at 20 59 28](https://github.com/gallery-so/gallery/assets/80802871/5465d2a1-4455-4304-8489-7c5611a1b8fa)


### Edge Cases
go to gallery.so/home

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
