### PR TITLE
[do not merge] TestFlight deprecation bottomsheet

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,42 +1,8 @@
 name: mobile-release
 
-on:
-  push:
-    branches:
-      - main
-    # We only want to run a build if things that could've affected mobile changed.
-    paths:
-      - yarn.lock
-      - package.json
-      - apps/mobile/**/*
-      - packages/shared/**/*
+on: [push]
 
 jobs:
-  release-android:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🏗 Setup repo
-        uses: actions/checkout@v3
-
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20.5.0
-          cache: yarn
-
-      - name: 🏗 Setup EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: 📦 Install dependencies
-        run: yarn install
-
-      - name: 🚀 Build app
-        run: |
-          cd apps/mobile;
-          eas build -p android -e production --non-interactive --auto-submit
   release-ios:
     runs-on: ubuntu-latest
     steps:

--- a/apps/mobile/src/components/TestflightDeprecationBottomSheet.tsx
+++ b/apps/mobile/src/components/TestflightDeprecationBottomSheet.tsx
@@ -1,0 +1,59 @@
+import { useCallback, useRef } from 'react';
+import { Linking, View } from 'react-native';
+import { useEffectOnAppForeground } from 'src/utils/useEffectOnAppForeground';
+
+import { contexts } from '~/shared/analytics/constants';
+
+import { Button } from './Button';
+import {
+  GalleryBottomSheetModal,
+  GalleryBottomSheetModalType,
+} from './GalleryBottomSheet/GalleryBottomSheetModal';
+import { Typography } from './Typography';
+
+const SNAP_POINTS = [360];
+
+const APP_STORE_URL = 'https://apps.apple.com/app/gallery/id6447068892';
+
+export function TestflightDeprecationBottomSheet() {
+  const bottomSheetRef = useRef<GalleryBottomSheetModalType>(null);
+
+  useEffectOnAppForeground(() => bottomSheetRef.current?.present());
+
+  const handlePress = useCallback(() => {
+    // NOTE: this will fail on Simulator because they don't come with App Store installed
+    Linking.openURL(APP_STORE_URL);
+  }, []);
+
+  return (
+    <GalleryBottomSheetModal ref={bottomSheetRef} index={0} snapPoints={SNAP_POINTS}>
+      <View className="flex flex-column space-y-8 mx-4 mt-2">
+        <View className="space-y-6">
+          <View>
+            <Typography
+              className="text-5xl text-center tracking-[-2px]"
+              font={{ family: 'GTAlpina', weight: 'Light' }}
+            >
+              Gallery is now on the App Store
+            </Typography>
+          </View>
+          <Typography
+            className="text-center text-sm"
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
+          >
+            Thank you for joining us on TestFlight! Our app is now available on the App Store.
+            Upgrade to the official version below to stay up to date with the latest features.
+          </Typography>
+        </View>
+
+        <Button
+          onPress={handlePress}
+          text="Upgrade  🎉"
+          eventElementId="Upgrade From TestFlight To App Store Button"
+          eventName="Upgrade From TestFlight To App Store"
+          eventContext={contexts.Onboarding}
+        />
+      </View>
+    </GalleryBottomSheetModal>
+  );
+}

--- a/apps/mobile/src/screens/HomeScreen/CuratedScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen/CuratedScreen.tsx
@@ -3,6 +3,7 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 
 import { MarfaCheckInSheet } from '~/components/MarfaCheckIn/MarfaCheckInSheet';
+import { TestflightDeprecationBottomSheet } from '~/components/TestflightDeprecationBottomSheet';
 import { WelcomeNewUser } from '~/components/WelcomeNewUser';
 import { CuratedScreenFragment$key } from '~/generated/CuratedScreenFragment.graphql';
 import { CuratedScreenQuery } from '~/generated/CuratedScreenQuery.graphql';
@@ -121,6 +122,9 @@ function CuratedScreenInner({ queryRef }: CuratedScreenInnerProps) {
           creatorName={routeParams?.postId ?? ''}
         />
       </Suspense>
+
+      {/* TESTFLIGHT ONLY */}
+      <TestflightDeprecationBottomSheet />
     </>
   );
 }


### PR DESCRIPTION
### Summary of Changes

- Deprecation bottomsheet only shipped to TestFlight
- Will be shown whenever app is foregrounded

### Demo or Before/After Pics

<img width="527" alt="Screenshot 2023-12-08 at 6 45 44 PM" src="https://github.com/gallery-so/gallery/assets/12162433/1b6cefaa-e780-4d6d-82a7-8a8477717786">

