### PR TITLE
fix description color for darkmode

### DIFF
--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -3,7 +3,6 @@ import { useColorScheme } from 'nativewind';
 import { useCallback } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
-
 import { graphql, useFragment } from 'react-relay';
 import { PoapIcon } from 'src/icons/PoapIcon';
 import { ShareIcon } from 'src/icons/ShareIcon';
@@ -14,6 +13,7 @@ import { Button } from '~/components/Button';
 import { GalleryLink } from '~/components/GalleryLink';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { IconContainer } from '~/components/IconContainer';
+import { Markdown } from '~/components/Markdown';
 import { Pill } from '~/components/Pill';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { Typography } from '~/components/Typography';
@@ -30,7 +30,6 @@ import { extractRelevantMetadataFromToken } from '~/shared/utils/extractRelevant
 import { NftAdditionalDetails } from './NftAdditionalDetails';
 import { NftDetailAsset } from './NftDetailAsset/NftDetailAsset';
 import { NftDetailAssetCacheSwapper } from './NftDetailAsset/NftDetailAssetCacheSwapper';
-import { Markdown } from '~/components/Markdown';
 
 type Props = {
   onShare: () => void;

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -3,7 +3,7 @@ import { useColorScheme } from 'nativewind';
 import { useCallback } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
-import Markdown from 'react-native-markdown-display';
+
 import { graphql, useFragment } from 'react-relay';
 import { PoapIcon } from 'src/icons/PoapIcon';
 import { ShareIcon } from 'src/icons/ShareIcon';
@@ -30,6 +30,7 @@ import { extractRelevantMetadataFromToken } from '~/shared/utils/extractRelevant
 import { NftAdditionalDetails } from './NftAdditionalDetails';
 import { NftDetailAsset } from './NftDetailAsset/NftDetailAsset';
 import { NftDetailAssetCacheSwapper } from './NftDetailAsset/NftDetailAssetCacheSwapper';
+import { Markdown } from '~/components/Markdown';
 
 type Props = {
   onShare: () => void;


### PR DESCRIPTION
### Summary of Changes
Fix Markdown import - was using different Markdown component so the color was incorrect on dark mode.




### Demo or Before/After Pics

Dark Mode
![CleanShot 2023-10-20 at 16 26 07](https://github.com/gallery-so/gallery/assets/80802871/44c1e6e0-992f-4846-a3b2-c0bc77906674)


Light Mode
![CleanShot 2023-10-20 at 16 26 22](https://github.com/gallery-so/gallery/assets/80802871/9cfdf237-c29b-494b-af2d-030c5378aae4)



### Edge Cases
na

### Testing Steps
View the NFT Detail Page on both light and dark mode

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
