### PR TITLE
Markdown render ignores header md styling 

### DIFF
--- a/apps/mobile/src/components/Markdown.tsx
+++ b/apps/mobile/src/components/Markdown.tsx
@@ -26,6 +26,15 @@ const markdownStyles = {
   strong: {
     fontFamily: 'ABCDiatypeBold',
   },
+  heading1: {
+    fontSize: 14,
+  },
+  heading2: {
+    fontSize: 14,
+  },
+  heading3: {
+    fontSize: 14,
+  },
 };
 
 const darkModeMarkdownStyles = {
@@ -67,7 +76,6 @@ export function Markdown({
 }: GalleryMarkdownProps) {
   const [showAll, setShowAll] = useState(false);
   const { colorScheme } = useColorScheme();
-
   const navigation = useNavigation<RootStackNavigatorProp>();
 
   const mergedStyles = useMemo(() => {

--- a/apps/mobile/src/components/Markdown.tsx
+++ b/apps/mobile/src/components/Markdown.tsx
@@ -76,6 +76,7 @@ export function Markdown({
 }: GalleryMarkdownProps) {
   const [showAll, setShowAll] = useState(false);
   const { colorScheme } = useColorScheme();
+
   const navigation = useNavigation<RootStackNavigatorProp>();
 
   const mergedStyles = useMemo(() => {


### PR DESCRIPTION
### Summary of Changes

the `Markdown` tag now ignores header md styling like prefixing a string with '#', '##', '###', as it used in instances where the description coming from a token/contract is also styled for markdown heading, which breaks our styling.

### Demo or Before/After Pics

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="475" alt="Screenshot 2024-01-18 at 4 08 16 PM" src="https://github.com/gallery-so/gallery/assets/49758803/8fe7c34d-ea43-4139-83de-7a324234f3dd"> | <img width="471" alt="Screenshot 2024-01-18 at 4 01 53 PM" src="https://github.com/gallery-so/gallery/assets/49758803/052564b0-1cd9-404b-abf6-bc2dec51abf6"> |


| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="492" alt="Screenshot 2024-01-18 at 4 08 23 PM" src="https://github.com/gallery-so/gallery/assets/49758803/286a40c0-1ec8-4e7f-9824-3ff86f8b9060"> | <img width="501" alt="Screenshot 2024-01-18 at 4 01 58 PM" src="https://github.com/gallery-so/gallery/assets/49758803/513eb3d2-cf54-41ea-9074-6bc8ac88f603"> |

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
