### PR TITLE
rename collection to section in user facing copy

### DIFF
--- a/apps/mobile/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -61,7 +61,7 @@ export function CollectionCreatedFeedEvent({
     <View className="flex flex-1">
       <FeedEventCarouselCellHeader>
         <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-          Created a new collection
+          Created a new section
         </Typography>
         <GalleryTouchableOpacity
           className="flex-1"

--- a/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
@@ -76,7 +76,7 @@ export function CollectionUpdatedFeedEvent({
             className="text-sm"
             font={{ family: 'ABCDiatype', weight: 'Bold' }}
           >
-            {eventData.collection?.name || 'their collection'}
+            {eventData.collection?.name || 'their section'}
           </Typography>
         </GalleryTouchableOpacity>
       </FeedEventCarouselCellHeader>

--- a/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -70,23 +70,25 @@ export function TokensAddedToCollectionFeedEvent({
     <View className="flex flex-1 flex-col">
       <FeedEventCarouselCellHeader>
         <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-          Added new tokens to
+          Added new pieces{collectionName && ' to '}
         </Typography>
-        <GalleryTouchableOpacity
-          className="flex-1"
-          onPress={handleCollectionNamePress}
-          eventElementId="Feed Collection Button"
-          eventName="Feed Collection Name Clicked"
-          eventContext={contexts.Feed}
-        >
-          <Typography
-            numberOfLines={1}
-            className="text-sm"
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
+        {collectionName && (
+          <GalleryTouchableOpacity
+            className="flex-1"
+            onPress={handleCollectionNamePress}
+            eventElementId="Feed Collection Button"
+            eventName="Feed Collection Name Clicked"
+            eventContext={contexts.Feed}
           >
-            {collectionName || 'their collection'}
-          </Typography>
-        </GalleryTouchableOpacity>
+            <Typography
+              numberOfLines={1}
+              className="text-sm"
+              font={{ family: 'ABCDiatype', weight: 'Bold' }}
+            >
+              {collectionName}
+            </Typography>
+          </GalleryTouchableOpacity>
+        )}
       </FeedEventCarouselCellHeader>
 
       <View className="flex flex-grow">

--- a/apps/web/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/apps/web/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -92,7 +92,7 @@ export default function CollectionCreatedFeedEvent({ eventDataRef, isSubEvent }:
                   </HStack>
                 )}{' '}
                 <BaseM>
-                  added {tokens.length} {pluralize(tokens.length, 'piece')} to their new collection
+                  added {tokens.length} {pluralize(tokens.length, 'piece')} to a new section
                   {collectionName ? `, ` : ' '}
                 </BaseM>
                 {collectionName && (

--- a/apps/web/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
+++ b/apps/web/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
@@ -87,7 +87,7 @@ export default function CollectionUpdatedFeedEvent({ eventDataRef, isSubEvent = 
                     <UserHoverCard userRef={event.owner} />
                   </HStack>
                 )}{' '}
-                made updates to {collectionName ? ' ' : 'their collection'}
+                made updates to {collectionName ? ' ' : 'their section'}
                 {collectionName}
               </StyledEventText>
               {!isSubEvent && <StyledTime>{getTimeSince(event.eventTime)}</StyledTime>}

--- a/apps/web/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/apps/web/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -103,7 +103,7 @@ export default function CollectorsNoteAddedToCollectionFeedEvent({
                   <UserHoverCard userRef={event.owner} />
                 </HStack>
               )}
-              <BaseM>added a description to {collectionName ? ' ' : ' their collection'}</BaseM>
+              <BaseM>added a description to {collectionName ? ' ' : ' their section'}</BaseM>
               <StyledEventLabel>{collectionName}</StyledEventLabel>
               {!isSubEvent && <StyledTime>{getTimeSince(event.eventTime)}</StyledTime>}
             </StyledEventText>

--- a/apps/web/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/apps/web/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -109,9 +109,8 @@ export default function TokensAddedToCollectionFeedEvent({
                   </HStack>
                 )}
                 <BaseM>
-                  added {isPreFeed ? '' : `${tokens.length} ${pluralize(tokens.length, 'piece')}`}{' '}
-                  to
-                  {collectionName ? ' ' : ' their collection'}
+                  added {isPreFeed ? '' : `${tokens.length} ${pluralize(tokens.length, 'piece')}`}
+                  {collectionName ? ' to ' : ''}
                 </BaseM>
                 <StyledEventLabel>{collectionName}</StyledEventLabel>
               </StyledEventText>

--- a/apps/web/src/components/GalleryEditor/CollectionCreateOrEditForm.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionCreateOrEditForm.tsx
@@ -80,14 +80,14 @@ export function CollectionCreateOrEditForm({
         <Input
           onChange={handleNameChange}
           defaultValue={unescapedCollectionName}
-          placeholder="Collection name"
+          placeholder="Section title"
           autoFocus
           variant="grande"
         />
         <VStack>
           <StyledTextAreaWithCharCount
             onChange={handleDescriptionChange}
-            placeholder="Tell us about your collection..."
+            placeholder="Tell us about your items..."
             defaultValue={unescapedCollectorsNote}
             currentCharCount={collectorsNote.length}
             maxCharCount={COLLECTION_DESCRIPTION_MAX_CHAR_COUNT}

--- a/apps/web/src/components/GalleryEditor/CollectionEditor/DragAndDrop/Section.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionEditor/DragAndDrop/Section.tsx
@@ -110,7 +110,7 @@ export const Section = forwardRef<HTMLDivElement, Props>(
         <StyledItemContainer columns={columns}>
           {isEmpty ? (
             <StyledEmptySectionMessage>
-              <TitleDiatypeM>Select the pieces you’d like to add to this section</TitleDiatypeM>
+              <TitleDiatypeM>Select the pieces you’d like to add</TitleDiatypeM>
             </StyledEmptySectionMessage>
           ) : (
             children
@@ -165,7 +165,7 @@ const StyledItemContainer = styled.div<{ columns: number | undefined }>`
 const StyledEmptySectionMessage = styled.div`
   margin: auto;
   padding-bottom: 12px;
-  width: 190px;
+  width: 220px;
   text-align: center;
 `;
 

--- a/apps/web/src/components/GalleryEditor/CollectionEditor/StagingArea.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionEditor/StagingArea.tsx
@@ -239,7 +239,7 @@ function StagingArea({ tokensRef }: Props) {
                 )}
                 <VStack>
                   <StyledCollectionName hasName={Boolean(escapedCollectionName)}>
-                    {escapedCollectionName || 'Untitled Collection'}
+                    {escapedCollectionName || 'Untitled section'}
                   </StyledCollectionName>
 
                   <BaseM>

--- a/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionListItem.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionListItem.tsx
@@ -103,7 +103,7 @@ export function CollectionListItem({ collectionId, queryRef }: CollectionListIte
       return escapedCollectionName;
     }
 
-    return 'Untitled collection';
+    return 'Untitled section';
   }, [escapedCollectionName]);
 
   return (

--- a/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionSearch.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionSearch.tsx
@@ -29,7 +29,7 @@ export function CollectionSearch({ queryRef }: Props) {
         <FadedInput
           value={searchQuery}
           onChange={setSearchQuery}
-          placeholder="Search all collections"
+          placeholder="Search all sections"
           size="md"
         />
       </CollectionSearchBoxContainer>

--- a/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionSidebar.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionSidebar/CollectionSidebar.tsx
@@ -29,7 +29,7 @@ function TitleSection() {
 
   return (
     <TitleSectionWrapper align="center" justify="space-between">
-      <TitleS>Collections</TitleS>
+      <TitleS>Sections</TitleS>
       <IconContainer
         variant="default"
         size="sm"

--- a/apps/web/src/components/GalleryEditor/CollectionSidebar/MoveCollectionModal.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionSidebar/MoveCollectionModal.tsx
@@ -165,7 +165,7 @@ export default function MoveCollectionModal({
     }
     return (
       <BaseM>
-        This will move your collection <strong>{collectionDisplayName}</strong> to another gallery.
+        This will move your section <strong>{collectionDisplayName}</strong> to another gallery.
       </BaseM>
     );
   }, [collectionDisplayName, hasUnsavedChanges]);

--- a/apps/web/src/components/GalleryEditor/CollectionSidebar/MoveCollectionModal.tsx
+++ b/apps/web/src/components/GalleryEditor/CollectionSidebar/MoveCollectionModal.tsx
@@ -89,7 +89,7 @@ export default function MoveCollectionModal({
             galleryId,
           },
         });
-        pushToast({ message: 'Failed to save your changes before moving your collection' });
+        pushToast({ message: 'Failed to save your changes before moving your section' });
         setIsLoading(false);
       }
     }
@@ -103,7 +103,7 @@ export default function MoveCollectionModal({
           onSuccess();
           setIsLoading(false);
           pushToast({
-            message: `Moved **${collection.name || 'Untitled collection'}** to **${
+            message: `Moved **${collection.name || 'Untitled section'}** to **${
               gallery.name || 'Untitled gallery'
             }**`,
           });
@@ -114,20 +114,20 @@ export default function MoveCollectionModal({
 
       setIsLoading(false);
       pushToast({
-        message: `Moved **${collection.name || 'Untitled collection'}** to **${
+        message: `Moved **${collection.name || 'Untitled section'}** to **${
           gallery.name || 'Untitled gallery'
         }**`,
       });
 
       hideModal();
     } catch (error) {
-      reportError('Failed to move collection', {
+      reportError('Failed to move section', {
         tags: {
           collectionId: collection.dbid,
           toGalleryId: selectedGalleryId,
         },
       });
-      pushToast({ message: 'Failed to move your collection' });
+      pushToast({ message: 'Failed to move your section' });
       setIsLoading(false);
     }
   }, [
@@ -150,7 +150,7 @@ export default function MoveCollectionModal({
     setSelectedGalleryId(selectedGalleryId);
   }, []);
 
-  const collectionDisplayName = collection.name || 'Untitled collection';
+  const collectionDisplayName = collection.name || 'Untitled section';
 
   const description = useMemo(() => {
     if (hasUnsavedChanges) {

--- a/apps/web/src/components/MultiGallery/Gallery.tsx
+++ b/apps/web/src/components/MultiGallery/Gallery.tsx
@@ -2,7 +2,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useRouter } from 'next/router';
 import { Route } from 'nextjs-routes';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
@@ -26,7 +26,7 @@ import SettingsDropdown from '../core/Dropdown/SettingsDropdown';
 import IconContainer from '../core/IconContainer';
 import { UnstyledLink } from '../core/Link/UnstyledLink';
 import { HStack, VStack } from '../core/Spacer/Stack';
-import { BaseM, TitleS, TitleXS } from '../core/Text/Text';
+import { TitleS, TitleXS } from '../core/Text/Text';
 import { GalleryNameAndDescriptionEditForm } from '../GalleryEditor/GalleryNameAndDescriptionEditForm';
 import DeleteGalleryConfirmation from './DeleteGalleryConfirmation';
 import useSetFeaturedGallery from './useSetFeaturedGallery';
@@ -63,10 +63,6 @@ export default function Gallery({
           large
         }
         hidden @required(action: THROW)
-        collections @required(action: THROW) {
-          id
-          hidden
-        }
         owner {
           id
           username @required(action: THROW)
@@ -123,15 +119,9 @@ export default function Gallery({
 
   const { showModal } = useModalActions();
 
-  const { name, collections, tokenPreviews, hidden, dbid } = gallery;
+  const { name, tokenPreviews, hidden, dbid } = gallery;
 
   const { pushToast } = useToastActions();
-
-  const totalCollections = useMemo(() => {
-    const visibleCollections = collections.filter((collection) => !collection?.hidden);
-
-    return visibleCollections.length;
-  }, [collections]);
 
   const reassignFeaturedGallery = useCallback(async () => {
     if (!isFeatured) return;
@@ -293,9 +283,6 @@ export default function Gallery({
                 )}
                 <TitleContainer>
                   <StyledGalleryTitle tabIndex={1}>{name || 'Untitled'}</StyledGalleryTitle>
-                  <BaseM>
-                    {totalCollections} collection{totalCollections === 1 ? '' : 's'}
-                  </BaseM>
                 </TitleContainer>
               </StyledGalleryTitleWrapper>
             </HStack>

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionRightContent.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/CollectionNavbar/CollectionRightContent.tsx
@@ -123,7 +123,7 @@ export function CollectionRightContent({
               href={editCollectionUrl}
               name="Collection Nav"
               eventContext={contexts.UserCollection}
-              label="Edit Collection"
+              label="Edit Section"
             />
           )}
           <DropdownItem

--- a/apps/web/src/scenes/CollectionGalleryPage/CollectionGallery.tsx
+++ b/apps/web/src/scenes/CollectionGalleryPage/CollectionGallery.tsx
@@ -54,7 +54,7 @@ function CollectionGallery({ queryRef }: Props) {
       </NftGalleryWrapper>
     );
   } else if (collection?.__typename === 'ErrCollectionNotFound') {
-    return <NotFound resource="collection" />;
+    return <NotFound resource="section" />;
   }
 
   // TODO: just throw to an error boundary and have that report to sentry

--- a/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
+++ b/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
@@ -114,7 +114,7 @@ function CollectionGalleryHeader({
           collectorsNote={collection.collectorsNote ?? undefined}
         />
       ),
-      headerText: 'Name and describe your collection',
+      headerText: 'Name and describe your section',
     });
   }, [
     collection.collectorsNote,

--- a/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
+++ b/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryHeader.tsx
@@ -201,7 +201,7 @@ function CollectionGalleryHeader({
                       }}
                       name="Manage Collection"
                       eventContext={contexts.UserCollection}
-                      label="Edit Collection"
+                      label="Edit Section"
                     />
                   )}
                 </DropdownSection>

--- a/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -120,7 +120,7 @@ function UserGalleryCollection({
           collectorsNote={collection.collectorsNote ?? ''}
         />
       ),
-      headerText: 'Name and describe your collection',
+      headerText: 'Name and describe your section',
     });
   }, [
     collection.collectorsNote,
@@ -154,7 +154,7 @@ function UserGalleryCollection({
                       onClick={handleEditNameClick}
                       name="Manage Collection"
                       eventContext={contexts.UserGallery}
-                      label="Edit Name & Collection"
+                      label="Edit Name & Description"
                     />
                     <DropdownLink
                       href={{

--- a/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGalleryCollection.tsx
@@ -163,7 +163,7 @@ function UserGalleryCollection({
                       }}
                       name="Manage Collection"
                       eventContext={contexts.UserGallery}
-                      label="Edit Collection"
+                      label="Edit Section"
                     />
                   </>
                 )}
@@ -171,7 +171,7 @@ function UserGalleryCollection({
                   href={collectionUrlPath}
                   name="Manage Collection"
                   eventContext={contexts.UserGallery}
-                  label="View Collection"
+                  label="View Section"
                 />
               </DropdownSection>
             </SettingsDropdown>


### PR DESCRIPTION
### Summary of Changes
In the context of galleries, rename collection to section to simplify. on web and mobile

Mainly affects 
- Editor (web only)
- Gallery
- Feed events

### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| ![CleanShot 2023-11-09 at 17 28 26](https://github.com/gallery-so/gallery/assets/80802871/dbcca3e8-3e74-4594-99db-1585fec083cf) | ![CleanShot 2023-11-09 at 17 19 19](https://github.com/gallery-so/gallery/assets/80802871/15816b56-1810-4b48-916e-ee4cc2ffd081) |
| ![CleanShot 2023-11-09 at 17 28 38](https://github.com/gallery-so/gallery/assets/80802871/e1862324-0979-40eb-b7cc-5600b697ad94) | ![CleanShot 2023-11-09 at 17 19 28](https://github.com/gallery-so/gallery/assets/80802871/5929d054-b69f-4090-9549-82ca6212fecf) |
| ![CleanShot 2023-11-09 at 17 28 47](https://github.com/gallery-so/gallery/assets/80802871/1555dc35-7850-496c-855e-6be3e10f1259)| ![CleanShot 2023-11-09 at 17 19 34](https://github.com/gallery-so/gallery/assets/80802871/c0edfaaa-92e3-4226-b52c-6450a96f8bfc) |
| ![CleanShot 2023-11-09 at 17 28 57](https://github.com/gallery-so/gallery/assets/80802871/f874e354-fcb7-483b-8779-27f6786a734d) | ![CleanShot 2023-11-09 at 17 19 45](https://github.com/gallery-so/gallery/assets/80802871/cfa1a946-025d-49cf-bc69-fcec4c0e78ce) |
| ![CleanShot 2023-11-09 at 17 29 03](https://github.com/gallery-so/gallery/assets/80802871/557a8916-1c2d-4849-b49e-9835342d30b4)| ![CleanShot 2023-11-09 at 17 19 55](https://github.com/gallery-so/gallery/assets/80802871/2638c019-889c-4c66-af42-b830ff4be461) |
| ![CleanShot 2023-11-09 at 17 29 17](https://github.com/gallery-so/gallery/assets/80802871/e0147d84-1990-4282-b70c-e3e8aa5764ab) | ![CleanShot 2023-11-09 at 17 21 10](https://github.com/gallery-so/gallery/assets/80802871/10c7cbe4-6236-4f16-919e-2395ae56a662) |
| ![CleanShot 2023-11-09 at 17 29 48](https://github.com/gallery-so/gallery/assets/80802871/81922806-bc5c-4512-b666-42fc7a808c97) | ![CleanShot 2023-11-09 at 17 21 58](https://github.com/gallery-so/gallery/assets/80802871/3203fe40-5afe-494f-958c-a0c7f6cb0949) |
| ![CleanShot 2023-11-09 at 17 30 04](https://github.com/gallery-so/gallery/assets/80802871/c78c22a6-95b2-4fbc-ae7a-1e8936ca046c) | ![CleanShot 2023-11-09 at 17 23 01](https://github.com/gallery-so/gallery/assets/80802871/8421e2a1-4ec6-4cde-bbac-13bce6f87dcd) |

### Edge Cases

maybe some areas missed, please call out 

### Testing Steps
use Gallery on web and mobile and look for any mentions of "collection" in a gallery context - this should now be called section

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
