### PR TITLE
follow up on nft detail page updates

### DIFF
--- a/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
@@ -84,12 +84,14 @@ const VisibilityContainer = styled.div`
 `;
 
 const StyledTextContainer = styled(VStack)`
-  margin-top: 56px;
-  padding-right: 10%;
-  padding-left: 10%;
-  width: 400px;
+  width: 100%;
+  margin-top: 24px;
 
   @media only screen and ${breakpoints.tablet} {
+    margin-top: 56px;
+    padding-right: 10%;
+    padding-left: 10%;
+    width: 400px;
     margin-left: 56px;
     margin-top: 0px;
     padding-right: 0%;
@@ -157,6 +159,8 @@ const StyledOwnerAndCreator = styled(HStack)`
 
 const StyledImage = styled.img<{ height: number; width: number }>`
   border: none;
+  height: min(100%, ${({ width }) => width}px);
+  width: min(100%, ${({ width }) => width}px);
 
   @media only screen and ${breakpoints.tablet} {
     height: min(80vh, ${({ height }) => height}px);

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
@@ -156,16 +156,19 @@ const StyledOwnerAndCreator = styled(HStack)`
 `;
 
 const StyledImage = styled.img<{ height: number; width: number }>`
-  height: min(80vh, ${({ height }) => height}px);
-  width: min(80vh, ${({ height }) => height}px);
   border: none;
+
+  @media only screen and ${breakpoints.tablet} {
+    height: min(80vh, ${({ height }) => height}px);
+    width: min(80vh, ${({ height }) => height}px);
+  }
 `;
 
 const StyledImageWrapper = styled.div<{ isVisible: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 600px;
+  width: 100%;
   height: 100%;
   opacity: 0;
   pointer-events: none;

--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -415,7 +415,7 @@ const StyledDetailLabel = styled.div<{ horizontalLayout: boolean; navbarHeight: 
   display: block;
   width: 100%;
   padding: 0 16px;
-
+  position: relative; // the content can be scrollable, so this ensures the taller content height doesnt affect the page height
   word-wrap: break-word;
 
   ${({ horizontalLayout, navbarHeight }) =>


### PR DESCRIPTION

### Summary of Changes
- fix scroll extra space bug
- fix oversized fallback image on mobile
- fix unexpected fallback placement on desktop

### Demo or Before/After Pics


**fix scroll extra space bug:**
Before:
https://github.com/gallery-so/gallery/assets/80802871/dc019eb4-3cd9-47f2-828b-b8fa1a45d160

After:
https://github.com/gallery-so/gallery/assets/80802871/ea5045b8-843c-4235-b4bd-4b218ad7b5fc


**fix oversized fallback image on mobile**
Before:
https://github.com/gallery-so/gallery/assets/80802871/1544ff19-7359-479e-b383-a1a2ff16fd24


After:
https://github.com/gallery-so/gallery/assets/80802871/34c3cb6a-dabd-434d-9727-9bb7e02c452b


**fix unexpected fallback placement on desktop**
Before:
https://github.com/gallery-so/gallery/assets/80802871/152fdf69-cad2-4433-ac03-10f804deae57


After:
https://github.com/gallery-so/gallery/assets/80802871/6c080902-97c0-44ae-980d-06c1b1e34c79



### Edge Cases


### Testing Steps
- To test fallback size on mobile, visit NFT Detail Page on Mobile 
- To test scroll, visit an NFT Detail Page with a tall description like /fraser/token/2aepj64Sx3cmsPaXgqGmgWrh95X
- To test unexpected fallback placement, check DJKERO/token/2aTWJiEF1wBA20I9vOivzS1h0Sm . this issue only happened for certain nft previews without dimensions


### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
