### PR TITLE
GAL-5132 fix mobile spacing on post page and gallery section page

### DIFF
--- a/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryPage.tsx
+++ b/apps/web/src/scenes/CollectionGalleryPage/CollectionGalleryPage.tsx
@@ -9,6 +9,7 @@ import useKeyDown from '~/hooks/useKeyDown';
 import { GalleryPageSpacing } from '~/pages/[username]';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 
+import { MobileSpacingContainer } from '../UserGalleryPage/UserGallery';
 import CollectionGallery from './CollectionGallery';
 
 type CollectionGalleryPageProps = {
@@ -101,7 +102,9 @@ function CollectionGalleryPage({ username, queryRef }: CollectionGalleryPageProp
         <title>{headTitle}</title>
       </Head>
       <GalleryPageSpacing>
-        <CollectionGallery queryRef={query} />
+        <MobileSpacingContainer>
+          <CollectionGallery queryRef={query} />
+        </MobileSpacingContainer>
       </GalleryPageSpacing>
     </>
   );

--- a/apps/web/src/scenes/Post/StandalonePostPage.tsx
+++ b/apps/web/src/scenes/Post/StandalonePostPage.tsx
@@ -8,6 +8,7 @@ import { StandalonePostPageQueryFragment$key } from '~/generated/StandalonePostP
 import { GalleryPageSpacing } from '~/pages/[username]';
 
 import NotFound from '../NotFound/NotFound';
+import { MobileSpacingContainer } from '../UserGalleryPage/UserGallery';
 import StandalonePostView from './StandalonePostView';
 
 type Props = {
@@ -71,7 +72,9 @@ function StandalonePostPage({ queryRef }: Props) {
         <title>{headTitle}</title>
       </Head>
       <GalleryPageSpacing>
-        <StandalonePostView postRef={post} queryRef={query} />
+        <MobileSpacingContainer>
+          <StandalonePostView postRef={post} queryRef={query} />
+        </MobileSpacingContainer>
       </GalleryPageSpacing>
     </>
   );


### PR DESCRIPTION
### Summary of Changes
fix mobile spacing on post page and gallery section page

### Demo or Before/After Pics

post page
before
![CleanShot 2024-02-06 at 10 41 08](https://github.com/gallery-so/gallery/assets/80802871/bf94bf82-7c2c-47fd-9059-339dcf58b9a1)

after
![CleanShot 2024-02-06 at 10 40 59](https://github.com/gallery-so/gallery/assets/80802871/600d74d7-c777-4623-be84-67f0315a9fe4)



gallery section page
before
![CleanShot 2024-02-06 at 10 39 57](https://github.com/gallery-so/gallery/assets/80802871/be558817-af6f-4ca6-b4c0-a078eaa56c23)

after
![CleanShot 2024-02-06 at 10 39 50](https://github.com/gallery-so/gallery/assets/80802871/58b10b2b-0325-42b1-99ba-83addac91912)


### Edge Cases
desktop should be unaffected

### Testing Steps
go to a gallery section page and go to an individual post page

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
