### PR TITLE
inline timestamp for someone replied to you notif

### DIFF
--- a/apps/mobile/src/components/Notification/Notifications/SomeoneRepliedToYourComment.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/SomeoneRepliedToYourComment.tsx
@@ -10,6 +10,7 @@ import { SomeoneRepliedToYourCommentFragment$key } from '~/generated/SomeoneRepl
 import { SomeoneRepliedToYourCommentQueryFragment$key } from '~/generated/SomeoneRepliedToYourCommentQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
+import { getTimeSince } from '~/shared/utils/time';
 
 type SomeoneCommentedOnYourFeedEventProps = {
   queryRef: SomeoneRepliedToYourCommentQueryFragment$key;
@@ -33,6 +34,7 @@ export function SomeoneRepliedToYourComment({
     graphql`
       fragment SomeoneRepliedToYourCommentFragment on SomeoneRepliedToYourCommentNotification {
         __typename
+        updatedTime
 
         comment {
           dbid
@@ -96,6 +98,12 @@ export function SomeoneRepliedToYourComment({
             className="text-sm"
           >
             comment
+          </Typography>{' '}
+          <Typography
+            className="text-metal text-xs"
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
+          >
+            {getTimeSince(notification.updatedTime)}
           </Typography>
         </Text>
 

--- a/apps/web/src/components/Notifications/notifications/SomeoneRepliedToYourComment.tsx
+++ b/apps/web/src/components/Notifications/notifications/SomeoneRepliedToYourComment.tsx
@@ -2,12 +2,13 @@ import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
-import { BaseM } from '~/components/core/Text/Text';
+import { BaseM, BaseS } from '~/components/core/Text/Text';
 import UserHoverCard from '~/components/HoverCard/UserHoverCard';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { SomeoneRepliedToYourCommentFragment$key } from '~/generated/SomeoneRepliedToYourCommentFragment.graphql';
 import { useReportError } from '~/shared/contexts/ErrorReportingContext';
 import colors from '~/shared/theme/colors';
+import { getTimeSince } from '~/shared/utils/time';
 
 import { NotificationPostPreviewWithBoundary } from './NotificationPostPreview';
 
@@ -22,6 +23,7 @@ export function SomeoneRepliedToYourComment({ notificationRef, onClose }: Props)
       fragment SomeoneRepliedToYourCommentFragment on SomeoneRepliedToYourCommentNotification {
         __typename
         dbid
+        updatedTime
         comment {
           commenter {
             ...UserHoverCardFragment
@@ -61,6 +63,7 @@ export function SomeoneRepliedToYourComment({ notificationRef, onClose }: Props)
   }
 
   const commenter = comment.commenter;
+  const timeAgo = getTimeSince(notification.updatedTime);
 
   return (
     <StyledNotificationContent align="center" justify="space-between" gap={8}>
@@ -73,6 +76,8 @@ export function SomeoneRepliedToYourComment({ notificationRef, onClose }: Props)
             <BaseM as="span">
               replied to your <strong>comment</strong>
             </BaseM>
+            &nbsp;
+            <TimeAgoText as="span">{timeAgo}</TimeAgoText>
           </StyledTextWrapper>
           <StyledCaption>{comment.comment}</StyledCaption>
         </VStack>
@@ -96,6 +101,12 @@ const StyledCaption = styled(BaseM)`
   overflow: hidden;
   line-clamp: 1;
   -webkit-line-clamp: 1;
+`;
+
+const TimeAgoText = styled(BaseS)`
+  color: ${colors.metal};
+  white-space: nowrap;
+  flex-shrink: 0;
 `;
 
 const StyledTextWrapper = styled(HStack)`


### PR DESCRIPTION
### Summary of Changes
as part of removing timestamps for all notif types except comment, mention and reply. this adds the timestamp for the new reply type notif

### Demo Web

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="439" alt="Screenshot 2023-12-08 at 6 34 02 AM" src="https://github.com/gallery-so/gallery/assets/49758803/2ed0693b-ec43-4da1-b165-a255c7fdac57"> | <img width="442" alt="Screenshot 2023-12-08 at 6 32 46 AM" src="https://github.com/gallery-so/gallery/assets/49758803/3371392c-4716-472b-ad19-339f0725c88a"> |

### Demo Mobile

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="456" alt="Screenshot 2023-12-08 at 6 34 54 AM" src="https://github.com/gallery-so/gallery/assets/49758803/41332d32-0838-4871-ad0b-3f958836952e"> | <img width="499" alt="Screenshot 2023-12-08 at 6 27 18 AM" src="https://github.com/gallery-so/gallery/assets/49758803/38becd8a-194a-48d9-96c6-6006f24e9854"> |

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
