### PR TITLE
Kaito/features external link

### DIFF
--- a/apps/web/src/components/core/GalleryLink/GalleryLink.tsx
+++ b/apps/web/src/components/core/GalleryLink/GalleryLink.tsx
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { Route } from 'nextjs-routes';
 import {
   ComponentProps,
@@ -130,6 +131,8 @@ export default function GalleryLink({
   return null;
 }
 
+const skipVerificationOnTheseRoutes = ['/features/'];
+
 export function GalleryLinkNeedsVerification({
   inheritLinkStyling = false,
   href,
@@ -141,6 +144,11 @@ export function GalleryLinkNeedsVerification({
 }) {
   const { showModal } = useModalActions();
   const track = useTrack();
+  const { pathname } = useRouter();
+
+  const skipVerification = skipVerificationOnTheseRoutes.some((route) =>
+    pathname.startsWith(route)
+  );
 
   const handleClick = useCallback(
     (e: MouseEvent, href: string) => {
@@ -151,13 +159,19 @@ export function GalleryLinkNeedsVerification({
         needsVerification: true,
       });
 
+      // on certain routes like our content pages, we trust the external links displayed and thefore dont need to show a verification
+      if (skipVerification && typeof window !== 'undefined') {
+        window.open(href, '_blank', 'noopener,noreferrer');
+        return;
+      }
+
       showModal({
         content: <VerifyNavigationPopover href={href} />,
         isFullPage: false,
         headerText: 'Leaving gallery.so?',
       });
     },
-    [showModal, track]
+    [showModal, skipVerification, track]
   );
   return (
     <GalleryLink

--- a/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
+++ b/apps/web/src/scenes/ContentPages/PostsFeaturePage.tsx
@@ -1,4 +1,7 @@
 import Head from 'next/head';
+import { Route } from 'nextjs-routes';
+import { useMemo } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
 import styled from 'styled-components';
 
 import breakpoints, { pageGutter } from '~/components/core/breakpoints';
@@ -7,6 +10,7 @@ import GalleryLink from '~/components/core/GalleryLink/GalleryLink';
 import Markdown from '~/components/core/Markdown/Markdown';
 import { VStack } from '~/components/core/Spacer/Stack';
 import { TitleCondensed, TitleDiatypeL, TitleXS } from '~/components/core/Text/Text';
+import { PostsFeaturePageContentQuery } from '~/generated/PostsFeaturePageContentQuery.graphql';
 import { contexts, flows } from '~/shared/analytics/constants';
 import colors from '~/shared/theme/colors';
 
@@ -30,6 +34,24 @@ export default function PostsFeaturePage({ pageContent }: Props) {
 }
 
 export function PostsFeaturePageContent({ pageContent }: Props) {
+  const query = useLazyLoadQuery<PostsFeaturePageContentQuery>(
+    graphql`
+      query PostsFeaturePageContentQuery {
+        viewer {
+          __typename
+        }
+      }
+    `,
+    {}
+  );
+
+  const isAuthenticated = query.viewer?.__typename === 'Viewer';
+  const ctaButtonRoute: Route = useMemo(() => {
+    if (!isAuthenticated) return { pathname: '/auth' };
+
+    return { pathname: '/home', query: { composer: 'true' } };
+  }, [isAuthenticated]);
+
   return (
     <StyledPage gap={96}>
       <StyledContent align="center" gap={96}>
@@ -49,7 +71,7 @@ export function PostsFeaturePageContent({ pageContent }: Props) {
             <StyledSubheading>{pageContent.introText}</StyledSubheading>
           </VStack>
           <GalleryLink
-            to={{ pathname: '/auth' }}
+            to={ctaButtonRoute}
             eventElementId="Posts Feature Page: Get Started"
             eventName="Posts Feature Page: Get Started Click"
             eventContext={contexts.Posts}
@@ -73,7 +95,7 @@ export function PostsFeaturePageContent({ pageContent }: Props) {
             </StyledSubheading>
           )}
           <GalleryLink
-            to={{ pathname: '/auth' }}
+            to={ctaButtonRoute}
             eventElementId="Posts Feature Page: Get Started"
             eventName="Posts Feature Page: Get Started Click"
             eventContext={contexts.Posts}


### PR DESCRIPTION
### Summary of Changes

This PR modifies GalleryLinkNeedsVerification so that we don't show the confirmation popup on certain routes such as our content pages. Since we know and trust the external links displayed on those pages, we want to immediately open them in a new tab when the user clicks them, as opposed to confirming that they want to access that url.

### Demo or Before/After Pics
no confirmation on Posts Feature page

https://github.com/gallery-so/gallery/assets/80802871/eebbaa1b-881b-4065-8027-bf8121d4e5d6

still show confirmation elsehwere

https://github.com/gallery-so/gallery/assets/80802871/8ff2dc88-e0c6-433c-8939-22cf46036b5a





### Edge Cases
na
### Testing Steps
 go to /features/posts and click the mirror article url. it should not show a confrimation


go to the feed and click a url. it should show a confirmation

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
