### PR TITLE
fix issue of missing feed items when remounting list

### DIFF
--- a/apps/web/src/components/Feed/FeedList.tsx
+++ b/apps/web/src/components/Feed/FeedList.tsx
@@ -97,6 +97,7 @@ export default function FeedList({
     [measurerCache]
   );
 
+  console.log({ feedData });
   //Render a list item or a loading indicator.
   const rowRenderer = useCallback(
     ({
@@ -122,6 +123,7 @@ export default function FeedList({
       }
 
       if (content.__typename === 'Post') {
+        console.log('returning');
         return (
           <CellMeasurer
             cache={measurerCache}
@@ -207,7 +209,7 @@ export default function FeedList({
         <AutoSizer disableHeight>
           {({ width }) => (
             // @ts-expect-error shitty react-virtualized types
-            <div ref={registerChild}>
+            <div ref={(el) => registerChild(el)}>
               <InfiniteLoader
                 isRowLoaded={isRowLoaded}
                 loadMoreRows={handleLoadMore}


### PR DESCRIPTION
### Summary of Changes

fixes bug where the feed is really short if you navigate from the feed -> user profile -> return to feed. 
seems related to this issue: https://github.com/bvaughn/react-virtualized/issues/1324
forcing the resize calculation causes the list to appear as expected.


### Demo or Before/After Pics

before


https://github.com/gallery-so/gallery/assets/80802871/b33bf8c4-55b1-4f3c-b179-057e923a43d9



after

https://github.com/gallery-so/gallery/assets/80802871/84dbff12-c837-4ac8-8508-ad2733a1659d



### Edge Cases
na


### Testing Steps

Provide steps on how the reviewer can test the changes
1. go to the feed /home
2. click on a username to visit their profile
3. click back in the browse to return to feed
4. verify that the feed is displayed as expected and you can continue to infinite scroll 

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
