### PR TITLE
Fix highlight reply notification web

### DIFF
--- a/apps/web/src/components/Notifications/Notification.tsx
+++ b/apps/web/src/components/Notifications/Notification.tsx
@@ -162,6 +162,7 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
         ... on SomeoneRepliedToYourCommentNotification {
           __typename
           comment {
+            dbid
             source {
               ... on Post {
                 __typename
@@ -337,11 +338,13 @@ export function Notification({ notificationRef, queryRef, toggleSubView }: Notif
           ? notification.comment?.source?.dbid
           : undefined;
 
+      const commentId = notification.comment?.dbid;
+
       return {
         showCaret: false,
         handleClick: function navigateToPostPage() {
           if (postId) {
-            push({ pathname: `/post/[postId]`, query: { postId } });
+            push({ pathname: `/post/[postId]`, query: { postId, commentId } });
           }
           hideDrawer();
         },


### PR DESCRIPTION
### Summary of Changes

- Fix click the `RepliedNotification` in the web, didn't highlight the comment automatically

### Demo or Before/After Pics


https://github.com/gallery-so/gallery/assets/4480258/f78c13f1-32d6-4c6d-81c1-e761a930be73


### Edge Cases

1. Check the mobile reply notification too. Works fine

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
