### PR TITLE
Fix overwriteURL detection for mint buttons

### DIFF
--- a/apps/mobile/src/components/MintLinkButton.tsx
+++ b/apps/mobile/src/components/MintLinkButton.tsx
@@ -57,7 +57,7 @@ export function MintLinkButton({
     token?.definition?.community?.contract?.contractAddress?.address ?? '';
   const tokenChain = token?.definition?.community?.contract?.contractAddress?.chain ?? '';
   const { url: mintURL, provider: mintProviderType } = getMintUrlWithReferrer(
-    overwriteURL ?? token?.definition?.community?.contract?.mintURL ?? '',
+    overwriteURL || (token?.definition?.community?.contract?.mintURL ?? ''),
     referrerAddress ?? ''
   );
 


### PR DESCRIPTION
### Summary of Changes

Using `overwriteURL ?? ...` evaluated to the left-hand side even if overwriteURL was an empty string. This prevented the server-provided mint URL from being used as the fallback.

