### PR TITLE
persist mint page URL in post composer context

### DIFF
--- a/apps/web/src/utils/useClearURLQueryParams.ts
+++ b/apps/web/src/utils/useClearURLQueryParams.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 // clears a given parameter(s) from the URL.
 //
@@ -26,5 +26,22 @@ export function useClearURLQueryParams(param: string | string[]) {
     // @ts-expect-error we're simply replacing the current page with the same path
     replace({ pathname, query: params.toString() }, undefined, { shallow: true });
     hasRenderedOnce.current = true;
+  }, [param, pathname, replace, urlQuery]);
+}
+
+// imperative version of above effect
+export function useClearURLQueryParamsImperatively(param: string | string[]) {
+  const { pathname, query: urlQuery, replace } = useRouter();
+
+  return useCallback(() => {
+    const params = new URLSearchParams(urlQuery as Record<string, string>);
+    const paramsToClear = typeof param === 'string' ? [param] : param;
+    for (const p of paramsToClear) {
+      if (params.has(p)) {
+        params.delete(p);
+      }
+    }
+    // @ts-expect-error we're simply replacing the current page with the same path
+    replace({ pathname, query: params.toString() }, undefined, { shallow: true });
   }, [param, pathname, replace, urlQuery]);
 }


### PR DESCRIPTION
### Summary of Changes

- persist `mint_page_url` that 3rd parties will provide us for rendering mint buttons
- add a util `clearUrlParamsAndSelections` to ensure URL params / context selections are cleared when appropriate

### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
