### PR TITLE
Community Gallery Mobile

### DIFF
--- a/apps/mobile/src/components/Community/CommunityGalleries/CommunityGalleries.tsx
+++ b/apps/mobile/src/components/Community/CommunityGalleries/CommunityGalleries.tsx
@@ -1,0 +1,121 @@
+import { ListRenderItem } from '@shopify/flash-list';
+import { useCallback, useMemo } from 'react';
+import { View } from 'react-native';
+import { Tabs } from 'react-native-collapsible-tab-view';
+import { graphql, usePaginationFragment } from 'react-relay';
+import { removeNullValues } from 'shared/relay/removeNullValues';
+import { GALLERIES_PER_PAGE } from 'src/constants/community';
+
+import { useListContentStyle } from '~/components/ProfileView/Tabs/useListContentStyle';
+import { Typography } from '~/components/Typography';
+import { CommunityGalleriesFragment$key } from '~/generated/CommunityGalleriesFragment.graphql';
+import { CommunityGalleriesRowFragment$key } from '~/generated/CommunityGalleriesRowFragment.graphql';
+
+import { CommunityGalleriesRow } from './CommunityGalleriesRow';
+
+type Props = {
+  communityRef: CommunityGalleriesFragment$key;
+};
+
+type GalleryItemList =
+  | {
+      kind: 'galleries-section-header';
+    }
+  | {
+      kind: 'galleries-row-item';
+      galleryRefs: CommunityGalleriesRowFragment$key;
+    };
+
+export function CommunityGalleries({ communityRef }: Props) {
+  const {
+    data: community,
+    loadNext,
+    hasNext,
+    isLoadingNext,
+  } = usePaginationFragment(
+    graphql`
+      fragment CommunityGalleriesFragment on Community
+      @refetchable(queryName: "CommunityGalleriesRefetchableFragment") {
+        galleries(first: $galleriesFirst, after: $galleriesAfter, maxPreviews: 2)
+          @connection(key: "CommunityGalleriesList_galleries") {
+          edges {
+            node {
+              __typename
+              ...CommunityGalleriesRowFragment
+            }
+          }
+        }
+      }
+    `,
+    communityRef
+  );
+
+  const nonNullGalleries = useMemo(() => {
+    return removeNullValues(community?.galleries?.edges?.map((edge) => edge?.node));
+  }, [community?.galleries?.edges]);
+
+  const items = useMemo(() => {
+    const items: GalleryItemList[] = [];
+
+    items.push({
+      kind: 'galleries-section-header',
+    });
+
+    for (let i = 0; i < nonNullGalleries.length; i += 2) {
+      const galleryRefs: CommunityGalleriesRowFragment$key = removeNullValues([
+        nonNullGalleries[i],
+        nonNullGalleries[i + 1],
+      ]);
+
+      if (galleryRefs.every((ref) => ref !== undefined)) {
+        items.push({
+          kind: 'galleries-row-item',
+          galleryRefs,
+        });
+      }
+    }
+
+    return items;
+  }, [nonNullGalleries]);
+
+  const renderItem = useCallback<ListRenderItem<GalleryItemList>>(({ item }) => {
+    switch (item.kind) {
+      case 'galleries-section-header':
+        return (
+          <View className="px-4 py-3">
+            <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }} className="text-sm">
+              Galleries
+            </Typography>
+          </View>
+        );
+      case 'galleries-row-item':
+        return <CommunityGalleriesRow galleryRefs={item.galleryRefs} />;
+    }
+  }, []);
+
+  const loadMore = useCallback(() => {
+    if (hasNext) {
+      loadNext(GALLERIES_PER_PAGE);
+    }
+  }, [hasNext, loadNext]);
+
+  const contentContainerStyle = useListContentStyle();
+
+  return (
+    <View
+      style={{
+        ...contentContainerStyle,
+        paddingTop: 0,
+      }}
+    >
+      <Tabs.FlashList
+        data={items}
+        estimatedItemSize={162}
+        renderItem={renderItem}
+        onEndReached={loadMore}
+        refreshing={isLoadingNext}
+        onEndReachedThreshold={0.8}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/components/Community/CommunityGalleries/CommunityGalleriesItem.tsx
+++ b/apps/mobile/src/components/Community/CommunityGalleries/CommunityGalleriesItem.tsx
@@ -69,7 +69,7 @@ export function CommunityGalleriesItem({ communityGalleryRef, style }: Props) {
       </View>
       <View className="space-y-1">
         <View className="flex-row items-center gap-1">
-          {gallery?.owner && <ProfilePicture size="sm" userRef={gallery.owner} />}
+          {gallery?.owner && <ProfilePicture size="xs" userRef={gallery.owner} />}
           <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }} className="text-sm">
             {gallery?.owner?.username}
           </Typography>

--- a/apps/mobile/src/components/Community/CommunityGalleries/CommunityGalleriesItem.tsx
+++ b/apps/mobile/src/components/Community/CommunityGalleries/CommunityGalleriesItem.tsx
@@ -1,0 +1,105 @@
+import { useNavigation } from '@react-navigation/native';
+import { ResizeMode } from 'expo-av';
+import { useCallback, useMemo } from 'react';
+import { View, ViewProps } from 'react-native';
+import { graphql, useFragment } from 'react-relay';
+import { contexts } from 'shared/analytics/constants';
+import { ReportingErrorBoundary } from 'shared/errors/ReportingErrorBoundary';
+import { removeNullValues } from 'shared/relay/removeNullValues';
+
+import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
+import { RawNftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
+import { NftPreviewErrorFallback } from '~/components/NftPreview/NftPreviewErrorFallback';
+import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
+import { Typography } from '~/components/Typography';
+import { CommunityGalleriesItemFragment$key } from '~/generated/CommunityGalleriesItemFragment.graphql';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
+
+type Props = {
+  communityGalleryRef: CommunityGalleriesItemFragment$key;
+  style?: ViewProps['style'];
+};
+
+export function CommunityGalleriesItem({ communityGalleryRef, style }: Props) {
+  const communityGallery = useFragment(
+    graphql`
+      fragment CommunityGalleriesItemFragment on CommunityGallery {
+        __typename
+        gallery {
+          dbid
+          name
+          owner {
+            username
+            ...ProfilePictureFragment
+          }
+        }
+        tokenPreviews {
+          medium
+        }
+      }
+    `,
+    communityGalleryRef
+  );
+
+  const { gallery } = communityGallery;
+
+  const nonNullTokenPreviews = useMemo(() => {
+    return removeNullValues(communityGallery.tokenPreviews);
+  }, [communityGallery.tokenPreviews]);
+
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
+  const handlePress = useCallback(() => {
+    if (!gallery?.dbid) return;
+    navigation.push('Gallery', { galleryId: gallery.dbid });
+  }, [gallery?.dbid, navigation]);
+
+  return (
+    <GalleryTouchableOpacity
+      className="p-2 bg-offWhite dark:bg-black-800 space-y-1 w-1/2 rounded"
+      eventElementId="Community Gallery Item"
+      eventName="Press Community Gallery Item"
+      eventContext={contexts.Community}
+      style={style}
+      onPress={handlePress}
+    >
+      <View className="flex w-full flex-row space-x-0.5">
+        {nonNullTokenPreviews.map((tokenPreview, index) => (
+          <NftPreview key={index} tokenUrl={tokenPreview.medium} />
+        ))}
+      </View>
+      <View className="space-y-1">
+        <View className="flex-row items-center gap-1">
+          {gallery?.owner && <ProfilePicture size="sm" userRef={gallery.owner} />}
+          <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }} className="text-sm">
+            {gallery?.owner?.username}
+          </Typography>
+        </View>
+        <Typography font={{ family: 'ABCDiatype', weight: 'Regular' }} className="text-xs">
+          {gallery?.name || 'Untitled'}
+        </Typography>
+      </View>
+    </GalleryTouchableOpacity>
+  );
+}
+
+function NftPreview({
+  tokenUrl,
+  style,
+}: {
+  style?: ViewProps['style'];
+  tokenUrl: string | null | undefined;
+}) {
+  return (
+    <View className="flex flex-1" style={style}>
+      <View className="aspect-square w-full">
+        {tokenUrl ? (
+          <ReportingErrorBoundary fallback={<NftPreviewErrorFallback />}>
+            <RawNftPreviewAsset tokenUrl={tokenUrl} resizeMode={ResizeMode.COVER} />
+          </ReportingErrorBoundary>
+        ) : (
+          <View />
+        )}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/Community/CommunityGalleries/CommunityGalleriesItem.tsx
+++ b/apps/mobile/src/components/Community/CommunityGalleries/CommunityGalleriesItem.tsx
@@ -55,7 +55,7 @@ export function CommunityGalleriesItem({ communityGalleryRef, style }: Props) {
 
   return (
     <GalleryTouchableOpacity
-      className="p-2 bg-offWhite dark:bg-black-800 space-y-1 w-1/2 rounded"
+      className="p-2 bg-offWhite dark:bg-black-700 space-y-1 w-1/2 rounded"
       eventElementId="Community Gallery Item"
       eventName="Press Community Gallery Item"
       eventContext={contexts.Community}

--- a/apps/mobile/src/components/Community/CommunityGalleries/CommunityGalleriesRow.tsx
+++ b/apps/mobile/src/components/Community/CommunityGalleries/CommunityGalleriesRow.tsx
@@ -1,0 +1,33 @@
+import { View } from 'react-native';
+import { graphql, useFragment } from 'react-relay';
+
+import { CommunityGalleriesRowFragment$key } from '~/generated/CommunityGalleriesRowFragment.graphql';
+
+import { CommunityGalleriesItem } from './CommunityGalleriesItem';
+
+type Props = {
+  galleryRefs: CommunityGalleriesRowFragment$key;
+};
+
+export function CommunityGalleriesRow({ galleryRefs }: Props) {
+  const galleries = useFragment(
+    graphql`
+      fragment CommunityGalleriesRowFragment on CommunityGallery @relay(plural: true) {
+        __typename
+        gallery {
+          dbid
+        }
+        ...CommunityGalleriesItemFragment
+      }
+    `,
+    galleryRefs
+  );
+
+  return (
+    <View className="flex-row px-4 space-x-1 mb-4">
+      {galleries.map((gallery) => (
+        <CommunityGalleriesItem key={gallery.gallery?.dbid} communityGalleryRef={gallery} />
+      ))}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/Community/CommunityTabsHeader.tsx
+++ b/apps/mobile/src/components/Community/CommunityTabsHeader.tsx
@@ -27,13 +27,18 @@ export function CommunityTabsHeader({ selectedRoute, onRouteChange, communityRef
             total
           }
         }
+        galleries(first: $galleriesFirst, after: $galleriesAfter, maxPreviews: 2) {
+          pageInfo {
+            total
+          }
+        }
       }
     `,
     communityRef
   );
-
   const totalOwners = community.holders?.pageInfo?.total ?? 0;
   const totalPosts = community.posts?.pageInfo?.total ?? 0;
+  const totalGalleries = community.galleries?.pageInfo?.total ?? 0;
 
   const routes = useMemo(() => {
     return [
@@ -45,8 +50,12 @@ export function CommunityTabsHeader({ selectedRoute, onRouteChange, communityRef
         name: 'Posts',
         counter: totalPosts,
       },
+      {
+        name: 'Galleries',
+        counter: totalGalleries,
+      },
     ];
-  }, [totalPosts, totalOwners]);
+  }, [totalPosts, totalOwners, totalGalleries]);
 
   return (
     <View>

--- a/apps/mobile/src/components/Community/CommunityView.tsx
+++ b/apps/mobile/src/components/Community/CommunityView.tsx
@@ -16,6 +16,7 @@ import { BackButton } from '../BackButton';
 import { GalleryTabsContainer } from '../GalleryTabs/GalleryTabsContainer';
 import { IconContainer } from '../IconContainer';
 import { CommunityCollectors } from './CommunityCollectors';
+import { CommunityGalleries } from './CommunityGalleries/CommunityGalleries';
 import { CommunityHeader } from './CommunityHeader';
 import { CommunityMeta } from './CommunityMeta';
 import { CommunityTabsHeader } from './CommunityTabsHeader';
@@ -37,6 +38,7 @@ export function CommunityView({ queryRef, communityRef }: Props) {
         ...CommunityViewPostsTabFragment
         ...CommunityTabsHeaderFragment
         ...extractRelevantMetadataFromCommunityFragment
+        ...CommunityGalleriesFragment
       }
     `,
     communityRef
@@ -151,6 +153,9 @@ export function CommunityView({ queryRef, communityRef }: Props) {
       </Tabs.Tab>
       <Tabs.Tab name="Posts">
         <CommunityViewPostsTab communityRef={community} queryRef={query} />
+      </Tabs.Tab>
+      <Tabs.Tab name="Galleries">
+        <CommunityGalleries communityRef={community} />
       </Tabs.Tab>
     </GalleryTabsContainer>
   );

--- a/apps/mobile/src/constants/community.ts
+++ b/apps/mobile/src/constants/community.ts
@@ -1,0 +1,1 @@
+export const GALLERIES_PER_PAGE = 24;

--- a/apps/mobile/src/screens/CommunityScreen/CommunityScreen.tsx
+++ b/apps/mobile/src/screens/CommunityScreen/CommunityScreen.tsx
@@ -2,6 +2,7 @@ import { RouteProp, useRoute } from '@react-navigation/native';
 import { Suspense, useMemo } from 'react';
 import { ScrollView, View } from 'react-native';
 import { graphql, useFragment, useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
+import { GALLERIES_PER_PAGE } from 'src/constants/community';
 import { POSTS_PER_PAGE } from 'src/constants/feed';
 import { useRefreshHandle } from 'src/hooks/useRefreshHandle';
 
@@ -72,6 +73,8 @@ function ContractCommunityView({ contractAddress, chain }: ContractCommunityView
         $listOwnersAfter: String
         $postLast: Int!
         $postBefore: String
+        $galleriesFirst: Int!
+        $galleriesAfter: String
       ) {
         community: contractCommunityByKey(key: $contractCommunityInput) @required(action: THROW) {
           ... on Community {
@@ -89,6 +92,7 @@ function ContractCommunityView({ contractAddress, chain }: ContractCommunityView
       },
       listOwnersFirst: 200,
       postLast: POSTS_PER_PAGE,
+      galleriesFirst: GALLERIES_PER_PAGE,
     },
     { fetchPolicy: 'store-or-network', UNSTABLE_renderPolicy: 'partial' }
   );
@@ -115,6 +119,8 @@ function ArtBlocksCommunityView({
         $listOwnersAfter: String
         $postLast: Int!
         $postBefore: String
+        $galleriesFirst: Int!
+        $galleriesAfter: String
       ) {
         community: artBlocksCommunityByKey(key: $artBlocksCommunityInput) @required(action: THROW) {
           ... on Community {
@@ -133,6 +139,7 @@ function ArtBlocksCommunityView({
       },
       listOwnersFirst: 200,
       postLast: POSTS_PER_PAGE,
+      galleriesFirst: GALLERIES_PER_PAGE,
     },
     { fetchPolicy: 'store-or-network', UNSTABLE_renderPolicy: 'partial' }
   );

--- a/schema.graphql
+++ b/schema.graphql
@@ -367,6 +367,7 @@ type Community implements Node {
   creator: GalleryUserOrAddress
   tokensInCommunity(before: String, after: String, first: Int, last: Int, onlyGalleryUsers: Boolean): TokensConnection @deprecated(reason: "Use Community.tokens")
   owners(before: String, after: String, first: Int, last: Int, onlyGalleryUsers: Boolean): TokenHoldersConnection @deprecated(reason: "Use Community.holders")
+  galleries(maxPreviews: Int!, before: String, after: String, first: Int, last: Int): CommunityGalleriesConnection
 }
 
 union CommunityByAddressOrError = Community | ErrCommunityNotFound | ErrInvalidInput
@@ -377,6 +378,21 @@ union CommunityByKeyOrError = Community | ErrCommunityNotFound | ErrInvalidInput
 
 type CommunityEdge {
   node: Community
+  cursor: String
+}
+
+type CommunityGalleriesConnection {
+  edges: [CommunityGalleryEdge]
+  pageInfo: PageInfo!
+}
+
+type CommunityGallery {
+  gallery: Gallery
+  tokenPreviews: [PreviewURLSet]
+}
+
+type CommunityGalleryEdge {
+  node: CommunityGallery
   cursor: String
 }
 


### PR DESCRIPTION
### Summary of Changes

- Add a galleries tab to the community screen for mobile
- We display all the tokens in the preview as 1:1 instead of using token's dimension

### Demo or Before/After Pics


https://github.com/gallery-so/gallery/assets/4480258/bfe379ed-a78c-46bf-96e0-7b24e615b22a


**Different aspect ratio**

**Portrait**

![CleanShot 2024-01-26 at 14 44 40@2x](https://github.com/gallery-so/gallery/assets/4480258/6d5732e9-1e7e-4390-a4f9-b7bc2fbe4342)

**Landscape**

![CleanShot 2024-01-26 at 14 45 26@2x](https://github.com/gallery-so/gallery/assets/4480258/8dbca503-8e00-4906-b8d3-f9ba201e7333)

**Mixed ratio**

![CleanShot 2024-01-26 at 14 44 26@2x](https://github.com/gallery-so/gallery/assets/4480258/8390d390-64d5-4fd7-99ed-0d95498bfb52)


### Edge Cases

1. Tested with different aspect ratio of token

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if mobile) I've tested the changes on both light and dark modes.
