### PR TITLE
remove wrapping to new line on social pill

### DIFF
--- a/apps/web/src/scenes/UserGalleryPage/UserSocialPill.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSocialPill.tsx
@@ -50,4 +50,5 @@ const StyledHandle = styled(TitleXS)`
   text-overflow: ellipsis;
   font-weight: 700;
   text-transform: initial;
+  white-space: nowrap;
 `;


### PR DESCRIPTION
### Summary of Changes
Adding a hyphen in the social pill is causing it to wrap to a new line, which is not desired

### Demo or Before/After Pics

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="392" alt="Screenshot 2023-10-31 at 1 18 26 AM" src="https://github.com/gallery-so/gallery/assets/49758803/3b35792c-cd96-4be2-b868-472ef9340458"> | <img width="392" alt="Screenshot 2023-10-31 at 1 18 26 AM" src="https://github.com/gallery-so/gallery/assets/49758803/baceacd6-1b69-4cfc-b0f3-5d9a6d2eafeb"> |

### Edge Cases
Tested different special character in the username

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
