### PR TITLE
add clear edit gallery button

### DIFF
--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryRightContent.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryRightContent.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from 'next/router';
+import router, { useRouter } from 'next/router';
 import { Route } from 'nextjs-routes';
 import { Suspense, useCallback, useMemo, useState } from 'react';
 import { useFragment } from 'react-relay';
@@ -58,6 +58,9 @@ export function GalleryRightContent({ queryRef, galleryRef, username }: GalleryR
             dbid
             galleries {
               __typename
+            }
+            featuredGallery {
+              dbid
             }
             ...FollowButtonUserFragment
           }
@@ -146,6 +149,18 @@ export function GalleryRightContent({ queryRef, galleryRef, username }: GalleryR
     });
   }, [query, showModal, track]);
 
+  const handleEditGalleryClick = useCallback(() => {
+    const routeGalleryId = router.query.galleryId as string;
+    // The Edit button appears on each Gallery page as well as the Featured Gallery page, so if there's a galleryId in the route, use that
+    const editGalleryId = routeGalleryId ?? query.userByUsername?.featuredGallery?.dbid;
+
+    const route = {
+      pathname: '/gallery/[galleryId]/edit',
+      query: { galleryId: editGalleryId },
+    };
+    router.push(route);
+  }, [query.userByUsername?.featuredGallery?.dbid]);
+
   const editGalleryUrl: Route | null = useMemo(() => {
     if (!gallery?.dbid) {
       return null;
@@ -217,6 +232,20 @@ export function GalleryRightContent({ queryRef, galleryRef, username }: GalleryR
           Add New
         </Button>
       </VStack>
+    );
+  }
+
+  if (isViewingSignedInUser) {
+    return (
+      <Button
+        eventElementId="Edit Gallery Button In Navbar"
+        eventName="Clicked Edit Gallery Button In Navbar"
+        eventContext={contexts.Editor}
+        variant="primary"
+        onClick={handleEditGalleryClick}
+      >
+        Edit
+      </Button>
     );
   }
 


### PR DESCRIPTION
### Summary of Changes

Add clear Edit gallery button for easy access. 
### Demo or Before/After Pics


Not logged in: see sign in buttons
![CleanShot 2024-02-01 at 17 01 21](https://github.com/gallery-so/gallery/assets/80802871/5b8a45a6-dc3c-4d21-8165-a4733858a07a)


Logged in, viewing own gallery: see Edit button
![CleanShot 2024-02-01 at 17 01 28](https://github.com/gallery-so/gallery/assets/80802871/3b48212d-2ff6-4b01-8ea5-0fae88f8b595)


Logged in, viewing someone else's gallery : no button
![CleanShot 2024-02-01 at 17 01 34](https://github.com/gallery-so/gallery/assets/80802871/a39a5753-3440-45ac-a8fe-f0462680fc87)


Button is also visible when viewing an individual gallery (gallery page)
![CleanShot 2024-02-01 at 17 01 43](https://github.com/gallery-so/gallery/assets/80802871/1b86b242-746f-435d-a73d-59f45eda12a7)


Video demonstrating the edit button navigates to the editor for the correct gallery:
https://github.com/gallery-so/gallery/assets/80802871/c218a359-2bd9-4cfc-a421-c5695af37923


Edit gallery icon appears on hover on the Gallery card on the Galleries tab.  
![CleanShot 2024-02-01 at 17 02 29](https://github.com/gallery-so/gallery/assets/80802871/abcf2b58-4acb-4dea-b927-47d333df0699)

Edit Gallery option is now in the dropdown on the same card.
![CleanShot 2024-02-01 at 17 02 34](https://github.com/gallery-so/gallery/assets/80802871/eda9559b-abe1-410f-9323-768fdef39c57)


### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
