### PR TITLE
[GAL-4436] notification regression

### DIFF
--- a/apps/web/src/components/Notifications/notifications/NotificationPostPreview.tsx
+++ b/apps/web/src/components/Notifications/notifications/NotificationPostPreview.tsx
@@ -28,7 +28,8 @@ function NotificationPostPreview({ tokenRef }: NotificationPostPreviewProps) {
 
 const StyledPostPreview = styled.img`
   height: 100%;
-  width: 100%;
+  width: 56px;
+  object-fit: cover;
 `;
 
 type NotificationPostPreviewWithBoundaryProps = {

--- a/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourPost.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourPost.tsx
@@ -88,6 +88,7 @@ const StyledCaption = styled(BaseM)`
   font-size: 12px;
   border-left: 2px solid ${colors.porcelain};
   padding-left: 8px;
+  word-break: break-word;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   overflow: hidden;


### PR DESCRIPTION
### Summary of Changes

update styling of SomeoneCommentedOnYourPost notification to accommodate text and token preview correctly

### Demo or Before/After Pics


| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="604" alt="Screenshot 2023-10-23 at 7 32 53 PM" src="https://github.com/gallery-so/gallery/assets/49758803/7ae8af23-b130-4b86-a0fe-70b32364d696"> | <img width="669" alt="Screenshot 2023-10-23 at 7 27 44 PM" src="https://github.com/gallery-so/gallery/assets/49758803/79a2de52-9966-4662-a054-8727b8540e3f">|

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="395" alt="Screenshot 2023-10-23 at 7 36 14 PM" src="https://github.com/gallery-so/gallery/assets/49758803/0c851db5-c42b-4c06-8a11-962c903ba676"> | <img width="394" alt="Screenshot 2023-10-23 at 7 38 10 PM" src="https://github.com/gallery-so/gallery/assets/49758803/5207df6f-39a6-44a6-9085-b954343efe5b"> |

### Edge Cases
List any common edge cases that you have considered and tested.


### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
