### PR TITLE
move event element id + name into mint link component

### DIFF
--- a/apps/mobile/src/components/Community/CommunityMeta.tsx
+++ b/apps/mobile/src/components/Community/CommunityMeta.tsx
@@ -221,8 +221,6 @@ export function CommunityMeta({ communityRef, queryRef }: Props) {
           <MintLinkButton
             tokenRef={token}
             size="sm"
-            eventElementId="Press Mint Link Button"
-            eventName="Press Mint Link"
             eventContext={contexts.Community}
             referrerAddress={creatorWalletAddress}
           />

--- a/apps/mobile/src/components/Feed/Posts/PostListMintButtonSection.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostListMintButtonSection.tsx
@@ -41,8 +41,6 @@ export function PostListMintButtonSection({ postRef }: Props) {
       <MintLinkButton
         tokenRef={token}
         variant="secondary"
-        eventElementId="Press Mint Link Button"
-        eventName="Press Mint Link Button"
         eventContext={contexts.Feed}
         referrerAddress={ownerWalletAddress}
         overwriteURL={userAddedMintURL}

--- a/apps/mobile/src/components/MintLinkButton.tsx
+++ b/apps/mobile/src/components/MintLinkButton.tsx
@@ -9,6 +9,7 @@ import { TopRightArrowIcon } from 'src/icons/TopRightArrowIcon';
 import { ZoraIcon } from 'src/icons/ZoraIcon';
 
 import { MintLinkButtonFragment$key } from '~/generated/MintLinkButtonFragment.graphql';
+import { GalleryElementTrackingProps } from '~/shared/contexts/AnalyticsContext';
 import colors from '~/shared/theme/colors';
 import { MINT_LINK_DISABLED_CONTRACTS } from '~/shared/utils/communities';
 import { getMintUrlWithReferrer } from '~/shared/utils/getMintUrlWithReferrer';
@@ -20,18 +21,21 @@ type Props = {
   style?: ViewStyle;
   referrerAddress?: string;
   overwriteURL?: string;
-} & ButtonProps;
+  variant?: ButtonProps['variant'];
+  size?: ButtonProps['size'];
+  eventContext: GalleryElementTrackingProps['eventContext'];
+};
 
 const CHAIN_ENABLED = ['Ethereum', 'Optimism', 'Base', 'Zora'];
 
 export function MintLinkButton({
   tokenRef,
-  referrerAddress,
   style,
+  referrerAddress,
+  overwriteURL,
   variant = 'primary',
   size = 'md',
-  overwriteURL,
-  ...props
+  eventContext,
 }: Props) {
   const token = useFragment(
     graphql`
@@ -130,7 +134,9 @@ export function MintLinkButton({
       footerElement={<TopRightArrowIcon color={arrowColor} />}
       style={style}
       size={size}
-      {...props}
+      eventElementId="Mint Link Button"
+      eventName="Press Mint Link Button"
+      eventContext={eventContext}
     />
   );
 }

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -364,8 +364,6 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
         ) : (
           <MintLinkButton
             tokenRef={token}
-            eventElementId="Press Mint Link Button"
-            eventName="Press Mint Link"
             eventContext={contexts['NFT Detail']}
             referrerAddress={ownerWalletAddress}
           />


### PR DESCRIPTION
### Summary of Changes

This PR moves the values for the eventElementId and eventName props into the MintLinkButton component itself, so that we only need to define them once.

Currently, due to defining the value for each distinct usage of MintLinkButton, we are using two different event names "Press Mint Link Button" and "Press Mint Link" for the same event, fragmenting our data unnecessarily.


### Demo or Before/After Pics
NA

### Edge Cases
NA

### Testing Steps
confirm the different usages of the Mint Link Button component trigger the same event name.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
