### PR TITLE
[GAl-4256] Displaying Creators in NFT Token Page

### DIFF
--- a/apps/mobile/src/components/Community/CommunityMeta.tsx
+++ b/apps/mobile/src/components/Community/CommunityMeta.tsx
@@ -12,6 +12,7 @@ import { PolygonIcon } from 'src/icons/PolygonIcon';
 import { TezosIcon } from 'src/icons/TezosIcon';
 import { ZoraIcon } from 'src/icons/ZoraIcon';
 
+import { EnsOrAddress } from '~/components/EnsOrAddress';
 import { useManageWalletActions } from '~/contexts/ManageWalletContext';
 import { Chain, CommunityMetaFragment$key } from '~/generated/CommunityMetaFragment.graphql';
 import { CommunityMetaQueryFragment$key } from '~/generated/CommunityMetaQueryFragment.graphql';
@@ -24,7 +25,6 @@ import colors from '~/shared/theme/colors';
 import { Button } from '../Button';
 import { GalleryBottomSheetModalType } from '../GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
-import { LinkableAddress } from '../LinkableAddress';
 import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
 import { RawProfilePicture } from '../ProfilePicture/RawProfilePicture';
 import { Typography } from '../Typography';
@@ -44,7 +44,7 @@ export function CommunityMeta({ communityRef, queryRef }: Props) {
         contractAddress {
           chain
           address
-          ...LinkableAddressFragment
+          ...EnsOrAddressWithSuspenseFragment
         }
         creator {
           __typename
@@ -183,20 +183,18 @@ export function CommunityMeta({ communityRef, queryRef }: Props) {
             eventName="Community PFP Press"
             eventContext={contexts.Community}
           />
-          <LinkableAddress
-            chainAddressRef={community.contractAddress}
-            textStyle={{ color: colorScheme === 'light' ? colors.black[800] : colors.offWhite }}
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
-            eventElementId="Community Contract Address"
-            eventName="Community Contract Address Press"
-            eventContext={contexts.Community}
-          />
+          <View>
+            <EnsOrAddress
+              chainAddressRef={community.contractAddress}
+              eventContext={contexts.Community}
+            />
+          </View>
         </View>
       );
     } else {
       return null;
     }
-  }, [colorScheme, community.creator, community.contractAddress, handleUsernamePress]);
+  }, [community.creator, community.contractAddress, handleUsernamePress]);
 
   return (
     <View className="flex flex-row justify-between">

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -10,9 +10,9 @@ import { ShareIcon } from 'src/icons/ShareIcon';
 import { BackButton } from '~/components/BackButton';
 import { TokenFailureBoundary } from '~/components/Boundaries/TokenFailureBoundary/TokenFailureBoundary';
 import { Button } from '~/components/Button';
+import { EnsOrAddress } from '~/components/EnsOrAddress';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { IconContainer } from '~/components/IconContainer';
-import { LinkableAddress } from '~/components/LinkableAddress';
 import { Markdown } from '~/components/Markdown';
 import { Pill } from '~/components/Pill';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
@@ -70,7 +70,7 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
               badgeURL
               creatorAddress {
                 address
-                ...LinkableAddressFragment
+                ...EnsOrAddressWithSuspenseFragment
               }
               contractAddress {
                 address
@@ -215,17 +215,16 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
             eventName="NftDetail Creator PFP"
             eventContext={contexts['NFT Detail']}
           />
-          <LinkableAddress
-            textStyle={{ color: colorScheme === 'dark' ? colors.white : colors.black['800'] }}
-            chainAddressRef={token.contract.creatorAddress}
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
-            eventElementId="NFT Detail Creator Address"
-            eventName="NFT Detail Creator Address Press"
-            eventContext={contexts['NFT Detail']}
-          />
+          <View>
+            <EnsOrAddress
+              chainAddressRef={token.contract.creatorAddress}
+              eventContext={contexts['NFT Detail']}
+            />
+          </View>
         </View>
       );
     }
+
     return null;
   }, [
     token.owner,
@@ -234,7 +233,6 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
     token.community?.creator,
     handleOwnerUsernamePress,
     handleCreatorUsernamePress,
-    colorScheme,
   ]);
 
   // const handleCreatorPress = useCallback(() => {

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -137,15 +137,13 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
   }, [navigation, token.contract?.contractAddress]);
 
   const handleUsernamePress = useCallback(
-    (username: any, contractAddress: any) => {
-      if (username) {
-        track('NFT Detail Collector Name Clicked', {
-          username: username,
-          contractAddress: contractAddress,
-          tokenId: token.tokenId,
-        });
-        navigation.push('Profile', { username: username });
-      }
+    (username: string, contractAddress: string) => {
+      track('NFT Detail Collector Name Clicked', {
+        username: username,
+        contractAddress: contractAddress,
+        tokenId: token.tokenId,
+      });
+      navigation.push('Profile', { username: username });
     },
     [navigation, track, token.tokenId]
   );
@@ -163,15 +161,17 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
   const creatorAddress =
     token.community?.creator?.__typename === 'ChainAddress' && token.community?.creator?.address;
 
-  const handleOwnerUsernamePress = useCallback(
-    () => handleUsernamePress(token.owner?.username, token.contract?.contractAddress?.address),
-    [handleUsernamePress, token.owner?.username, token.contract?.contractAddress?.address]
-  );
+  const handleOwnerUsernamePress = useCallback(() => {
+    if (token.owner?.username && token.contract?.contractAddress?.address) {
+      handleUsernamePress(token.owner?.username, token.contract?.contractAddress?.address);
+    }
+  }, [handleUsernamePress, token.owner?.username, token.contract?.contractAddress?.address]);
 
-  const handleCreatorUsernamePress = useCallback(
-    () => handleUsernamePress(creatorUsername, creatorAddress),
-    [handleUsernamePress, creatorUsername, creatorAddress]
-  );
+  const handleCreatorUsernamePress = useCallback(() => {
+    if (creatorUsername && creatorAddress) {
+      handleUsernamePress(creatorUsername, creatorAddress);
+    }
+  }, [handleUsernamePress, creatorUsername, creatorAddress]);
 
   const CreatorLink = useMemo(() => {
     const creator = token.community?.creator;

--- a/apps/web/src/components/NftPreview/NftPreviewLabel.tsx
+++ b/apps/web/src/components/NftPreview/NftPreviewLabel.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import { HStack } from '~/components/core/Spacer/Stack';
 import { BaseM } from '~/components/core/Text/Text';
-import { ENABLED_CREATOR } from '~/constants/creator';
 import { NftPreviewLabelCollectionNameFragment$key } from '~/generated/NftPreviewLabelCollectionNameFragment.graphql';
 import { NftPreviewLabelFragment$key } from '~/generated/NftPreviewLabelFragment.graphql';
 import colors from '~/shared/theme/colors';
@@ -118,35 +117,12 @@ function CollectionName({ tokenRef, interactive }: CollectionNameProps) {
     <StyledGalleryLink to={communityUrl}>
       <HStack gap={4} align="center">
         {token.contract?.badgeURL && <StyledBadge src={token.contract.badgeURL} />}
-
-        <StyledBaseM color={colors.porcelain}>
-          {collectionName}
-
-          {ENABLED_CREATOR && (
-            <>
-              {' '}
-              <BaseM color={colors.metal} as="span">
-                by Artist
-              </BaseM>
-            </>
-          )}
-        </StyledBaseM>
+        <StyledBaseM color={colors.porcelain}>{collectionName}</StyledBaseM>
       </HStack>
     </StyledGalleryLink>
   ) : (
     <HStack gap={4} align="center">
-      <StyledBaseM color={colors.porcelain}>
-        {collectionName}
-
-        {ENABLED_CREATOR && (
-          <>
-            {' '}
-            <BaseM color={colors.metal} as="span">
-              by Artist
-            </BaseM>
-          </>
-        )}
-      </StyledBaseM>
+      <StyledBaseM color={colors.porcelain}>{collectionName}</StyledBaseM>
     </HStack>
   );
 }

--- a/apps/web/src/constants/creator.ts
+++ b/apps/web/src/constants/creator.ts
@@ -1,1 +1,0 @@
-export const ENABLED_CREATOR = false;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -15,7 +15,6 @@ import CommunityHoverCard from '~/components/HoverCard/CommunityHoverCard';
 import UserHoverCard from '~/components/HoverCard/UserHoverCard';
 import { PostComposerModal } from '~/components/Posts/PostComposerModal';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
-import { ENABLED_CREATOR } from '~/constants/creator';
 import { useGlobalNavbarHeight } from '~/contexts/globalLayout/GlobalNavbar/useGlobalNavbarHeight';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { NftDetailTextFragment$key } from '~/generated/NftDetailTextFragment.graphql';
@@ -90,22 +89,6 @@ function NftDetailText({ tokenRef, authenticatedUserOwnsAsset }: Props) {
 
   const handleBuyNowClick = useCallback(() => {
     track('Buy Now Button Click', {
-      username: token.owner?.username ? token.owner.username.toLowerCase() : undefined,
-      contractAddress: token.contract?.contractAddress?.address,
-      tokenId: token.tokenId,
-      externaUrl: openseaUrl,
-    });
-  }, [
-    track,
-    token.owner?.username,
-    token.contract?.contractAddress?.address,
-    token.tokenId,
-    openseaUrl,
-  ]);
-
-  const handleCreatorNameClick = useCallback(() => {
-    // TODO: Update this to track the creator name click
-    track('NFT Detail Creator Name Click', {
       username: token.owner?.username ? token.owner.username.toLowerCase() : undefined,
       contractAddress: token.contract?.contractAddress?.address,
       tokenId: token.tokenId,
@@ -194,24 +177,6 @@ function NftDetailText({ tokenRef, authenticatedUserOwnsAsset }: Props) {
                 </HStack>
               </VStack>
             </UserHoverCard>
-          )}
-          {ENABLED_CREATOR && (
-            // TODO: Update this to use the creator's username
-            <VStack gap={2}>
-              <TitleXS>CREATOR</TitleXS>
-              <GalleryLink
-                onClick={handleCreatorNameClick}
-                to={{ pathname: '/[username]', query: { username: 'riley' } }}
-              >
-                <BaseM color={colors.shadow}>riley.eth</BaseM>
-              </GalleryLink>
-              <GalleryLink
-                onClick={handleCreatorNameClick}
-                to={{ pathname: '/[username]', query: { username: 'riley' } }}
-              >
-                <BaseM color={colors.shadow}>peterson.eth</BaseM>
-              </GalleryLink>
-            </VStack>
           )}
         </HStack>
 

--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -22,7 +22,6 @@ import { useBreakpoint, useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import { NftAdditionalDetails } from '~/scenes/NftDetailPage/NftAdditionalDetails/NftAdditionalDetails';
 import { contexts, flows } from '~/shared/analytics/constants';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
-import colors from '~/shared/theme/colors';
 import { extractRelevantMetadataFromToken } from '~/shared/utils/extractRelevantMetadataFromToken';
 import unescape from '~/shared/utils/unescape';
 import { getCommunityUrlForToken } from '~/utils/getCommunityUrlForToken';


### PR DESCRIPTION
### Summary of Changes
1. deprecate ENABLED_CREATOR hard-coded variable
2. use this logic for NftDetailText
  
ownerIsHolder
 -> true -> display Owner
  -> false -> display null
  
ownerIsCreator
  -> true -> display Creator
  -> false -> look up contract's creator
      -> if exists -> display Creator
      -> else -> display null

## Demo or Before/After Pics
### For creator being a gallery user

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="421" alt="Screenshot 2023-10-26 at 1 55 17 AM" src="https://github.com/gallery-so/gallery/assets/49758803/bd4f6ac9-bdf4-4177-acb2-f568de338172"> | <img width="426" alt="Screenshot 2023-10-26 at 1 14 12 AM" src="https://github.com/gallery-so/gallery/assets/49758803/fda1a78f-5977-4c5e-9080-79a185b80175"> |

### For creator only having contract
| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="442" alt="Screenshot 2023-10-23 at 9 17 56 PM" src="https://github.com/gallery-so/gallery/assets/49758803/85ca022f-f731-43b3-986e-8fd79ac6a226"> | <img width="427" alt="Screenshot 2023-10-23 at 9 12 26 PM" src="https://github.com/gallery-so/gallery/assets/49758803/8eba013a-8ebc-4e9c-9fb7-0b0c5eadbfae"> |

### For owner also being the creator
| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="437" alt="Screenshot 2023-10-23 at 9 17 47 PM" src="https://github.com/gallery-so/gallery/assets/49758803/ad50f974-faab-400c-9c51-f6563923eed8"> | <img width="452" alt="Screenshot 2023-10-23 at 9 17 32 PM" src="https://github.com/gallery-so/gallery/assets/49758803/852196bb-03d9-44e0-b7a6-b541ed3f581d"> |

## Other improvements
Now handles ens name for contracts on nft detail and community view
| After                                     | After  (clicking on link)                                    |
| ------------------------------------------ | ------------------------------------------ |
| <img width="436" alt="Screenshot 2023-11-01 at 5 06 18 AM" src="https://github.com/gallery-so/gallery/assets/49758803/fd5863ff-0f72-4e33-8f1f-319c15be201d"> | <img width="427" alt="Screenshot 2023-11-01 at 5 06 53 AM" src="https://github.com/gallery-so/gallery/assets/49758803/50efb0a5-8321-4962-8d12-1f4a0092889a"> |
### Edge Cases


List any common edge cases that you have considered and tested.



### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
