### PR TITLE
Fix mobile logouts for local dev

### DIFF
--- a/apps/mobile/src/hooks/useLogout.ts
+++ b/apps/mobile/src/hooks/useLogout.ts
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import { useWalletConnectModal } from '@walletconnect/modal-react-native';
+import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import { useCallback } from 'react';
 import { graphql } from 'react-relay';
@@ -31,22 +32,34 @@ export function useLogout(): [() => void, boolean] {
     try {
       magic.user.logout();
       provider?.disconnect();
-      const expoPushToken = await Notifications.getExpoPushTokenAsync();
-      const response = await mutate({
-        variables: {
-          token: expoPushToken.data,
-        },
-      });
 
-      if (response.logout?.__typename === 'LogoutPayload') {
-        navigation.reset({ index: 0, routes: [{ name: 'Login', params: { screen: 'Landing' } }] });
-      } else {
-        reportError(
-          new ErrorWithSentryMetadata('Unexpected typename received from logout mutation', {
-            typename: response.logout?.__typename,
-          })
-        );
+      // only go through official logout flow if user is using a real device, since we
+      // need to de-register their push token (which doesn't exist for simulator)
+      if (Device.isDevice) {
+        const expoPushToken = await Notifications.getExpoPushTokenAsync();
+        const response = await mutate({
+          variables: {
+            token: expoPushToken.data,
+          },
+        });
+        if (response.logout?.__typename === 'LogoutPayload') {
+          navigation.reset({
+            index: 0,
+            routes: [{ name: 'Login', params: { screen: 'Landing' } }],
+          });
+        } else {
+          reportError(
+            new ErrorWithSentryMetadata('Unexpected typename received from logout mutation', {
+              typename: response.logout?.__typename,
+            })
+          );
+        }
+        return;
       }
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'Login', params: { screen: 'Landing' } }],
+      });
     } catch (error) {
       if (error instanceof Error) {
         reportError(error);


### PR DESCRIPTION
### Summary of Changes

Only go through official logout flow if user is using a real device, since we need to de-register their push token (which doesn't exist for simulator)

