### PR TITLE
nft detail skeleton on web

### DIFF
--- a/apps/web/src/contexts/fullPageNftDetailModalListener/FullPageNftDetailModalListener.tsx
+++ b/apps/web/src/contexts/fullPageNftDetailModalListener/FullPageNftDetailModalListener.tsx
@@ -3,8 +3,8 @@ import { Suspense, useEffect } from 'react';
 import styled from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
-import FullPageLoader from '~/components/core/Loader/FullPageLoader';
 import NftDetailPage from '~/scenes/NftDetailPage/NftDetailPage';
+import NftDetailPageFallback from '~/scenes/NftDetailPage/NftDetailPageFallback';
 import { LoadableTokenDetailView } from '~/scenes/TokenDetailPage/TokenDetailView';
 
 import { useModalActions, useModalState } from '../modal/ModalContext';
@@ -41,7 +41,7 @@ export default function FullPageNftDetailModalListener() {
     }
 
     const content = collectionId ? (
-      <Suspense fallback={<FullPageLoader />}>
+      <Suspense fallback={<NftDetailPageFallback />}>
         <NftDetailPage
           username={username as string}
           collectionId={collectionId as string}
@@ -50,7 +50,7 @@ export default function FullPageNftDetailModalListener() {
       </Suspense>
     ) : (
       <StyledTokenPreviewModal>
-        <Suspense fallback={<FullPageLoader />}>
+        <Suspense fallback={<NftDetailPageFallback />}>
           <LoadableTokenDetailView tokenId={tokenId as string} />
         </Suspense>
       </StyledTokenPreviewModal>

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 
 import breakpoints, { pageGutter } from '~/components/core/breakpoints';
 import { Directions } from '~/components/core/enums';
-import FullPageLoader from '~/components/core/Loader/FullPageLoader';
 import transitions, {
   ANIMATED_COMPONENT_TRANSLATION_PIXELS_LARGE,
 } from '~/components/core/transitions';
@@ -23,6 +22,7 @@ import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 
 import NavigationHandle from './NavigationHandle';
+import NftDetailPageFallback from './NftDetailPageFallback';
 import NftDetailView from './NftDetailView';
 import shiftNftCarousel, { MountedNft } from './utils/shiftNftCarousel';
 
@@ -347,7 +347,7 @@ const StyledNftDetailPage = styled.div`
 function NftDetailPageWithBoundary({ username, collectionId, tokenId }: NftDetailPageWrapperProps) {
   return (
     <StyledNftDetailPageWithBoundary>
-      <Suspense fallback={<FullPageLoader />}>
+      <Suspense fallback={<NftDetailPageFallback />}>
         <ErrorBoundary>
           <NftDetailPageWrapper username={username} collectionId={collectionId} tokenId={tokenId} />
         </ErrorBoundary>

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
@@ -12,17 +12,16 @@ export default function NftDetailPageFallback() {
         <StyledSkeleton />
         <StyledOwnerAndCreator>
           <VStack gap={2}>
-            <StyledDetailsHeaderSkeleton />
+            <StyledHeaderSkeleton />
           </VStack>
-
           <VStack gap={2}>
-            <StyledDetailsHeaderSkeleton />
+            <StyledHeaderSkeleton />
           </VStack>
         </StyledOwnerAndCreator>
         <StyledDescriptionSkeleton />
         <StyledThinSkeleton />
-        <StyledSmallSkeleton />
-        <StyledSmallSkeleton />
+        <StyledButtonSkeleton />
+        <StyledButtonSkeleton />
       </VStack>
     </StyledFullPageLoader>
   );
@@ -69,7 +68,7 @@ const StyledThinSkeleton = styled(Skeleton)`
   }
 `;
 
-const StyledSmallSkeleton = styled(Skeleton)`
+const StyledButtonSkeleton = styled(Skeleton)`
   width: 100%;
   height: 45px;
 
@@ -87,7 +86,7 @@ const StyledDescriptionSkeleton = styled(Skeleton)`
   }
 `;
 
-const StyledDetailsHeaderSkeleton = styled(Skeleton)`
+const StyledHeaderSkeleton = styled(Skeleton)`
   height: 50px;
   width: 65%;
 `;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
@@ -1,0 +1,99 @@
+import Skeleton from 'react-loading-skeleton';
+import styled from 'styled-components';
+
+import breakpoints from '~/components/core/breakpoints';
+import { HStack, VStack } from '~/components/core/Spacer/Stack';
+
+export default function NftDetailPageFallback() {
+  return (
+    <StyledFullPageLoader>
+      <StyledNftSkeleton />
+      <VStack gap={24}>
+        <StyledSkeleton />
+        <StyledOwnerAndCreator>
+          <VStack gap={2}>
+            <StyledDetailsHeaderSkeleton />
+          </VStack>
+
+          <VStack gap={2}>
+            <StyledDetailsHeaderSkeleton />
+          </VStack>
+        </StyledOwnerAndCreator>
+        <StyledDescriptionSkeleton />
+        <StyledThinSkeleton />
+        <StyledSmallSkeleton />
+        <StyledSmallSkeleton />
+      </VStack>
+    </StyledFullPageLoader>
+  );
+}
+
+const StyledFullPageLoader = styled.div`
+  display: flex;
+  gap: 60px;
+  height: 100vh;
+  width: 100%;
+
+  @media only screen and ${breakpoints.tablet} {
+    justify-content: center;
+    align-items: center;
+  }
+`;
+
+const StyledNftSkeleton = styled(Skeleton)`
+  width: 500px;
+  height: 500px;
+
+  @media only screen and ${breakpoints.tablet} {
+    width: 600px;
+    height: 600px;
+    margin-left: 80px;
+  }
+`;
+
+const StyledSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 57px;
+
+  @media only screen and ${breakpoints.tablet} {
+    width: 440px;
+  }
+`;
+
+const StyledThinSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 40px;
+
+  @media only screen and ${breakpoints.tablet} {
+    width: 440px;
+  }
+`;
+
+const StyledSmallSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 45px;
+
+  @media only screen and ${breakpoints.tablet} {
+    width: 180px;
+  }
+`;
+
+const StyledDescriptionSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 140px;
+
+  @media only screen and ${breakpoints.tablet} {
+    width: 420px;
+  }
+`;
+
+const StyledDetailsHeaderSkeleton = styled(Skeleton)`
+  height: 50px;
+  width: 65%;
+`;
+
+const StyledOwnerAndCreator = styled(HStack)`
+  > ${VStack} {
+    width: 50%;
+  }
+`;

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailPage.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailPage.tsx
@@ -4,10 +4,10 @@ import { graphql, useLazyLoadQuery } from 'react-relay';
 import styled from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
-import FullPageLoader from '~/components/core/Loader/FullPageLoader';
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/CommentsModal/CommentsModal';
 import { TokenDetailPageQuery } from '~/generated/TokenDetailPageQuery.graphql';
 
+import NftDetailPageFallback from '../NftDetailPage/NftDetailPageFallback';
 import NotFound from '../NotFound/NotFound';
 import TokenDetailView from './TokenDetailView';
 
@@ -67,7 +67,7 @@ const StyledTokenDetailPage = styled.div`
 export default function TokenDetailPageWithBoundary({ tokenId }: TokenDetailPageProps) {
   return (
     <StyledTokenDetailPageWithBoundary>
-      <Suspense fallback={<FullPageLoader />}>
+      <Suspense fallback={<NftDetailPageFallback />}>
         <ErrorBoundary>
           <TokenDetailPage tokenId={tokenId} />
         </ErrorBoundary>


### PR DESCRIPTION
### Summary of Changes
Adds a skeleton state for the `NftDetailView` on web. this is triggered basically whenever you click on a token from the feed or a user's gallery 

### Before
https://github.com/gallery-so/gallery/assets/49758803/8a00354a-48b0-4afc-9e32-18570c7feeae

### After
https://github.com/gallery-so/gallery/assets/49758803/d9ad5ddf-bbfa-4021-aa57-017e904a9733

### Demo moweb

https://github.com/gallery-so/gallery/assets/49758803/104ac801-f0e1-4893-8e71-2c336067302b




### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
