### PR TITLE
remove full page loader from global app level boundary suspense

### DIFF
--- a/apps/web/src/contexts/boundary/Boundary.tsx
+++ b/apps/web/src/contexts/boundary/Boundary.tsx
@@ -1,12 +1,35 @@
-import { memo, PropsWithChildren, Suspense } from 'react';
+import { useRouter } from 'next/router';
+import { memo, PropsWithChildren, Suspense, useMemo } from 'react';
+
+import FullPageLoader from '~/components/core/Loader/FullPageLoader';
 
 import ErrorBoundary from './ErrorBoundary';
 
-const Boundary = memo(({ children }: PropsWithChildren) => (
-  <Suspense>
-    <ErrorBoundary>{children}</ErrorBoundary>
-  </Suspense>
-));
+const NO_FULL_PAGE_LOADER_PATHS = ['/features'];
+
+const isPathExcluded = (pathname: string) => {
+  return NO_FULL_PAGE_LOADER_PATHS.some((path) => pathname.startsWith(path));
+};
+
+const Boundary = memo(({ children }: PropsWithChildren) => {
+  const { pathname } = useRouter();
+
+  const isFullPageLoaderExcluded = useMemo(() => isPathExcluded(pathname), [pathname]);
+
+  if (isFullPageLoaderExcluded) {
+    return (
+      <Suspense>
+        <ErrorBoundary>{children}</ErrorBoundary>;
+      </Suspense>
+    );
+  }
+
+  return (
+    <Suspense fallback={<FullPageLoader />}>
+      <ErrorBoundary>{children}</ErrorBoundary>
+    </Suspense>
+  );
+});
 
 Boundary.displayName = 'Boundary';
 

--- a/apps/web/src/contexts/boundary/Boundary.tsx
+++ b/apps/web/src/contexts/boundary/Boundary.tsx
@@ -1,11 +1,9 @@
 import { memo, PropsWithChildren, Suspense } from 'react';
 
-import FullPageLoader from '~/components/core/Loader/FullPageLoader';
-
 import ErrorBoundary from './ErrorBoundary';
 
 const Boundary = memo(({ children }: PropsWithChildren) => (
-  <Suspense fallback={<FullPageLoader />}>
+  <Suspense>
     <ErrorBoundary>{children}</ErrorBoundary>
   </Suspense>
 ));


### PR DESCRIPTION
### Summary of Changes
This PR modifies the global app level boundary to allow disabling the Full Page Loader for specified paths.
This is so that we can avoid showing a full screen loader for content pages like the Features Posts page.

This change should only affect the Features Posts page and not other pages.

### Demo or Before/After Pics
No loader on Posts Feature page:
https://github.com/gallery-so/gallery/assets/80802871/808fef71-b546-41c5-a65a-e96edb2dccf9


Loader still shows for Collection Page:
https://github.com/gallery-so/gallery/assets/80802871/720bb353-6e3c-4a8f-93d5-4e8f3d7a01fe


Loader still shows for User Page:
https://github.com/gallery-so/gallery/assets/80802871/b2981f62-3613-4326-ad5a-68acdabaf461

Loader still shows for Feed;

https://github.com/gallery-so/gallery/assets/80802871/496155e0-d7b2-4342-8a29-5565e37d5cb1



### Edge Cases
n/a

### Testing Steps
go to /features/posts and verify there's no full page loader. the content should just appear.
go to other pages and verify that a loader is shown (assuming it is currently shown on prod)

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
