### PR TITLE
update pill styling

### DIFF
--- a/apps/web/src/scenes/UserGalleryPage/UserSocialPill.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserSocialPill.tsx
@@ -33,6 +33,7 @@ export default function UserSocialPill({ url, icon, username, className, platfor
 
 export const StyledUserSocialPill = styled(GalleryPill)`
   flex-basis: 0;
+  height: 24px;
 `;
 
 const StyledPillContent = styled(HStack)`

--- a/apps/web/src/scenes/UserGalleryPage/UserTwitterSection.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserTwitterSection.tsx
@@ -1,6 +1,8 @@
 import { graphql, useFragment } from 'react-relay';
+import styled from 'styled-components';
 
 import { HStack } from '~/components/core/Spacer/Stack';
+import { BaseS } from '~/components/core/Text/Text';
 import { GalleryPill } from '~/components/GalleryPill';
 import { TWITTER_AUTH_URL } from '~/constants/twitter';
 import { UserTwitterSectionFragment$key } from '~/generated/UserTwitterSectionFragment.graphql';
@@ -51,7 +53,7 @@ export default function UserTwitterSection({ queryRef, userRef }: Props) {
   if (isAuthenticatedUser && !userTwitterAccount) {
     return (
       <HStack align="flex-start" gap={8}>
-        <GalleryPill
+        <StyledPill
           eventElementId="Connect Twitter Pill"
           eventName="Connect Twitter"
           eventContext={contexts['External Social']}
@@ -61,9 +63,11 @@ export default function UserTwitterSection({ queryRef, userRef }: Props) {
         >
           <HStack gap={5} align="center">
             <TwitterIcon />
-            <strong>Connect Twitter</strong>
+            <strong>
+              <BaseS>Connect Twitter</BaseS>
+            </strong>
           </HStack>
-        </GalleryPill>
+        </StyledPill>
       </HStack>
     );
   }
@@ -83,3 +87,7 @@ export default function UserTwitterSection({ queryRef, userRef }: Props) {
     />
   );
 }
+
+const StyledPill = styled(GalleryPill)`
+  height: 24px;
+`;


### PR DESCRIPTION
### Summary of Changes

update pill styling for social profile pills to match design


### Demo or Before/After Pics
Before:
![CleanShot 2024-01-23 at 21 13 32@2x](https://github.com/gallery-so/gallery/assets/80802871/199ccbb3-73ab-451f-9e15-b0b304ef9661)

After
![CleanShot 2024-01-23 at 21 12 07@2x](https://github.com/gallery-so/gallery/assets/80802871/ecd25531-27b8-4e0c-9205-3bb69c13a85d)

![CleanShot 2024-01-23 at 21 12 28@2x](https://github.com/gallery-so/gallery/assets/80802871/6fccd76e-e86d-4d17-91ca-b076fdffc154)



good on mobile too
![CleanShot 2024-01-23 at 21 15 15@2x](https://github.com/gallery-so/gallery/assets/80802871/d640f43b-bf81-430f-ac7d-8dfb6eebe156)


### Edge Cases
- twitter connected vs not connected 

### Testing Steps
go to user profile and look at social pills

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
