### PR TITLE
update copy icon state on share post bottom sheet

### DIFF
--- a/apps/mobile/src/screens/PostScreen/SharePostBottomSheet.tsx
+++ b/apps/mobile/src/screens/PostScreen/SharePostBottomSheet.tsx
@@ -181,6 +181,7 @@ function SharePostBottomSheet(
     Clipboard.setString(postUrl);
     setHasCopiedUrl(true);
     setTimeout(() => bottomSheetRef.current?.dismiss(), 800);
+    setTimeout(() => setHasCopiedUrl(false), 800);
   }, [postUrl]);
 
   const profileImageUrl = useMemo(() => {

--- a/apps/mobile/src/screens/PostScreen/SharePostBottomSheet.tsx
+++ b/apps/mobile/src/screens/PostScreen/SharePostBottomSheet.tsx
@@ -180,8 +180,10 @@ function SharePostBottomSheet(
   const handleCopyButtonPress = useCallback(() => {
     Clipboard.setString(postUrl);
     setHasCopiedUrl(true);
-    setTimeout(() => bottomSheetRef.current?.dismiss(), 800);
-    setTimeout(() => setHasCopiedUrl(false), 800);
+    setTimeout(() => {
+      bottomSheetRef.current?.dismiss();
+      setHasCopiedUrl(false);
+    }, 800);
   }, [postUrl]);
 
   const profileImageUrl = useMemo(() => {


### PR DESCRIPTION
### Summary of Changes
After copying url from x post bottomSheet, and bottomSheet is reopened the tick mark is updated to to copy icon again. does this by updating local state after bottom sheet is dismissed (because the bottom sheet never really dismounts.)

### Demo 

https://github.com/gallery-so/gallery/assets/49758803/42d35eb5-148f-4fac-a8ae-bbc260a17b1d

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
