### PR TITLE
only enable mint links on zora, or when manually set

### DIFF
--- a/apps/mobile/src/screens/PostScreen/PostComposerScreen.tsx
+++ b/apps/mobile/src/screens/PostScreen/PostComposerScreen.tsx
@@ -51,6 +51,7 @@ function PostComposerScreenInner() {
                 ...useNavigateToCommunityScreenFragment
               }
               mintUrl
+              chain
             }
             ...PostComposerScreenTokenFragment
             ...PostInputTokenFragment
@@ -100,7 +101,15 @@ function PostComposerScreenInner() {
 
   const [isInvalidMintLink, setIsInvalidMintLink] = useState(false);
   const [mintURL, setMintURL] = useState<string>(mintURLWithRef ?? '');
-  const [includeMintLink, setIncludeMintLink] = useState(true);
+
+  // only toggle the mint link on by default if it's on zora network. disable it by defalut on any other chain.
+  // NOTE: on web, if a mint link is manually provided via params (e.g. share-on-gallery from another chain), it'll
+  // enable the mint link. we'll need to do this here too once we support better deeplinks.
+  const shouldEnableMintLinkByDefault = useMemo(() => {
+    return token.definition.chain === 'Zora';
+  }, [token.definition.chain]);
+
+  const [includeMintLink, setIncludeMintLink] = useState(shouldEnableMintLinkByDefault);
 
   const {
     aliasKeyword,


### PR DESCRIPTION
### Summary of Changes

- disable automatic mint links for all ETH tokens
- only auto-enable if zora chain, or manually provided via URL params

### Demo or Before/After Pics

**Web Mainnet (not set)**
<img width="657" alt="Screenshot 2024-01-08 at 7 59 01 PM" src="https://github.com/gallery-so/gallery/assets/12162433/fccc4d83-ec21-4eec-b20b-8e2b93ae9466">

**Web Mainnet (set when provided via URL params)**
<img width="659" alt="Screenshot 2024-01-08 at 7 59 55 PM" src="https://github.com/gallery-so/gallery/assets/12162433/d94e4d76-8698-4a97-984b-7f7156f24791">

**Zora (autoset)**
<img width="689" alt="Screenshot 2024-01-08 at 7 59 12 PM" src="https://github.com/gallery-so/gallery/assets/12162433/6e728b9c-3b65-474a-b5d9-ae0c0be2a1ad">

**Mobile Mainnet (not set)**
<img width="527" alt="Screenshot 2024-01-08 at 8 12 24 PM" src="https://github.com/gallery-so/gallery/assets/12162433/51d145e7-a678-4cd3-81f6-4429959c60b7">

**Mobile Zora (autoset)**
<img width="527" alt="Screenshot 2024-01-08 at 8 12 54 PM" src="https://github.com/gallery-so/gallery/assets/12162433/6bbca602-e292-4361-8d29-3ee2ac731d03">



### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
