### PR TITLE
Update how we write/store mention

### DIFF
--- a/packages/shared/src/hooks/useMentionableMessage.test.ts
+++ b/packages/shared/src/hooks/useMentionableMessage.test.ts
@@ -1,0 +1,113 @@
+import isEqual from 'lodash/isEqual';
+import uniqWith from 'lodash/uniqWith';
+
+import { MentionDataType, updateMentionPositions } from './useMentionableMessage';
+
+describe('updateMentionPositions', () => {
+  it('It should correctly identify and update the positions of mentions in a text string.', () => {
+    const text = '@gallery Love what you guys doing';
+    const mentions: MentionDataType[] = [
+      {
+        interval: {
+          start: 0,
+          length: 0,
+        },
+        userId: 'abc',
+        label: 'gallery',
+      },
+    ];
+
+    const updatedMentions = updateMentionPositions(text, mentions);
+
+    const expectedMentions: MentionDataType[] = [
+      {
+        interval: {
+          start: 0,
+          length: 8,
+        },
+        userId: 'abc',
+        label: 'gallery',
+      },
+    ];
+
+    expect(uniqWith(updatedMentions, isEqual)).toEqual(expectedMentions);
+
+    const secondText = '@gallery Love what you guys doing - @kaito @robin';
+    mentions.push({
+      interval: {
+        start: 0,
+        length: 0,
+      },
+      userId: 'abc',
+      label: 'kaito',
+    });
+
+    expect(uniqWith(updateMentionPositions(secondText, mentions), isEqual)).toEqual([
+      ...expectedMentions,
+      {
+        interval: {
+          start: 36,
+          length: 6,
+        },
+        userId: 'abc',
+        label: 'kaito',
+      },
+    ]);
+
+    const thirdText = '@gallery Love what you guys doing - @kaito @robin';
+
+    mentions.push({
+      interval: {
+        start: 0,
+        length: 0,
+      },
+      userId: '123',
+      label: 'robin',
+    });
+
+    expect(uniqWith(updateMentionPositions(thirdText, mentions), isEqual)).toEqual([
+      ...expectedMentions,
+      {
+        interval: {
+          start: 36,
+          length: 6,
+        },
+        userId: 'abc',
+        label: 'kaito',
+      },
+      {
+        interval: {
+          start: 43,
+          length: 6,
+        },
+        userId: '123',
+        label: 'robin',
+      },
+    ]);
+
+    const fourthText = '@GALLERY @gallery Love what you guys doing - @kaito @robin';
+    mentions.push({
+      interval: {
+        start: 0,
+        length: 0,
+      },
+      userId: '123',
+      label: 'GALLERY',
+    });
+
+    expect(uniqWith(updateMentionPositions(fourthText, mentions), isEqual)).toEqual([
+      {
+        interval: { start: 9, length: 8 },
+        userId: 'abc',
+        label: 'gallery',
+      },
+      { interval: { start: 45, length: 6 }, userId: 'abc', label: 'kaito' },
+      { interval: { start: 52, length: 6 }, userId: '123', label: 'robin' },
+      {
+        interval: { start: 0, length: 8 },
+        userId: '123',
+        label: 'GALLERY',
+      },
+    ]);
+  });
+});

--- a/packages/shared/src/hooks/useMentionableMessage.ts
+++ b/packages/shared/src/hooks/useMentionableMessage.ts
@@ -136,7 +136,7 @@ export function useMentionableMessage() {
   };
 }
 
-function updateMentionPositions(text: string, mentions: MentionDataType[]) {
+export function updateMentionPositions(text: string, mentions: MentionDataType[]) {
   const updatedMentions: MentionDataType[] = [];
   mentions.forEach((mention) => {
     // use regex to find all mentions in text

--- a/packages/shared/src/hooks/useMentionableMessage.ts
+++ b/packages/shared/src/hooks/useMentionableMessage.ts
@@ -1,3 +1,5 @@
+import isEqual from 'lodash/isEqual';
+import uniqWith from 'lodash/uniqWith';
 import { useCallback, useMemo, useState } from 'react';
 
 import { WHITESPACE_REGEX } from '../utils/regex';
@@ -153,5 +155,5 @@ function updateMentionPositions(text: string, mentions: MentionDataType[]) {
     }
   });
 
-  return updatedMentions;
+  return uniqWith(updatedMentions, isEqual);
 }

--- a/packages/shared/src/hooks/useMentionableMessage.ts
+++ b/packages/shared/src/hooks/useMentionableMessage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { WHITESPACE_REGEX } from '../utils/regex';
 import useDebounce from './useDebounce';
@@ -10,21 +10,13 @@ export type MentionDataType = {
   };
   userId?: string;
   communityId?: string;
+  label?: string;
 };
 
 export type MentionType = {
   type: 'User' | 'Community';
   label: string;
   value: string;
-};
-
-type Mention = {
-  interval: {
-    start: number;
-    length: number;
-  };
-  userId?: string;
-  communityId?: string;
 };
 
 export function useMentionableMessage() {
@@ -51,11 +43,12 @@ export function useMentionableMessage() {
 
       setMessage(newMessage);
 
-      const newMention: Mention = {
+      const newMention: MentionDataType = {
         interval: {
           start: mentionStartPos,
           length: mention.label.length + 1, // +1 for the @
         },
+        label: mention.label,
       };
 
       if (mention.type === 'User') {
@@ -64,39 +57,12 @@ export function useMentionableMessage() {
         newMention.communityId = mention.value;
       }
 
-      // Check if the mention already exists
-      const mentionExists = mentions.some(
-        (existingMention) =>
-          (existingMention.userId === newMention.userId ||
-            existingMention.communityId === newMention.communityId) &&
-          existingMention.interval.start === newMention.interval.start &&
-          existingMention.interval.length === newMention.interval.length
-      );
-
-      if (mentionExists) {
-        return newMessage; // If the mention already exists, return here
-      }
-
-      // Calculate the length difference between the old alias and the new mention
-      const lengthDifference = mention.label.length + 1 - aliasKeyword.length; // +1 for the @
-
-      // Adjust the positions of mentions that come after the newly added mention
-      const adjustedMentions = mentions.map((existingMention) => {
-        if (existingMention.interval.start >= mentionStartPos) {
-          return {
-            ...existingMention,
-            interval: {
-              start: existingMention.interval.start + lengthDifference,
-              length: existingMention.interval.length,
-            },
-          };
-        }
-        return existingMention;
-      });
-
       setIsSelectingMentions(false);
 
-      setMentions([...adjustedMentions, newMention]);
+      const updatedMentions = updateMentionPositions(newMessage, [...mentions, newMention]);
+
+      setMentions(updatedMentions);
+
       setAliasKeyword('');
 
       return newMessage;
@@ -123,37 +89,12 @@ export function useMentionableMessage() {
         setAliasKeyword(wordAtCursor);
       }
 
-      // Determine how many characters were added or removed
-      const diff = message.length - text.length;
-
-      // Update the positions of the mentions based on the added/removed characters
-      let updatedMentions = mentions.map((mention) => {
-        // If the change occurred before a mention, adjust its position
-        if (mention.interval.start >= selection.start) {
-          return {
-            ...mention,
-            interval: {
-              ...mention.interval,
-              start: mention.interval.start - diff,
-            },
-          };
-        }
-        return mention;
-      });
-
-      // Remove any mentions that were deleted
-      updatedMentions = updatedMentions.filter((mention) => {
-        // if start < 0, it means the mention was deleted
-        return (
-          mention.interval.start >= 0 &&
-          mention.interval.start + mention.interval.length <= text.length
-        );
-      });
+      const updatedMentions = updateMentionPositions(text, mentions);
 
       setMentions(updatedMentions);
       setMessage(text);
     },
-    [mentions, message, selection]
+    [mentions, selection]
   );
 
   const resetMentions = useCallback(() => {
@@ -172,16 +113,45 @@ export function useMentionableMessage() {
     setAliasKeyword('');
   }, []);
 
+  const internalMentions = useMemo(() => {
+    return mentions.map((mention) => {
+      const { label, ...rest } = mention;
+      return rest;
+    });
+  }, [mentions]);
+
   return {
     aliasKeyword: debouncedAliasKeyword,
     isSelectingMentions,
     message,
     setMessage: handleSetMessage,
     selectMention: handleSetMention,
-    mentions: mentions || [],
+    mentions: internalMentions || [],
     resetMentions,
     handleSelectionChange,
     selection,
     closeMention: handleClosingMention,
   };
+}
+
+function updateMentionPositions(text: string, mentions: MentionDataType[]) {
+  const updatedMentions: MentionDataType[] = [];
+  mentions.forEach((mention) => {
+    // use regex to find all mentions in text
+    const regex = new RegExp(`@${mention.label}`, 'g');
+    let matches;
+
+    while ((matches = regex.exec(text))) {
+      const label = mention?.label || '';
+      updatedMentions.push({
+        ...mention,
+        interval: {
+          start: matches.index || 0,
+          length: label.length + 1, // +1 for the @
+        },
+      });
+    }
+  });
+
+  return updatedMentions;
 }


### PR DESCRIPTION
### Summary of Changes

Improve on how we calculate the positioning of `Mention`. 

Previously, we are tracking on every keystroke and update the position manually. Its getting tricky to make it perfect and we didn't have much confident that it will works 100%. 

Current solution would be use regex to the whole string and get the index for each mention.

### Demo or Before/After Pics

https://github.com/gallery-so/gallery/assets/4480258/5579aadb-6594-4281-bbe7-5c061022fa08



### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
