### PR TITLE
update url and copy for mobile page

### DIFF
--- a/apps/web/src/scenes/ContentPages/MobileAppLandingPage.tsx
+++ b/apps/web/src/scenes/ContentPages/MobileAppLandingPage.tsx
@@ -28,13 +28,12 @@ export default function MobileAppLandingPage() {
                   We’re building a fresh approach to creativity and self expression, and that starts
                   with a mobile app.
                 </BaseXL>
-                <BaseXL>TestFlight access on iOS is now open to all Gallery users.</BaseXL>
-                {/* <BaseXL>Join the waitlist to be the first to try it out.</BaseXL> */}
+                <BaseXL>Available now for iOS via the App Store.</BaseXL>
               </BodyText>
             </VStack>
             <VStack gap={8}>
               <StyledLink
-                href="https://testflight.apple.com/join/rc0NcVih"
+                href="https://apps.apple.com/jp/app/gallery/id6447068892?l=en-US"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
### Summary of Changes

Now that we are on the App Store, update download url and copy on mobile page
![CleanShot 2023-12-07 at 18 12 23@2x](https://github.com/gallery-so/gallery/assets/80802871/68b44feb-5fd4-46ee-a647-3ed0b0e05694)


### Edge Cases
NA

### Testing Steps
click on link, it should take you to the App Store

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
