### PR TITLE
comments modal adjusments - height, spacing, etc

### DIFF
--- a/apps/web/src/components/Feed/Socialize/CommentBox/CommentBox.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentBox/CommentBox.tsx
@@ -205,7 +205,7 @@ export function CommentBox({ queryRef, onSubmitComment, isSubmittingComment }: P
     <Wrapper>
       <InputWrapper gap={12} ref={reference}>
         <StyledTextArea
-          placeholder=""
+          placeholder="Add a comment"
           onInput={handleChange}
           ref={textareaRef}
           value={message}
@@ -292,4 +292,5 @@ const Wrapper = styled.div`
   background: ${colors.white};
 
   padding: 16px;
+  margin-top: auto;
 `;

--- a/apps/web/src/components/Feed/Socialize/CommentsModal/CommentNote.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentsModal/CommentNote.tsx
@@ -92,7 +92,7 @@ const StyledProfilePictureWrapper = styled.div`
 `;
 
 const StyledListItem = styled(ListItem)<{ isHighlighted?: boolean }>`
-  padding: 8px 16px 16px;
+  padding: 0px 16px 16px;
 
   ${({ isHighlighted }) =>
     isHighlighted &&

--- a/apps/web/src/components/Feed/Socialize/CommentsModal/CommentsModal.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentsModal/CommentsModal.tsx
@@ -90,6 +90,8 @@ export function CommentsModal({
     return new CellMeasurerCache({
       fixedWidth: true,
       minHeight: 0,
+      // _rowHeightCache is a private property of CellMeasurerCache but we need to use it seems to be the only way to
+      // trigger an effect when the row heights change. measurerCache itself doesnt trigger an effect.
     }) as CellMeasurerCache & { _rowHeightCache: Record<number, number> };
   }, []);
 


### PR DESCRIPTION
### Summary of Changes

- increase comments modal height
- Fix list height calculation to accurately reflect row heights
- reduce padding between heading and comment list
- add input placeholder cta


### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="758" alt="CleanShot 2023-11-16 at 18 12 57@2x" src="https://github.com/gallery-so/gallery/assets/80802871/7d7da7be-df45-496e-962f-e7ca332b1144"> | <img width="1512" alt="CleanShot 2023-11-16 at 18 07 40@2x" src="https://github.com/gallery-so/gallery/assets/80802871/3fffaf7b-29c9-4210-b267-11c04de08644"> |
| <img width="1512" alt="CleanShot 2023-11-16 at 18 13 07@2x" src="https://github.com/gallery-so/gallery/assets/80802871/9d978bf7-f167-46f9-8625-23e3a79a0894">  | <img width="1507" alt="CleanShot 2023-11-16 at 18 09 22@2x" src="https://github.com/gallery-so/gallery/assets/80802871/9dfeff8e-914d-49bd-94fd-d9bbd5548b37"> | <img src="https://placehold.co/500x300" /> | <img src="https://placehold.co/500x300" /> |

Empty state looking good
<img width="1502" alt="CleanShot 2023-11-16 at 18 07 34@2x" src="https://github.com/gallery-so/gallery/assets/80802871/2f38d63e-35cf-4b92-b2cb-8c9d1196dcb5">

Single comment looking good
<img width="760" alt="CleanShot 2023-11-16 at 18 16 26" src="https://github.com/gallery-so/gallery/assets/80802871/393e51ff-486d-4af6-8417-37a8f89e6f7c">


Mobile still good
<img width="395" alt="CleanShot 2023-11-16 at 18 06 47@2x" src="https://github.com/gallery-so/gallery/assets/80802871/a752b98e-2574-49fa-80cd-715b6eb0e36b">

<img width="384" alt="CleanShot 2023-11-16 at 18 07 01@2x" src="https://github.com/gallery-so/gallery/assets/80802871/e0fcb03f-d1f9-48df-9efe-002abc774be3">


### Edge Cases
no comments, 1 comment,  2 comments, multi line comments, lots of comments that stretch beyond max modal height

### Testing Steps
Play with comments on web


### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
