### PR TITLE
Mobile syncing skeleton support

### DIFF
--- a/apps/mobile/src/components/AnimatedRefreshIcon.tsx
+++ b/apps/mobile/src/components/AnimatedRefreshIcon.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
-import { Animated } from 'react-native';
+import { useCallback } from 'react';
 import { RefreshIcon } from 'src/icons/RefreshIcon';
 
 import { IconContainer } from '~/components/IconContainer';
@@ -26,47 +25,15 @@ export function AnimatedRefreshIcon({
     onRefresh();
   }, [isSyncing, onRefresh, onSync]);
 
-  const spinValue = useRef(new Animated.Value(0)).current;
-
-  const spin = useCallback(() => {
-    spinValue.setValue(0);
-    Animated.timing(spinValue, {
-      toValue: 1,
-      duration: 1000,
-      useNativeDriver: true,
-    }).start(({ finished }) => {
-      // Only repeat the animation if it completed (wasn't interrupted) and isSyncing is still true
-      if (finished && isSyncing) {
-        spin();
-      }
-    });
-  }, [isSyncing, spinValue]);
-
-  const spinAnimation = spinValue.interpolate({
-    inputRange: [0, 1],
-    outputRange: ['0deg', '360deg'],
-  });
-
-  useEffect(() => {
-    if (isSyncing) {
-      spin();
-    } else {
-      spinValue.stopAnimation();
-    }
-  }, [isSyncing, spin, spinValue]);
-
   return (
     <IconContainer
       size="sm"
       onPress={handleSync}
-      icon={
-        <Animated.View style={{ transform: [{ rotate: spinAnimation }] }}>
-          <RefreshIcon />
-        </Animated.View>
-      }
+      icon={<RefreshIcon />}
       eventElementId={eventElementId}
       eventName={eventName}
       eventContext={contexts.Posts}
+      style={{ opacity: isSyncing ? 0.3 : 1 }}
     />
   );
 }

--- a/apps/mobile/src/contexts/SyncTokensContext.tsx
+++ b/apps/mobile/src/contexts/SyncTokensContext.tsx
@@ -77,13 +77,6 @@ const SyncTokensProvider = memo(({ children }: Props) => {
   const sync = useCallback(
     async (chain: Chain) => {
       try {
-        // TODO: refactor this logic later, add success toast afterwards.
-        // may need to look into weird timeout interference with `syncTokens` async call
-        pushToast({
-          message: 'Refreshing your collection. This may take a minute!',
-          withoutNavbar: true,
-        });
-
         setIsSyncing(true);
         const response = await syncTokens({
           variables: {
@@ -107,7 +100,7 @@ const SyncTokensProvider = memo(({ children }: Props) => {
         setIsSyncing(false);
       }
     },
-    [clearTokenFailureState, pushToast, showFailure, syncTokens]
+    [clearTokenFailureState, showFailure, syncTokens]
   );
 
   const [syncCreatedTokensMutation] =
@@ -144,13 +137,6 @@ const SyncTokensProvider = memo(({ children }: Props) => {
   const syncCreatedTokens = useCallback(
     async (chain: Chain) => {
       try {
-        // TODO: refactor this logic later, add success toast afterwards.
-        // may need to look into weird timeout interference with `syncTokens` async call
-        pushToast({
-          message: 'Refreshing your collection. This may take a minute!',
-          withoutNavbar: true,
-        });
-
         setIsSyncingCreatedTokens(true);
         const response = await syncCreatedTokensMutation({
           variables: {
@@ -177,7 +163,7 @@ const SyncTokensProvider = memo(({ children }: Props) => {
         setIsSyncingCreatedTokens(false);
       }
     },
-    [clearTokenFailureState, pushToast, showFailure, syncCreatedTokensMutation]
+    [clearTokenFailureState, showFailure, syncCreatedTokensMutation]
   );
 
   const [syncCreatedTokensForExistingContractMutate] =
@@ -213,13 +199,6 @@ const SyncTokensProvider = memo(({ children }: Props) => {
   const syncCreatedTokensForExistingContract = useCallback(
     async (contractId: string) => {
       try {
-        // TODO: refactor this logic later, add success toast afterwards.
-        // may need to look into weird timeout interference with `syncTokens` async call
-        pushToast({
-          message: 'Refreshing your collection. This may take a minute!',
-          withoutNavbar: true,
-        });
-
         setIsSyncingCreatedTokensForContract(true);
         const response = await syncCreatedTokensForExistingContractMutate({
           variables: { input: { contractId } },
@@ -246,7 +225,7 @@ const SyncTokensProvider = memo(({ children }: Props) => {
       }
     },
 
-    [pushToast, syncCreatedTokensForExistingContractMutate, showFailure, clearTokenFailureState]
+    [syncCreatedTokensForExistingContractMutate, showFailure, clearTokenFailureState]
   );
 
   const value = useMemo(() => {

--- a/apps/mobile/src/icons/SpinnerIcon.tsx
+++ b/apps/mobile/src/icons/SpinnerIcon.tsx
@@ -7,9 +7,10 @@ import colors from '~/shared/theme/colors';
 
 type Props = {
   spin?: boolean;
+  size?: 's' | 'm';
 } & SvgProps;
 
-export function SpinnerIcon({ spin, ...props }: Props) {
+export function SpinnerIcon({ spin, size = 'm', ...props }: Props) {
   const { colorScheme } = useColorScheme();
 
   const spinValue = useRef(new Animated.Value(0)).current;
@@ -47,7 +48,7 @@ export function SpinnerIcon({ spin, ...props }: Props) {
   return (
     <Animated.View
       style={{
-        transform: [{ rotate: spin ? spinAnimation : '0deg' }],
+        transform: [{ rotate: spin ? spinAnimation : '0deg' }, { scale: size === 'm' ? 1 : 0.5 }],
         width: 101,
       }}
     >

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorContractScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorContractScreen.tsx
@@ -16,6 +16,8 @@ import { MainTabStackNavigatorParamList, MainTabStackNavigatorProp } from '~/nav
 import { NftSelectorPickerSingularAsset } from '~/screens/NftSelectorScreen/NftSelectorPickerSingularAsset';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 
+import { NftSelectorLoadingSkeleton } from './NftSelectorLoadingSkeleton';
+
 export function NftSelectorContractScreen() {
   const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'NftSelectorContractScreen'>>();
   const query = useLazyLoadQuery<NftSelectorContractScreenQuery>(
@@ -157,7 +159,11 @@ export function NftSelectorContractScreen() {
           ) : null}
         </View>
         <View className="flex-1 w-full">
-          <FlashList renderItem={renderItem} data={rows} estimatedItemSize={100} />
+          {isSyncingCreatedTokensForContract ? (
+            <NftSelectorLoadingSkeleton />
+          ) : (
+            <FlashList renderItem={renderItem} data={rows} estimatedItemSize={100} />
+          )}
         </View>
       </View>
     </View>

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorLoadingSkeleton.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorLoadingSkeleton.tsx
@@ -1,0 +1,22 @@
+import { View } from 'react-native';
+
+const ROWS = 6;
+const COLUMNS = 3;
+
+export function NftSelectorLoadingSkeleton() {
+  return (
+    <View className="flex flex-col space-y-2 p-2">
+      {Array.from({ length: ROWS }).map((_, i) => {
+        return (
+          <View key={i} className="flex flex-row space-x-2">
+            {Array.from({ length: COLUMNS }).map((_, j) => {
+              return (
+                <View key={j} className="flex-1 aspect-square bg-offWhite dark:bg-black-800" />
+              );
+            })}
+          </View>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorLoadingSkeleton.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorLoadingSkeleton.tsx
@@ -1,22 +1,41 @@
 import { View } from 'react-native';
+import { SpinnerIcon } from 'src/icons/SpinnerIcon';
 
-const ROWS = 6;
+import { Typography } from '~/components/Typography';
+
+const ROWS = 5;
 const COLUMNS = 3;
 
 export function NftSelectorLoadingSkeleton() {
   return (
-    <View className="flex flex-col space-y-2 p-2">
-      {Array.from({ length: ROWS }).map((_, i) => {
-        return (
-          <View key={i} className="flex flex-row space-x-2">
-            {Array.from({ length: COLUMNS }).map((_, j) => {
-              return (
-                <View key={j} className="flex-1 aspect-square bg-offWhite dark:bg-black-800" />
-              );
-            })}
-          </View>
-        );
-      })}
-    </View>
+    <>
+      <View className="flex flex-col space-y-2 p-2">
+        {Array.from({ length: ROWS }).map((_, i) => {
+          return (
+            <View key={i} className="flex flex-row space-x-2">
+              {Array.from({ length: COLUMNS }).map((_, j) => {
+                return (
+                  <View key={j} className="flex-1 aspect-square bg-offWhite dark:bg-black-800" />
+                );
+              })}
+            </View>
+          );
+        })}
+      </View>
+      <View className="absolute flex justify-center items-center w-full h-full">
+        <View className="space-y-2">
+          <Typography
+            className="text-3xl text-center"
+            font={{ family: 'GTAlpina', weight: 'StandardLight', italic: true }}
+          >
+            Fetching your collection
+          </Typography>
+          <Typography className="text-center" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+            This may take up to a minute
+          </Typography>
+        </View>
+        <SpinnerIcon spin size="s" />
+      </View>
+    </>
   );
 }

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerGrid.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerGrid.tsx
@@ -38,6 +38,8 @@ import { contexts } from '~/shared/analytics/constants';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import { doesUserOwnWalletFromChainFamily } from '~/shared/utils/doesUserOwnWalletFromChainFamily';
 
+import { NftSelectorLoadingSkeleton } from './NftSelectorLoadingSkeleton';
+
 type NftSelectorPickerGridProps = {
   style?: ViewProps['style'];
   searchCriteria: {
@@ -294,6 +296,10 @@ export function NftSelectorPickerGrid({
     },
     [screen, searchCriteria.ownerFilter]
   );
+
+  if (isSyncing || isSyncingCreatedTokens) {
+    return <NftSelectorLoadingSkeleton />;
+  }
 
   if (!rows.length) {
     return (

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
@@ -111,8 +111,6 @@ export function NftSelectorPickerScreen() {
     queryRef: query,
   });
 
-  // setCreatorBetaAnnouncementSeen({ experienced: false });
-
   useEffect(() => {
     if (ownershipTypeFilter === 'Created' && !creatorBetaAnnouncementSeen) {
       announcementBottomSheetRef.current?.present();


### PR DESCRIPTION
### Summary of Changes

Our mobile syncing state is very ugly!
- Adds skeleton states
- Kills refresh icon spinning; uses opacity instead
- Removes initial toast; still displays error toast

### Demo or Before/After Pics


https://github.com/gallery-so/gallery/assets/12162433/6fdeaede-f2d6-4548-ad5c-ac2c261f8496



| network view                                     | contract view                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="527" alt="Screenshot 2023-11-22 at 2 40 45 PM" src="https://github.com/gallery-so/gallery/assets/12162433/41588d46-2589-4711-abbb-357577a9d3cd"> | <img width="527" alt="Screenshot 2023-11-22 at 2 40 23 PM" src="https://github.com/gallery-so/gallery/assets/12162433/1d1b5955-bd7e-4f41-9397-0f659e580c52"> |



### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
