### PR TITLE
bug fix for tokens adjacent to broken token media in gallery

### DIFF
--- a/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -9,10 +9,12 @@ import { NftDetailViewQuery } from '~/generated/NftDetailViewQuery.graphql';
 import { NftDetailViewQueryFragment$key } from '~/generated/NftDetailViewQueryFragment.graphql';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import TokenViewEmitter from '~/shared/components/TokenViewEmitter';
+import ErrorBoundary from '~/contexts/boundary/ErrorBoundary';
 
 import NftDetailAsset from './NftDetailAsset';
 import NftDetailNote from './NftDetailNote';
 import NftDetailText from './NftDetailText';
+import Shimmer from '~/components/Shimmer/Shimmer';
 
 type Props = {
   authenticatedUserOwnsAsset: boolean;
@@ -103,11 +105,13 @@ export default function NftDetailView({
         <StyledVStack>
           <StyledAssetAndNoteContainer>
             <Container>
-              <NftDetailAsset
-                tokenRef={collectionNft}
-                hasExtraPaddingForNote={showCollectorsNoteComponent}
-                visibility={visibility}
-              />
+              <ErrorBoundary fallback={<Shimmer />}>
+                <NftDetailAsset
+                  tokenRef={collectionNft}
+                  hasExtraPaddingForNote={showCollectorsNoteComponent}
+                  visibility={visibility}
+                />
+              </ErrorBoundary>
             </Container>
           </StyledAssetAndNoteContainer>
           {!isMobileOrMobileLarge && showCollectorsNoteComponent && (

--- a/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailView.tsx
@@ -4,17 +4,17 @@ import styled from 'styled-components';
 
 import breakpoints from '~/components/core/breakpoints';
 import { NOTES_PER_PAGE } from '~/components/Feed/Socialize/CommentsModal/CommentsModal';
+import { NftFailureFallback } from '~/components/NftFailureFallback/NftFailureFallback';
+import ErrorBoundary from '~/contexts/boundary/ErrorBoundary';
 import { NftDetailViewFragment$key } from '~/generated/NftDetailViewFragment.graphql';
 import { NftDetailViewQuery } from '~/generated/NftDetailViewQuery.graphql';
 import { NftDetailViewQueryFragment$key } from '~/generated/NftDetailViewQueryFragment.graphql';
 import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import TokenViewEmitter from '~/shared/components/TokenViewEmitter';
-import ErrorBoundary from '~/contexts/boundary/ErrorBoundary';
 
 import NftDetailAsset from './NftDetailAsset';
 import NftDetailNote from './NftDetailNote';
 import NftDetailText from './NftDetailText';
-import Shimmer from '~/components/Shimmer/Shimmer';
 
 type Props = {
   authenticatedUserOwnsAsset: boolean;
@@ -105,7 +105,7 @@ export default function NftDetailView({
         <StyledVStack>
           <StyledAssetAndNoteContainer>
             <Container>
-              <ErrorBoundary fallback={<Shimmer />}>
+              <ErrorBoundary fallback={<NftFailureFallback tokenId={token.dbid} />}>
                 <NftDetailAsset
                   tokenRef={collectionNft}
                   hasExtraPaddingForNote={showCollectorsNoteComponent}

--- a/packages/shared/src/relay/getPreviewImageUrlsInlineDangerously.ts
+++ b/packages/shared/src/relay/getPreviewImageUrlsInlineDangerously.ts
@@ -23,10 +23,6 @@ export type GetPreviewImageUrlsResult =
   | {
       type: 'error';
       error: CouldNotRenderNftError;
-    }
-  | {
-      // TODO: rohan - remove later and throw error
-      type: 'temp';
     };
 
 type Props = {
@@ -242,7 +238,15 @@ export function getPreviewImageUrlsInlineDangerously({
 
   if (!previewUrls) {
     return {
-      type: 'temp',
+      type: 'error',
+      error: new CouldNotRenderNftError(
+        'getPreviewImageUrlsInlineDangerously',
+        'No preview URLs returned for token!',
+        {
+          id: token?.dbid,
+          assetType: media?.__typename,
+        }
+      ),
     };
   }
 

--- a/packages/shared/src/relay/getPreviewImageUrlsInlineDangerously.ts
+++ b/packages/shared/src/relay/getPreviewImageUrlsInlineDangerously.ts
@@ -25,9 +25,9 @@ export type GetPreviewImageUrlsResult =
       error: CouldNotRenderNftError;
     }
   | {
-    // TODO: rohan - remove later and throw error
-    type: 'temp';
-  };
+      // TODO: rohan - remove later and throw error
+      type: 'temp';
+    };
 
 type Props = {
   tokenRef: getPreviewImageUrlsInlineDangerouslyFragment$key;
@@ -239,7 +239,6 @@ export function getPreviewImageUrlsInlineDangerously({
       return { type: SyncingMediaWithoutFallback };
     }
   }
-
 
   if (!previewUrls) {
     return {

--- a/packages/shared/src/relay/getPreviewImageUrlsInlineDangerously.ts
+++ b/packages/shared/src/relay/getPreviewImageUrlsInlineDangerously.ts
@@ -23,7 +23,11 @@ export type GetPreviewImageUrlsResult =
   | {
       type: 'error';
       error: CouldNotRenderNftError;
-    };
+    }
+  | {
+    // TODO: rohan - remove later and throw error
+    type: 'temp';
+  };
 
 type Props = {
   tokenRef: getPreviewImageUrlsInlineDangerouslyFragment$key;
@@ -236,17 +240,10 @@ export function getPreviewImageUrlsInlineDangerously({
     }
   }
 
+
   if (!previewUrls) {
     return {
-      type: 'error',
-      error: new CouldNotRenderNftError(
-        'getPreviewImageUrlsInlineDangerously',
-        'No preview URLs returned for token!',
-        {
-          id: token?.dbid,
-          assetType: media?.__typename,
-        }
-      ),
+      type: 'temp',
     };
   }
 


### PR DESCRIPTION
### Summary of Changes
From a gallery, when you click on nft detail page of a token adjacent to a token with broken token media, we render an error page. This ignores the error for now so that the token clicked can render as it's media is valid

### Before

https://github.com/gallery-so/gallery/assets/49758803/0b19d422-674e-4093-ae42-eb664da70c8b

### After

https://github.com/gallery-so/gallery/assets/49758803/5cfc2d3d-b6f5-441f-91a4-aa73cf2754e9



### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
