### PR TITLE
Replace testflight link with app store link

### DIFF
--- a/apps/web/src/components/Announcement/constants.ts
+++ b/apps/web/src/components/Announcement/constants.ts
@@ -21,8 +21,7 @@ export const ANNOUNCEMENT_CONTENT: AnnouncementType[] = [
   {
     key: 'MobileBetaUpsell',
     title: 'The Wait is Over!',
-    description:
-      'Download the Gallery Mobile App on Testflight and take your collection everywhere.',
+    description: 'Download the Gallery Mobile App and take your collection everywhere.',
     date: '2023-06-20T16:00:00.154845Z',
     link: '/mobile',
     ctaText: 'Download',

--- a/apps/web/src/scenes/ContentPages/MobileAppLandingPage.tsx
+++ b/apps/web/src/scenes/ContentPages/MobileAppLandingPage.tsx
@@ -28,13 +28,11 @@ export default function MobileAppLandingPage() {
                   We’re building a fresh approach to creativity and self expression, and that starts
                   with a mobile app.
                 </BaseXL>
-                <BaseXL>TestFlight access on iOS is now open to all Gallery users.</BaseXL>
-                {/* <BaseXL>Join the waitlist to be the first to try it out.</BaseXL> */}
               </BodyText>
             </VStack>
             <VStack gap={8}>
               <StyledLink
-                href="https://testflight.apple.com/join/rc0NcVih"
+                href="https://apps.apple.com/us/app/gallery/id6447068892"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
### Summary of Changes

- Replace link since app is up to parity
- Remove TestFlight copy

