### PR TITLE
opengraph truncation bug fix

### DIFF
--- a/apps/web/src/components/opengraph/PostOpenGraphPreview.tsx
+++ b/apps/web/src/components/opengraph/PostOpenGraphPreview.tsx
@@ -4,8 +4,8 @@ import OpenBracket from 'public/icons/open_bracket.svg';
 import styled from 'styled-components';
 
 import { pageGutter } from '~/components/core/breakpoints';
-import Markdown from '~/components/core/Markdown/Markdown';
 import { BaseXL, TitleDiatypeL } from '~/components/core/Text/Text';
+import ProcessedText from '~/components/ProcessedText/ProcessedText';
 
 import { RawProfilePicture } from '../ProfilePicture/RawProfilePicture';
 
@@ -35,7 +35,7 @@ export const PostOpenGraphPreview = ({ username, caption, imageUrl, profileImage
             </StyledUserInfoContainer>
             <StyledDescription>
               {caption ? (
-                <Markdown text={unescape(caption)} eventContext={null} />
+                <ProcessedText text={caption} eventContext={null} />
               ) : (
                 <>
                   View this post on <strong>gallery.so</strong>

--- a/apps/web/src/components/opengraph/PostOpenGraphPreview.tsx
+++ b/apps/web/src/components/opengraph/PostOpenGraphPreview.tsx
@@ -35,7 +35,7 @@ export const PostOpenGraphPreview = ({ username, caption, imageUrl, profileImage
             </StyledUserInfoContainer>
             <StyledDescription>
               {caption ? (
-                <ProcessedText text={caption} eventContext={null} />
+                <ProcessedText text={unescape(caption)} eventContext={null} />
               ) : (
                 <>
                   View this post on <strong>gallery.so</strong>


### PR DESCRIPTION
### Summary of Changes
Ensure the caption in opengraph is truncated to 5 lines exactly and there is no overflow.
This is achieved by replacing the `Markdown` component with the new `ProcesedText` component

### Demo or Before/After Pics




| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="1263" alt="Screenshot 2023-11-25 at 7 16 15 AM" src="https://github.com/gallery-so/gallery/assets/49758803/91c8a01c-bda0-46c0-9eef-7a20da8edd3f"> | <img width="1208" alt="Screenshot 2023-11-25 at 7 16 52 AM" src="https://github.com/gallery-so/gallery/assets/49758803/bfe51029-a0d3-4b9d-9f31-cb22736d160a"> |

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
