### PR TITLE
fix shop - update import syntax for web3 utils

### DIFF
--- a/apps/web/src/hooks/useMintContractWithQuantity.tsx
+++ b/apps/web/src/hooks/useMintContractWithQuantity.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAccount } from 'wagmi';
-import web3Utils from 'web3-utils';
+import * as web3Utils from 'web3-utils';
 
 import { useConnectEthereum } from '~/components/WalletSelector/multichain/useConnectEthereum';
 import { TransactionStatus } from '~/constants/transaction';
@@ -32,6 +32,7 @@ export default function useMintContractWithQuantity({
   const [transactionHash, setTransactionHash] = useState('');
 
   const address = rawAddress?.toLowerCase();
+  console.log({ web3Utils });
 
   // SUPPLIES
   const [publicSupply, setPublicSupply] = useState(0);

--- a/apps/web/src/hooks/useMintContractWithQuantity.tsx
+++ b/apps/web/src/hooks/useMintContractWithQuantity.tsx
@@ -32,7 +32,6 @@ export default function useMintContractWithQuantity({
   const [transactionHash, setTransactionHash] = useState('');
 
   const address = rawAddress?.toLowerCase();
-  console.log({ web3Utils });
 
   // SUPPLIES
   const [publicSupply, setPublicSupply] = useState(0);

--- a/apps/web/src/utils/MerkleTree.ts
+++ b/apps/web/src/utils/MerkleTree.ts
@@ -13,7 +13,6 @@ export default class MerkleTree {
 
   constructor(elements) {
     // Filter empty strings and hash elements
-    console.log(web3Utils);
     this.elements = elements
       .filter((el) => el)
       .map((el) => Buffer.from(web3Utils.hexToBytes(web3Utils.sha3(el, { encoding: 'hex' }))));

--- a/apps/web/src/utils/MerkleTree.ts
+++ b/apps/web/src/utils/MerkleTree.ts
@@ -5,7 +5,7 @@
 // from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.0.1/test/helpers/merkleTree.js
 
 import { bufferToHex } from 'ethereumjs-util';
-import web3Utils from 'web3-utils';
+import * as web3Utils from 'web3-utils';
 
 export default class MerkleTree {
   elements: Buffer[];
@@ -13,6 +13,7 @@ export default class MerkleTree {
 
   constructor(elements) {
     // Filter empty strings and hash elements
+    console.log(web3Utils);
     this.elements = elements
       .filter((el) => el)
       .map((el) => Buffer.from(web3Utils.hexToBytes(web3Utils.sha3(el, { encoding: 'hex' }))));


### PR DESCRIPTION
### Summary of Changes

Shop was broken, didnt load because of an error while calling a function from the web3-util library. Syntax was outdated after a library version upgrade.


### Demo or Before/After Pics
loads now
![CleanShot 2024-01-23 at 17 33 53@2x](https://github.com/gallery-so/gallery/assets/80802871/54e74a8d-c77b-4907-984d-9aad35708f4d)

### Edge Cases

na

### Testing Steps

go to /shop

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
