### PR TITLE
GAL-5095 make feed infinite scroll and remove footer from home

### DIFF
--- a/apps/web/pages/home.tsx
+++ b/apps/web/pages/home.tsx
@@ -43,6 +43,7 @@ export default function Home({ preloadedQuery }: Props) {
       navbar={<HomeNavbar queryRef={query} />}
       sidebar={<StandardSidebar queryRef={query} />}
       element={<CuratedHomePage queryRef={query} />}
+      footer={false}
     />
   );
 }

--- a/apps/web/src/components/Feed/FeedList.tsx
+++ b/apps/web/src/components/Feed/FeedList.tsx
@@ -187,7 +187,6 @@ export default function FeedList({
   const [, setIsLoading] = useState(false);
 
   const handleLoadMore = useCallback(async () => {
-    console.log('loading more');
     setIsLoading(true);
     await loadNextPage();
     setIsLoading(false);


### PR DESCRIPTION
### Summary of Changes

Make /home feed infinite scroll. 
and hide footer because users won't be able to reach it 

### Demo or Before/After Pics



https://github.com/gallery-so/gallery/assets/80802871/736fbf98-e488-4fcf-86f4-8d339fcfb40f



### Edge Cases
na

### Testing Steps

scroll the feed on /home. it should load the next page automatically

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
