### PR TITLE
Fix feed randomly refetch on comment

### DIFF
--- a/apps/web/src/hooks/api/posts/useCommentOnPost.ts
+++ b/apps/web/src/hooks/api/posts/useCommentOnPost.ts
@@ -39,6 +39,10 @@ export default function useCommentOnPost() {
               __typename
               dbid
             }
+
+            post {
+              totalComments
+            }
           }
         }
       }

--- a/apps/web/src/utils/useClearURLQueryParams.ts
+++ b/apps/web/src/utils/useClearURLQueryParams.ts
@@ -18,13 +18,18 @@ export function useClearURLQueryParams(param: string | string[]) {
     if (hasRenderedOnce.current) return;
     const params = new URLSearchParams(urlQuery as Record<string, string>);
     const paramsToClear = typeof param === 'string' ? [param] : param;
+    let paramDeleted = false;
     for (const p of paramsToClear) {
       if (params.has(p)) {
         params.delete(p);
+        paramDeleted = true;
       }
     }
-    // @ts-expect-error we're simply replacing the current page with the same path
-    replace({ pathname, query: params.toString() }, undefined, { shallow: true });
+    if (paramDeleted) {
+      // @ts-expect-error we're simply replacing the current page with the same path
+      replace({ pathname, query: params.toString() }, undefined, { shallow: true });
+    }
+
     hasRenderedOnce.current = true;
   }, [param, pathname, replace, urlQuery]);
 }


### PR DESCRIPTION
### Summary of Changes

- Fix optimistic update whenever user comment
- Fix random refresh feed whenever the user comment on any post

This bug only happens if the user comment on post (not reply). This line triggered the refresh

https://github.com/gallery-so/gallery/blob/main/apps/web/src/components/Feed/Socialize/CommentsModal/PostCommentsModal.tsx#L61

### Demo or Before/After Pics

**Optimistic Update**

https://github.com/gallery-so/gallery/assets/4480258/68742bd8-86c9-4f32-88a1-aa519cad0a46

**Random Feed refetch**


https://github.com/gallery-so/gallery/assets/4480258/3bf8cc74-bd1e-42c4-ac8a-d0e53b7eeb1f




### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
