### PR TITLE
Apply badge filtering on mobile

### DIFF
--- a/apps/mobile/src/components/Trending/TrendingUserCard.tsx
+++ b/apps/mobile/src/components/Trending/TrendingUserCard.tsx
@@ -13,6 +13,7 @@ import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
+import { BADGE_ENABLED_COMMUNITY_ADDRESSES } from '~/shared/utils/communities';
 
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
 import { Markdown } from '../Markdown';
@@ -38,6 +39,11 @@ export function TrendingUserCard({ style, userRef, queryRef }: Props) {
         username
         badges {
           imageURL
+          contract {
+            contractAddress {
+              address
+            }
+          }
         }
         bio
         galleries {
@@ -68,7 +74,15 @@ export function TrendingUserCard({ style, userRef, queryRef }: Props) {
   }, [user.galleries]);
 
   const filteredBadges = useMemo(() => {
-    return badges?.filter((badge) => badge?.imageURL) ?? [];
+    return (
+      badges
+        ?.filter((badge) => badge?.imageURL)
+        ?.filter((badge) => {
+          return BADGE_ENABLED_COMMUNITY_ADDRESSES.has(
+            badge?.contract?.contractAddress?.address ?? ''
+          );
+        }) ?? []
+    );
   }, [badges]);
 
   const tokenPreviews = useMemo(() => {

--- a/apps/web/src/components/Badge/Badge.tsx
+++ b/apps/web/src/components/Badge/Badge.tsx
@@ -6,10 +6,10 @@ import styled from 'styled-components';
 import GalleryLink from '~/components/core/GalleryLink/GalleryLink';
 import IconContainer from '~/components/core/IconContainer';
 import Tooltip from '~/components/Tooltip/Tooltip';
-import { BADGE_ENABLED_COMMUNITY_ADDRESSES } from '~/constants/community';
 import { BadgeFragment$key } from '~/generated/BadgeFragment.graphql';
 import { GalleryElementTrackingProps } from '~/shared/contexts/AnalyticsContext';
 import { LowercaseChain } from '~/shared/utils/chains';
+import { BADGE_ENABLED_COMMUNITY_ADDRESSES } from '~/shared/utils/communities';
 
 type Props = {
   badgeRef: BadgeFragment$key;

--- a/apps/web/src/constants/community.ts
+++ b/apps/web/src/constants/community.ts
@@ -1,16 +1,2 @@
 export const GRID_ITEM_PER_PAGE = 40;
 export const LIST_ITEM_PER_PAGE = 200;
-
-export const GRID_ENABLED_COMMUNITY_ADDRESSES = [
-  // Art Gobblers
-  '0x60bb1e2aa1c9acafb4d34f71585d7e959f387769',
-  // Monarch
-  '0xc729ce9bf1030fbb639849a96fa8bbd013680b64',
-  // Cryptocoven
-  '0x5180db8f5c931aae63c74266b211f580155ecac8',
-];
-
-export const BADGE_ENABLED_COMMUNITY_ADDRESSES = new Set([
-  // Gallery Premium Membership Cards
-  '0xe01569ca9b39e55bc7c0dfa09f05fa15cb4c7698',
-]);

--- a/apps/web/src/scenes/CommunityPage/CommunityPageCollectorsTab.tsx
+++ b/apps/web/src/scenes/CommunityPage/CommunityPageCollectorsTab.tsx
@@ -6,9 +6,9 @@ import CommunityHolderList from '~/components/Community/CommunityHolderList';
 import CommunityHolderGrid from '~/components/CommunityHolderGrid/CommunityHolderGrid';
 import { DisplayLayout } from '~/components/core/enums';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { GRID_ENABLED_COMMUNITY_ADDRESSES } from '~/constants/community';
 import { CommunityPageCollectorsTabFragment$key } from '~/generated/CommunityPageCollectorsTabFragment.graphql';
 import { CommunityPageCollectorsTabQueryFragment$key } from '~/generated/CommunityPageCollectorsTabQueryFragment.graphql';
+import { GRID_ENABLED_COMMUNITY_ADDRESSES } from '~/shared/utils/communities';
 
 import LayoutToggleButton from './LayoutToggleButton';
 

--- a/packages/shared/src/utils/communities.ts
+++ b/packages/shared/src/utils/communities.ts
@@ -1,0 +1,13 @@
+export const GRID_ENABLED_COMMUNITY_ADDRESSES = [
+  // Art Gobblers
+  '0x60bb1e2aa1c9acafb4d34f71585d7e959f387769',
+  // Monarch
+  '0xc729ce9bf1030fbb639849a96fa8bbd013680b64',
+  // Cryptocoven
+  '0x5180db8f5c931aae63c74266b211f580155ecac8',
+];
+
+export const BADGE_ENABLED_COMMUNITY_ADDRESSES = new Set([
+  // Gallery Premium Membership Cards
+  '0xe01569ca9b39e55bc7c0dfa09f05fa15cb4c7698',
+]);


### PR DESCRIPTION
### Summary of Changes

Badges that weren't being displayed on web were being showcased on mobile.

This PR move the badge filter to a shared package and applies it to mobile.

![image](https://github.com/gallery-so/gallery/assets/12162433/26a3b5f3-dbfa-4db6-b8e2-029ceddf4e4a)
