### PR TITLE
bottomSheet for leaf icon on mobile

### DIFF
--- a/apps/mobile/src/components/Feed/Posts/FirstTimePosterBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/Posts/FirstTimePosterBottomSheet.tsx
@@ -1,0 +1,76 @@
+import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
+import { ForwardedRef, forwardRef, useRef } from 'react';
+import { View } from 'react-native';
+
+import { Button } from '~/components/Button';
+import {
+  GalleryBottomSheetModal,
+  GalleryBottomSheetModalType,
+} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
+import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
+import { Typography } from '~/components/Typography';
+import { contexts } from '~/shared/analytics/constants';
+
+const SNAP_POINTS = ['CONTENT_HEIGHT'];
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Props = {};
+
+function FirstTimePosterBottomSheet(props: Props, ref: ForwardedRef<GalleryBottomSheetModalType>) {
+  const { bottom } = useSafeAreaPadding();
+
+  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+
+  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
+    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
+
+  return (
+    <GalleryBottomSheetModal
+      ref={(value) => {
+        bottomSheetRef.current = value;
+
+        if (typeof ref === 'function') {
+          ref(value);
+        } else if (ref) {
+          ref.current = value;
+        }
+      }}
+      snapPoints={animatedSnapPoints}
+      handleHeight={animatedHandleHeight}
+      contentHeight={animatedContentHeight}
+    >
+      <View
+        onLayout={handleContentLayout}
+        style={{ paddingBottom: bottom }}
+        className="p-4 flex flex-col space-y-4"
+      >
+        <View className="flex flex-col space-y-2">
+          <Typography
+            className="text-lg text-black-900 dark:text-offWhite"
+            font={{ family: 'ABCDiatype', weight: 'Bold' }}
+          >
+            First-time poster
+          </Typography>
+          <Typography
+            className="text-lg text-black-900 dark:text-offWhite"
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
+          >
+            This is my first post, say hi!
+          </Typography>
+        </View>
+
+        <Button
+          onPress={() => bottomSheetRef.current?.dismiss()}
+          text="CLOSE"
+          eventElementId={null}
+          eventName={null}
+          eventContext={contexts.Posts}
+        />
+      </View>
+    </GalleryBottomSheetModal>
+  );
+}
+
+const ForwardedFirstTimePosterBottomSheet = forwardRef(FirstTimePosterBottomSheet);
+
+export { ForwardedFirstTimePosterBottomSheet as FirstTimePosterBottomSheet };

--- a/apps/mobile/src/components/Feed/Posts/FirstTimePosterBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/Posts/FirstTimePosterBottomSheet.tsx
@@ -42,9 +42,9 @@ function FirstTimePosterBottomSheet(props: Props, ref: ForwardedRef<GalleryBotto
       <View
         onLayout={handleContentLayout}
         style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-4"
+        className="p-4 flex flex-col space-y-6"
       >
-        <View className="flex flex-col space-y-2">
+        <View className="flex flex-col space-y-4">
           <Typography
             className="text-lg text-black-900 dark:text-offWhite"
             font={{ family: 'ABCDiatype', weight: 'Bold' }}

--- a/apps/mobile/src/components/Feed/Posts/PostListSectionHeader.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostListSectionHeader.tsx
@@ -19,6 +19,7 @@ import { contexts } from '~/shared/analytics/constants';
 import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
 import { getTimeSince } from '~/shared/utils/time';
 
+import { FirstTimePosterBottomSheet } from './FirstTimePosterBottomSheet';
 import { PostBottomSheet } from './PostBottomSheet';
 
 type PostListSectionHeaderProps = {
@@ -64,6 +65,7 @@ export function PostListSectionHeader({ feedPostRef, queryRef }: PostListSection
   const navigation = useNavigation<MainTabStackNavigatorProp>();
 
   const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const firstTimePosterBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
   const loggedInUserId = useLoggedInUserId(query);
   const isOwnPost = loggedInUserId === feedPost.author?.id;
@@ -111,7 +113,17 @@ export function PostListSectionHeader({ feedPostRef, queryRef }: PostListSection
                 {feedPost?.author?.username}
               </Typography>
               {activeBadge && <TopMemberBadgeIcon />}
-              {feedPost.isFirstPost && <LeafIcon />}
+              {feedPost.isFirstPost && (
+                <GalleryTouchableOpacity
+                  className="flex"
+                  onPress={() => firstTimePosterBottomSheetRef.current?.present()}
+                  eventElementId="First Time Poster Leaf Icon Button"
+                  eventName="First Time Poster Leaf Icon Button Clicked"
+                  eventContext={contexts.Posts}
+                >
+                  <LeafIcon />
+                </GalleryTouchableOpacity>
+              )}
             </GalleryTouchableOpacity>
           </View>
         </View>
@@ -134,6 +146,7 @@ export function PostListSectionHeader({ feedPostRef, queryRef }: PostListSection
         </View>
       </View>
 
+      <FirstTimePosterBottomSheet ref={firstTimePosterBottomSheetRef} />
       <PostBottomSheet
         ref={bottomSheetRef}
         isOwnPost={isOwnPost}


### PR DESCRIPTION
### Summary of Changes
adds a bottomSheet on mobile that is triggered when you click on the leaf icon that shows up on feed posts by a first time poster

### Demo
https://github.com/gallery-so/gallery/assets/49758803/1f8ebc5a-02c8-479a-859b-27e2aa4a279b

bottom sheet on light mode
<img width="519" alt="Screenshot 2023-12-08 at 6 19 19 AM" src="https://github.com/gallery-so/gallery/assets/49758803/b5501ba9-2d8d-47e5-b31d-e62b2043b419">


### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
