### PR TITLE
Increase displayed nft size on detail page + other polish

### DIFF
--- a/apps/web/src/hooks/useContainedDimensionsForToken.ts
+++ b/apps/web/src/hooks/useContainedDimensionsForToken.ts
@@ -4,10 +4,11 @@ import { graphql } from 'relay-runtime';
 
 import { useContainedDimensionsForTokenFragment$key } from '~/generated/useContainedDimensionsForTokenFragment.graphql';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
-import { fitDimensionsToContainerContain } from '~/shared/utils/fitDimensionsToContainer';
-
-const DESKTOP_TOKEN_DETAIL_VIEW_SIZE = 600;
-const MOBILE_TOKEN_DETAIL_VIEW_SIZE = 296;
+import {
+  DESKTOP_TOKEN_DETAIL_VIEW_SIZE,
+  fitDimensionsToContainerContain,
+  MOBILE_TOKEN_DETAIL_VIEW_SIZE,
+} from '~/shared/utils/fitDimensionsToContainer';
 
 type useContainedDimensionsForTokenArgs = {
   mediaRef: useContainedDimensionsForTokenFragment$key;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -316,15 +316,13 @@ const StyledAssetContainer = styled.div<AssetContainerProps>`
   ${({ backgroundColorOverride }) =>
     backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 
-    @media only screen and ${breakpoints.tablet} {
-      width: 100%;
-  
-    }
-  
-    @media only screen and ${breakpoints.desktop} {
-      max-width: 800px;
-  
-    }
+  @media only screen and ${breakpoints.tablet} {
+    width: 100%;
+  }
+
+  @media only screen and ${breakpoints.desktop} {
+    max-width: 800px;
+  }
 
   // enforce auto width on NFT detail page as to not stretch to shimmer container
   ${StyledImageWithLoading} {

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -316,10 +316,6 @@ const StyledAssetContainer = styled.div<AssetContainerProps>`
   ${({ backgroundColorOverride }) =>
     backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 
-  @media only screen and ${breakpoints.tablet} {
-    width: 100%;
-  }
-
   @media only screen and ${breakpoints.desktop} {
     max-width: 800px;
   }

--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -316,15 +316,15 @@ const StyledAssetContainer = styled.div<AssetContainerProps>`
   ${({ backgroundColorOverride }) =>
     backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 
-  @media only screen and ${breakpoints.tablet} {
-    width: 450px;
-    min-height: 450px;
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    width: 600px;
-    min-height: 600px;
-  }
+    @media only screen and ${breakpoints.tablet} {
+      width: 100%;
+  
+    }
+  
+    @media only screen and ${breakpoints.desktop} {
+      max-width: 800px;
+  
+    }
 
   // enforce auto width on NFT detail page as to not stretch to shimmer container
   ${StyledImageWithLoading} {
@@ -332,10 +332,10 @@ const StyledAssetContainer = styled.div<AssetContainerProps>`
   }
 `;
 
-const StyledImage = styled.img<{ height: number; width: number }>`
-  height: ${({ height }) => height}px;
-  width: ${({ width }) => width}px;
+const StyledImage = styled.img`
   border: none;
+  max-width: 100%;
+  max-height: 100%;
 `;
 
 const VisibilityContainer = styled.div`

--- a/apps/web/src/scenes/NftDetailPage/NftDetailNote.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailNote.tsx
@@ -198,28 +198,19 @@ function NftDetailNote({
   authenticatedUserOwnsAsset,
 }: Props) {
   return (
-    <Wrapper>
-      <StyledContainer footerHeight={GLOBAL_FOOTER_HEIGHT}>
-        {authenticatedUserOwnsAsset ? (
-          <NoteEditor
-            nftCollectorsNote={nftCollectorsNote}
-            tokenId={tokenId}
-            collectionId={collectionId}
-          />
-        ) : (
-          <NoteViewer nftCollectorsNote={nftCollectorsNote} />
-        )}
-      </StyledContainer>
-    </Wrapper>
+    <StyledContainer footerHeight={GLOBAL_FOOTER_HEIGHT}>
+      {authenticatedUserOwnsAsset ? (
+        <NoteEditor
+          nftCollectorsNote={nftCollectorsNote}
+          tokenId={tokenId}
+          collectionId={collectionId}
+        />
+      ) : (
+        <NoteViewer nftCollectorsNote={nftCollectorsNote} />
+      )}
+    </StyledContainer>
   );
 }
-
-const Wrapper = styled.div`
-  @media only screen and ${breakpoints.tablet} {
-    position: relative;
-    height: 0;
-  }
-`;
 
 export const StyledContainer = styled.div<{ footerHeight: number }>`
   padding-top: 12px;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailNote.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailNote.tsx
@@ -216,21 +216,20 @@ export const StyledContainer = styled.div<{ footerHeight: number }>`
   padding-top: 12px;
   // On tablet and smaller, the note will have the same styling as the NftDetailText (it will be directly on top of it)
   display: block;
-  max-width: 296px;
-  min-width: 296px;
+  padding: 0 16px 16px;
+  width: 100%;
+  min-width: 0;
   margin: auto;
   word-wrap: break-word;
 
   // On larger screens, the note will be sized according to its parent container and will be flush with the asset
   @media only screen and ${breakpoints.tablet} {
+    padding: 0;
     width: 100%;
     min-width: 0;
     max-width: none;
     position: absolute; // So that it does not affect height of the flex container
-  }
-
-  // We only apply padding to account for footer, which is not fixed on mobile
-  @media only screen and ${breakpoints.tablet} {
+    // We only apply padding to account for footer, which is not fixed on mobile
     padding-bottom: ${({ footerHeight }) =>
       footerHeight + 20}px; // 20px is roughly the height of character counter/Markdown container
   }

--- a/apps/web/src/scenes/NftDetailPage/NftDetailNote.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailNote.tsx
@@ -198,19 +198,28 @@ function NftDetailNote({
   authenticatedUserOwnsAsset,
 }: Props) {
   return (
-    <StyledContainer footerHeight={GLOBAL_FOOTER_HEIGHT}>
-      {authenticatedUserOwnsAsset ? (
-        <NoteEditor
-          nftCollectorsNote={nftCollectorsNote}
-          tokenId={tokenId}
-          collectionId={collectionId}
-        />
-      ) : (
-        <NoteViewer nftCollectorsNote={nftCollectorsNote} />
-      )}
-    </StyledContainer>
+    <Wrapper>
+      <StyledContainer footerHeight={GLOBAL_FOOTER_HEIGHT}>
+        {authenticatedUserOwnsAsset ? (
+          <NoteEditor
+            nftCollectorsNote={nftCollectorsNote}
+            tokenId={tokenId}
+            collectionId={collectionId}
+          />
+        ) : (
+          <NoteViewer nftCollectorsNote={nftCollectorsNote} />
+        )}
+      </StyledContainer>
+    </Wrapper>
   );
 }
+
+const Wrapper = styled.div`
+  @media only screen and ${breakpoints.tablet} {
+    position: relative;
+    height: 0;
+  }
+`;
 
 export const StyledContainer = styled.div<{ footerHeight: number }>`
   padding-top: 12px;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -5,7 +5,7 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 import styled from 'styled-components';
 
-import breakpoints, { pageGutter } from '~/components/core/breakpoints';
+import breakpoints from '~/components/core/breakpoints';
 import { Directions } from '~/components/core/enums';
 import transitions, {
   ANIMATED_COMPONENT_TRANSLATION_PIXELS_LARGE,

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -16,6 +16,7 @@ import { NftDetailPageFragment$key } from '~/generated/NftDetailPageFragment.gra
 import { NftDetailPageQuery } from '~/generated/NftDetailPageQuery.graphql';
 import { NftDetailPageQueryFragment$key } from '~/generated/NftDetailPageQueryFragment.graphql';
 import useKeyDown from '~/hooks/useKeyDown';
+import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import NotFound from '~/scenes/NotFound/NotFound';
 import GalleryViewEmitter from '~/shared/components/GalleryViewEmitter';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
@@ -202,6 +203,7 @@ function NftDetailPage({
 
   useKeyDown('ArrowRight', handleNextPress);
   useKeyDown('ArrowLeft', handlePrevPress);
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
 
   return (
     <>
@@ -209,7 +211,9 @@ function NftDetailPage({
         <title>{headTitle}</title>
       </Head>
       <GalleryViewEmitter queryRef={query} />
-      {prevNft && <NavigationHandle direction={Directions.LEFT} onClick={handlePrevPress} />}
+      {!isMobile && prevNft && (
+        <NavigationHandle direction={Directions.LEFT} onClick={handlePrevPress} />
+      )}
       {mountedNfts.map(({ token, visibility }) => (
         <_DirectionalFade key={token.token.dbid} visibility={visibility}>
           <NftDetailView
@@ -220,7 +224,9 @@ function NftDetailPage({
           />
         </_DirectionalFade>
       ))}
-      {nextNft && <NavigationHandle direction={Directions.RIGHT} onClick={handleNextPress} />}
+      {!isMobile && nextNft && (
+        <NavigationHandle direction={Directions.RIGHT} onClick={handleNextPress} />
+      )}
     </>
   );
 }
@@ -335,12 +341,6 @@ const StyledNftDetailPage = styled.div`
 
   display: flex;
   justify-content: center;
-
-  @media only screen and ${breakpoints.mobile} {
-    ${_DirectionalFade} {
-      padding: 48px ${pageGutter.tablet}px 0px ${pageGutter.tablet}px;
-    }
-  }
 
   @media only screen and ${breakpoints.tablet} {
     align-items: center;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPage.tsx
@@ -311,6 +311,7 @@ function NftDetailPageWrapper({ username, tokenId, collectionId }: NftDetailPage
 
 const _DirectionalFade = styled.div<{ visibility: string }>`
   position: absolute;
+  width: 100%;
   opacity: ${({ visibility }) => (visibility === 'visible' ? 1 : 0)};
   transform: ${({ visibility }) => {
     if (visibility === 'visible') {

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
@@ -79,9 +79,6 @@ const StyledFullPageLoader = styled.div`
 
 const VisibilityContainer = styled.div`
   position: relative;
-  @media only screen and ${breakpoints.tablet} {
-    margin-left: 84px;
-  }
 `;
 
 const StyledTextContainer = styled(VStack)`
@@ -104,9 +101,8 @@ export const StyledNftSkeleton = styled(Skeleton)`
   height: 350px;
 
   @media only screen and ${breakpoints.tablet} {
-    width: 600px;
-    height: 600px;
-    margin-left: 80px;
+    width: min(80vh, ${DESKTOP_TOKEN_DETAIL_VIEW_SIZE}px);
+    height: min(80vh, ${DESKTOP_TOKEN_DETAIL_VIEW_SIZE}px);
   }
 `;
 

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
@@ -70,10 +70,12 @@ const StyledFullPageLoader = styled.div`
   flex-direction: column;
   padding-left: 24px;
   padding-right: 24px;
+  margin-top: 48px;
 
   @media only screen and ${breakpoints.tablet} {
     padding: 0;
     flex-direction: row;
+    margin-top: 0;
   }
 `;
 

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
@@ -156,8 +156,8 @@ const StyledOwnerAndCreator = styled(HStack)`
 `;
 
 const StyledImage = styled.img<{ height: number; width: number }>`
-  height: ${({ height }) => height}px;
-  width: ${({ width }) => width}px;
+  height: min(80vh, ${({ height }) => height}px);
+  width: min(80vh, ${({ height }) => height}px);
   border: none;
 `;
 

--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -434,7 +434,6 @@ const StyledDetailLabel = styled.div<{ horizontalLayout: boolean; navbarHeight: 
     padding: 0;
     max-width: 420px;
     min-width: 420px;
-    margin-left: 56px;
     margin-top: 0;
   }
 `;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -413,8 +413,9 @@ const StyledButtonContainer = styled(HStack)`
 
 const StyledDetailLabel = styled.div<{ horizontalLayout: boolean; navbarHeight: number }>`
   display: block;
-  max-width: 296px;
-  min-width: 296px;
+  width: 100%;
+  padding: 0 16px;
+
   word-wrap: break-word;
 
   ${({ horizontalLayout, navbarHeight }) =>
@@ -430,6 +431,7 @@ const StyledDetailLabel = styled.div<{ horizontalLayout: boolean; navbarHeight: 
     `}
 
   @media only screen and ${breakpoints.tablet} {
+    padding: 0;
     max-width: 420px;
     min-width: 420px;
     margin-left: 56px;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -111,12 +111,14 @@ export default function NftDetailView({
             </Container>
           </StyledAssetAndNoteContainer>
           {!isMobileOrMobileLarge && showCollectorsNoteComponent && (
-            <NftDetailNote
-              tokenId={token.dbid}
-              authenticatedUserOwnsAsset={authenticatedUserOwnsAsset}
-              nftCollectorsNote={token.collectorsNote ?? ''}
-              collectionId={collection.dbid}
-            />
+            <NotePositionWrapper>
+              <NftDetailNote
+                tokenId={token.dbid}
+                authenticatedUserOwnsAsset={authenticatedUserOwnsAsset}
+                nftCollectorsNote={token.collectorsNote ?? ''}
+                collectionId={collection.dbid}
+              />
+            </NotePositionWrapper>
           )}
         </StyledVStack>
 
@@ -169,7 +171,6 @@ const Container = styled.div`
   position: relative;
   width: 100%;
   height: 100%;
-  margin-top: 8px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -181,6 +182,13 @@ const StyledAssetAndNoteContainer = styled.div`
   height: 100%;
   display: flex;
   justify-content: center;
+`;
+
+const NotePositionWrapper = styled.div`
+  @media only screen and ${breakpoints.tablet} {
+    position: relative;
+    height: 0;
+  }
 `;
 
 // We position the arrows using position absolute (so they reach the page bounds)

--- a/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -179,6 +179,7 @@ const Container = styled.div`
 
   @media only screen and ${breakpoints.tablet} {
     padding: 0;
+    margin: 0;
   }
 `;
 

--- a/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -163,6 +163,7 @@ const StyledContentContainer = styled.div`
   @media only screen and ${breakpoints.tablet} {
     flex-direction: row;
     justify-content: center;
+    gap: 0 48px;
   }
 `;
 

--- a/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -174,6 +174,12 @@ const Container = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 0 16px;
+  margin-top: 24px;
+
+  @media only screen and ${breakpoints.tablet} {
+    padding: 0;
+  }
 `;
 
 const StyledAssetAndNoteContainer = styled.div`

--- a/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -100,14 +100,16 @@ export default function NftDetailView({
       <TokenViewEmitter collectionID={collection.dbid} tokenID={token.dbid} />
       {!isMobileOrMobileLarge && <StyledNavigationBuffer />}
       <StyledContentContainer>
-        <StyledAssetAndNoteContainer>
-          <Container>
-            <NftDetailAsset
-              tokenRef={collectionNft}
-              hasExtraPaddingForNote={showCollectorsNoteComponent}
-              visibility={visibility}
-            />
-          </Container>
+        <StyledVStack>
+          <StyledAssetAndNoteContainer>
+            <Container>
+              <NftDetailAsset
+                tokenRef={collectionNft}
+                hasExtraPaddingForNote={showCollectorsNoteComponent}
+                visibility={visibility}
+              />
+            </Container>
+          </StyledAssetAndNoteContainer>
           {!isMobileOrMobileLarge && showCollectorsNoteComponent && (
             <NftDetailNote
               tokenId={token.dbid}
@@ -116,7 +118,7 @@ export default function NftDetailView({
               collectionId={collection.dbid}
             />
           )}
-        </StyledAssetAndNoteContainer>
+        </StyledVStack>
 
         <NftDetailText
           queryRef={query}
@@ -132,7 +134,7 @@ export default function NftDetailView({
           />
         )}
       </StyledContentContainer>
-      {!useIsMobileOrMobileLargeWindowWidth && <StyledNavigationBuffer />}
+      {!isMobileOrMobileLarge && <StyledNavigationBuffer />}
     </StyledBody>
   );
 }
@@ -140,38 +142,34 @@ export default function NftDetailView({
 const StyledBody = styled.div`
   display: flex;
   width: 100%;
+`;
 
-  @media only screen and ${breakpoints.mobile} {
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    width: auto;
-  }
+const StyledVStack = styled.div`
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  width: 100%;
+  max-width: min(80vh, 800px);
 `;
 
 const StyledContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-
   width: 100%;
 
   @media only screen and ${breakpoints.tablet} {
     flex-direction: row;
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    width: initial;
+    justify-content: center;
   }
 `;
 
 const Container = styled.div`
   min-width: 0;
-
   position: relative;
   width: 100%;
   height: 100%;
-
+  margin-top: 8px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -181,6 +179,8 @@ const StyledAssetAndNoteContainer = styled.div`
   position: relative;
   width: 100%;
   height: 100%;
+  display: flex;
+  justify-content: center;
 `;
 
 // We position the arrows using position absolute (so they reach the page bounds)

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
@@ -139,13 +139,11 @@ const StyledAssetContainer = styled.div<AssetContainerProps>`
     backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 
   @media only screen and ${breakpoints.tablet} {
-    width: 450px;
-    min-height: 450px;
+    width: 100%;
   }
 
   @media only screen and ${breakpoints.desktop} {
-    width: 600px;
-    min-height: 600px;
+    max-width: 800px;
   }
 
   // enforce auto width on NFT detail page as to not stretch to shimmer container
@@ -154,10 +152,10 @@ const StyledAssetContainer = styled.div<AssetContainerProps>`
   }
 `;
 
-const StyledImage = styled.img<{ height: number; width: number }>`
-  height: ${({ height }) => height}px;
-  width: ${({ width }) => width}px;
+const StyledImage = styled.img`
   border: none;
+  max-width: 100%;
+  max-height: 100%;
 `;
 
 const VisibilityContainer = styled.div`

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailAsset.tsx
@@ -138,10 +138,6 @@ const StyledAssetContainer = styled.div<AssetContainerProps>`
   ${({ backgroundColorOverride }) =>
     backgroundColorOverride && `background-color: ${backgroundColorOverride}`}};
 
-  @media only screen and ${breakpoints.tablet} {
-    width: 100%;
-  }
-
   @media only screen and ${breakpoints.desktop} {
     max-width: 800px;
   }
@@ -181,11 +177,6 @@ const AssetContainer = styled.div<{ isVisible: boolean }>`
   opacity: 1;
   pointer-events: auto;
   `}
-
-  @media only screen and (max-width: ${size.tablet}px) {
-    height: 296px;
-    width: 296px;
-  }
 `;
 
 const ShimmerContainer = styled.div`

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
@@ -144,6 +144,7 @@ const StyledContentContainer = styled.div`
   @media only screen and ${breakpoints.tablet} {
     flex-direction: row;
     justify-content: center;
+    gap: 0 48px;
   }
 `;
 

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
@@ -125,7 +125,7 @@ export default function TokenDetailView({ tokenRef, queryRef }: Props) {
           </StyledContainer>
         )}
       </StyledContentContainer>
-      {!useIsMobileOrMobileLargeWindowWidth && <StyledNavigationBuffer />}
+      {!isMobileOrMobileLarge && <StyledNavigationBuffer />}
     </StyledBody>
   );
 }
@@ -133,28 +133,17 @@ export default function TokenDetailView({ tokenRef, queryRef }: Props) {
 const StyledBody = styled.div`
   display: flex;
   width: 100%;
-
-  @media only screen and ${breakpoints.mobile} {
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    width: auto;
-  }
 `;
 
 const StyledContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-
   width: 100%;
 
   @media only screen and ${breakpoints.tablet} {
     flex-direction: row;
-  }
-
-  @media only screen and ${breakpoints.desktop} {
-    width: initial;
+    justify-content: center;
   }
 `;
 
@@ -179,10 +168,11 @@ const StyledAssetAndNoteContainer = styled.div`
   position: relative;
   width: 100%;
   height: 100%;
+  display: flex;
+  justify-content: center;
 
-  @media only screen and (max-width: ${size.tablet}px) {
-    display: flex;
-    justify-content: center;
+  @media only screen and ${breakpoints.tablet} {
+    max-width: min(80vh, 800px);
   }
 `;
 

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
@@ -152,7 +152,6 @@ const Container = styled.div`
   position: relative;
   width: 100%;
   height: 100%;
-  margin-top: 8px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
@@ -160,6 +160,7 @@ const Container = styled.div`
 
   @media only screen and ${breakpoints.tablet} {
     padding: 0;
+    margin-top: 0;
   }
 `;
 

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
@@ -155,11 +155,11 @@ const Container = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 0 16px;
+  margin-top: 24px;
 
-  @media only screen and (max-width: ${size.tablet}px) {
-    margin-top: 48px;
-    height: 296px;
-    width: 296px;
+  @media only screen and ${breakpoints.tablet} {
+    padding: 0;
   }
 `;
 

--- a/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
+++ b/apps/web/src/scenes/TokenDetailPage/TokenDetailView.tsx
@@ -2,7 +2,7 @@ import { useFragment, useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
-import breakpoints, { size } from '~/components/core/breakpoints';
+import breakpoints from '~/components/core/breakpoints';
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/CommentsModal/CommentsModal';
 import { GLOBAL_FOOTER_HEIGHT } from '~/contexts/globalLayout/GlobalFooter/GlobalFooter';
 import { TokenDetailViewFragment$key } from '~/generated/TokenDetailViewFragment.graphql';

--- a/packages/shared/src/utils/fitDimensionsToContainer.ts
+++ b/packages/shared/src/utils/fitDimensionsToContainer.ts
@@ -1,7 +1,7 @@
 export type Dimensions = { width: number; height: number };
 
 export const DESKTOP_TOKEN_DETAIL_VIEW_SIZE = 800;
-export const MOBILE_TOKEN_DETAIL_VIEW_SIZE = 296;
+export const MOBILE_TOKEN_DETAIL_VIEW_SIZE = 394;
 
 type fitDimensionToContainerArgs = {
   container: Dimensions;

--- a/packages/shared/src/utils/fitDimensionsToContainer.ts
+++ b/packages/shared/src/utils/fitDimensionsToContainer.ts
@@ -1,6 +1,6 @@
 export type Dimensions = { width: number; height: number };
 
-export const DESKTOP_TOKEN_DETAIL_VIEW_SIZE = 600;
+export const DESKTOP_TOKEN_DETAIL_VIEW_SIZE = 800;
 export const MOBILE_TOKEN_DETAIL_VIEW_SIZE = 296;
 
 type fitDimensionToContainerArgs = {


### PR DESCRIPTION
### Summary of Changes

This PR updates how the NFT on the NFT Detail Page is sized.
- Increased max size so that the artwork takes up more space on the detail page.
- as a general rule, the Detail Text (non artwork content) has a fixed width, and the artwork grows to take up the available space on the screen, up until whichever is smaller: 80vh or 800px.
- adjusted skeleton states too to reflect the updated sizes
- removed the next and previous nav arrows on the detail page on mobile web, after chatting with design



### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| ![CleanShot 2024-01-05 at 16 31 56@2x](https://github.com/gallery-so/gallery/assets/80802871/6aef0c83-81ee-4505-a564-5ad09f38b684) | ![CleanShot 2024-01-05 at 16 00 45@2x](https://github.com/gallery-so/gallery/assets/80802871/31656dd5-ff0e-428f-a799-87a880c82374) |
| ![CleanShot 2024-01-05 at 16 32 10@2x](https://github.com/gallery-so/gallery/assets/80802871/8e0baea0-7f8d-4a60-b39a-906299540015) | ![CleanShot 2024-01-05 at 16 01 10@2x](https://github.com/gallery-so/gallery/assets/80802871/5e25b2e7-4912-4309-8da8-c47f32b04637) |


Preview -> Original transition is still smooth at the new size

https://github.com/gallery-so/gallery/assets/80802871/b198a22b-a860-4abc-ade8-329f932ec5ed


https://github.com/gallery-so/gallery/assets/80802871/80197d7a-44a2-4e91-8894-9535ee77c628




### Edge Cases
- all the different nft types and dimensions

### Testing Steps
Click into nft detail pages on the feed and user gallery

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
