### PR TITLE
[GAL-4678] Fix network autoselect

### DIFF
--- a/apps/web/src/contexts/postComposer/PostComposerContext.tsx
+++ b/apps/web/src/contexts/postComposer/PostComposerContext.tsx
@@ -82,7 +82,7 @@ const PostComposerProvider = memo(({ children }: Props) => {
   const isMobile = useIsMobileWindowWidth();
 
   useEffect(() => {
-    if (chain && typeof chain === 'string' && isSupportedChain(chain)) {
+    if (composer === 'true' && chain && typeof chain === 'string' && isSupportedChain(chain)) {
       // Capitalize the first letter of the chain name that we get from the router to match the Chain type
       const capitalizedChainName = chain.charAt(0).toUpperCase() + chain.slice(1);
       setNetwork(capitalizedChainName as Chain);


### PR DESCRIPTION
### Summary of Changes

Before: The composer filters network based on most recent collection page viewed.

After: The composer should reset to default (ethereum) after a user has left a specific collection page

- [x] Ensure this doesn't cause a regression on share-to-gallery links

### Checklist
- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
