### PR TITLE
Automated version bump script

### DIFF
--- a/apps/mobile/moon.yml
+++ b/apps/mobile/moon.yml
@@ -84,3 +84,6 @@ tasks:
     deps:
       - '~:relay-codegen'
     command: tsc
+
+  version-bump:
+    command: yarn run version-bump

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -89,6 +89,7 @@
     "eas-build-post-install": "node_modules/.bin/moon run mobile:relay-codegen",
     "start": "expo start --dev-client",
     "android": "expo run:android",
-    "ios": "expo run:ios"
+    "ios": "expo run:ios",
+    "version-bump": "chmod +x ./version-bump.sh && ./version-bump.sh"
   }
 }

--- a/apps/mobile/version-bump.sh
+++ b/apps/mobile/version-bump.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# The path to your app.config.ts file
+FILE="app.config.ts"
+
+# Extract the current version number
+current_version=$(grep "version:" $FILE | sed -E "s/.*'([0-9]+\.[0-9]+\.[0-9]+)'.*/\1/")
+
+# Break the version number into an array (major.minor.patch)
+IFS='.' read -r -a version_parts <<< "$current_version"
+
+# Increment the patch version
+patch_version=$((version_parts[2]+1))
+
+# Construct the new version number
+new_version="${version_parts[0]}.${version_parts[1]}.$patch_version"
+
+# Replace the version number in the file
+sed -i '' "s/version: '${version_parts[0]}\.${version_parts[1]}\.${version_parts[2]}'/version: '${new_version}'/" $FILE
+
+echo "Version updated to $new_version"
+
+# Git operations
+# Make sure you are in the repository directory or adjust these commands accordingly
+
+# Create a new branch with the new version name
+git checkout -b $new_version
+
+# Add the changed file
+git add $FILE
+
+# Commit the changes with a message
+git commit -m "Incremented version number to $new_version"
+
+# Push the branch to the remote repository
+# git push origin $new_version
+
+echo "Git operations completed: branch $new_version created and pushed"

--- a/apps/mobile/version-bump.sh
+++ b/apps/mobile/version-bump.sh
@@ -33,6 +33,6 @@ git add $FILE
 git commit -m "Incremented version number to $new_version"
 
 # Push the branch to the remote repository
-# git push origin $new_version
+git push origin $new_version
 
 echo "Git operations completed: branch $new_version created and pushed"


### PR DESCRIPTION
### Summary of Changes

New helper script: `moon run mobile:version-bump`

Automates a slightly tedious process for bumping the mobile version number.

1. Goes to `app.config.ts`
2. Finds the version (e.g. `1.0.29`)
3. Increments the patch number (e.g. `1.0.30`)
4. Creates a new branch called `1.0.30`
5. Commits the changes
6. Pushes up the changes for PR creation

### Demo or Before/After Pics

<img width="595" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/20273d99-f84e-476a-8672-4adcec1e56fe">


