### PR TITLE
upgrade to new OG URLs

### DIFF
--- a/apps/web/pages/[username]/[collectionId]/[tokenId]/index.tsx
+++ b/apps/web/pages/[username]/[collectionId]/[tokenId]/index.tsx
@@ -79,7 +79,8 @@ export const getServerSideProps: GetServerSideProps<NftDetailPageProps> = async 
       metaTags: tokenId
         ? openGraphMetaTags({
             title: `${username} | Gallery`,
-            previewPath: `/opengraph/nft/${tokenId}`,
+            path: `/nft/${tokenId}`,
+            isFcFrameCompatible: false,
           })
         : null,
     },

--- a/apps/web/pages/[username]/[collectionId]/index.tsx
+++ b/apps/web/pages/[username]/[collectionId]/index.tsx
@@ -91,7 +91,8 @@ export const getServerSideProps: GetServerSideProps<CollectionGalleryProps> = as
       metaTags: collectionId
         ? openGraphMetaTags({
             title: `${username} | Gallery`,
-            previewPath: `/opengraph/collection/${collectionId}`,
+            path: `/collection/${collectionId}`,
+            isFcFrameCompatible: true,
           })
         : null,
     },

--- a/apps/web/pages/[username]/galleries/[galleryId].tsx
+++ b/apps/web/pages/[username]/galleries/[galleryId].tsx
@@ -85,7 +85,8 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ params }) 
       metaTags: username
         ? openGraphMetaTags({
             title: `${username} | Gallery`,
-            previewPath: `/opengraph/gallery/${galleryId}`,
+            path: `/gallery/${galleryId}`,
+            isFcFrameCompatible: false,
           })
         : null,
     },

--- a/apps/web/pages/[username]/index.tsx
+++ b/apps/web/pages/[username]/index.tsx
@@ -152,7 +152,8 @@ export const getServerSideProps: GetServerSideProps<
       metaTags: username
         ? openGraphMetaTags({
             title: `${username} | Gallery`,
-            previewPath: `/opengraph/user/${username}`,
+            path: `/user/${username}`,
+            isFcFrameCompatible: true,
           })
         : null,
     },

--- a/apps/web/pages/[username]/posts.tsx
+++ b/apps/web/pages/[username]/posts.tsx
@@ -103,7 +103,8 @@ export const getServerSideProps: GetServerSideProps<
       metaTags: username
         ? openGraphMetaTags({
             title: `${username} | Gallery`,
-            previewPath: `/opengraph/user/${username}`,
+            path: `/user/${username}`,
+            isFcFrameCompatible: true,
           })
         : null,
     },

--- a/apps/web/pages/[username]/token/[tokenId]/index.tsx
+++ b/apps/web/pages/[username]/token/[tokenId]/index.tsx
@@ -75,7 +75,8 @@ export const getServerSideProps: GetServerSideProps<TokenDetailPageProps> = asyn
       metaTags: tokenId
         ? openGraphMetaTags({
             title: `${username} | Gallery`,
-            previewPath: `/opengraph/nft/${tokenId}`,
+            path: `/nft/${tokenId}`,
+            isFcFrameCompatible: false,
           })
         : null,
     },

--- a/apps/web/pages/post/[postId].tsx
+++ b/apps/web/pages/post/[postId].tsx
@@ -50,7 +50,8 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ params }) 
       metaTags: postId
         ? openGraphMetaTags({
             title: `Gallery`, //todo opengraph title and content
-            previewPath: `/opengraph/post/${postId}`,
+            path: `/post/${postId}`,
+            isFcFrameCompatible: false,
           })
         : null,
     },

--- a/apps/web/src/utils/openGraphMetaTags.ts
+++ b/apps/web/src/utils/openGraphMetaTags.ts
@@ -7,66 +7,59 @@ import isProduction from './isProduction';
 
 type Params = {
   title: string;
-  previewPath: string;
+  path: string;
+  isFcFrameCompatible: boolean;
 };
 
-const baseurl = `https://gallery-opengraph${
-  isProduction() ? '' : '-preview'
-}.vercel.app/api/opengraph/image`;
+const baseurl = `https://gallery-opengraph${isProduction() ? '' : '-preview'}.vercel.app/api/og`;
 
 export const openGraphMetaTags = ({
   title,
-  previewPath,
+  path,
+  isFcFrameCompatible,
 }: Params): Required<MetaTagProps['metaTags']> => {
   const tags = [
     { property: 'og:title', content: title },
     // TODO: add description
     {
       property: 'og:image',
-      content: `${baseurl}?${new URLSearchParams({
-        path: previewPath,
-        fallback:
-          'https://storage.googleapis.com/gallery-prod-325303.appspot.com/gallery_full_logo_v2.1.png',
-      }).toString()}`,
+      content: `${baseurl}${path}`,
     },
     { property: 'twitter:card', content: 'summary_large_image' },
     {
       property: 'twitter:image',
       content: `${baseurl}?${new URLSearchParams({
-        path: previewPath,
+        path,
         width: WIDTH_OPENGRAPH_IMAGE.toString(),
         height: HEIGHT_OPENGRAPH_IMAGE.toString(),
         fallback:
           'https://storage.googleapis.com/gallery-prod-325303.appspot.com/gallery_full_logo_v2.1.png',
       }).toString()}`,
     },
-    // farcaster frame embed
-    // https://warpcast.notion.site/Farcaster-Frames-4bd47fe97dc74a42a48d3a234636d8c5
-    {
-      property: 'fc:frame',
-      content: 'vNext',
-    },
-    {
-      property: `fc:frame:button:1`,
-      content: '→',
-    },
-    {
-      property: 'fc:frame:image',
-      content: `${baseurl}?${new URLSearchParams({
-        path: `${previewPath}/fcframe`,
-        fallback:
-          'https://storage.googleapis.com/gallery-prod-325303.appspot.com/gallery_full_logo_v2.1.png',
-      }).toString()}`,
-    },
-    {
-      property: 'fc:frame:post_url',
-      content: `${baseurl}?${new URLSearchParams({
-        path: `${previewPath}/fcframe`,
-        fallback:
-          'https://storage.googleapis.com/gallery-prod-325303.appspot.com/gallery_full_logo_v2.1.png',
-      }).toString()}`,
-    },
   ];
+
+  // farcaster frame embed
+  // https://warpcast.notion.site/Farcaster-Frames-4bd47fe97dc74a42a48d3a234636d8c5
+  if (isFcFrameCompatible) {
+    tags.push(
+      {
+        property: 'fc:frame',
+        content: 'vNext',
+      },
+      {
+        property: `fc:frame:button:1`,
+        content: '→',
+      },
+      {
+        property: 'fc:frame:image',
+        content: `${baseurl}${path}/fcframe`,
+      },
+      {
+        property: 'fc:frame:post_url',
+        content: `${baseurl}${path}/fcframe`,
+      }
+    );
+  }
 
   return removeNullValues(tags);
 };


### PR DESCRIPTION
### Summary of Changes

- Upgrade to new OG URLs defined in https://github.com/gallery-so/opengraph/pull/8
- Only include frame meta tags if compatible

**User**
<img width="1480" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/c0842107-cea3-4e08-b23d-5db8a2130d25">

<img width="1475" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/ce6769df-b23e-4371-b829-5dc47ddd2662">

**User frame**
<img width="1473" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/3d84579f-797e-49b3-939c-00d673a0e316">

**Collection**

https://gallery-opengraph.vercel.app/api/og/collection/27OZhb3WThH2NfbEoojqRtVr2XV

Doesn't seem to work, likely because we don't support `HTMLMedia` from the OG service

<img width="1477" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/a507d906-4d21-4554-9e1a-4850f62d4ef0">

**Collection frame**

Busted, likely for the same reason

https://gallery-opengraph.vercel.app/api/og/collection/27OZhb3WThH2NfbEoojqRtVr2XV/

**User Gallery**
https://gallery-opengraph.vercel.app/api/og/gallery/27Gj11lEF6opjoWwewUakY7hhXi

<img width="1477" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/ba500947-ae74-4652-a12c-db43306e9e0f">

**User Gallery frame**
NOT IMPLEMENTED; low prio

**Single token**

https://gallery-opengraph.vercel.app/api/og/nft/28w4uPmP2k5xTq6tvLBShuE3A5i

<img width="1476" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/6565f80d-e2fb-4dd0-ac0e-2a04dac4b779">

**Post**
https://gallery-opengraph.vercel.app/api/og/post/2bm9lhTOD3cbLLFX9WYU7mgl2Ng

<img width="1479" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/690ab858-3a22-42d0-8851-cd613a457d5b">
