### PR TITLE
improvement to nft detail page transition

### DIFF
--- a/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAsset.tsx
@@ -330,6 +330,7 @@ const StyledImage = styled.img`
   border: none;
   max-width: 100%;
   max-height: 100%;
+  object-fit: contain;
 `;
 
 const VisibilityContainer = styled.div`

--- a/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailPageFallback.tsx
@@ -92,7 +92,7 @@ const StyledTextContainer = styled(VStack)`
     padding-right: 10%;
     padding-left: 10%;
     width: 400px;
-    margin-left: 56px;
+    margin-left: 46px;
     margin-top: 0px;
     padding-right: 0%;
     padding-left: 0%;


### PR DESCRIPTION
### Summary of Changes

apply same styling for preview in page and skeleton to change remove the shifting and the stretching of image

### Before

https://github.com/gallery-so/gallery/assets/49758803/df516c80-a3c5-419d-833b-00196bd1a61b


### After

https://github.com/gallery-so/gallery/assets/49758803/806febcf-e7f8-47a7-8622-03dff42419ed



### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
