### PR TITLE
make numberOfLines prop apply to processed text and update web clamp count 

### DIFF
--- a/apps/mobile/src/components/Notification/Notifications/SomeoneMentionedYou.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/SomeoneMentionedYou.tsx
@@ -178,7 +178,7 @@ export function SomeoneMentionedYou({
         </Text>
 
         <View className="border-l-2 border-[#d9d9d9] pl-2 px-2">
-          <ProcessedText text={message ?? ''} numberOfLines={3} />
+          <ProcessedText text={message ?? ''} numberOfLines={2} />
         </View>
       </View>
     </NotificationSkeleton>

--- a/apps/mobile/src/components/Notification/Notifications/SomeoneYouFollowPostedTheirFirstPost.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/SomeoneYouFollowPostedTheirFirstPost.tsx
@@ -111,7 +111,7 @@ export function SomeoneYouFollowPostedTheirFirstPost({ queryRef, notificationRef
         </View>
         {post?.caption && (
           <View className="border-l-2 border-[#d9d9d9] pl-2 px-2">
-            <ProcessedText text={post.caption} numberOfLines={3} />
+            <ProcessedText text={post.caption} numberOfLines={2} />
           </View>
         )}
       </View>

--- a/apps/mobile/src/components/ProcessedText/ProcessedText.tsx
+++ b/apps/mobile/src/components/ProcessedText/ProcessedText.tsx
@@ -19,6 +19,7 @@ export default function ProcessedText({
   text,
   mentionsRef = [],
   mentionsInText,
+  ...props
 }: ProcessedTextProps) {
   const mentions = useFragment(
     graphql`
@@ -39,6 +40,7 @@ export default function ProcessedText({
       MentionComponent={MentionComponent}
       BreakComponent={() => <Text>{'\n'}</Text>}
       mentionsInText={mentionsInText}
+      {...props}
     />
   );
 }

--- a/apps/web/src/components/Notifications/notifications/SomeoneMentionedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneMentionedYou.tsx
@@ -139,8 +139,8 @@ const StyledCaption = styled(BaseM)`
   display: -webkit-box;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  line-clamp: 1;
-  -webkit-line-clamp: 1;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
 `;
 
 const StyledTextWrapper = styled(HStack)`

--- a/apps/web/src/components/Notifications/notifications/SomeoneYouFollowPostedTheirFirstPost.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneYouFollowPostedTheirFirstPost.tsx
@@ -82,6 +82,6 @@ const StyledCaption = styled(BaseM)`
   display: -webkit-box;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  line-clamp: 1;
-  -webkit-line-clamp: 1;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
 `;

--- a/packages/shared/src/components/GalleryProccessedText/GalleryProcessedText.tsx
+++ b/packages/shared/src/components/GalleryProccessedText/GalleryProcessedText.tsx
@@ -27,6 +27,7 @@ export default function GalleryProcessedText({
   LinkComponent,
   MentionComponent,
   mentionsInText = [],
+  ...props
 }: GalleryProcessedTextProps) {
   const mentions = useFragment(
     graphql`
@@ -98,7 +99,7 @@ export default function GalleryProcessedText({
     BreakComponent,
   ]);
 
-  return <TextComponent>{processedText}</TextComponent>;
+  return <TextComponent {...props}>{processedText}</TextComponent>;
 }
 
 type addLinkElementProps = {


### PR DESCRIPTION

### Summary of Changes
- truncate caption and comment previews in mobile app notifications by making sure the numberOfLines prop is applied to the processedText component
- set web clamp for notifications to 2 lines


### Demo or Before/After Pics


Before
![CleanShot 2023-11-17 at 19 05 19](https://github.com/gallery-so/gallery/assets/80802871/c24d4cec-35f2-49ab-8b94-d9a4de03127f)

![CleanShot 2023-11-17 at 19 05 12](https://github.com/gallery-so/gallery/assets/80802871/09d9bc09-a3c5-447f-9fe0-8331468a5f75)


After
![CleanShot 2023-11-17 at 19 01 44](https://github.com/gallery-so/gallery/assets/80802871/3295dc3f-4027-458d-8ff2-f2630b9dc3e3)


![CleanShot 2023-11-17 at 19 01 53](https://github.com/gallery-so/gallery/assets/80802871/4004cf02-a325-4702-be5b-70ceb80284a2)


### Edge Cases
notifications with different length caption/comments

### Testing Steps
check notifications on web and mobile

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
