### PR TITLE
contain fallback image size on nft detail page

### DIFF
--- a/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
@@ -159,6 +159,7 @@ const StyledOwnerAndCreator = styled(HStack)`
 
 const StyledImage = styled.img<{ height: number; width: number }>`
   border: none;
+  object-fit: contain;
   height: min(100%, ${({ width }) => width}px);
   width: min(100%, ${({ width }) => width}px);
 


### PR DESCRIPTION
### Summary of Changes
Fix an issue with the NFT Detail page fallback where the images are enlarged to fill the square container , which skews any portrait or landscape orientation images. 
object-fit: contain maintains the image aspect ratio

### Demo or Before/After Pics

before
https://github.com/gallery-so/gallery/assets/80802871/4e59df8d-79c7-49a1-839e-22bd5422064a



after
https://github.com/gallery-so/gallery/assets/80802871/16fde6e3-9c85-4d5b-bad6-87f80950ad48



### Edge Cases
for this specific bug, there shouldn't be any edge cases


### Testing Steps
click into the nft detail page of any non-square nft. as the image loads in, there shouldn't be any obvious changes in aspect ratio of the image where you see the image stretched too wide or tall.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
