### PR TITLE
remove hardcoded bg color for punks

### DIFF
--- a/apps/web/src/utils/token.ts
+++ b/apps/web/src/utils/token.ts
@@ -36,7 +36,6 @@ export function graphqlGetResizedNftImageUrlWithFallback(
 
 const backgroundColorOverrides: Record<string, string> = {
   '0x30cdac3871c41a63767247c8d1a2de59f5714e78': '#E0E0E0', // Obits
-  '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb': '#648494', // Cryptopunks
 };
 
 export function getBackgroundColorOverrideForContract(contractAddress: string) {


### PR DESCRIPTION
### Summary of Changes

Remove hardcoded bg color for punks.

### Demo or Before/After Pics

before
![CleanShot 2024-01-30 at 11 01 19](https://github.com/gallery-so/gallery/assets/80802871/7eee5a47-5c9c-468f-b7fb-17f7c0eeb03b)

after

![CleanShot 2024-01-30 at 11 01 11](https://github.com/gallery-so/gallery/assets/80802871/6ea0036e-c96f-4fc7-802f-2c0f19553b29)


### Edge Cases
na

### Testing Steps
go to view a punk like /rodo/2UDToNdkPZtTKpJrIltKhIy2sZQ/2UDPCpSdAf9Y58Q6IYLQzx4kVnQ

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
