### PR TITLE
fix typo for mention notification

### DIFF
--- a/apps/web/src/components/Notifications/notifications/SomeoneRepliedToYourComment.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneRepliedToYourComment.tsx
@@ -71,7 +71,7 @@ export function SomeoneRepliedToYourComment({ notificationRef, onClose }: Props)
             <UserHoverCard userRef={commenter} onClick={onClose} />
             &nbsp;
             <BaseM as="span">
-              replied to your <strong>post</strong>
+              replied to your <strong>comment</strong>
             </BaseM>
           </StyledTextWrapper>
           <StyledCaption>{comment.comment}</StyledCaption>


### PR DESCRIPTION
### Summary of Changes
Fixing small typo for Replies notification on web

### Demo or Before/After Pics

before
![CleanShot 2023-12-07 at 18 20 08@2x](https://github.com/gallery-so/gallery/assets/80802871/0c57815b-3d69-4346-a3dd-7bfe8c75ac29)
after
![CleanShot 2023-12-07 at 18 22 11@2x](https://github.com/gallery-so/gallery/assets/80802871/1f8e64c5-4a2b-488b-9e9a-eafabefaa755)



### Edge Cases
na

### Testing Steps
look at "someone replied to your comment" notification and verify copy

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
