### PR TITLE
[GAL-4757] Fix duplicate mention tagging

### DIFF
--- a/packages/shared/src/components/GalleryProccessedText/GalleryTextElementParser.ts
+++ b/packages/shared/src/components/GalleryProccessedText/GalleryTextElementParser.ts
@@ -1,3 +1,5 @@
+import isEqual from 'lodash/isEqual';
+import uniqWith from 'lodash/uniqWith';
 import { graphql, readInlineData } from 'react-relay';
 
 import { GalleryProcessedTextFragment$data } from '~/generated/GalleryProcessedTextFragment.graphql';
@@ -51,11 +53,14 @@ export function getMentionElements(
     );
   }
 
-  const mentions: GalleryTextElementParserMentionsFragment$data[] = [];
+  let mentions: GalleryTextElementParserMentionsFragment$data[] = [];
 
   mentionRefs.forEach((mentionRef) => {
     mentions.push(fetchMention(mentionRef));
   });
+
+  // Remove duplicate mentions
+  mentions = uniqWith(mentions, isEqual);
 
   const elements: TextElement[] = [];
 


### PR DESCRIPTION
### Summary of Changes

Fix duplicate mention tagging. Found out at the issue happens when there is multiple `mention` interval


### Demo or Before/After Pics


| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| ![image](https://github.com/gallery-so/gallery/assets/4480258/531696b8-7126-4597-8291-ef2d7a656ed2) | ![CleanShot 2023-11-13 at 18 11 24@2x](https://github.com/gallery-so/gallery/assets/4480258/de6090cd-2ad4-45ce-b55f-0045d0eb72b0) |
| ![image](https://github.com/gallery-so/gallery/assets/4480258/1d352b79-d525-4853-b7f7-692c40ef4e2c) | ![CleanShot 2023-11-13 at 18 12 35@2x](https://github.com/gallery-so/gallery/assets/4480258/155b1cc4-a385-4d19-93e5-ce06a1e26ef4)|



### Testing Steps

- Open any post/comment that has multiple tagging

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
