### PR TITLE
disable deep link for mint pages

### DIFF
--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -40,6 +40,7 @@
           "NOT /members",
           "NOT /membership",
           "NOT /messages",
+          "NOT /mint/*",
           "NOT /nft",
           "NOT /nfts",
           "NOT /notifications",


### PR DESCRIPTION
### Summary of Changes

Disable deep link for mint pages 


### Testing Steps
Open a url like gallery.so/mint/mementos and confirm it doesn't deep link to the app.


### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
