### PR TITLE
show creator announcement in mobile composer and make useExperience shared

### DIFF
--- a/apps/mobile/src/screens/NftSelectorScreen/CreatorSupportAnnouncementBottomSheet.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/CreatorSupportAnnouncementBottomSheet.tsx
@@ -10,6 +10,7 @@ import {
 import { GalleryLink } from '~/components/GalleryLink';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 import { Typography } from '~/components/Typography';
+import { contexts } from '~/shared/analytics/constants';
 
 const SNAP_POINTS = ['CONTENT_HEIGHT'];
 
@@ -57,16 +58,16 @@ function CreatorSupportAnnouncementBottomSheet(
             Gallery for Creators is now in beta
           </Typography>
           <Typography
-            className="text-center text-sm leading-5"
+            className="text-center text-sm leading-6"
             font={{ family: 'ABCDiatype', weight: 'Regular' }}
           >
             Welcome to our new creator support feature, currently in beta. Share and display works
             you’ve created on Gallery. Learn more about how it works in{' '}
             <GalleryLink
               href="https://gallery-so.notion.site/Creator-FAQs-22b6a0cd877946efb06f25ce4a70cb5a"
-              eventElementId={null}
-              eventName={null}
-              eventContext={null}
+              eventElementId={'Creator Support Announcement Bottom Sheet FAQ Link'}
+              eventName={'Opened Creator Support Announcement Bottom Sheet FAQ Link'}
+              eventContext={contexts.Posts}
             >
               our FAQ here
             </GalleryLink>
@@ -76,9 +77,9 @@ function CreatorSupportAnnouncementBottomSheet(
         <Button
           text="Continue"
           onPress={handleContinuePress}
-          eventElementId={null}
-          eventName={null}
-          eventContext={null}
+          eventElementId={'Creator Support Announcement Bottom Sheet Continue Button'}
+          eventName={'Pressed Creator Support Announcement Bottom Sheet Continue Button'}
+          eventContext={contexts.Posts}
         />
       </View>
     </GalleryBottomSheetModal>

--- a/apps/mobile/src/screens/NftSelectorScreen/CreatorSupportAnnouncementBottomSheet.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/CreatorSupportAnnouncementBottomSheet.tsx
@@ -1,0 +1,92 @@
+import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
+import { ForwardedRef, forwardRef, useCallback, useRef } from 'react';
+import { View } from 'react-native';
+
+import { Button } from '~/components/Button';
+import {
+  GalleryBottomSheetModal,
+  GalleryBottomSheetModalType,
+} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
+import { GalleryLink } from '~/components/GalleryLink';
+import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
+import { Typography } from '~/components/Typography';
+
+const SNAP_POINTS = ['CONTENT_HEIGHT'];
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Props = {};
+
+function CreatorSupportAnnouncementBottomSheet(
+  {}: Props,
+  ref: ForwardedRef<GalleryBottomSheetModalType>
+) {
+  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
+    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
+
+  const handleContinuePress = useCallback(() => {
+    bottomSheetRef.current?.close();
+  }, []);
+  const { bottom } = useSafeAreaPadding();
+
+  return (
+    <GalleryBottomSheetModal
+      ref={(value) => {
+        bottomSheetRef.current = value;
+
+        if (typeof ref === 'function') {
+          ref(value);
+        } else if (ref) {
+          ref.current = value;
+        }
+      }}
+      snapPoints={animatedSnapPoints}
+      handleHeight={animatedHandleHeight}
+      contentHeight={animatedContentHeight}
+    >
+      <View
+        onLayout={handleContentLayout}
+        style={{ paddingBottom: bottom }}
+        className="p-4 flex flex-col space-y-6"
+      >
+        <View className="flex flex-col space-y-3">
+          <Typography
+            className="text-5xl text-center -tracking-[2]"
+            font={{ family: 'GTAlpina', weight: 'Light' }}
+          >
+            Gallery for Creators is now in beta
+          </Typography>
+          <Typography
+            className="text-center text-sm leading-5"
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
+          >
+            Welcome to our new creator support feature, currently in beta. Share and display works
+            you’ve created on Gallery. Learn more about how it works in{' '}
+            <GalleryLink
+              href="https://gallery-so.notion.site/Creator-FAQs-22b6a0cd877946efb06f25ce4a70cb5a"
+              eventElementId={null}
+              eventName={null}
+              eventContext={null}
+            >
+              our FAQ here
+            </GalleryLink>
+            .
+          </Typography>
+        </View>
+        <Button
+          text="Continue"
+          onPress={handleContinuePress}
+          eventElementId={null}
+          eventName={null}
+          eventContext={null}
+        />
+      </View>
+    </GalleryBottomSheetModal>
+  );
+}
+
+const ForwardedCreatorSupportAnnouncementBottomSheet = forwardRef(
+  CreatorSupportAnnouncementBottomSheet
+);
+
+export { ForwardedCreatorSupportAnnouncementBottomSheet as CreatorSupportAnnouncementBottomSheet };

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
@@ -1,5 +1,5 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
-import { Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View } from 'react-native';
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
 import { SlidersIcon } from 'src/icons/SlidersIcon';
@@ -20,8 +20,10 @@ import { NftSelectorPickerScreenRefetchQuery } from '~/generated/NftSelectorPick
 import { SearchIcon } from '~/navigation/MainTabNavigator/SearchIcon';
 import { MainTabStackNavigatorParamList } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
+import useExperience from '~/shared/hooks/useExperience';
 import { chains } from '~/shared/utils/chains';
 
+import { CreatorSupportAnnouncementBottomSheet } from './CreatorSupportAnnouncementBottomSheet';
 import {
   NetworkChoice,
   NftSelectorFilterBottomSheet,
@@ -45,6 +47,7 @@ export function NftSelectorPickerScreen() {
     graphql`
       query NftSelectorPickerScreenQuery {
         ...NftSelectorPickerScreenFragment
+        ...useExperienceFragment
       }
     `,
     {}
@@ -68,6 +71,7 @@ export function NftSelectorPickerScreen() {
 
   const { top } = useSafeAreaPadding();
   const filterBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const announcementBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
   const handleSettingsPress = useCallback(() => {
     filterBottomSheetRef.current?.present();
@@ -102,95 +106,112 @@ export function NftSelectorPickerScreen() {
     setNetworkFilter(network);
   }, []);
 
+  const [creatorBetaAnnouncementSeen, setCreatorBetaAnnouncementSeen] = useExperience({
+    type: 'CreatorBetaMicroAnnouncementModal',
+    queryRef: query,
+  });
+
+  useEffect(() => {
+    if (ownershipTypeFilter === 'Created' && !creatorBetaAnnouncementSeen) {
+      announcementBottomSheetRef.current?.present();
+      setCreatorBetaAnnouncementSeen({ experienced: true });
+    }
+  }, [creatorBetaAnnouncementSeen, ownershipTypeFilter, setCreatorBetaAnnouncementSeen]);
+
   return (
-    <View
-      className="flex-1 bg-white dark:bg-black-900"
-      style={{
-        paddingTop: isFullscreen ? top : 16,
-      }}
-    >
-      <View className="flex flex-col flex-grow space-y-8">
-        <View className="px-4 relative">
-          <BackButton />
+    <>
+      <View
+        className="flex-1 bg-white dark:bg-black-900"
+        style={{
+          paddingTop: isFullscreen ? top : 16,
+        }}
+      >
+        <View className="flex flex-col flex-grow space-y-8">
+          <View className="px-4 relative">
+            <BackButton />
 
-          <View
-            className="absolute inset-0 flex flex-row justify-center items-center"
-            pointerEvents="none"
-          >
-            <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-              {screenTitle}
-            </Typography>
-          </View>
-        </View>
-
-        <View className="flex flex-col flex-grow space-y-4">
-          <View className="px-4">
-            <FadedInput
-              // TODO: Follow up w/ Fraser on input divergence here
-              inputMode="search"
-              value={searchQuery}
-              onChangeText={setSearchQuery}
-              style={{ height: 36 }}
-              icon={<SearchIcon width={16} height={16} />}
-              placeholder="Search pieces"
-            />
-          </View>
-
-          <View className="px-4 flex flex-row items-center justify-between">
-            <Select
-              className="w-32"
-              title="Network"
-              eventElementId="NftSelectorNetworkFilter"
-              onChange={handleNetworkChange}
-              selectedId={networkFilter}
-              options={NETWORKS}
-            />
-
-            <View className="flex flex-row space-x-1">
-              <AnimatedRefreshIcon
-                onSync={handleSync}
-                onRefresh={handleRefresh}
-                isSyncing={ownershipTypeFilter === 'Collected' ? isSyncing : isSyncingCreatedTokens}
-                eventElementId="NftSelectorSelectorRefreshButton"
-                eventName="NftSelectorSelectorRefreshButton pressed"
-              />
-
-              <IconContainer
-                size="sm"
-                onPress={handleSettingsPress}
-                icon={<SlidersIcon />}
-                eventElementId="NftSelectorSelectorSettingsButton"
-                eventName="NftSelectorSelectorSettingsButton pressed"
-                eventContext={contexts.Posts}
-              />
-
-              <NftSelectorFilterBottomSheet
-                ref={filterBottomSheetRef}
-                ownerFilter={ownershipTypeFilter}
-                onOwnerFilterChange={setFilter}
-                sortView={sortView}
-                onSortViewChange={setSortView}
-              />
+            <View
+              className="absolute inset-0 flex flex-row justify-center items-center"
+              pointerEvents="none"
+            >
+              <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+                {screenTitle}
+              </Typography>
             </View>
           </View>
 
-          <View className="flex-grow flex-1 w-full">
-            <Suspense fallback={<NftSelectorScreenFallback />}>
-              <NftSelectorPickerGrid
-                searchCriteria={{
-                  searchQuery,
-                  ownerFilter: ownershipTypeFilter,
-                  networkFilter: networkFilter,
-                  sortView,
-                }}
-                queryRef={data}
-                screen={currentScreen}
-                onRefresh={handleRefresh}
+          <View className="flex flex-col flex-grow space-y-4">
+            <View className="px-4">
+              <FadedInput
+                // TODO: Follow up w/ Fraser on input divergence here
+                inputMode="search"
+                value={searchQuery}
+                onChangeText={setSearchQuery}
+                style={{ height: 36 }}
+                icon={<SearchIcon width={16} height={16} />}
+                placeholder="Search pieces"
               />
-            </Suspense>
+            </View>
+
+            <View className="px-4 flex flex-row items-center justify-between">
+              <Select
+                className="w-32"
+                title="Network"
+                eventElementId="NftSelectorNetworkFilter"
+                onChange={handleNetworkChange}
+                selectedId={networkFilter}
+                options={NETWORKS}
+              />
+
+              <View className="flex flex-row space-x-1">
+                <AnimatedRefreshIcon
+                  onSync={handleSync}
+                  onRefresh={handleRefresh}
+                  isSyncing={
+                    ownershipTypeFilter === 'Collected' ? isSyncing : isSyncingCreatedTokens
+                  }
+                  eventElementId="NftSelectorSelectorRefreshButton"
+                  eventName="NftSelectorSelectorRefreshButton pressed"
+                />
+
+                <IconContainer
+                  size="sm"
+                  onPress={handleSettingsPress}
+                  icon={<SlidersIcon />}
+                  eventElementId="NftSelectorSelectorSettingsButton"
+                  eventName="NftSelectorSelectorSettingsButton pressed"
+                  eventContext={contexts.Posts}
+                />
+
+                <NftSelectorFilterBottomSheet
+                  ref={filterBottomSheetRef}
+                  ownerFilter={ownershipTypeFilter}
+                  onOwnerFilterChange={setFilter}
+                  sortView={sortView}
+                  onSortViewChange={setSortView}
+                />
+              </View>
+            </View>
+
+            <View className="flex-grow flex-1 w-full">
+              <Suspense fallback={<NftSelectorScreenFallback />}>
+                <NftSelectorPickerGrid
+                  searchCriteria={{
+                    searchQuery,
+                    ownerFilter: ownershipTypeFilter,
+                    networkFilter: networkFilter,
+                    sortView,
+                  }}
+                  queryRef={data}
+                  screen={currentScreen}
+                  onRefresh={handleRefresh}
+                />
+              </Suspense>
+            </View>
           </View>
         </View>
       </View>
-    </View>
+      <CreatorSupportAnnouncementBottomSheet ref={announcementBottomSheetRef} />
+    </>
   );
 }

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
@@ -111,6 +111,8 @@ export function NftSelectorPickerScreen() {
     queryRef: query,
   });
 
+  // setCreatorBetaAnnouncementSeen({ experienced: false });
+
   useEffect(() => {
     if (ownershipTypeFilter === 'Created' && !creatorBetaAnnouncementSeen) {
       announcementBottomSheetRef.current?.present();

--- a/apps/web/pages/_/reset.tsx
+++ b/apps/web/pages/_/reset.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { VStack } from '~/components/core/Spacer/Stack';
 import { TitleL } from '~/components/core/Text/Text';
 import { UserExperienceType } from '~/generated/enums';
-import useUpdateUserExperience from '~/utils/graphql/experiences/useUpdateUserExperience';
+import useUpdateUserExperience from '~/shared/relay/useUpdateUserExperience';
 
 const experiences: UserExperienceType[] = [
   'MultiGalleryAnnouncement',

--- a/apps/web/src/components/Announcement/AnnouncementList.tsx
+++ b/apps/web/src/components/Announcement/AnnouncementList.tsx
@@ -8,9 +8,9 @@ import { useDrawerActions } from '~/contexts/globalLayout/GlobalSidebar/SidebarD
 import { AnnouncementListFragment$key } from '~/generated/AnnouncementListFragment.graphql';
 import { contexts } from '~/shared/analytics/constants';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
+import { useOptimisticallyDismissExperience } from '~/shared/relay/useUpdateUserExperience';
 import colors from '~/shared/theme/colors';
 import { HTTPS_URL } from '~/shared/utils/regex';
-import { useOptimisticallyDismissExperience } from '~/utils/graphql/experiences/useUpdateUserExperience';
 
 import { GalleryChip } from '../core/Chip/Chip';
 import { HStack, VStack } from '../core/Spacer/Stack';

--- a/apps/web/src/components/GalleryEditor/GalleryOnboardingGuide/OnboardingDialogContext.tsx
+++ b/apps/web/src/components/GalleryEditor/GalleryOnboardingGuide/OnboardingDialogContext.tsx
@@ -3,7 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 
 import { OnboardingDialogContextFragment$key } from '~/generated/OnboardingDialogContextFragment.graphql';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
-import useExperience from '~/utils/graphql/experiences/useExperience';
+import useExperience from '~/shared/hooks/useExperience';
 import isMac from '~/utils/isMac';
 
 type OnboardingDialogContextType = {

--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/PiecesSidebar.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/PiecesSidebar.tsx
@@ -17,10 +17,10 @@ import { PiecesSidebarViewerFragment$key } from '~/generated/PiecesSidebarViewer
 import useSyncTokens from '~/hooks/api/tokens/useSyncTokens';
 import { RefreshIcon } from '~/icons/RefreshIcon';
 import { contexts, flows } from '~/shared/analytics/constants';
+import useExperience from '~/shared/hooks/useExperience';
 import colors from '~/shared/theme/colors';
 import { ChainMetadata, chainsMap } from '~/shared/utils/chains';
 import { doesUserOwnWalletFromChainFamily } from '~/shared/utils/doesUserOwnWalletFromChainFamily';
-import useExperience from '~/utils/graphql/experiences/useExperience';
 
 import OnboardingDialog from '../GalleryOnboardingGuide/OnboardingDialog';
 import { useOnboardingDialogContext } from '../GalleryOnboardingGuide/OnboardingDialogContext';

--- a/apps/web/src/components/NftSelector/NftSelectorTokens.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorTokens.tsx
@@ -6,8 +6,8 @@ import { NftSelectorTokensFragment$key } from '~/generated/NftSelectorTokensFrag
 import { NftSelectorTokensQueryFragment$key } from '~/generated/NftSelectorTokensQueryFragment.graphql';
 import { contexts } from '~/shared/analytics/constants';
 import { GalleryElementTrackingProps } from '~/shared/contexts/AnalyticsContext';
+import useExperience from '~/shared/hooks/useExperience';
 import { Chain } from '~/shared/utils/chains';
-import useExperience from '~/utils/graphql/experiences/useExperience';
 
 import CreatorSupportAnnouncement from '../Announcement/CreatorSupportAnnouncement';
 import { VStack } from '../core/Spacer/Stack';

--- a/apps/web/src/components/Notifications/NotificationList.tsx
+++ b/apps/web/src/components/Notifications/NotificationList.tsx
@@ -7,7 +7,7 @@ import { VStack } from '~/components/core/Spacer/Stack';
 import { TitleDiatypeL } from '~/components/core/Text/Text';
 import { SeeMore } from '~/components/Notifications/SeeMore';
 import { NotificationListFragment$key } from '~/generated/NotificationListFragment.graphql';
-import useExperience from '~/utils/graphql/experiences/useExperience';
+import useExperience from '~/shared/hooks/useExperience';
 
 import { Notification } from './Notification';
 import { NotificationEmailAlert } from './NotificationEmailAlert';

--- a/apps/web/src/components/Notifications/NotificationTwitterAlert.tsx
+++ b/apps/web/src/components/Notifications/NotificationTwitterAlert.tsx
@@ -9,8 +9,8 @@ import { NotificationTwitterAlertFragment$key } from '~/generated/NotificationTw
 import CloseIcon from '~/icons/CloseIcon';
 import InfoCircleIcon from '~/icons/InfoCircleIcon';
 import { contexts } from '~/shared/analytics/constants';
+import useExperience from '~/shared/hooks/useExperience';
 import colors from '~/shared/theme/colors';
-import useExperience from '~/utils/graphql/experiences/useExperience';
 
 import GalleryLink from '../core/GalleryLink/GalleryLink';
 import { HStack } from '../core/Spacer/Stack';

--- a/apps/web/src/components/UpsellBanner/UpsellBanner.tsx
+++ b/apps/web/src/components/UpsellBanner/UpsellBanner.tsx
@@ -3,7 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 
 import { UpsellBannerQuery$key } from '~/generated/UpsellBannerQuery.graphql';
 import useAddWalletModal from '~/hooks/useAddWalletModal';
-import useExperience from '~/utils/graphql/experiences/useExperience';
+import useExperience from '~/shared/hooks/useExperience';
 
 import { GlobalBanner } from '../core/GlobalBanner/GlobalBanner';
 

--- a/apps/web/src/contexts/globalLayout/GlobalAnnouncementPopover/useGlobalAnnouncementPopover.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalAnnouncementPopover/useGlobalAnnouncementPopover.tsx
@@ -7,7 +7,7 @@ import { useModalActions } from '~/contexts/modal/ModalContext';
 import { useGlobalAnnouncementPopoverFragment$key } from '~/generated/useGlobalAnnouncementPopoverFragment.graphql';
 import { creatorsFeaturePageContentQuery } from '~/pages/features/creators';
 import { CreatorsFeaturePageContent } from '~/scenes/ContentPages/FeaturePage/CreatorsFeaturePage';
-import useExperience from '~/utils/graphql/experiences/useExperience';
+import useExperience from '~/shared/hooks/useExperience';
 import { fetchSanityContent } from '~/utils/sanity';
 
 // Keeping for future use

--- a/apps/web/src/contexts/globalLayout/GlobalBanner/MobileBetaUpsell.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalBanner/MobileBetaUpsell.tsx
@@ -6,7 +6,7 @@ import { GlobalBanner } from '~/components/core/GlobalBanner/GlobalBanner';
 import { UserExperienceType } from '~/generated/enums';
 import { MobileBetaUpsellFragment$key } from '~/generated/MobileBetaUpsellFragment.graphql';
 import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
-import useExperience from '~/utils/graphql/experiences/useExperience';
+import useExperience from '~/shared/hooks/useExperience';
 import isIOS from '~/utils/isIOS';
 
 import MobileBetaReleaseBanner from './MobileBetaReleaseBanner';

--- a/packages/shared/src/hooks/useExperience.ts
+++ b/packages/shared/src/hooks/useExperience.ts
@@ -2,9 +2,10 @@ import { useCallback, useMemo } from 'react';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import { UserExperienceType } from '~/generated/enums';
 import { useExperienceFragment$key } from '~/generated/useExperienceFragment.graphql';
-import useUpdateUserExperience from '~/utils/graphql/experiences/useUpdateUserExperience';
+import { UserExperienceType } from '~/generated/useUpdateUserExperienceMutation.graphql';
+
+import useUpdateUserExperience from '../relay/useUpdateUserExperience';
 
 type Props = {
   type: UserExperienceType;

--- a/packages/shared/src/relay/useUpdateUserExperience.tsx
+++ b/packages/shared/src/relay/useUpdateUserExperience.tsx
@@ -1,13 +1,13 @@
 import { useCallback } from 'react';
 import { graphql } from 'react-relay';
 
-import { useToastActions } from '~/contexts/toast/ToastContext';
 import {
   UserExperienceType,
   useUpdateUserExperienceMutation,
   useUpdateUserExperienceMutation$data,
 } from '~/generated/useUpdateUserExperienceMutation.graphql';
-import { usePromisifiedMutation } from '~/shared/relay/usePromisifiedMutation';
+
+import { usePromisifiedMutation } from './usePromisifiedMutation';
 
 type Props = {
   type: UserExperienceType;
@@ -42,8 +42,6 @@ export default function useUpdateUserExperience() {
     }
   `);
 
-  const { pushToast } = useToastActions();
-
   return useCallback(
     async ({ type, experienced, optimisticExperiencesList }: Props) => {
       try {
@@ -66,13 +64,11 @@ export default function useUpdateUserExperience() {
         });
       } catch (error) {
         if (error instanceof Error) {
-          pushToast({
-            message: 'Unfortunately there was an error to save the settings.',
-          });
+          // TODO throw error for consumer to use
         }
       }
     },
-    [pushToast, updateUserExperience]
+    [updateUserExperience]
   );
 }
 


### PR DESCRIPTION

### Summary of Changes
Show Creator Support announcement to users when they select the "Created" filter in the composer.
We use an experience flag to make sure they only see it once. This uses the same flag as the frontend, so if they've seen the announcement on web, they won't see it in the app.
This is the first time using experiences in the mobile app, so I moved the useExperience hook and relay files from web into shared.

Note: there's currently a visual issue where the Token Sync toast is displayed above the announcement. I believe we are removing the toast as part of the other follow up changes, so this should be temporary.
Note2: the useUpdateUserExperience file I moved from web to shared used the web toast hook, so I just removed the toast for now. I don't think it's important for the user to be shown the success or error state of updating the experience, since they didn't trigger it and wouldn't know what it's referring to.

### Demo or Before/After Pics

https://github.com/gallery-so/gallery/assets/80802871/4ceae66a-6644-4f72-8116-ba0347c468e6

dark mode is good
![CleanShot 2023-11-22 at 19 25 00@2x](https://github.com/gallery-so/gallery/assets/80802871/15789300-445a-42dc-a1d1-af56abc48f38)

### Edge Cases


### Testing Steps
In the mobile app and go to the Post Composer nft selector. select the Created filter, and confirm you see the announcement. Once you see it, you shouldn't see it again.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
