### PR TITLE
update Posts Features page cta for signed in users

### DIFF
--- a/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
+++ b/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
@@ -1,4 +1,7 @@
 import Head from 'next/head';
+import { Route } from 'nextjs-routes';
+import { useMemo } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
 import styled from 'styled-components';
 
 import breakpoints, { pageGutter } from '~/components/core/breakpoints';
@@ -7,6 +10,7 @@ import GalleryLink from '~/components/core/GalleryLink/GalleryLink';
 import Markdown from '~/components/core/Markdown/Markdown';
 import { VStack } from '~/components/core/Spacer/Stack';
 import { TitleCondensed, TitleDiatypeL, TitleXS } from '~/components/core/Text/Text';
+import { PostsFeaturePageContentQuery } from '~/generated/PostsFeaturePageContentQuery.graphql';
 import { contexts, flows } from '~/shared/analytics/constants';
 import colors from '~/shared/theme/colors';
 
@@ -30,6 +34,24 @@ export default function PostsFeaturePage({ pageContent }: Props) {
 }
 
 export function PostsFeaturePageContent({ pageContent }: Props) {
+  const query = useLazyLoadQuery<PostsFeaturePageContentQuery>(
+    graphql`
+      query PostsFeaturePageContentQuery {
+        viewer {
+          __typename
+        }
+      }
+    `,
+    {}
+  );
+
+  const isAuthenticated = query.viewer?.__typename === 'Viewer';
+  const ctaButtonRoute: Route = useMemo(() => {
+    if (!isAuthenticated) return { pathname: '/auth' };
+
+    return { pathname: '/home', query: { composer: 'true' } };
+  }, [isAuthenticated]);
+
   return (
     <StyledPage gap={96}>
       <StyledContent align="center" gap={96}>
@@ -49,7 +71,7 @@ export function PostsFeaturePageContent({ pageContent }: Props) {
             <StyledSubheading>{pageContent.introText}</StyledSubheading>
           </VStack>
           <GalleryLink
-            to={{ pathname: '/auth' }}
+            to={ctaButtonRoute}
             eventElementId="Posts Feature Page: Get Started"
             eventName="Posts Feature Page: Get Started Click"
             eventContext={contexts.Posts}
@@ -73,7 +95,7 @@ export function PostsFeaturePageContent({ pageContent }: Props) {
             </StyledSubheading>
           )}
           <GalleryLink
-            to={{ pathname: '/auth' }}
+            to={ctaButtonRoute}
             eventElementId="Posts Feature Page: Get Started"
             eventName="Posts Feature Page: Get Started Click"
             eventContext={contexts.Posts}


### PR DESCRIPTION
### Summary of Changes
This PR updates the cta button destination on the Posts Features page such that if the viewer is signed in, the button takes them to the feed and opens the Composer.
If they are not signed in they are taken to the auth page.

### Demo or Before/After Pics
Signed in
https://github.com/gallery-so/gallery/assets/80802871/f772e327-4f01-460a-a75b-c20dcbb795d2



https://github.com/gallery-so/gallery/assets/80802871/4c36c386-1430-4880-b92c-94cb8bae66c0


### Edge Cases

na
### Testing Steps
go to /features/posts and hit the Get Started button

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
