### PR TITLE
send correct wallet chainAddress for ENS pfp updates

### DIFF
--- a/apps/web/src/components/Profile/ProfilePictureDropdown.tsx
+++ b/apps/web/src/components/Profile/ProfilePictureDropdown.tsx
@@ -30,16 +30,16 @@ export function ProfilePictureDropdown({ open, onClose, queryRef }: Props) {
           ... on Viewer {
             user {
               __typename
-              primaryWallet {
-                chainAddress {
-                  address
-                  chain
-                }
-              }
 
               potentialEnsProfileImage {
                 __typename
                 ... on EnsProfileImage {
+                  wallet {
+                    chainAddress {
+                      chain
+                      address
+                    }
+                  }
                   profileImage {
                     previewURLs {
                       small
@@ -76,7 +76,7 @@ export function ProfilePictureDropdown({ open, onClose, queryRef }: Props) {
 
   const ensProfileImage = user.potentialEnsProfileImage?.profileImage?.previewURLs?.small;
 
-  const { chainAddress } = user.primaryWallet || {};
+  const { chainAddress } = user.potentialEnsProfileImage?.wallet || {};
 
   const handleSetEnsProfilePicture = useCallback(() => {
     track('PFP: Clicked Use ENS Avatar');


### PR DESCRIPTION
### Summary of Changes

we were defaulting to sending the `primaryWallet` chainAddress when updating PFPs, which broke if the ENS PFP was set on a non-primary wallet.

### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="576" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/92ecae14-62e5-4c02-818a-ac96ea56957b"> | ![image](https://github.com/gallery-so/gallery/assets/12162433/a1bf202d-6f7c-40d8-a09e-3503f654fccb) |

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
