### PR TITLE
inline timestamp notifs for web

### DIFF
--- a/apps/web/src/components/Notifications/Notification.tsx
+++ b/apps/web/src/components/Notifications/Notification.tsx
@@ -5,7 +5,6 @@ import { ConnectionHandler, graphql } from 'relay-runtime';
 import styled, { css } from 'styled-components';
 
 import { HStack } from '~/components/core/Spacer/Stack';
-import { BaseS } from '~/components/core/Text/Text';
 import { SomeoneAdmiredYourFeedEvent } from '~/components/Notifications/notifications/SomeoneAdmiredYourFeedEvent';
 import { SomeoneCommentedOnYourFeedEvent } from '~/components/Notifications/notifications/SomeoneCommentedOnYourFeedEvent';
 import { SomeoneFollowedYou } from '~/components/Notifications/notifications/SomeoneFollowedYou';
@@ -22,7 +21,6 @@ import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { ReportingErrorBoundary } from '~/shared/errors/ReportingErrorBoundary';
 import { useClearNotifications } from '~/shared/relay/useClearNotifications';
 import colors from '~/shared/theme/colors';
-import { getTimeSince } from '~/shared/utils/time';
 
 import { NewTokens } from './notifications/NewTokens';
 import SomeoneAdmiredYourPost from './notifications/SomeoneAdmiredYourPost';
@@ -44,7 +42,6 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
       fragment NotificationFragment on Notification {
         id
         seen
-        updatedTime
 
         __typename
 
@@ -289,8 +286,6 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
     track,
   ]);
 
-  const timeAgo = getTimeSince(notification.updatedTime);
-
   if (
     ![
       'SomeoneAdmiredYourFeedEventNotification',
@@ -338,26 +333,21 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
   return (
     <ReportingErrorBoundary fallback={null}>
       <Container isClickable={isClickable} onClick={handleClick}>
-        <HStack gap={8} align="center" justify="space-between">
+        <HStack gap={8} align="center">
+          {!notification.seen && (
+            <StyledDotContainer align="center">
+              <UnseenDot />
+            </StyledDotContainer>
+          )}
           <NotificationInner notificationRef={notification} queryRef={query} />
-          <StyledDotAndTimeAgo align="center" gap={4}>
-            <HStack grow justify="flex-end" gap={16}>
-              <TimeAgoText color={colors.metal}>{timeAgo}</TimeAgoText>
-            </HStack>
-            {!notification.seen && (
-              <UnseenDotContainer>
-                <UnseenDot />
-              </UnseenDotContainer>
-            )}
-          </StyledDotAndTimeAgo>
         </HStack>
       </Container>
     </ReportingErrorBoundary>
   );
 }
 
-const StyledDotAndTimeAgo = styled(HStack)`
-  width: 35px;
+const StyledDotContainer = styled(HStack)`
+  width: 10px;
 `;
 
 type NotificationInnerProps = {
@@ -479,17 +469,6 @@ function NotificationInner({ notificationRef, queryRef }: NotificationInnerProps
 
   return null;
 }
-
-export const TimeAgoText = styled(BaseS)`
-  white-space: nowrap;
-  flex-shrink: 0;
-`;
-
-const UnseenDotContainer = styled.div`
-  align-self: stretch;
-  display: flex;
-  align-items: center;
-`;
 
 const UnseenDot = styled.div`
   width: 8px;

--- a/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourFeedEvent.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourFeedEvent.tsx
@@ -4,11 +4,13 @@ import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
 import { VStack } from '~/components/core/Spacer/Stack';
-import { BaseM } from '~/components/core/Text/Text';
+import { BaseM, BaseS } from '~/components/core/Text/Text';
 import UserHoverCard from '~/components/HoverCard/UserHoverCard';
 import { CollectionLink } from '~/components/Notifications/CollectionLink';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { SomeoneCommentedOnYourFeedEventFragment$key } from '~/generated/SomeoneCommentedOnYourFeedEventFragment.graphql';
+import colors from '~/shared/theme/colors';
+import { getTimeSince } from '~/shared/utils/time';
 import unescape from '~/shared/utils/unescape';
 
 type SomeoneCommentedOnYourFeedEventProps = {
@@ -24,6 +26,7 @@ export function SomeoneCommentedOnYourFeedEvent({
     graphql`
       fragment SomeoneCommentedOnYourFeedEventFragment on SomeoneCommentedOnYourFeedEventNotification {
         __typename
+        updatedTime
 
         comment {
           commenter {
@@ -70,6 +73,7 @@ export function SomeoneCommentedOnYourFeedEvent({
   );
 
   const eventType = notification.feedEvent?.eventData?.__typename;
+  const timeAgo = getTimeSince(notification.updatedTime);
 
   const verb = useMemo(() => {
     switch (eventType) {
@@ -105,13 +109,20 @@ export function SomeoneCommentedOnYourFeedEvent({
         {` ${verb} `}
         {collection ? <CollectionLink collectionRef={collection} /> : <>your collection</>}
       </BaseM>
-
+      &nbsp;
+      <TimeAgoText as="span">{timeAgo}</TimeAgoText>
       <CommentPreviewContainer>
         <BaseM>{unescape(notification.comment?.comment ?? '')}</BaseM>
       </CommentPreviewContainer>
     </VStack>
   );
 }
+
+const TimeAgoText = styled(BaseS)`
+  color: ${colors.metal};
+  white-space: nowrap;
+  flex-shrink: 0;
+`;
 
 const CommentPreviewContainer = styled.div`
   margin-left: 16px;

--- a/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourPost.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneCommentedOnYourPost.tsx
@@ -2,12 +2,13 @@ import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM } from '~/components/core/Text/Text';
+import { BaseM, BaseS } from '~/components/core/Text/Text';
 import UserHoverCard from '~/components/HoverCard/UserHoverCard';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { SomeoneCommentedOnYourPostFragment$key } from '~/generated/SomeoneCommentedOnYourPostFragment.graphql';
 import { useReportError } from '~/shared/contexts/ErrorReportingContext';
 import colors from '~/shared/theme/colors';
+import { getTimeSince } from '~/shared/utils/time';
 import unescape from '~/shared/utils/unescape';
 
 import { NotificationPostPreviewWithBoundary } from './NotificationPostPreview';
@@ -23,6 +24,7 @@ export default function SomeoneCommentedOnYourPost({ notificationRef, onClose }:
       fragment SomeoneCommentedOnYourPostFragment on SomeoneCommentedOnYourPostNotification {
         __typename
         dbid
+        updatedTime
         post {
           tokens {
             ...NotificationPostPreviewWithBoundaryFragment
@@ -59,6 +61,7 @@ export default function SomeoneCommentedOnYourPost({ notificationRef, onClose }:
   }
 
   const commenter = comment.commenter;
+  const timeAgo = getTimeSince(notification.updatedTime);
 
   return (
     <StyledNotificationContent align="center" justify="space-between" gap={8}>
@@ -71,6 +74,8 @@ export default function SomeoneCommentedOnYourPost({ notificationRef, onClose }:
             <BaseM as="span">
               commented on your <strong>post</strong>
             </BaseM>
+            &nbsp;
+            <TimeAgoText as="span">{timeAgo}</TimeAgoText>
           </StyledTextWrapper>
           <StyledCaption>{unescape(comment.comment)}</StyledCaption>
         </VStack>
@@ -94,6 +99,12 @@ const StyledCaption = styled(BaseM)`
   overflow: hidden;
   line-clamp: 1;
   -webkit-line-clamp: 1;
+`;
+
+const TimeAgoText = styled(BaseS)`
+  color: ${colors.metal};
+  white-space: nowrap;
+  flex-shrink: 0;
 `;
 
 const StyledTextWrapper = styled(HStack)`

--- a/apps/web/src/components/Notifications/notifications/SomeoneMentionedYou.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneMentionedYou.tsx
@@ -3,12 +3,13 @@ import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM } from '~/components/core/Text/Text';
+import { BaseM, BaseS } from '~/components/core/Text/Text';
 import UserHoverCard from '~/components/HoverCard/UserHoverCard';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { SomeoneMentionedYouFragment$key } from '~/generated/SomeoneMentionedYouFragment.graphql';
 import { useReportError } from '~/shared/contexts/ErrorReportingContext';
 import colors from '~/shared/theme/colors';
+import { getTimeSince } from '~/shared/utils/time';
 
 import { NotificationPostPreviewWithBoundary } from './NotificationPostPreview';
 
@@ -23,6 +24,7 @@ export function SomeoneMentionedYou({ notificationRef, onClose }: Props) {
       fragment SomeoneMentionedYouFragment on SomeoneMentionedYouNotification {
         __typename
         dbid
+        updatedTime
         mentionSource @required(action: THROW) {
           __typename
           ... on Post {
@@ -99,6 +101,7 @@ export function SomeoneMentionedYou({ notificationRef, onClose }: Props) {
   if (!notificationData) return null;
 
   const { author, message, type, token } = notificationData;
+  const timeAgo = getTimeSince(notification.updatedTime);
 
   if (!author) {
     reportError(
@@ -118,6 +121,8 @@ export function SomeoneMentionedYou({ notificationRef, onClose }: Props) {
             <BaseM as="span">
               mentioned you in a <strong>{type}</strong>
             </BaseM>
+            &nbsp;
+            <TimeAgoText as="span">{timeAgo}</TimeAgoText>
           </StyledTextWrapper>
           <StyledCaption>{message}</StyledCaption>
         </VStack>
@@ -141,6 +146,12 @@ const StyledCaption = styled(BaseM)`
   overflow: hidden;
   line-clamp: 2;
   -webkit-line-clamp: 2;
+`;
+
+const TimeAgoText = styled(BaseS)`
+  color: ${colors.metal};
+  white-space: nowrap;
+  flex-shrink: 0;
 `;
 
 const StyledTextWrapper = styled(HStack)`


### PR DESCRIPTION
### Summary of Changes

remove timestamp in web notification and make it inline only for these activities:
-comment
-mention
-reply
also move unseen notification blue dot to left side from existing right side of notification row

slack context: https://galleryso.slack.com/archives/C056S2FD5HU/p1699930021897119

### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.




| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="482" alt="Screenshot 2023-11-28 at 1 28 31 PM" src="https://github.com/gallery-so/gallery/assets/49758803/a5399f19-28da-4ce6-bf57-b04dacaa3402"> | <img width="487" alt="Screenshot 2023-11-28 at 1 23 42 PM" src="https://github.com/gallery-so/gallery/assets/49758803/73f21e4e-8e9f-4189-8b8d-781d137bb1bf"> |



### Edge Cases
Other notifs types
<img width="423" alt="Screenshot 2023-11-28 at 1 22 34 PM" src="https://github.com/gallery-so/gallery/assets/49758803/b7cf2337-6c9f-4695-90bf-42226b975318">


### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
