### PR TITLE
GAL-5015 wrap nft detail preview in a tag

### DIFF
--- a/apps/web/src/scenes/NftDetailPage/LinkToFullPageNftDetailModal.tsx
+++ b/apps/web/src/scenes/NftDetailPage/LinkToFullPageNftDetailModal.tsx
@@ -108,7 +108,7 @@ export default function LinkToFullPageNftDetailModal({
   );
 }
 
-const StyledAnchor = styled.div`
+const StyledAnchor = styled.a`
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
### Summary of Changes

Make it possible to command-click an nft on the feed or gallery to open in new tab by wrapping it in an a tag


### Demo or Before/After Pics

command-click opens in new tab, regular click opens in same window

https://github.com/gallery-so/gallery/assets/80802871/d9d882d0-79c8-4663-a2e1-33aea9a8a291


### Edge Cases
this still won't work for iframes because they don't register the click to open the nft detail page in the first place. this change only applies to nfts that already open an nft detail page when clicked

### Testing Steps
command click an nft on the feed or in a gallery

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
