### PR TITLE
fix shared info modal regression and make height dynamic

### DIFF
--- a/apps/web/src/components/HoverCard/CommunityHoverCard.tsx
+++ b/apps/web/src/components/HoverCard/CommunityHoverCard.tsx
@@ -58,6 +58,7 @@ type Props = PropsWithChildren<{
   communityRef: CommunityHoverCardFragment$key;
   communityName: string;
   onClick?: HoverCardProps<CommunityHoverCardQuery>['onHoverableElementClick'];
+  fitContent?: boolean;
 }>;
 
 export default function CommunityHoverCard({
@@ -65,6 +66,7 @@ export default function CommunityHoverCard({
   communityName,
   communityRef,
   onClick,
+  fitContent,
 }: Props) {
   const community = useFragment(
     graphql`
@@ -116,6 +118,7 @@ export default function CommunityHoverCard({
       }
       preloadQuery={handlePreloadQuery}
       preloadedQuery={preloadedHoverCardQuery}
+      fitContent={fitContent}
     />
   );
 }

--- a/apps/web/src/components/HoverCard/HoverCard.tsx
+++ b/apps/web/src/components/HoverCard/HoverCard.tsx
@@ -39,6 +39,7 @@ export type HoverCardProps<T extends OperationType> = {
   preloadQuery: () => void;
   preloadedQuery?: PreloadedQuery<T> | null;
   HoveringContent: React.ReactNode;
+  fitContent?: boolean; // whether hover card width expands to fit parent (false) or is tight around content (true)
 };
 
 export default function HoverCard<T extends OperationType>({
@@ -48,6 +49,7 @@ export default function HoverCard<T extends OperationType>({
   HoveringContent,
   preloadedQuery,
   preloadQuery,
+  fitContent = true,
 }: HoverCardProps<T>) {
   const [isHovering, setIsHovering] = useState(false);
 
@@ -80,9 +82,9 @@ export default function HoverCard<T extends OperationType>({
   );
 
   return (
-    <StyledContainer>
+    <StyledContainer fitContent={fitContent}>
       <StyledLinkContainer ref={reference} {...getReferenceProps()}>
-        <GalleryLink
+        <StyledGalleryLink
           to={hoverableElementHref}
           onClick={handleClick}
           eventElementId="Hover Card Hoverable Element"
@@ -90,7 +92,7 @@ export default function HoverCard<T extends OperationType>({
           eventContext={contexts['Hover Card']}
         >
           {HoverableElement}
-        </GalleryLink>
+        </StyledGalleryLink>
       </StyledLinkContainer>
 
       <AnimatePresence>
@@ -129,14 +131,21 @@ export default function HoverCard<T extends OperationType>({
   );
 }
 
-const StyledContainer = styled.span`
+const StyledContainer = styled.span<{ fitContent: boolean }>`
   position: relative;
   display: inline-grid;
   cursor: initial;
+
+  width: ${({ fitContent }) => (fitContent ? 'fit-content' : '100%;')};
 `;
 
 const StyledLinkContainer = styled.span`
   display: inline-flex;
+  width: 100%;
+`;
+
+const StyledGalleryLink = styled(GalleryLink)`
+  width: 100%;
 `;
 
 const StyledCardContainer = styled.div`

--- a/apps/web/src/components/HoverCard/UserHoverCard.tsx
+++ b/apps/web/src/components/HoverCard/UserHoverCard.tsx
@@ -62,9 +62,10 @@ const UserHoverCardContentQueryNode = graphql`
 type Props = PropsWithChildren<{
   userRef: UserHoverCardFragment$key;
   onClick?: HoverCardProps<UserHoverCardContentQuery>['onHoverableElementClick'];
+  fitContent?: boolean;
 }>;
 
-export default function UserHoverCard({ children, userRef, onClick }: Props) {
+export default function UserHoverCard({ children, userRef, onClick, fitContent }: Props) {
   const user = useFragment(
     graphql`
       fragment UserHoverCardFragment on GalleryUser {
@@ -108,6 +109,7 @@ export default function UserHoverCard({ children, userRef, onClick }: Props) {
       }
       preloadQuery={handlePreloadQuery}
       preloadedQuery={preloadedHoverCardQuery}
+      fitContent={fitContent}
     />
   );
 }

--- a/apps/web/src/contexts/modal/AnimatedModal.tsx
+++ b/apps/web/src/contexts/modal/AnimatedModal.tsx
@@ -98,7 +98,7 @@ function AnimatedModal({
       <StyledModal isFullPage={isFullPage}>
         <_ToggleTranslate isActive={isActive}>
           <StyledContainer isFullPage={isFullPage} maxWidth={maxWidth} width={width}>
-            <StyledHeader isPaddingDisabled={isPaddingDisabled}>
+            <StyledHeader isPaddingDisabled={!headerText && isPaddingDisabled}>
               {headerText ? <StyledTitleS>{headerText}</StyledTitleS> : null}
               <StyledModalActions align="center">
                 {headerActions}

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedCommunitiesList.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedCommunitiesList.tsx
@@ -18,6 +18,10 @@ import PaginatedListRow from './SharedInfoListRow';
 type Props = {
   userRef: SharedCommunitiesListFragment$key;
 };
+
+const ROW_HEIGHT = 56;
+const MAX_LIST_HEIGHT = 400;
+
 export default function SharedCommunitiesList({ userRef }: Props) {
   const { data, loadNext, hasNext } = usePaginationFragment(
     graphql`
@@ -58,6 +62,10 @@ export default function SharedCommunitiesList({ userRef }: Props) {
   const isRowLoaded = ({ index }: { index: number }) =>
     !hasNext || index < sharedCommunities.length;
 
+  const listHeight = useMemo(() => {
+    return Math.min(rowCount * ROW_HEIGHT, MAX_LIST_HEIGHT);
+  }, [rowCount]);
+
   const rowRenderer = useCallback<ListRowRenderer>(
     ({ index, key, style }: { index: number; key: string; style: React.CSSProperties }) => {
       const community = sharedCommunities[index]?.node;
@@ -84,7 +92,11 @@ export default function SharedCommunitiesList({ userRef }: Props) {
 
       return (
         <div style={style} key={key}>
-          <CommunityHoverCard communityRef={community} communityName={displayName}>
+          <CommunityHoverCard
+            communityRef={community}
+            communityName={displayName}
+            fitContent={false}
+          >
             <PaginatedListRow
               title={community.name ?? ''}
               subTitle={descriptionFirstLine}
@@ -102,8 +114,8 @@ export default function SharedCommunitiesList({ userRef }: Props) {
 
   return (
     <StyledList fullscreen={isMobile} gap={24}>
-      <AutoSizer>
-        {({ width, height }) => (
+      <AutoSizer disableHeight>
+        {({ width }) => (
           <InfiniteLoader
             isRowLoaded={isRowLoaded}
             loadMoreRows={handleLoadMore}
@@ -115,7 +127,7 @@ export default function SharedCommunitiesList({ userRef }: Props) {
                 onRowsRendered={onRowsRendered}
                 rowRenderer={rowRenderer}
                 width={width}
-                height={height}
+                height={listHeight}
                 rowHeight={56}
                 rowCount={sharedCommunities.length}
               />
@@ -123,8 +135,6 @@ export default function SharedCommunitiesList({ userRef }: Props) {
           </InfiniteLoader>
         )}
       </AutoSizer>
-
-      <VStack></VStack>
     </StyledList>
   );
 }
@@ -133,5 +143,5 @@ const StyledList = styled(VStack)<{ fullscreen: boolean }>`
   width: 375px;
   max-width: 375px;
   margin: 4px;
-  height: ${({ fullscreen }) => (fullscreen ? '100%' : '640px')};
+  height: 100%;
 `;

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedCommunitiesList.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedCommunitiesList.tsx
@@ -20,7 +20,7 @@ type Props = {
 };
 
 const ROW_HEIGHT = 56;
-const MAX_LIST_HEIGHT = 400;
+const MAX_LIST_HEIGHT = 640;
 
 export default function SharedCommunitiesList({ userRef }: Props) {
   const { data, loadNext, hasNext } = usePaginationFragment(
@@ -62,9 +62,13 @@ export default function SharedCommunitiesList({ userRef }: Props) {
   const isRowLoaded = ({ index }: { index: number }) =>
     !hasNext || index < sharedCommunities.length;
 
+  const isMobile = useIsMobileWindowWidth();
+
   const listHeight = useMemo(() => {
-    return Math.min(rowCount * ROW_HEIGHT, MAX_LIST_HEIGHT);
-  }, [rowCount]);
+    // 60px accounts for the header + margin height on mobile
+    const modalMaxHeight = isMobile ? window.innerHeight - 60 : MAX_LIST_HEIGHT;
+    return Math.min(rowCount * ROW_HEIGHT, modalMaxHeight);
+  }, [isMobile, rowCount]);
 
   const rowRenderer = useCallback<ListRowRenderer>(
     ({ index, key, style }: { index: number; key: string; style: React.CSSProperties }) => {
@@ -109,8 +113,6 @@ export default function SharedCommunitiesList({ userRef }: Props) {
     },
     [sharedCommunities]
   );
-
-  const isMobile = useIsMobileWindowWidth();
 
   return (
     <StyledList fullscreen={isMobile} gap={24}>

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 export const FOLLOWERS_PER_PAGE = 20;
 const ROW_HEIGHT = 56;
-const MAX_LIST_HEIGHT = 400;
+const MAX_LIST_HEIGHT = 640;
 
 export default function SharedFollowersList({ userRef }: Props) {
   const { data, loadNext, hasNext } = usePaginationFragment(
@@ -72,14 +72,16 @@ export default function SharedFollowersList({ userRef }: Props) {
     [sharedFollowers]
   );
 
-  const listHeight = useMemo(() => {
-    return Math.min(rowCount * ROW_HEIGHT, MAX_LIST_HEIGHT);
-  }, [rowCount]);
-
   const isMobile = useIsMobileWindowWidth();
+
+  const listHeight = useMemo(() => {
+    const modalMaxHeight = isMobile ? window.innerHeight - 60 : MAX_LIST_HEIGHT;
+    return Math.min(rowCount * ROW_HEIGHT, modalMaxHeight);
+  }, [isMobile, rowCount]);
+
   return (
     <StyledList fullscreen={isMobile} gap={24}>
-      <AutoSizer>
+      <AutoSizer disableHeight>
         {({ width }) => (
           <InfiniteLoader
             isRowLoaded={isRowLoaded}
@@ -108,7 +110,7 @@ const StyledList = styled(VStack)<{ fullscreen: boolean }>`
   width: 375px;
   max-width: 375px;
   margin: 4px;
-  height: ${({ fullscreen }) => (fullscreen ? '100%' : '400px')};
+  height: 100%;
 `;
 
 function SharedFollowersListRow({ userRef }: { userRef: SharedFollowersListRowFragment$key }) {

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedFollowersList.tsx
@@ -19,6 +19,8 @@ type Props = {
 };
 
 export const FOLLOWERS_PER_PAGE = 20;
+const ROW_HEIGHT = 56;
+const MAX_LIST_HEIGHT = 400;
 
 export default function SharedFollowersList({ userRef }: Props) {
   const { data, loadNext, hasNext } = usePaginationFragment(
@@ -70,11 +72,15 @@ export default function SharedFollowersList({ userRef }: Props) {
     [sharedFollowers]
   );
 
+  const listHeight = useMemo(() => {
+    return Math.min(rowCount * ROW_HEIGHT, MAX_LIST_HEIGHT);
+  }, [rowCount]);
+
   const isMobile = useIsMobileWindowWidth();
   return (
     <StyledList fullscreen={isMobile} gap={24}>
       <AutoSizer>
-        {({ width, height }) => (
+        {({ width }) => (
           <InfiniteLoader
             isRowLoaded={isRowLoaded}
             loadMoreRows={handleLoadMore}
@@ -86,8 +92,8 @@ export default function SharedFollowersList({ userRef }: Props) {
                 onRowsRendered={onRowsRendered}
                 rowRenderer={rowRenderer}
                 width={width}
-                height={height}
-                rowHeight={56}
+                height={listHeight}
+                rowHeight={ROW_HEIGHT}
                 rowCount={sharedFollowers.length}
               />
             )}
@@ -127,7 +133,7 @@ function SharedFollowersListRow({ userRef }: { userRef: SharedFollowersListRowFr
   };
 
   return (
-    <UserHoverCard userRef={user}>
+    <UserHoverCard userRef={user} fitContent={false}>
       <PaginatedListRow
         href={userUrlPath}
         title={user.username ?? ''}

--- a/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedInfoListRow.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSharedInfo/UserSharedInfoList/SharedInfoListRow.tsx
@@ -60,7 +60,6 @@ export default function SharedInfoListRow({ title, subTitle, href, imageContent 
 }
 
 const StyledRowNonLink = styled.div`
-  padding: 8px 12px;
   &:hover {
     background: ${colors.offWhite};
   }
@@ -71,6 +70,7 @@ const StyledRowLink = styled(GalleryLink)`
   text-decoration: none;
   max-height: 56px;
   display: block;
+  width: 100%;
 
   &:hover {
     background: ${colors.offWhite};


### PR DESCRIPTION
### Summary of Changes

- made animated modal always add padding if there's a header
- made shared followers and communities modal dynamic height
- adjust hover card to optionally expand to fit space via prop

### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| ![CleanShot 2023-11-17 at 16 25 39](https://github.com/gallery-so/gallery/assets/80802871/8d36a954-1aad-4f04-af85-18a0be8bdcdc) | ![CleanShot 2023-11-17 at 16 23 59](https://github.com/gallery-so/gallery/assets/80802871/ab0a1303-2522-4557-9f07-5572c49b4326) |
| ![CleanShot 2023-11-17 at 16 26 14](https://github.com/gallery-so/gallery/assets/80802871/8d9a8ff6-574e-43d4-a0d2-6954d948f8d4) | ![CleanShot 2023-11-17 at 16 23 45](https://github.com/gallery-so/gallery/assets/80802871/848b877d-e80f-4f2d-84f8-8bccdbc3ba29) |



Mobile
| ![CleanShot 2023-11-17 at 16 25 46](https://github.com/gallery-so/gallery/assets/80802871/4ac5c1c7-0a32-4ad9-9b1d-a9e1e2b61843) | ![CleanShot 2023-11-17 at 16 23 06](https://github.com/gallery-so/gallery/assets/80802871/cae5204f-f214-4437-b286-7b773f080f98) |



Verified that the Hover Card changes didn't cause a regression for other used areas (ie post)
Temporary border illustrates the width of the element, wrapping the content
![CleanShot 2023-11-17 at 14 58 03](https://github.com/gallery-so/gallery/assets/80802871/190090d4-2a49-4505-a41d-d1ef4c527efb)

Temporary border illustrates the width of the element, expanding to fit parent
![CleanShot 2023-11-17 at 14 58 07](https://github.com/gallery-so/gallery/assets/80802871/753f2982-e7f4-41e2-bf1a-58715ddf9516)


### Edge Cases
- checked short and long lists of collection and user lists


### Testing Steps

Go to someones profile while signed in and look at the mutual users and collections modal.
### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
