### PR TITLE
add single gallery frame compatibility

### DIFF
--- a/apps/web/pages/[username]/galleries/[galleryId].tsx
+++ b/apps/web/pages/[username]/galleries/[galleryId].tsx
@@ -93,7 +93,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ params }) 
         ? openGraphMetaTags({
             title: `${username} | Gallery`,
             path: `/gallery/${galleryId}`,
-            isFcFrameCompatible: false,
+            isFcFrameCompatible: true,
           })
         : null,
     },


### PR DESCRIPTION
### Summary of Changes

We allowed fc frame compatibility for user profiles and collection pages, but not gallery pages. Paired with https://github.com/gallery-so/opengraph/pull/12

