### PR TITLE
dont deep link to app on features pages

### DIFF
--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -26,6 +26,7 @@
           "NOT /explore",
           "NOT /faq",
           "NOT /featured",
+          "NOT /features/*",
           "NOT /feed",
           "NOT /feeds",
           "NOT /gallery",


### PR DESCRIPTION
### Summary of Changes

Don't deep link to app on Features pages (like Posts Feature page)

### Demo or Before/After Pics

### Testing Steps
open a url for /features/posts and it should open in the browser instead of deep linking to app
### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
