### PR TITLE
add beta label to posts feature page

### DIFF
--- a/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
+++ b/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
@@ -6,7 +6,7 @@ import { Button } from '~/components/core/Button/Button';
 import GalleryLink from '~/components/core/GalleryLink/GalleryLink';
 import Markdown from '~/components/core/Markdown/Markdown';
 import { VStack } from '~/components/core/Spacer/Stack';
-import { TitleCondensed, TitleDiatypeL } from '~/components/core/Text/Text';
+import { TitleCondensed, TitleDiatypeL, TitleXS } from '~/components/core/Text/Text';
 import { contexts, flows } from '~/shared/analytics/constants';
 import colors from '~/shared/theme/colors';
 
@@ -35,11 +35,16 @@ export function PostsFeaturePageContent({ pageContent }: Props) {
       <StyledContent align="center" gap={96}>
         <StyledIntro gap={48} align="center">
           <VStack gap={32}>
-            <VStack>
-              <StyledHeading>Introducing</StyledHeading>
-              <StyledHeading>
-                <strong>Posts</strong>
-              </StyledHeading>
+            <VStack align="center" gap={16}>
+              <VStack>
+                <StyledHeading>Introducing</StyledHeading>
+                <StyledHeading>
+                  <strong>Posts</strong>
+                </StyledHeading>
+              </VStack>
+              <StyledBetaPill>
+                <TitleXS color={colors.activeBlue}>BETA</TitleXS>
+              </StyledBetaPill>
             </VStack>
             <StyledSubheading>{pageContent.introText}</StyledSubheading>
           </VStack>
@@ -124,6 +129,13 @@ const StyledHeading = styled(TitleCondensed)`
     line-height: 96px;
     width: 500px;
   }
+`;
+
+const StyledBetaPill = styled.div`
+  width: fit-content;
+  border-radius: 24px;
+  padding: 4px 12px;
+  border: 1px solid ${colors.activeBlue};
 `;
 
 const StyledSubheading = styled(TitleDiatypeL)`


### PR DESCRIPTION
### Summary of Changes
Adding a beta label to the posts feature page.

### Demo or Before/After Pics



| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
|
<img width="620" alt="CleanShot 2023-10-18 at 16 01 35@2x" src="https://github.com/gallery-so/gallery/assets/80802871/ab7b5e72-e0d3-4186-919d-6912e27e0fe3">
 | 
<img width="667" alt="CleanShot 2023-10-18 at 16 00 21@2x" src="https://github.com/gallery-so/gallery/assets/80802871/2a5ce012-c957-4c11-9874-913fe0e6dbcd">
 |

### Edge Cases

n/a

### Testing Steps

go to /features/posts
### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
