### PR TITLE
TextArea in Post Composer Web truncated early

### DIFF
--- a/apps/web/src/components/core/TextArea/TextArea.tsx
+++ b/apps/web/src/components/core/TextArea/TextArea.tsx
@@ -146,7 +146,6 @@ const StyledTextArea = styled.textarea<TextAreaProps>`
   padding: 12px;
   font-family: 'ABC Diatype', Helvetica, Arial, sans-serif;
   border: none;
-  border-bottom: 36px solid transparent;
   resize: none;
   font-size: 14px;
   line-height: 20px;


### PR DESCRIPTION
### Summary of Changes
TextArea in Post Composer Web truncated early and this removes the early truncation

### Demo or Before/After Pics

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="740" alt="Screenshot 2023-10-20 at 3 22 10 PM" src="https://github.com/gallery-so/gallery/assets/49758803/63b3031e-08d0-4ed7-8dd3-ac4c9f02f314"> | <img width="755" alt="Screenshot 2023-10-20 at 3 21 38 PM" src="https://github.com/gallery-so/gallery/assets/49758803/786dab7c-44f4-4e72-9ad1-121c11711255"> |

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
