### PR TITLE
GAL-5006 disable comment submit button if over max length

### DIFF
--- a/apps/web/src/components/Feed/Socialize/CommentBox/CommentBox.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentBox/CommentBox.tsx
@@ -220,7 +220,10 @@ export function CommentBox({ queryRef, onSubmitComment, isSubmittingComment, rep
 
         <HStack gap={12} align="center">
           <BaseM color={colors.metal}>{MAX_TEXT_LENGTH - message.length}</BaseM>
-          <SendButton enabled={message.length > 0 && !isSubmittingComment} onClick={handleSubmit} />
+          <SendButton
+            enabled={message.length > 0 && message.length < MAX_TEXT_LENGTH && !isSubmittingComment}
+            onClick={handleSubmit}
+          />
         </HStack>
       </InputWrapper>
 

--- a/apps/web/src/components/Feed/Socialize/CommentBox/CommentBox.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentBox/CommentBox.tsx
@@ -221,7 +221,9 @@ export function CommentBox({ queryRef, onSubmitComment, isSubmittingComment, rep
         <HStack gap={12} align="center">
           <BaseM color={colors.metal}>{MAX_TEXT_LENGTH - message.length}</BaseM>
           <SendButton
-            enabled={message.length > 0 && message.length < MAX_TEXT_LENGTH && !isSubmittingComment}
+            enabled={
+              message.length > 0 && message.length <= MAX_TEXT_LENGTH && !isSubmittingComment
+            }
             onClick={handleSubmit}
           />
         </HStack>


### PR DESCRIPTION
### Summary of Changes


### Demo or Before/After Pics
Before
![CleanShot 2024-01-03 at 22 42 39@2x](https://github.com/gallery-so/gallery/assets/80802871/99bec58d-4b55-46fd-9b39-cc3196548a16)


After
![CleanShot 2024-01-03 at 22 42 29@2x](https://github.com/gallery-so/gallery/assets/80802871/05615f89-2b86-4197-9aa3-e827dfb17c30)


(can submit if equal to max length)
![CleanShot 2024-01-03 at 22 43 45@2x](https://github.com/gallery-so/gallery/assets/80802871/7054c185-68aa-438e-bfed-561e9399edbe)



### Edge Cases
NA

### Testing Steps
type a comment longer than max length and see if you can submit, you should not be able to

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
