### PR TITLE
Fix stale notifications on mobile

### DIFF
--- a/apps/mobile/src/components/Notification/NotificationList.tsx
+++ b/apps/mobile/src/components/Notification/NotificationList.tsx
@@ -89,7 +89,7 @@ export function NotificationList({ queryRef }: Props) {
   // if user go outside of notifications screen, clear notifications
   useFocusEffect(
     useCallback(() => {
-      refetch({});
+      refetch({}, { fetchPolicy: 'store-and-network' });
 
       clearNotifications();
     }, [clearNotifications, refetch])

--- a/apps/mobile/src/hooks/useMobileClearNotifications.ts
+++ b/apps/mobile/src/hooks/useMobileClearNotifications.ts
@@ -31,7 +31,7 @@ export function useMobileClearNotifications() {
 
     if (query?.viewer?.id && query.viewer?.user?.dbid) {
       await clearNotifications(environment, query.viewer.user.dbid, [
-        ConnectionHandler.getConnectionID(query.viewer.id, 'TabBarMainTabNavigator_notifications'),
+        ConnectionHandler.getConnectionID(query.viewer.id, 'NotificationBlueDot_notifications'),
         ConnectionHandler.getConnectionID(query.viewer.id, 'NotificationsFragment_notifications'),
       ]);
     }

--- a/apps/mobile/src/navigation/MainTabNavigator/NotificationBlueDot.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/NotificationBlueDot.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
-import { useEffectOnAppForeground } from 'src/utils/useEffectOnAppForeground';
+import { useIntervalEffectOnAppForeground } from 'src/utils/useIntervalEffectOnAppForeground';
 
 import { NotificationBlueDotFragment$key } from '~/generated/NotificationBlueDotFragment.graphql';
 import { NotificationBlueDotQuery } from '~/generated/NotificationBlueDotQuery.graphql';
+import { RefetchableNotificationBlueDotFragmentQuery } from '~/generated/RefetchableNotificationBlueDotFragmentQuery.graphql';
 
 export function LazyNotificationBlueDot() {
   const query = useLazyLoadQuery<NotificationBlueDotQuery>(
@@ -27,7 +28,10 @@ type BlueDotProps = {
 };
 
 function BlueDot({ queryRef }: BlueDotProps) {
-  const [query, refetch] = useRefetchableFragment<any, any>(
+  const [query, refetch] = useRefetchableFragment<
+    RefetchableNotificationBlueDotFragmentQuery,
+    NotificationBlueDotFragment$key
+  >(
     graphql`
       fragment NotificationBlueDotFragment on Query
       @refetchable(queryName: "RefetchableNotificationBlueDotFragmentQuery") {
@@ -55,12 +59,10 @@ function BlueDot({ queryRef }: BlueDotProps) {
     refetch({}, { fetchPolicy: 'network-only' });
   }, [refetch]);
 
-  useEffectOnAppForeground(handleNotificationRefresh);
+  useIntervalEffectOnAppForeground(handleNotificationRefresh);
 
   const hasUnreadNotifications = useMemo(() => {
     if (query.viewer && query.viewer.__typename === 'Viewer') {
-      // 12345
-      console.log('---- unseen count', query.viewer?.notifications?.unseenCount);
       return (query.viewer?.notifications?.unseenCount ?? 0) > 0;
     }
 

--- a/apps/mobile/src/navigation/MainTabNavigator/NotificationBlueDot.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/NotificationBlueDot.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useMemo } from 'react';
+import { View } from 'react-native';
+import { graphql, useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
+import { useEffectOnAppForeground } from 'src/utils/useEffectOnAppForeground';
+
+import { NotificationBlueDotFragment$key } from '~/generated/NotificationBlueDotFragment.graphql';
+import { NotificationBlueDotQuery } from '~/generated/NotificationBlueDotQuery.graphql';
+
+export function LazyNotificationBlueDot() {
+  const query = useLazyLoadQuery<NotificationBlueDotQuery>(
+    graphql`
+      query NotificationBlueDotQuery($before: String, $last: Int) {
+        ...NotificationBlueDotFragment
+      }
+    `,
+    {
+      before: null,
+      last: 1,
+    }
+  );
+
+  return <BlueDot queryRef={query} />;
+}
+
+type BlueDotProps = {
+  queryRef: NotificationBlueDotFragment$key;
+};
+
+function BlueDot({ queryRef }: BlueDotProps) {
+  const [query, refetch] = useRefetchableFragment<any, any>(
+    graphql`
+      fragment NotificationBlueDotFragment on Query
+      @refetchable(queryName: "RefetchableNotificationBlueDotFragmentQuery") {
+        viewer {
+          ... on Viewer {
+            __typename
+            notifications(before: $before, last: $last)
+              @connection(key: "NotificationBlueDot_notifications") {
+              unseenCount
+              # Relay requires that we grab the edges field if we use the connection directive
+              # We're selecting __typename since that shouldn't have a cost
+              # eslint-disable-next-line relay/unused-fields
+              edges {
+                __typename
+              }
+            }
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  const handleNotificationRefresh = useCallback(() => {
+    refetch({}, { fetchPolicy: 'network-only' });
+  }, [refetch]);
+
+  useEffectOnAppForeground(handleNotificationRefresh);
+
+  const hasUnreadNotifications = useMemo(() => {
+    if (query.viewer && query.viewer.__typename === 'Viewer') {
+      // 12345
+      console.log('---- unseen count', query.viewer?.notifications?.unseenCount);
+      return (query.viewer?.notifications?.unseenCount ?? 0) > 0;
+    }
+
+    return false;
+  }, [query.viewer]);
+
+  if (hasUnreadNotifications) {
+    return <View className="bg-activeBlue absolute right-0 top-0 h-2 w-2 rounded-full" />;
+  }
+
+  return null;
+}

--- a/apps/mobile/src/navigation/MainTabNavigator/TabBar.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/TabBar.tsx
@@ -2,7 +2,7 @@ import { MaterialTopTabBarProps } from '@react-navigation/material-top-tabs';
 import { NavigationRoute } from '@sentry/react-native/dist/js/tracing/reactnavigation';
 import clsx from 'clsx';
 import { useColorScheme } from 'nativewind';
-import { ReactNode, Suspense, useCallback, useMemo, useState } from 'react';
+import { ReactNode, Suspense, useCallback, useState } from 'react';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useLazyLoadQuery } from 'react-relay';
@@ -11,7 +11,6 @@ import { graphql } from 'relay-runtime';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { useManageWalletActions } from '~/contexts/ManageWalletContext';
-import { TabBarLazyNotificationBlueDotQuery } from '~/generated/TabBarLazyNotificationBlueDotQuery.graphql';
 import { TabBarLazyPostIconQuery } from '~/generated/TabBarLazyPostIconQuery.graphql';
 import { TabBarLazyProfilePictureQuery } from '~/generated/TabBarLazyProfilePictureQuery.graphql';
 import { GLogo } from '~/navigation/MainTabNavigator/GLogo';
@@ -24,6 +23,7 @@ import { noop } from '~/shared/utils/noop';
 
 import { AccountIcon } from '../../icons/AccountIcon';
 import { SettingsIcon } from '../../icons/SettingsIcon';
+import { LazyNotificationBlueDot } from './NotificationBlueDot';
 import { PostIcon } from './PostIcon';
 
 type TabItemProps = {
@@ -153,44 +153,6 @@ export function TabBar({ state, navigation }: TabBarProps) {
       })}
     </View>
   );
-}
-
-function LazyNotificationBlueDot() {
-  const query = useLazyLoadQuery<TabBarLazyNotificationBlueDotQuery>(
-    graphql`
-      query TabBarLazyNotificationBlueDotQuery {
-        viewer {
-          ... on Viewer {
-            __typename
-            notifications(last: 1) @connection(key: "TabBarMainTabNavigator_notifications") {
-              unseenCount
-              # Relay requires that we grab the edges field if we use the connection directive
-              # We're selecting __typename since that shouldn't have a cost
-              # eslint-disable-next-line relay/unused-fields
-              edges {
-                __typename
-              }
-            }
-          }
-        }
-      }
-    `,
-    {}
-  );
-
-  const hasUnreadNotifications = useMemo(() => {
-    if (query.viewer && query.viewer.__typename === 'Viewer') {
-      return (query.viewer?.notifications?.unseenCount ?? 0) > 0;
-    }
-
-    return false;
-  }, [query.viewer]);
-
-  if (hasUnreadNotifications) {
-    return <View className="bg-activeBlue absolute right-0 top-0 h-2 w-2 rounded-full" />;
-  }
-
-  return null;
 }
 
 function LazyNotificationIcon() {

--- a/apps/mobile/src/screens/PostScreen/PostScreen.tsx
+++ b/apps/mobile/src/screens/PostScreen/PostScreen.tsx
@@ -21,7 +21,7 @@ function PostScreenInner() {
       }
     `,
     { postId: route.params.postId },
-    { fetchPolicy: 'store-or-network' }
+    { fetchPolicy: 'store-and-network' }
   );
 
   const [query, refetch] = useRefetchableFragment<

--- a/apps/mobile/src/utils/useEffectOnAppForeground.ts
+++ b/apps/mobile/src/utils/useEffectOnAppForeground.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+
+export function useEffectOnAppForeground(callback: () => void) {
+  const [appState, setAppState] = useState(AppState.currentState);
+
+  useEffect(
+    function fetchMaintenanceModeOnAppForeground() {
+      const handleAppStateChange = (nextAppState: AppStateStatus) => {
+        if ((appState === 'inactive' || appState === 'background') && nextAppState === 'active') {
+          // app has come into the foreground
+          callback();
+        }
+        setAppState(nextAppState);
+      };
+      const listener = AppState.addEventListener('change', handleAppStateChange);
+      return () => {
+        listener.remove();
+      };
+    },
+    [appState, callback]
+  );
+}

--- a/apps/mobile/src/utils/useIntervalEffectOnAppForeground.ts
+++ b/apps/mobile/src/utils/useIntervalEffectOnAppForeground.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+
+export function useIntervalEffectOnAppForeground(callback: () => void) {
+  useEffect(() => {
+    let interval: number;
+
+    // Set up the interval when the component mounts
+    interval = setInterval(callback, 10000);
+
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      if (nextAppState === 'active') {
+        // When the app comes into the foreground, trigger the callback
+        // and kick off the interval
+        callback();
+        interval = setInterval(callback, 10000);
+      } else if (nextAppState === 'background' || nextAppState === 'inactive') {
+        // When the app goes to the background, clear the interval
+        if (interval) {
+          clearInterval(interval);
+        }
+      }
+    };
+
+    // Add event listener for app state changes
+    const listener = AppState.addEventListener('change', handleAppStateChange);
+
+    // Clear the interval when the component unmounts
+    return () => {
+      clearInterval(interval);
+      listener.remove();
+    };
+  }, [callback]);
+}

--- a/apps/mobile/src/utils/useSanityMaintenanceCheckMobile.ts
+++ b/apps/mobile/src/utils/useSanityMaintenanceCheckMobile.ts
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
-import { AppState, AppStateStatus } from 'react-native';
+import { useEffect } from 'react';
 
 import { useSanityMaintenanceCheck } from './sanity';
+import { useEffectOnAppForeground } from './useEffectOnAppForeground';
 
 export function useSanityMaintenanceCheckMobile() {
   // NOTE: this is deprecated and should use shared/MaintenanceStatusContext instead
@@ -19,24 +19,7 @@ export function useSanityMaintenanceCheckMobile() {
     [fetchMaintenanceModeStatus]
   );
 
-  const [appState, setAppState] = useState(AppState.currentState);
-
-  useEffect(
-    function fetchMaintenanceModeOnAppForeground() {
-      const handleAppStateChange = (nextAppState: AppStateStatus) => {
-        if ((appState === 'inactive' || appState === 'background') && nextAppState === 'active') {
-          // app has come into the foreground
-          fetchMaintenanceModeStatus();
-        }
-        setAppState(nextAppState);
-      };
-      const listener = AppState.addEventListener('change', handleAppStateChange);
-      return () => {
-        listener.remove();
-      };
-    },
-    [appState, fetchMaintenanceModeStatus]
-  );
+  useEffectOnAppForeground(fetchMaintenanceModeStatus);
 
   return {
     maintenanceCheckLoadedOrError,


### PR DESCRIPTION
### Summary of Changes

- [x] refetch notifications list properly when visited
- [x] ensure blue dot appears on app foreground
- [x] periodically refetch blue dot every 10s
- [x] ensure admire count gets un-stale

cool helper functions: `useEffectOnAppForeground`, `useIntervalEffectOnAppForeground`

### Demo or Before/After Pics

https://www.loom.com/share/c0da1d2b7024400c9b76d00e75560021?sid=939c250e-4eaa-4225-8490-0ec878212c03

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
