### PR TITLE
fix admire token text color not updating correctly

### DIFF
--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -208,7 +208,7 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
   const { contractName } = extractRelevantMetadataFromToken(token);
 
   const blueToDisplay = useMemo(
-    () => (colorScheme === 'dark' ? 'darkModeBlue' : 'hyperBlue'),
+    () => (colorScheme === 'dark' ? '[#7597FF]' : 'activeBlue'),
     [colorScheme]
   );
 
@@ -362,7 +362,7 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
           eventContext={contexts['NFT Detail']}
           onPress={toggleTokenAdmire}
           text={hasViewerAdmiredEvent ? 'admired' : 'admire'}
-          textClassName={hasViewerAdmiredEvent ? `text-${blueToDisplay}` : undefined}
+          textClassName={hasViewerAdmiredEvent ? `text-${blueToDisplay}` : ''}
           containerClassName={
             hasViewerAdmiredEvent ? 'border border-[#7597FF]' : 'border border-porcelain'
           }


### PR DESCRIPTION
### Summary of Changes

for some reason just does not work when textClassName is `text-darkModeBlue` when the darkModeBlue is defined in `colors.ts`

### Demo or Before/After Pics


| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="486" alt="Screenshot 2023-12-05 at 6 09 35 PM" src="https://github.com/gallery-so/gallery/assets/49758803/8f60f3bc-1733-4524-8536-e100fe2b3aec"> | <img width="502" alt="Screenshot 2023-12-05 at 6 07 52 PM" src="https://github.com/gallery-so/gallery/assets/49758803/29a3abdb-8507-4ed7-967d-3a9879126253"> |

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
