### PR TITLE
add space after selecting mention

### DIFF
--- a/packages/shared/src/hooks/useMentionableMessage.ts
+++ b/packages/shared/src/hooks/useMentionableMessage.ts
@@ -47,7 +47,7 @@ export function useMentionableMessage() {
 
       const newMessage = `${message.substring(0, mentionStartPos)}@${
         mention.label
-      }${message.substring(mentionEndPos)}`;
+      } ${message.substring(mentionEndPos)}`;
 
       setMessage(newMessage);
 


### PR DESCRIPTION
### Summary of Changes
Automatically add a space after selecting a mention


### Demo or Before/After Pics
https://github.com/gallery-so/gallery/assets/80802871/f96840f6-4ad6-47e4-897a-88b083d4cea0



### Edge Cases
- adding a mention at the end of the input (standard case)
- adding a mention in the start/middle of the input (less common case)

### Testing Steps
- mention a user and confirm a space is automatically added after the username

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
