### PR TITLE
Bookmarks on Mobile

### DIFF
--- a/apps/mobile/src/components/Community/CommunityCollectors.tsx
+++ b/apps/mobile/src/components/Community/CommunityCollectors.tsx
@@ -39,6 +39,7 @@ export function CommunityCollectors({ communityRef, queryRef }: Props) {
   const query = useFragment(
     graphql`
       fragment CommunityCollectorsQueryFragment on Query {
+        ...CommunityCollectorsGridRowQueryFragment
         ...CommunityCollectorsListItemQueryFragment
       }
     `,
@@ -144,7 +145,7 @@ export function CommunityCollectors({ communityRef, queryRef }: Props) {
         case 'collector-section-header':
           return <CommunityCollectorsHeader layout={tokenLayout} onLayoutChange={setTokenLayout} />;
         case 'collector-grid-item':
-          return <CommunityCollectorsGridRow tokenRefs={item.tokenRefs} />;
+          return <CommunityCollectorsGridRow queryRef={query} tokenRefs={item.tokenRefs} />;
         case 'collector-list-item':
           return <CommunityCollectorsListItem queryRef={query} userRef={item.userRef} />;
       }

--- a/apps/mobile/src/components/Community/CommunityCollectors/CommunityCollectorsGridItem.tsx
+++ b/apps/mobile/src/components/Community/CommunityCollectors/CommunityCollectorsGridItem.tsx
@@ -12,14 +12,25 @@ import { UniversalNftPreviewWithBoundary } from '~/components/NftPreview/Univers
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { Typography } from '~/components/Typography';
 import { CommunityCollectorsGridItemFragment$key } from '~/generated/CommunityCollectorsGridItemFragment.graphql';
+import { CommunityCollectorsGridItemQueryFragment$key } from '~/generated/CommunityCollectorsGridItemQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 
 type Props = {
+  queryRef: CommunityCollectorsGridItemQueryFragment$key;
   tokenRef: CommunityCollectorsGridItemFragment$key;
   style?: ViewProps['style'];
 };
 
-export function CommunityCollectorsGridItem({ tokenRef, style }: Props) {
+export function CommunityCollectorsGridItem({ queryRef, tokenRef, style }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment CommunityCollectorsGridItemQueryFragment on Query {
+        ...UniversalNftPreviewWithBoundaryQueryFragment
+      }
+    `,
+    queryRef
+  );
+
   const token = useFragment(
     graphql`
       fragment CommunityCollectorsGridItemFragment on Token {
@@ -68,6 +79,7 @@ export function CommunityCollectorsGridItem({ tokenRef, style }: Props) {
     <View className="w-1/2 space-y-2" style={style}>
       <View className="h-[175] w-[175] max-w-full">
         <UniversalNftPreviewWithBoundary
+          queryRef={query}
           tokenRef={token}
           onPress={handlePress}
           resizeMode={ResizeMode.CONTAIN}

--- a/apps/mobile/src/components/Community/CommunityCollectors/CommunityCollectorsGridRow.tsx
+++ b/apps/mobile/src/components/Community/CommunityCollectors/CommunityCollectorsGridRow.tsx
@@ -2,14 +2,24 @@ import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
 import { CommunityCollectorsGridRowFragment$key } from '~/generated/CommunityCollectorsGridRowFragment.graphql';
+import { CommunityCollectorsGridRowQueryFragment$key } from '~/generated/CommunityCollectorsGridRowQueryFragment.graphql';
 
 import { CommunityCollectorsGridItem } from './CommunityCollectorsGridItem';
 
 type Props = {
+  queryRef: CommunityCollectorsGridRowQueryFragment$key;
   tokenRefs: CommunityCollectorsGridRowFragment$key;
 };
 
-export function CommunityCollectorsGridRow({ tokenRefs }: Props) {
+export function CommunityCollectorsGridRow({ queryRef, tokenRefs }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment CommunityCollectorsGridRowQueryFragment on Query {
+        ...CommunityCollectorsGridItemQueryFragment
+      }
+    `,
+    queryRef
+  );
   const tokens = useFragment(
     graphql`
       fragment CommunityCollectorsGridRowFragment on Token @relay(plural: true) {
@@ -24,7 +34,7 @@ export function CommunityCollectorsGridRow({ tokenRefs }: Props) {
   return (
     <View className="flex-row px-4 space-x-2 mb-[20]">
       {tokens.map((token) => (
-        <CommunityCollectorsGridItem key={token.dbid} tokenRef={token} />
+        <CommunityCollectorsGridItem key={token.dbid} queryRef={query} tokenRef={token} />
       ))}
     </View>
   );

--- a/apps/mobile/src/components/Feed/EventTokenGrid.tsx
+++ b/apps/mobile/src/components/Feed/EventTokenGrid.tsx
@@ -238,7 +238,15 @@ export function EventTokenGrid({
     } else {
       throw new Error('Tried to render EventTokenGrid without any tokens');
     }
-  }, [collectionTokens, fullHeight, fullWidth, handlePress, imagePriority, preserveAspectRatio]);
+  }, [
+    collectionTokens,
+    fullHeight,
+    fullWidth,
+    handlePress,
+    imagePriority,
+    preserveAspectRatio,
+    query,
+  ]);
 
   return (
     <View className="flex flex-1 flex-col pt-1" style={{ width: dimensions.width }}>

--- a/apps/mobile/src/components/Feed/EventTokenGrid.tsx
+++ b/apps/mobile/src/components/Feed/EventTokenGrid.tsx
@@ -10,6 +10,7 @@ import {
   EventTokenGridFragment$data,
   EventTokenGridFragment$key,
 } from '~/generated/EventTokenGridFragment.graphql';
+import { EventTokenGridQueryFragment$key } from '~/generated/EventTokenGridQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { getPreviewImageUrlsInlineDangerously } from '~/shared/relay/getPreviewImageUrlsInlineDangerously';
 
@@ -17,6 +18,7 @@ import { NftPreviewWithBoundary } from '../NftPreview/NftPreview';
 import { DOUBLE_TAP_WINDOW } from './constants';
 
 type EventTokenGridProps = {
+  queryRef: EventTokenGridQueryFragment$key;
   imagePriority: Priority;
   allowPreserveAspectRatio: boolean;
   collectionTokenRefs: EventTokenGridFragment$key;
@@ -25,11 +27,21 @@ type EventTokenGridProps = {
 };
 
 export function EventTokenGrid({
+  queryRef,
   collectionTokenRefs,
   allowPreserveAspectRatio,
   imagePriority,
   onDoubleTap,
 }: EventTokenGridProps) {
+  const query = useFragment(
+    graphql`
+      fragment EventTokenGridQueryFragment on Query {
+        ...NftPreviewWithBoundaryQueryFragment
+      }
+    `,
+    queryRef
+  );
+
   const collectionTokens = useFragment(
     graphql`
       fragment EventTokenGridFragment on CollectionToken @relay(plural: true) {
@@ -136,6 +148,7 @@ export function EventTokenGrid({
           <HalfHeightRow>
             <QuarterCell>
               <NftPreviewWithBoundary
+                queryRef={query}
                 onPress={() => handlePress(firstToken, firstToken.medium)}
                 priority={imagePriority}
                 resizeMode={ResizeMode.COVER}
@@ -145,6 +158,7 @@ export function EventTokenGrid({
             </QuarterCell>
             <QuarterCell>
               <NftPreviewWithBoundary
+                queryRef={query}
                 onPress={() => handlePress(secondToken, secondToken.medium)}
                 priority={imagePriority}
                 resizeMode={ResizeMode.COVER}
@@ -157,6 +171,7 @@ export function EventTokenGrid({
           <HalfHeightRow>
             <QuarterCell>
               <NftPreviewWithBoundary
+                queryRef={query}
                 onPress={() => handlePress(thirdToken, thirdToken.medium)}
                 priority={imagePriority}
                 resizeMode={ResizeMode.COVER}
@@ -166,6 +181,7 @@ export function EventTokenGrid({
             </QuarterCell>
             <QuarterCell>
               <NftPreviewWithBoundary
+                queryRef={query}
                 onPress={() => handlePress(fourthToken, fourthToken.medium)}
                 priority={imagePriority}
                 resizeMode={ResizeMode.COVER}
@@ -181,6 +197,7 @@ export function EventTokenGrid({
         <HalfHeightRow>
           <QuarterCell>
             <NftPreviewWithBoundary
+              queryRef={query}
               onPress={() => handlePress(firstToken, firstToken.large)}
               priority={imagePriority}
               resizeMode={ResizeMode.COVER}
@@ -190,6 +207,7 @@ export function EventTokenGrid({
           </QuarterCell>
           <QuarterCell>
             <NftPreviewWithBoundary
+              queryRef={query}
               onPress={() => handlePress(secondToken, secondToken.large)}
               priority={imagePriority}
               resizeMode={ResizeMode.COVER}
@@ -208,6 +226,7 @@ export function EventTokenGrid({
           }}
         >
           <NftPreviewWithBoundary
+            queryRef={query}
             onPress={() => handlePress(firstToken, firstToken.large)}
             resizeMode={preserveAspectRatio ? ResizeMode.CONTAIN : ResizeMode.COVER}
             priority={imagePriority}

--- a/apps/mobile/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionCreatedFeedEvent.tsx
@@ -7,6 +7,7 @@ import { graphql } from 'relay-runtime';
 
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { CollectionCreatedFeedEventFragment$key } from '~/generated/CollectionCreatedFeedEventFragment.graphql';
+import { CollectionCreatedFeedEventQueryFragment$key } from '~/generated/CollectionCreatedFeedEventQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
@@ -17,6 +18,7 @@ import { FeedEventCarouselCellHeader } from '../FeedEventCarouselCellHeader';
 import { FeedListCollectorsNote } from '../FeedListCollectorsNote';
 
 type CollectionCreatedFeedEventProps = {
+  queryRef: CollectionCreatedFeedEventQueryFragment$key;
   isFirstSlide: boolean;
   allowPreserveAspectRatio: boolean;
   collectionUpdatedFeedEventDataRef: CollectionCreatedFeedEventFragment$key;
@@ -24,11 +26,20 @@ type CollectionCreatedFeedEventProps = {
 };
 
 export function CollectionCreatedFeedEvent({
+  queryRef,
   isFirstSlide,
   allowPreserveAspectRatio,
   collectionUpdatedFeedEventDataRef,
   onDoubleTap,
 }: CollectionCreatedFeedEventProps) {
+  const query = useFragment(
+    graphql`
+      fragment CollectionCreatedFeedEventQueryFragment on Query {
+        ...EventTokenGridQueryFragment
+      }
+    `,
+    queryRef
+  );
   const eventData = useFragment(
     graphql`
       fragment CollectionCreatedFeedEventFragment on CollectionCreatedFeedEventData {
@@ -86,6 +97,7 @@ export function CollectionCreatedFeedEvent({
 
       <View className="flex flex-grow">
         <EventTokenGrid
+          queryRef={query}
           onDoubleTap={onDoubleTap}
           imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
           allowPreserveAspectRatio={allowPreserveAspectRatio}

--- a/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectionUpdatedFeedEvent.tsx
@@ -7,6 +7,7 @@ import { graphql } from 'relay-runtime';
 
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { CollectionUpdatedFeedEventFragment$key } from '~/generated/CollectionUpdatedFeedEventFragment.graphql';
+import { CollectionUpdatedFeedEventQueryFragment$key } from '~/generated/CollectionUpdatedFeedEventQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
@@ -17,6 +18,7 @@ import { FeedEventCarouselCellHeader } from '../FeedEventCarouselCellHeader';
 import { FeedListCollectorsNote } from '../FeedListCollectorsNote';
 
 type CollectionUpdatedFeedEventProps = {
+  queryRef: CollectionUpdatedFeedEventQueryFragment$key;
   isFirstSlide: boolean;
   allowPreserveAspectRatio: boolean;
   collectionUpdatedFeedEventDataRef: CollectionUpdatedFeedEventFragment$key;
@@ -24,11 +26,20 @@ type CollectionUpdatedFeedEventProps = {
 };
 
 export function CollectionUpdatedFeedEvent({
+  queryRef,
   isFirstSlide,
   allowPreserveAspectRatio,
   collectionUpdatedFeedEventDataRef,
   onDoubleTap,
 }: CollectionUpdatedFeedEventProps) {
+  const query = useFragment(
+    graphql`
+      fragment CollectionUpdatedFeedEventQueryFragment on Query {
+        ...EventTokenGridQueryFragment
+      }
+    `,
+    queryRef
+  );
   const eventData = useFragment(
     graphql`
       fragment CollectionUpdatedFeedEventFragment on CollectionUpdatedFeedEventData {
@@ -87,6 +98,7 @@ export function CollectionUpdatedFeedEvent({
 
       <View className="flex flex-grow">
         <EventTokenGrid
+          queryRef={query}
           onDoubleTap={onDoubleTap}
           imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
           allowPreserveAspectRatio={allowPreserveAspectRatio}

--- a/apps/mobile/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/CollectorsNoteAddedToCollectionFeedEvent.tsx
@@ -7,6 +7,7 @@ import { graphql } from 'relay-runtime';
 
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { CollectorsNoteAddedToCollectionFeedEventFragment$key } from '~/generated/CollectorsNoteAddedToCollectionFeedEventFragment.graphql';
+import { CollectorsNoteAddedToCollectionFeedEventQueryFragment$key } from '~/generated/CollectorsNoteAddedToCollectionFeedEventQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
@@ -17,6 +18,7 @@ import { FeedEventCarouselCellHeader } from '../FeedEventCarouselCellHeader';
 import { FeedListCollectorsNote } from '../FeedListCollectorsNote';
 
 type CollectorsNoteAddedToCollectionFeedEventProps = {
+  queryRef: CollectorsNoteAddedToCollectionFeedEventQueryFragment$key;
   isFirstSlide: boolean;
   allowPreserveAspectRatio: boolean;
   collectionUpdatedFeedEventDataRef: CollectorsNoteAddedToCollectionFeedEventFragment$key;
@@ -24,11 +26,20 @@ type CollectorsNoteAddedToCollectionFeedEventProps = {
 };
 
 export function CollectorsNoteAddedToCollectionFeedEvent({
+  queryRef,
   isFirstSlide,
   allowPreserveAspectRatio,
   collectionUpdatedFeedEventDataRef,
   onDoubleTap,
 }: CollectorsNoteAddedToCollectionFeedEventProps) {
+  const query = useFragment(
+    graphql`
+      fragment CollectorsNoteAddedToCollectionFeedEventQueryFragment on Query {
+        ...EventTokenGridQueryFragment
+      }
+    `,
+    queryRef
+  );
   const eventData = useFragment(
     graphql`
       fragment CollectorsNoteAddedToCollectionFeedEventFragment on CollectorsNoteAddedToCollectionFeedEventData {
@@ -87,6 +98,7 @@ export function CollectorsNoteAddedToCollectionFeedEvent({
 
       <View className="flex flex-grow">
         <EventTokenGrid
+          queryRef={query}
           onDoubleTap={onDoubleTap}
           imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
           allowPreserveAspectRatio={allowPreserveAspectRatio}

--- a/apps/mobile/src/components/Feed/Events/GalleryUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/GalleryUpdatedFeedEvent.tsx
@@ -112,7 +112,7 @@ export function GalleryUpdatedFeedEvent({
     } else {
       return inner;
     }
-  }, [eventId, handleScroll, isPaginated, onAdmire, subEvents, width]);
+  }, [eventId, handleScroll, isPaginated, onAdmire, query, subEvents, width]);
 
   return (
     <View className="flex flex-col space-y-3">

--- a/apps/mobile/src/components/Feed/Events/GalleryUpdatedFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/GalleryUpdatedFeedEvent.tsx
@@ -12,21 +12,33 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
 import { GalleryUpdatedFeedEventFragment$key } from '~/generated/GalleryUpdatedFeedEventFragment.graphql';
+import { GalleryUpdatedFeedEventQueryFragment$key } from '~/generated/GalleryUpdatedFeedEventQueryFragment.graphql';
 
 import { SUPPORTED_FEED_EVENT_TYPES } from '../constants';
 import { NonRecursiveFeedListItem } from './NonRecursiveFeedListItem';
 
 type GalleryUpdatedFeedEventProps = {
+  queryRef: GalleryUpdatedFeedEventQueryFragment$key;
   eventId: string;
   eventDataRef: GalleryUpdatedFeedEventFragment$key;
   onAdmire: () => void;
 };
 
 export function GalleryUpdatedFeedEvent({
+  queryRef,
   eventDataRef,
   eventId,
   onAdmire,
 }: GalleryUpdatedFeedEventProps) {
+  const query = useFragment(
+    graphql`
+      fragment GalleryUpdatedFeedEventQueryFragment on Query {
+        ...NonRecursiveFeedListItemQueryFragment
+      }
+    `,
+    queryRef
+  );
+
   const eventData = useFragment(
     graphql`
       fragment GalleryUpdatedFeedEventFragment on GalleryUpdatedFeedEventData {
@@ -69,6 +81,7 @@ export function GalleryUpdatedFeedEvent({
     const inner = subEvents.map((subEvent, index) => {
       return (
         <NonRecursiveFeedListItem
+          queryRef={query}
           key={index}
           onAdmire={onAdmire}
           eventId={eventId}

--- a/apps/mobile/src/components/Feed/Events/NonRecursiveFeedListItem.tsx
+++ b/apps/mobile/src/components/Feed/Events/NonRecursiveFeedListItem.tsx
@@ -126,7 +126,7 @@ export function NonRecursiveFeedListItem({
       default:
         throw new TriedToRenderUnsupportedFeedEvent(eventId);
     }
-  }, [eventCount, eventData, eventId, onAdmire, slideIndex]);
+  }, [eventCount, eventData, eventId, onAdmire, query, slideIndex]);
 
   return (
     <View className="flex-1" style={{ width }}>

--- a/apps/mobile/src/components/Feed/Events/NonRecursiveFeedListItem.tsx
+++ b/apps/mobile/src/components/Feed/Events/NonRecursiveFeedListItem.tsx
@@ -4,6 +4,7 @@ import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
 import { NonRecursiveFeedListItemFragment$key } from '~/generated/NonRecursiveFeedListItemFragment.graphql';
+import { NonRecursiveFeedListItemQueryFragment$key } from '~/generated/NonRecursiveFeedListItemQueryFragment.graphql';
 import { TriedToRenderUnsupportedFeedEvent } from '~/shared/errors/TriedToRenderUnsupportedFeedEvent';
 
 import { CollectionCreatedFeedEvent } from './CollectionCreatedFeedEvent';
@@ -13,6 +14,7 @@ import { TokensAddedToCollectionFeedEvent } from './TokensAddedToCollectionFeedE
 import { UserFollowedUsersFeedEvent } from './UserFollowedUsersFeedEvent';
 
 type NonRecursiveFeedListItemProps = {
+  queryRef: NonRecursiveFeedListItemQueryFragment$key;
   eventId: string;
   slideIndex: number;
   eventCount: number;
@@ -21,12 +23,24 @@ type NonRecursiveFeedListItemProps = {
 };
 
 export function NonRecursiveFeedListItem({
+  queryRef,
   eventId,
   eventDataRef,
   eventCount,
   slideIndex,
   onAdmire,
 }: NonRecursiveFeedListItemProps) {
+  const query = useFragment(
+    graphql`
+      fragment NonRecursiveFeedListItemQueryFragment on Query {
+        ...CollectorsNoteAddedToCollectionFeedEventQueryFragment
+        ...CollectionUpdatedFeedEventQueryFragment
+        ...CollectionCreatedFeedEventQueryFragment
+        ...TokensAddedToCollectionFeedEventQueryFragment
+      }
+    `,
+    queryRef
+  );
   const eventData = useFragment(
     graphql`
       fragment NonRecursiveFeedListItemFragment on FeedEventData {
@@ -70,6 +84,7 @@ export function NonRecursiveFeedListItem({
       case 'CollectorsNoteAddedToCollectionFeedEventData':
         return (
           <CollectorsNoteAddedToCollectionFeedEvent
+            queryRef={query}
             onDoubleTap={onAdmire}
             isFirstSlide={slideIndex === 0}
             allowPreserveAspectRatio={allowPreserveAspectRatio}
@@ -79,6 +94,7 @@ export function NonRecursiveFeedListItem({
       case 'CollectionUpdatedFeedEventData':
         return (
           <CollectionUpdatedFeedEvent
+            queryRef={query}
             onDoubleTap={onAdmire}
             isFirstSlide={slideIndex === 0}
             allowPreserveAspectRatio={allowPreserveAspectRatio}
@@ -88,6 +104,7 @@ export function NonRecursiveFeedListItem({
       case 'CollectionCreatedFeedEventData':
         return (
           <CollectionCreatedFeedEvent
+            queryRef={query}
             onDoubleTap={onAdmire}
             isFirstSlide={slideIndex === 0}
             allowPreserveAspectRatio={allowPreserveAspectRatio}
@@ -97,6 +114,7 @@ export function NonRecursiveFeedListItem({
       case 'TokensAddedToCollectionFeedEventData':
         return (
           <TokensAddedToCollectionFeedEvent
+            queryRef={query}
             onDoubleTap={onAdmire}
             isFirstSlide={slideIndex === 0}
             allowPreserveAspectRatio={allowPreserveAspectRatio}

--- a/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/TokensAddedToCollectionFeedEvent.tsx
@@ -7,6 +7,7 @@ import { graphql } from 'relay-runtime';
 
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { TokensAddedToCollectionFeedEventFragment$key } from '~/generated/TokensAddedToCollectionFeedEventFragment.graphql';
+import { TokensAddedToCollectionFeedEventQueryFragment$key } from '~/generated/TokensAddedToCollectionFeedEventQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
@@ -17,6 +18,7 @@ import { EventTokenGrid } from '../EventTokenGrid';
 import { FeedEventCarouselCellHeader } from '../FeedEventCarouselCellHeader';
 
 type TokensAddedToCollectionFeedEventProps = {
+  queryRef: TokensAddedToCollectionFeedEventQueryFragment$key;
   isFirstSlide: boolean;
   allowPreserveAspectRatio: boolean;
   collectionUpdatedFeedEventDataRef: TokensAddedToCollectionFeedEventFragment$key;
@@ -24,11 +26,21 @@ type TokensAddedToCollectionFeedEventProps = {
 };
 
 export function TokensAddedToCollectionFeedEvent({
+  queryRef,
   isFirstSlide,
   allowPreserveAspectRatio,
   collectionUpdatedFeedEventDataRef,
   onDoubleTap,
 }: TokensAddedToCollectionFeedEventProps) {
+  const query = useFragment(
+    graphql`
+      fragment TokensAddedToCollectionFeedEventQueryFragment on Query {
+        ...EventTokenGridQueryFragment
+      }
+    `,
+    queryRef
+  );
+
   const eventData = useFragment(
     graphql`
       fragment TokensAddedToCollectionFeedEventFragment on TokensAddedToCollectionFeedEventData {
@@ -93,6 +105,7 @@ export function TokensAddedToCollectionFeedEvent({
 
       <View className="flex flex-grow">
         <EventTokenGrid
+          queryRef={query}
           onDoubleTap={onDoubleTap}
           imagePriority={isFirstSlide ? FastImage.priority.high : FastImage.priority.normal}
           allowPreserveAspectRatio={allowPreserveAspectRatio}

--- a/apps/mobile/src/components/Feed/FeedListItem.tsx
+++ b/apps/mobile/src/components/Feed/FeedListItem.tsx
@@ -22,6 +22,8 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
     graphql`
       fragment FeedListItemQueryFragment on Query {
         ...useToggleAdmireQueryFragment
+        ...NonRecursiveFeedListItemQueryFragment
+        ...GalleryUpdatedFeedEventQueryFragment
       }
     `,
     queryRef
@@ -70,6 +72,7 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
     if (event.eventData.__typename === 'GalleryUpdatedFeedEventData') {
       return (
         <GalleryUpdatedFeedEvent
+          queryRef={query}
           onAdmire={handleAdmire}
           eventId={eventId}
           eventDataRef={event.eventData}
@@ -80,6 +83,7 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
     return (
       <View className="overflow-hidden">
         <NonRecursiveFeedListItem
+          queryRef={query}
           onAdmire={handleAdmire}
           eventId={eventId}
           slideIndex={0}
@@ -88,7 +92,7 @@ export function FeedListItem({ eventId, queryRef, eventDataRef }: FeedListItemPr
         />
       </View>
     );
-  }, [event.eventData, eventId, handleAdmire]);
+  }, [event.eventData, eventId, handleAdmire, query]);
 
   return <View>{inner}</View>;
 }

--- a/apps/mobile/src/components/Feed/Posts/PostListItem.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostListItem.tsx
@@ -65,6 +65,7 @@ export function PostListItem({ feedPostRef, queryRef }: Props) {
     graphql`
       fragment PostListItemQueryFragment on Query {
         ...useTogglePostAdmireQueryFragment
+        ...UniversalNftPreviewWithBoundaryQueryFragment
       }
     `,
     queryRef
@@ -175,6 +176,7 @@ export function PostListItem({ feedPostRef, queryRef }: Props) {
     }
     return (
       <UniversalNftPreviewWithBoundary
+        queryRef={query}
         tokenRef={firstToken}
         onPress={handlePress}
         resizeMode={ResizeMode.CONTAIN}
@@ -182,7 +184,7 @@ export function PostListItem({ feedPostRef, queryRef }: Props) {
         size="large"
       />
     );
-  }, [firstToken, handleError, handleLoad, handlePress, imageUrl, resultDimensions]);
+  }, [firstToken, handleError, handleLoad, handlePress, imageUrl, query, resultDimensions]);
 
   return (
     <View className="flex flex-1 flex-col pt-1" style={{ width: dimensions.width }}>

--- a/apps/mobile/src/components/Gallery/CollectionVirtualizedRow.tsx
+++ b/apps/mobile/src/components/Gallery/CollectionVirtualizedRow.tsx
@@ -1,18 +1,29 @@
 import clsx from 'clsx';
 import { useWindowDimensions, View } from 'react-native';
+import { graphql, useFragment } from 'react-relay';
 
 import { WhitespaceBlock } from '~/components/Gallery/createVirtualizedCollectionRows';
 import { GalleryTokenPreview } from '~/components/Gallery/GalleryTokenPreview';
+import { CollectionVirtualizedRowQueryFragment$key } from '~/generated/CollectionVirtualizedRowQueryFragment.graphql';
 import { GalleryTokenPreviewFragment$key } from '~/generated/GalleryTokenPreviewFragment.graphql';
 
 type CollectionRowProps = {
+  queryRef: CollectionVirtualizedRowQueryFragment$key;
   isFirst: boolean;
   isLast: boolean;
   columns: number;
   items: Array<WhitespaceBlock | GalleryTokenPreviewFragment$key>;
 };
 
-export function CollectionRow({ columns, items, isFirst, isLast }: CollectionRowProps) {
+export function CollectionRow({ queryRef, columns, items, isFirst, isLast }: CollectionRowProps) {
+  const query = useFragment(
+    graphql`
+      fragment CollectionVirtualizedRowQueryFragment on Query {
+        ...GalleryTokenPreviewQueryFragment
+      }
+    `,
+    queryRef
+  );
   const horizontalRowPadding = 16;
   const inBetweenColumnPadding = 8;
 
@@ -46,7 +57,11 @@ export function CollectionRow({ columns, items, isFirst, isLast }: CollectionRow
               <View className="aspect-square w-full" style={{ width: widthPerToken }} />
             ) : (
               <View className="flex items-center justify-center ">
-                <GalleryTokenPreview containerWidth={widthPerToken} tokenRef={item} />
+                <GalleryTokenPreview
+                  queryRef={query}
+                  containerWidth={widthPerToken}
+                  tokenRef={item}
+                />
               </View>
             )}
           </View>

--- a/apps/mobile/src/components/Gallery/GalleryTokenPreview.tsx
+++ b/apps/mobile/src/components/Gallery/GalleryTokenPreview.tsx
@@ -6,6 +6,7 @@ import { graphql } from 'relay-runtime';
 
 import { NftPreviewWithBoundary } from '~/components/NftPreview/NftPreview';
 import { GalleryTokenPreviewFragment$key } from '~/generated/GalleryTokenPreviewFragment.graphql';
+import { GalleryTokenPreviewQueryFragment$key } from '~/generated/GalleryTokenPreviewQueryFragment.graphql';
 import { Dimensions } from '~/screens/NftDetailScreen/NftDetailAsset/types';
 import { getPreviewImageUrlsInlineDangerously } from '~/shared/relay/getPreviewImageUrlsInlineDangerously';
 import { fitDimensionsToContainerContain } from '~/shared/utils/fitDimensionsToContainer';
@@ -13,11 +14,24 @@ import { fitDimensionsToContainerContain } from '~/shared/utils/fitDimensionsToC
 import { ImageState } from '../NftPreview/UniversalNftPreview';
 
 type GalleryTokenPreviewProps = {
+  queryRef: GalleryTokenPreviewQueryFragment$key;
   tokenRef: GalleryTokenPreviewFragment$key;
   containerWidth: number;
 };
 
-export function GalleryTokenPreview({ tokenRef, containerWidth }: GalleryTokenPreviewProps) {
+export function GalleryTokenPreview({
+  queryRef,
+  tokenRef,
+  containerWidth,
+}: GalleryTokenPreviewProps) {
+  const query = useFragment(
+    graphql`
+      fragment GalleryTokenPreviewQueryFragment on Query {
+        ...NftPreviewWithBoundaryQueryFragment
+      }
+    `,
+    queryRef
+  );
   const token = useFragment(
     graphql`
       fragment GalleryTokenPreviewFragment on CollectionToken {
@@ -103,6 +117,7 @@ export function GalleryTokenPreview({ tokenRef, containerWidth }: GalleryTokenPr
       style={resultDimensions ? resultDimensions : { width: containerWidth, aspectRatio: 1 }}
     >
       <NftPreviewWithBoundary
+        queryRef={query}
         onImageStateChange={handleImageStateChange}
         collectionTokenRef={token}
         resizeMode={ResizeMode.CONTAIN}

--- a/apps/mobile/src/components/Gallery/GalleryVirtualizedRow.tsx
+++ b/apps/mobile/src/components/Gallery/GalleryVirtualizedRow.tsx
@@ -1,10 +1,12 @@
 import { useNavigation } from '@react-navigation/native';
 import { View } from 'react-native';
+import { graphql, useFragment } from 'react-relay';
 
 import { CollectionRow } from '~/components/Gallery/CollectionVirtualizedRow';
 import { GalleryListItemType } from '~/components/Gallery/createVirtualizedGalleryRows';
 import { Markdown } from '~/components/Markdown';
 import { Typography } from '~/components/Typography';
+import { GalleryVirtualizedRowQueryFragment$key } from '~/generated/GalleryVirtualizedRowQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 import unescape from '~/shared/utils/unescape';
@@ -12,11 +14,20 @@ import unescape from '~/shared/utils/unescape';
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
 
 type Props = {
+  queryRef: GalleryVirtualizedRowQueryFragment$key;
   item: GalleryListItemType;
   isOnCollectionScreen?: boolean;
 };
 
-export function GalleryVirtualizedRow({ item, isOnCollectionScreen }: Props) {
+export function GalleryVirtualizedRow({ queryRef, item, isOnCollectionScreen }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment GalleryVirtualizedRowQueryFragment on Query {
+        ...CollectionVirtualizedRowQueryFragment
+      }
+    `,
+    queryRef
+  );
   const navigation = useNavigation<MainTabStackNavigatorProp>();
 
   if (item.kind === 'gallery-header') {
@@ -77,6 +88,7 @@ export function GalleryVirtualizedRow({ item, isOnCollectionScreen }: Props) {
   } else if (item.kind === 'collection-row') {
     return (
       <CollectionRow
+        queryRef={query}
         columns={item.columns}
         isLast={item.isLast}
         isFirst={item.isFirst}

--- a/apps/mobile/src/components/GalleryTabs/GalleryTabBar.tsx
+++ b/apps/mobile/src/components/GalleryTabs/GalleryTabBar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { Text, View, ScrollView } from 'react-native';
+import { ScrollView, Text, View } from 'react-native';
 
 import { GalleryElementTrackingProps } from '~/shared/contexts/AnalyticsContext';
 

--- a/apps/mobile/src/components/GalleryTabs/GalleryTabBar.tsx
+++ b/apps/mobile/src/components/GalleryTabs/GalleryTabBar.tsx
@@ -1,5 +1,5 @@
-import { useCallback } from 'react';
-import { Text, View } from 'react-native';
+import { useCallback, useMemo } from 'react';
+import { Text, View, ScrollView } from 'react-native';
 
 import { GalleryElementTrackingProps } from '~/shared/contexts/AnalyticsContext';
 
@@ -72,23 +72,33 @@ export function GalleryTabBar({
   activeRoute,
   onRouteChange,
 }: Props) {
+  const Tabs = useMemo(() => {
+    return routes.map((route) => {
+      return (
+        <TabItem
+          key={route.name}
+          route={route.name}
+          onRouteChange={onRouteChange}
+          activeRoute={activeRoute}
+          counter={route.counter}
+          eventElementId={eventElementId}
+          eventName={eventName}
+          eventContext={eventContext}
+          eventFlow={eventFlow}
+        />
+      );
+    });
+  }, [activeRoute, eventContext, eventElementId, eventFlow, eventName, onRouteChange, routes]);
   return (
     <View className="border-porcelain dark:border-black-500 mt-4 flex flex-row items-center justify-center border-t border-b px-2 py-3">
-      {routes.map((route) => {
-        return (
-          <TabItem
-            key={route.name}
-            route={route.name}
-            onRouteChange={onRouteChange}
-            activeRoute={activeRoute}
-            counter={route.counter}
-            eventElementId={eventElementId}
-            eventName={eventName}
-            eventContext={eventContext}
-            eventFlow={eventFlow}
-          />
-        );
-      })}
+      {/* ScrollView doesnt have a built in way to center the tabs if it doesnt overflow, so only use ScrollView if there are more than 4 tabs */}
+      {routes.length > 4 ? (
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          {Tabs}
+        </ScrollView>
+      ) : (
+        Tabs
+      )}
     </View>
   );
 }

--- a/apps/mobile/src/components/Login/WalletSelectorBottomSheet.tsx
+++ b/apps/mobile/src/components/Login/WalletSelectorBottomSheet.tsx
@@ -129,7 +129,7 @@ function WalletSelectorBottomSheet(
           </View>
         </View>
       </GalleryBottomSheetModal>
-      {/* <WalletConnectModal projectId={projectId} providerMetadata={providerMetadata} /> */}
+      <WalletConnectModal projectId={projectId} providerMetadata={providerMetadata} />
     </>
   );
 }

--- a/apps/mobile/src/components/Login/WalletSelectorBottomSheet.tsx
+++ b/apps/mobile/src/components/Login/WalletSelectorBottomSheet.tsx
@@ -129,7 +129,7 @@ function WalletSelectorBottomSheet(
           </View>
         </View>
       </GalleryBottomSheetModal>
-      <WalletConnectModal projectId={projectId} providerMetadata={providerMetadata} />
+      {/* <WalletConnectModal projectId={projectId} providerMetadata={providerMetadata} /> */}
     </>
   );
 }

--- a/apps/mobile/src/components/NftPreview/NftPreview.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreview.tsx
@@ -9,7 +9,10 @@ import { RawNftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
 import { NftPreviewContextMenuPopup } from '~/components/NftPreview/NftPreviewContextMenuPopup';
 import { NftPreviewFragment$key } from '~/generated/NftPreviewFragment.graphql';
 import { NftPreviewInnerFragment$key } from '~/generated/NftPreviewInnerFragment.graphql';
+import { NftPreviewInnerQueryFragment$key } from '~/generated/NftPreviewInnerQueryFragment.graphql';
+import { NftPreviewQueryFragment$key } from '~/generated/NftPreviewQueryFragment.graphql';
 import { NftPreviewWithBoundaryFragment$key } from '~/generated/NftPreviewWithBoundaryFragment.graphql';
+import { NftPreviewWithBoundaryQueryFragment$key } from '~/generated/NftPreviewWithBoundaryQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { Dimensions } from '~/screens/NftDetailScreen/NftDetailAsset/types';
 import { CouldNotRenderNftError } from '~/shared/errors/CouldNotRenderNftError';
@@ -24,19 +27,28 @@ import { GallerySkeleton } from '../GallerySkeleton';
 import { ImageState, NftPreviewSharedProps } from './UniversalNftPreview';
 
 type NftPreviewInnerProps = {
+  queryRef: NftPreviewInnerQueryFragment$key;
   collectionTokenRef: NftPreviewInnerFragment$key;
   tokenUrl: string | null | undefined;
 } & NftPreviewSharedProps;
 
 function NftPreviewInner({
+  queryRef,
   collectionTokenRef,
   tokenUrl,
   resizeMode,
   priority,
-
   onPress,
   onImageStateChange,
 }: NftPreviewInnerProps) {
+  const query = useFragment(
+    graphql`
+      fragment NftPreviewInnerQueryFragment on Query {
+        ...NftPreviewContextMenuPopupQueryFragment
+      }
+    `,
+    queryRef
+  );
   const collectionToken = useFragment(
     graphql`
       fragment NftPreviewInnerFragment on CollectionToken {
@@ -99,6 +111,7 @@ function NftPreviewInner({
 
   return (
     <NftPreviewContextMenuPopup
+      queryRef={query}
       fallbackTokenUrl={tokenUrl}
       collectionTokenRef={collectionToken}
       imageDimensions={imageState.kind === 'loaded' ? imageState.dimensions : null}
@@ -127,11 +140,20 @@ function NftPreviewInner({
 }
 
 type NftPreviewProps = {
+  queryRef: NftPreviewQueryFragment$key;
   collectionTokenRef: NftPreviewFragment$key;
   size: useGetSinglePreviewImageProps['size'];
 } & NftPreviewSharedProps;
 
-function NftPreview({ collectionTokenRef, size, ...props }: NftPreviewProps) {
+function NftPreview({ queryRef, collectionTokenRef, size, ...props }: NftPreviewProps) {
+  const query = useFragment(
+    graphql`
+      fragment NftPreviewQueryFragment on Query {
+        ...NftPreviewInnerQueryFragment
+      }
+    `,
+    queryRef
+  );
   const collectionToken = useFragment(
     graphql`
       fragment NftPreviewFragment on CollectionToken {
@@ -150,15 +172,24 @@ function NftPreview({ collectionTokenRef, size, ...props }: NftPreviewProps) {
 
   const imageUrl = useGetSinglePreviewImage({ tokenRef: collectionToken.token, size }) ?? '';
 
-  return <NftPreviewInner {...props} collectionTokenRef={collectionToken} tokenUrl={imageUrl} />;
+  return (
+    <NftPreviewInner
+      {...props}
+      queryRef={query}
+      collectionTokenRef={collectionToken}
+      tokenUrl={imageUrl}
+    />
+  );
 }
 
 type NftPreviewWithBoundaryProps = {
+  queryRef: NftPreviewWithBoundaryQueryFragment$key;
   collectionTokenRef: NftPreviewWithBoundaryFragment$key;
   size: useGetSinglePreviewImageProps['size'];
 } & NftPreviewSharedProps;
 
 export function NftPreviewWithBoundary({
+  queryRef,
   collectionTokenRef,
   onImageStateChange,
   resizeMode,
@@ -166,6 +197,14 @@ export function NftPreviewWithBoundary({
   onPress,
   size,
 }: NftPreviewWithBoundaryProps) {
+  const query = useFragment(
+    graphql`
+      fragment NftPreviewWithBoundaryQueryFragment on Query {
+        ...NftPreviewQueryFragment
+      }
+    `,
+    queryRef
+  );
   const collectionToken = useFragment(
     graphql`
       fragment NftPreviewWithBoundaryFragment on CollectionToken {
@@ -185,6 +224,7 @@ export function NftPreviewWithBoundary({
   return (
     <TokenFailureBoundary tokenRef={collectionToken.token}>
       <NftPreview
+        queryRef={query}
         collectionTokenRef={collectionToken}
         onPress={onPress}
         onImageStateChange={onImageStateChange}

--- a/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
@@ -123,7 +123,7 @@ export function NftPreviewContextMenuPopup({
       //   });
       // }
     },
-    [collectionToken.collection, fallbackTokenUrl, navigation, token]
+    [collectionToken.collection, fallbackTokenUrl, navigation, toggleTokenBookmark, token]
   );
 
   const track = useTrack();

--- a/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
+++ b/apps/mobile/src/components/NftPreview/NftPreviewContextMenuPopup.tsx
@@ -6,11 +6,13 @@ import { ContextMenuView, OnPressMenuItemEvent } from 'react-native-ios-context-
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
+import { useToggleTokenAdmire } from 'src/hooks/useToggleTokenAdmire';
 
 import { GallerySkeleton } from '~/components/GallerySkeleton';
 import { RawNftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
 import { Typography } from '~/components/Typography';
 import { NftPreviewContextMenuPopupFragment$key } from '~/generated/NftPreviewContextMenuPopupFragment.graphql';
+import { NftPreviewContextMenuPopupQueryFragment$key } from '~/generated/NftPreviewContextMenuPopupQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { Dimensions } from '~/screens/NftDetailScreen/NftDetailAsset/types';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
@@ -20,6 +22,7 @@ import { shareToken } from '../../utils/shareToken';
 import { TokenFailureBoundary } from '../Boundaries/TokenFailureBoundary/TokenFailureBoundary';
 
 type NftPreviewContextMenuPopupProps = PropsWithChildren<{
+  queryRef: NftPreviewContextMenuPopupQueryFragment$key;
   collectionTokenRef: NftPreviewContextMenuPopupFragment$key;
   imageDimensions: Dimensions | null;
   fallbackTokenUrl: string;
@@ -28,11 +31,20 @@ type NftPreviewContextMenuPopupProps = PropsWithChildren<{
 const ENABLED_ARTIST = false;
 
 export function NftPreviewContextMenuPopup({
+  queryRef,
   collectionTokenRef,
   imageDimensions,
   fallbackTokenUrl,
   children,
 }: NftPreviewContextMenuPopupProps) {
+  const query = useFragment(
+    graphql`
+      fragment NftPreviewContextMenuPopupQueryFragment on Query {
+        ...useToggleTokenAdmireQueryFragment
+      }
+    `,
+    queryRef
+  );
   const collectionToken = useFragment(
     graphql`
       fragment NftPreviewContextMenuPopupFragment on CollectionToken {
@@ -63,6 +75,7 @@ export function NftPreviewContextMenuPopup({
 
           ...shareTokenFragment
           ...TokenFailureBoundaryFragment
+          ...useToggleTokenAdmireFragment
         }
       }
     `,
@@ -82,6 +95,11 @@ export function NftPreviewContextMenuPopup({
     setPopupAssetLoaded(true);
   }, []);
 
+  const { hasViewerAdmiredEvent, toggleTokenAdmire: toggleTokenBookmark } = useToggleTokenAdmire({
+    tokenRef: token,
+    queryRef: query,
+  });
+
   const handleMenuItemPress = useCallback<OnPressMenuItemEvent>(
     (event) => {
       if (event.nativeEvent.actionKey === 'view-details') {
@@ -96,6 +114,8 @@ export function NftPreviewContextMenuPopup({
         navigation.push('Gallery', {
           galleryId: collectionToken.collection?.gallery?.dbid ?? 'not-found',
         });
+      } else if (event.nativeEvent.actionKey === 'bookmark') {
+        toggleTokenBookmark();
       }
       // else if (event.nativeEvent.actionKey === 'view-artist') {
       //   navigation.push('Profile', {
@@ -122,6 +142,10 @@ export function NftPreviewContextMenuPopup({
           {
             actionKey: 'view-details',
             actionTitle: 'View Details',
+          },
+          {
+            actionKey: 'bookmark',
+            actionTitle: hasViewerAdmiredEvent ? 'Remove from Bookmarks' : 'Add to Bookmarks',
           },
           {
             actionKey: 'view-gallery',

--- a/apps/mobile/src/components/NftPreview/UniversalNftPreview.tsx
+++ b/apps/mobile/src/components/NftPreview/UniversalNftPreview.tsx
@@ -9,7 +9,10 @@ import { graphql } from 'relay-runtime';
 import { RawNftPreviewAsset } from '~/components/NftPreview/NftPreviewAsset';
 import { UniversalNftPreviewFragment$key } from '~/generated/UniversalNftPreviewFragment.graphql';
 import { UniversalNftPreviewInnerFragment$key } from '~/generated/UniversalNftPreviewInnerFragment.graphql';
+import { UniversalNftPreviewInnerQueryFragment$key } from '~/generated/UniversalNftPreviewInnerQueryFragment.graphql';
+import { UniversalNftPreviewQueryFragment$key } from '~/generated/UniversalNftPreviewQueryFragment.graphql';
 import { UniversalNftPreviewWithBoundaryFragment$key } from '~/generated/UniversalNftPreviewWithBoundaryFragment.graphql';
+import { UniversalNftPreviewWithBoundaryQueryFragment$key } from '~/generated/UniversalNftPreviewWithBoundaryQueryFragment.graphql';
 import { Dimensions } from '~/screens/NftDetailScreen/NftDetailAsset/types';
 import { CouldNotRenderNftError } from '~/shared/errors/CouldNotRenderNftError';
 import {
@@ -32,11 +35,13 @@ export type NftPreviewSharedProps = {
 };
 
 type UniversalNftPreviewInnerProps = {
+  queryRef: UniversalNftPreviewInnerQueryFragment$key;
   tokenRef: UniversalNftPreviewInnerFragment$key;
   tokenUrl: string | null | undefined;
 } & NftPreviewSharedProps;
 
 function UniversalNftPreviewInner({
+  queryRef,
   tokenRef,
   tokenUrl,
   resizeMode,
@@ -44,6 +49,14 @@ function UniversalNftPreviewInner({
   onPress,
   onImageStateChange,
 }: UniversalNftPreviewInnerProps) {
+  const query = useFragment(
+    graphql`
+      fragment UniversalNftPreviewInnerQueryFragment on Query {
+        ...UniversalNftPreviewContextMenuPopupQueryFragment
+      }
+    `,
+    queryRef
+  );
   const token = useFragment(
     graphql`
       fragment UniversalNftPreviewInnerFragment on Token {
@@ -116,11 +129,20 @@ function UniversalNftPreviewInner({
 }
 
 type UniversalNftPreviewProps = {
+  queryRef: UniversalNftPreviewQueryFragment$key;
   tokenRef: UniversalNftPreviewFragment$key;
   size: useGetSinglePreviewImageProps['size'];
 } & NftPreviewSharedProps;
 
-function UniversalNftPreview({ tokenRef, size, ...props }: UniversalNftPreviewProps) {
+function UniversalNftPreview({ queryRef, tokenRef, size, ...props }: UniversalNftPreviewProps) {
+  const query = useFragment(
+    graphql`
+      fragment UniversalNftPreviewQueryFragment on Query {
+        ...UniversalNftPreviewInnerQueryFragment
+      }
+    `,
+    queryRef
+  );
   const token = useFragment(
     graphql`
       fragment UniversalNftPreviewFragment on Token {
@@ -133,15 +155,19 @@ function UniversalNftPreview({ tokenRef, size, ...props }: UniversalNftPreviewPr
 
   const imageUrl = useGetSinglePreviewImage({ tokenRef: token, size }) ?? '';
 
-  return <UniversalNftPreviewInner {...props} tokenRef={token} tokenUrl={imageUrl} />;
+  return (
+    <UniversalNftPreviewInner {...props} queryRef={query} tokenRef={token} tokenUrl={imageUrl} />
+  );
 }
 
 type UniversalNftPreviewWithBoundaryProps = {
+  queryRef: UniversalNftPreviewWithBoundaryQueryFragment$key;
   tokenRef: UniversalNftPreviewWithBoundaryFragment$key;
   size: useGetSinglePreviewImageProps['size'];
 } & NftPreviewSharedProps;
 
 export function UniversalNftPreviewWithBoundary({
+  queryRef,
   tokenRef,
   onImageStateChange,
   resizeMode,
@@ -149,6 +175,14 @@ export function UniversalNftPreviewWithBoundary({
   onPress,
   size,
 }: UniversalNftPreviewWithBoundaryProps) {
+  const query = useFragment(
+    graphql`
+      fragment UniversalNftPreviewWithBoundaryQueryFragment on Query {
+        ...UniversalNftPreviewQueryFragment
+      }
+    `,
+    queryRef
+  );
   const token = useFragment(
     graphql`
       fragment UniversalNftPreviewWithBoundaryFragment on Token {
@@ -162,6 +196,7 @@ export function UniversalNftPreviewWithBoundary({
   return (
     <TokenFailureBoundary tokenRef={token}>
       <UniversalNftPreview
+        queryRef={query}
         tokenRef={token}
         onPress={onPress}
         onImageStateChange={onImageStateChange}

--- a/apps/mobile/src/components/NftPreview/UniversalNftPreview.tsx
+++ b/apps/mobile/src/components/NftPreview/UniversalNftPreview.tsx
@@ -87,6 +87,7 @@ function UniversalNftPreviewInner({
 
   return (
     <UniversalNftPreviewContextMenuPopup
+      queryRef={query}
       tokenRef={token}
       fallbackTokenUrl={tokenUrl}
       imageDimensions={imageState.kind === 'loaded' ? imageState.dimensions : null}

--- a/apps/mobile/src/components/NftPreview/UniversalNftPreviewContextMenuPopup.tsx
+++ b/apps/mobile/src/components/NftPreview/UniversalNftPreviewContextMenuPopup.tsx
@@ -18,6 +18,7 @@ import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import { fitDimensionsToContainerCover } from '~/shared/utils/fitDimensionsToContainer';
 
 import { TokenFailureBoundary } from '../Boundaries/TokenFailureBoundary/TokenFailureBoundary';
+import { useToggleTokenAdmire } from 'src/hooks/useToggleTokenAdmire';
 
 type NftPreviewContextMenuPopupProps = PropsWithChildren<{
   tokenRef: UniversalNftPreviewContextMenuPopupTokenFragment$key;
@@ -53,6 +54,7 @@ export function UniversalNftPreviewContextMenuPopup({
         }
         ...shareTokenUniversalFragment
         ...TokenFailureBoundaryFragment
+        ...useToggleTokenAdmireFragment
       }
     `,
     tokenRef
@@ -69,6 +71,14 @@ export function UniversalNftPreviewContextMenuPopup({
     setPopupAssetLoaded(true);
   }, []);
 
+  const {
+    hasViewerAdmiredEvent: hasViewerBookmarkedEvent,
+    toggleTokenAdmire: toggleTokenBookmark,
+  } = useToggleTokenAdmire({
+    tokenRef: token,
+    queryRef: query,
+  });
+
   const handleMenuItemPress = useCallback<OnPressMenuItemEvent>(
     (event) => {
       if (event.nativeEvent.actionKey === 'view-details') {
@@ -78,6 +88,8 @@ export function UniversalNftPreviewContextMenuPopup({
         });
       } else if (event.nativeEvent.actionKey === 'share') {
         shareUniversalToken(token);
+      } else if (event.nativeEvent.actionKey === 'bookmark') {
+        // add or remove bookmark
       }
     },
     [fallbackTokenUrl, navigation, token]
@@ -99,6 +111,10 @@ export function UniversalNftPreviewContextMenuPopup({
           {
             actionKey: 'view-details',
             actionTitle: 'View Details',
+          },
+          {
+            actionKey: 'bookmark',
+            actionTitle: 'Add to Bookmarks',
           },
           //   {
           //     actionKey: 'view-gallery',

--- a/apps/mobile/src/components/ProfileView/ProfileView.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileView.tsx
@@ -1,4 +1,5 @@
-import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, ViewProps } from 'react-native';
 import { CollapsibleRef, Tabs } from 'react-native-collapsible-tab-view';
@@ -6,7 +7,6 @@ import FastImage from 'react-native-fast-image';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import { TopMemberBadgeIcon } from 'src/icons/TopMemberBadgeIcon';
-import { RouteProp, useRoute } from '@react-navigation/native';
 
 import { ButtonChip } from '~/components/ButtonChip';
 import { GalleryProfileNavBar } from '~/components/ProfileView/GalleryProfileNavBar';

--- a/apps/mobile/src/components/ProfileView/ProfileView.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileView.tsx
@@ -1,4 +1,4 @@
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, ViewProps } from 'react-native';
 import { CollapsibleRef, Tabs } from 'react-native-collapsible-tab-view';
@@ -6,6 +6,7 @@ import FastImage from 'react-native-fast-image';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import { TopMemberBadgeIcon } from 'src/icons/TopMemberBadgeIcon';
+import { RouteProp, useRoute } from '@react-navigation/native';
 
 import { ButtonChip } from '~/components/ButtonChip';
 import { GalleryProfileNavBar } from '~/components/ProfileView/GalleryProfileNavBar';
@@ -20,7 +21,7 @@ import { ProfileViewConnectedProfilePictureFragment$key } from '~/generated/Prof
 import { ProfileViewConnectedQueryFragment$key } from '~/generated/ProfileViewConnectedQueryFragment.graphql';
 import { ProfileViewQueryFragment$key } from '~/generated/ProfileViewQueryFragment.graphql';
 import { ProfileViewUsernameFragment$key } from '~/generated/ProfileViewUsernameFragment.graphql';
-import { MainTabStackNavigatorProp } from '~/navigation/types';
+import { MainTabStackNavigatorParamList, MainTabStackNavigatorProp } from '~/navigation/types';
 import GalleryViewEmitter from '~/shared/components/GalleryViewEmitter';
 import { BADGE_ENABLED_COMMUNITY_ADDRESSES } from '~/shared/utils/communities';
 
@@ -31,6 +32,7 @@ import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
 import { PfpBottomSheet } from '../PfpPicker/PfpBottomSheet';
 import { ProfilePicture } from '../ProfilePicture/ProfilePicture';
 import { BadgeProfileBottomSheet } from './BadgeProfileBottomSheet';
+import { ProfileViewBookmarksTab } from './Tabs/ProfileViewBookmarksTab';
 
 type ProfileViewProps = {
   shouldShowBackButton: boolean;
@@ -51,6 +53,7 @@ export function ProfileView({ queryRef, shouldShowBackButton }: ProfileViewProps
         ...ProfileViewUsernameFragment
         ...ProfileViewConnectedProfilePictureFragment
         ...FollowButtonQueryFragment
+        ...ProfileViewBookmarksTabFragment
         viewer {
           ... on Viewer {
             user {
@@ -69,8 +72,10 @@ export function ProfileView({ queryRef, shouldShowBackButton }: ProfileViewProps
     `,
     queryRef
   );
+  const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'Profile'>>();
 
-  const [selectedRoute, setSelectedRoute] = useState('Featured');
+  const navigateToTab = route.params?.navigateToTab;
+  const [selectedRoute, setSelectedRoute] = useState(navigateToTab ?? 'Featured');
 
   const Header = useCallback(() => {
     return (
@@ -88,6 +93,14 @@ export function ProfileView({ queryRef, shouldShowBackButton }: ProfileViewProps
       containerRef.current.jumpToTab(selectedRoute);
     }
   }, [selectedRoute]);
+
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
+  useEffect(() => {
+    if (navigateToTab) {
+      setSelectedRoute(navigateToTab);
+      navigation.setParams({ navigateToTab: null });
+    }
+  }, [navigateToTab, navigation]);
 
   const isLoggedInUser = Boolean(
     query.userByUsername &&
@@ -133,6 +146,11 @@ export function ProfileView({ queryRef, shouldShowBackButton }: ProfileViewProps
           <Tabs.Tab name="Posts">
             <ProfileViewActivityTab queryRef={query} />
           </Tabs.Tab>
+          {isLoggedInUser ? (
+            <Tabs.Tab name="Bookmarks">
+              <ProfileViewBookmarksTab queryRef={query} />
+            </Tabs.Tab>
+          ) : null}
           <Tabs.Tab name="Followers">
             <ProfileViewFollowersTab queryRef={query} />
           </Tabs.Tab>

--- a/apps/mobile/src/components/ProfileView/ProfileView.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileView.tsx
@@ -21,7 +21,11 @@ import { ProfileViewConnectedProfilePictureFragment$key } from '~/generated/Prof
 import { ProfileViewConnectedQueryFragment$key } from '~/generated/ProfileViewConnectedQueryFragment.graphql';
 import { ProfileViewQueryFragment$key } from '~/generated/ProfileViewQueryFragment.graphql';
 import { ProfileViewUsernameFragment$key } from '~/generated/ProfileViewUsernameFragment.graphql';
-import { MainTabStackNavigatorParamList, MainTabStackNavigatorProp } from '~/navigation/types';
+import {
+  MainTabStackNavigatorParamList,
+  MainTabStackNavigatorProp,
+  RootStackNavigatorProp,
+} from '~/navigation/types';
 import GalleryViewEmitter from '~/shared/components/GalleryViewEmitter';
 import { BADGE_ENABLED_COMMUNITY_ADDRESSES } from '~/shared/utils/communities';
 
@@ -94,7 +98,7 @@ export function ProfileView({ queryRef, shouldShowBackButton }: ProfileViewProps
     }
   }, [selectedRoute]);
 
-  const navigation = useNavigation<MainTabStackNavigatorProp>();
+  const navigation = useNavigation<RootStackNavigatorProp>();
   useEffect(() => {
     if (navigateToTab) {
       setSelectedRoute(navigateToTab);
@@ -136,7 +140,11 @@ export function ProfileView({ queryRef, shouldShowBackButton }: ProfileViewProps
       </View>
 
       <View className="flex-grow">
-        <GalleryTabsContainer Header={Header} ref={containerRef}>
+        <GalleryTabsContainer
+          Header={Header}
+          ref={containerRef}
+          initialTabName={navigateToTab ?? 'Featured'}
+        >
           <Tabs.Tab name="Featured">
             <ProfileViewFeaturedTab queryRef={query} />
           </Tabs.Tab>

--- a/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
@@ -114,7 +114,7 @@ export default function ProfileViewBookmarkItem({ queryRef, tokenRef }: Props) {
 
   return (
     <View className="flex flex-column flex-1 space-x-1 h-full space-y-2 w-1/2 justify-end ">
-      <View className="flex border border-red" style={{ height: selfHeight }}>
+      <View className="flex" style={{ height: selfHeight }}>
         <UniversalNftPreviewWithBoundary
           queryRef={query}
           tokenRef={token}

--- a/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import { ResizeMode } from 'expo-av';
 import React, { useCallback, useMemo } from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 import FastImage from 'react-native-fast-image';
 import { graphql, useFragment } from 'react-relay';
 import { contexts } from 'shared/analytics/constants';

--- a/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
@@ -1,0 +1,105 @@
+import { useNavigation } from '@react-navigation/native';
+import { ResizeMode } from 'expo-av';
+import React, { useCallback, useMemo } from 'react';
+import { Text, View } from 'react-native';
+import FastImage from 'react-native-fast-image';
+import { graphql, useFragment } from 'react-relay';
+import { useGetSinglePreviewImage } from 'shared/relay/useGetPreviewImages';
+
+import { ProfileViewBookmarkItemFragment$key } from '~/generated/ProfileViewBookmarkItemFragment.graphql';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
+
+import { UniversalNftPreviewWithBoundary } from '../NftPreview/UniversalNftPreview';
+import { truncateAddress } from 'shared/utils/wallet';
+import { TitleXS } from '../Text';
+import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
+import { extractRelevantMetadataFromCommunity } from 'shared/utils/extractRelevantMetadataFromCommunity';
+import { useNavigateToCommunityScreen } from 'src/hooks/useNavigateToCommunityScreen';
+import { contexts } from 'shared/analytics/constants';
+
+type Props = {
+  tokenRef: ProfileViewBookmarkItemFragment$key;
+};
+
+export default function ProfileViewBookmarkItem({ tokenRef }: Props) {
+  const token = useFragment(
+    graphql`
+      fragment ProfileViewBookmarkItemFragment on Token {
+        dbid
+        definition {
+          community {
+            name
+            ...useNavigateToCommunityScreenFragment
+            # ...getCommunityUrlFromCommunityFragment
+          }
+          contract {
+            contractAddress {
+              address
+            }
+          }
+        }
+        ...UniversalNftPreviewWithBoundaryFragment
+        ...useGetPreviewImagesSingleFragment
+      }
+    `,
+    tokenRef
+  );
+
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
+
+  const imageUrl = useGetSinglePreviewImage({
+    tokenRef: token,
+    preferStillFrameFromGif: true,
+    size: 'large',
+    // we're simply using the URL for warming the cache;
+    // no need to throw an error if image is invalid
+    shouldThrow: false,
+  });
+
+  const handlePress = useCallback(() => {
+    navigation.navigate('UniversalNftDetail', {
+      cachedPreviewAssetUrl: imageUrl ?? '',
+      tokenId: token.dbid,
+    });
+  }, [imageUrl, navigation, token.dbid]);
+
+  const contractAddress = token.definition.contract?.contractAddress?.address ?? '';
+
+  const collectionName = useMemo(
+    () => token.definition.community?.name || truncateAddress(contractAddress),
+    [contractAddress, token.definition.community?.name]
+  );
+
+  const navigateToCommunity = useNavigateToCommunityScreen();
+
+  const handleCollectionNamePress = useCallback(() => {
+    if (token.definition.community) {
+      navigateToCommunity(token.definition.community);
+    }
+  }, [navigateToCommunity, token.definition.community]);
+
+  return (
+    <View className="border border-black flex flex-column flex-1 space-x-1 h-full space-y-2">
+      <View className="aspect-square">
+        <UniversalNftPreviewWithBoundary
+          tokenRef={token}
+          onPress={handlePress}
+          resizeMode={ResizeMode.CONTAIN}
+          priority={FastImage.priority.normal}
+          size="small"
+        />
+      </View>
+      <View>
+        <TitleXS>Collection</TitleXS>
+        <GalleryTouchableOpacity
+          onPress={handleCollectionNamePress}
+          eventName="Pressed Collection Name On Bookmarked Token In Bookmarks Tab"
+          eventElementId="Collection Name On Bookmarked Token In Bookmarks Tab"
+          eventContext={contexts.Bookmarks}
+        >
+          <Text>{collectionName}</Text>
+        </GalleryTouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
@@ -4,24 +4,35 @@ import React, { useCallback, useMemo } from 'react';
 import { Text, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
 import { graphql, useFragment } from 'react-relay';
+import { contexts } from 'shared/analytics/constants';
 import { useGetSinglePreviewImage } from 'shared/relay/useGetPreviewImages';
 
+import { truncateAddress } from 'shared/utils/wallet';
+import { useNavigateToCommunityScreen } from 'src/hooks/useNavigateToCommunityScreen';
+
 import { ProfileViewBookmarkItemFragment$key } from '~/generated/ProfileViewBookmarkItemFragment.graphql';
+import { ProfileViewBookmarkItemQueryFragment$key } from '~/generated/ProfileViewBookmarkItemQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 
-import { UniversalNftPreviewWithBoundary } from '../NftPreview/UniversalNftPreview';
-import { truncateAddress } from 'shared/utils/wallet';
-import { TitleXS } from '../Text';
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
-import { extractRelevantMetadataFromCommunity } from 'shared/utils/extractRelevantMetadataFromCommunity';
-import { useNavigateToCommunityScreen } from 'src/hooks/useNavigateToCommunityScreen';
-import { contexts } from 'shared/analytics/constants';
+import { UniversalNftPreviewWithBoundary } from '../NftPreview/UniversalNftPreview';
+import { TitleXS } from '../Text';
 
 type Props = {
+  queryRef: ProfileViewBookmarkItemQueryFragment$key;
   tokenRef: ProfileViewBookmarkItemFragment$key;
 };
 
-export default function ProfileViewBookmarkItem({ tokenRef }: Props) {
+export default function ProfileViewBookmarkItem({ queryRef, tokenRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment ProfileViewBookmarkItemQueryFragment on Query {
+        ...UniversalNftPreviewWithBoundaryQueryFragment
+      }
+    `,
+    queryRef
+  );
+
   const token = useFragment(
     graphql`
       fragment ProfileViewBookmarkItemFragment on Token {
@@ -79,9 +90,10 @@ export default function ProfileViewBookmarkItem({ tokenRef }: Props) {
   }, [navigateToCommunity, token.definition.community]);
 
   return (
-    <View className="border border-black flex flex-column flex-1 space-x-1 h-full space-y-2">
+    <View className=" flex flex-column flex-1 space-x-1 h-full space-y-2 w-1/2">
       <View className="aspect-square">
         <UniversalNftPreviewWithBoundary
+          queryRef={query}
           tokenRef={token}
           onPress={handlePress}
           resizeMode={ResizeMode.CONTAIN}

--- a/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
@@ -6,7 +6,6 @@ import FastImage from 'react-native-fast-image';
 import { graphql, useFragment } from 'react-relay';
 import { contexts } from 'shared/analytics/constants';
 import { useGetSinglePreviewImage } from 'shared/relay/useGetPreviewImages';
-
 import { truncateAddress } from 'shared/utils/wallet';
 import { useNavigateToCommunityScreen } from 'src/hooks/useNavigateToCommunityScreen';
 
@@ -17,6 +16,7 @@ import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
 import { UniversalNftPreviewWithBoundary } from '../NftPreview/UniversalNftPreview';
 import { TitleXS } from '../Text';
+import { Typography } from '../Typography';
 
 type Props = {
   queryRef: ProfileViewBookmarkItemQueryFragment$key;
@@ -109,7 +109,12 @@ export default function ProfileViewBookmarkItem({ queryRef, tokenRef }: Props) {
           eventElementId="Collection Name On Bookmarked Token In Bookmarks Tab"
           eventContext={contexts.Bookmarks}
         >
-          <Text>{collectionName}</Text>
+          <Typography
+            className="text-sm leading-4  text-black dark:text-white"
+            font={{ family: 'ABCDiatype', weight: 'Bold' }}
+          >
+            {collectionName}
+          </Typography>
         </GalleryTouchableOpacity>
       </View>
     </View>

--- a/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
@@ -99,7 +99,8 @@ export default function ProfileViewBookmarkItem({ queryRef, tokenRef }: Props) {
       if (
         imageState.kind !== 'loaded' ||
         !imageState.dimensions?.width ||
-        !imageState.dimensions?.height
+        !imageState.dimensions?.height ||
+        selfHeight
       ) {
         return;
       }
@@ -107,14 +108,15 @@ export default function ProfileViewBookmarkItem({ queryRef, tokenRef }: Props) {
       // this is screen width - spacing / 2 (the number of items per row)
       const itemWidth = (screenWidth - 56) / 2;
       const ratio = imageState.dimensions?.width / itemWidth;
+
       setSelfHeight(imageState.dimensions?.height / ratio);
     },
-    [screenWidth]
+    [screenWidth, selfHeight]
   );
 
   return (
     <View className="flex flex-column flex-1 space-x-1 h-full space-y-2 w-1/2 justify-end ">
-      <View className="flex  " style={{ height: selfHeight }}>
+      <View className="flex" style={{ height: selfHeight }}>
         <UniversalNftPreviewWithBoundary
           queryRef={query}
           tokenRef={token}

--- a/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewBookmarkItem.tsx
@@ -41,7 +41,6 @@ export default function ProfileViewBookmarkItem({ queryRef, tokenRef }: Props) {
           community {
             name
             ...useNavigateToCommunityScreenFragment
-            # ...getCommunityUrlFromCommunityFragment
           }
           contract {
             contractAddress {
@@ -99,24 +98,23 @@ export default function ProfileViewBookmarkItem({ queryRef, tokenRef }: Props) {
       if (
         imageState.kind !== 'loaded' ||
         !imageState.dimensions?.width ||
-        !imageState.dimensions?.height ||
-        selfHeight
+        !imageState.dimensions?.height
       ) {
         return;
       }
       // determine the intended width of the bookmark item.
       // this is screen width - spacing / 2 (the number of items per row)
-      const itemWidth = (screenWidth - 56) / 2;
+      const itemWidth = (screenWidth - 48) / 2;
       const ratio = imageState.dimensions?.width / itemWidth;
 
       setSelfHeight(imageState.dimensions?.height / ratio);
     },
-    [screenWidth, selfHeight]
+    [screenWidth]
   );
 
   return (
     <View className="flex flex-column flex-1 space-x-1 h-full space-y-2 w-1/2 justify-end ">
-      <View className="flex" style={{ height: selfHeight }}>
+      <View className="flex border border-red" style={{ height: selfHeight }}>
         <UniversalNftPreviewWithBoundary
           queryRef={query}
           tokenRef={token}
@@ -139,7 +137,6 @@ export default function ProfileViewBookmarkItem({ queryRef, tokenRef }: Props) {
             className="text-sm leading-4 text-black dark:text-white h-8 mt-1"
             numberOfLines={2}
             font={{ family: 'ABCDiatype', weight: 'Bold' }}
-            style={{}}
           >
             {collectionName}
           </Typography>

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
@@ -1,13 +1,17 @@
+import { useNavigation } from '@react-navigation/native';
 import { ListRenderItem } from '@shopify/flash-list';
 import { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { Tabs } from 'react-native-collapsible-tab-view';
 import { graphql, usePaginationFragment } from 'react-relay';
+import { contexts } from 'shared/analytics/constants';
 import { BookmarkIcon } from 'src/icons/BookmarkIcon';
 
+import { Button } from '~/components/Button';
 import { Typography } from '~/components/Typography';
 import { ProfileViewBookmarkItemFragment$key } from '~/generated/ProfileViewBookmarkItemFragment.graphql';
 import { ProfileViewBookmarksTabFragment$key } from '~/generated/ProfileViewBookmarksTabFragment.graphql';
+import { RootStackNavigatorProp } from '~/navigation/types';
 
 import ProfileViewBookmarkItem from '../ProfileViewBookmarkItem';
 import { useListContentStyle } from './useListContentStyle';
@@ -126,15 +130,52 @@ export function ProfileViewBookmarksTab({ queryRef }: Props) {
     }
   }, [hasNext, loadNext]);
 
+  const navigation = useNavigation<RootStackNavigatorProp>();
+  const onExplorePress = useCallback(() => {
+    navigation.navigate('MainTabs', {
+      screen: 'HomeTab',
+      params: { screen: 'Home', params: { screen: 'For You', params: {} } },
+    });
+  }, [navigation]);
+
   return (
     <View style={contentContainerStyle}>
-      <Tabs.FlashList
-        // ref={ref}
-        data={items}
-        renderItem={renderItem}
-        estimatedItemSize={100}
-        onEndReached={loadMore}
-      />
+      {items.length > 0 ? (
+        <Tabs.FlashList
+          data={items}
+          renderItem={renderItem}
+          estimatedItemSize={100}
+          onEndReached={loadMore}
+        />
+      ) : (
+        <Tabs.ScrollView>
+          <View className="flex px-4">
+            <View className="flex flex-row mb-12  justify-start items-center" style={{ gap: 10 }}>
+              <Typography className="text-md" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+                Bookmarks
+              </Typography>
+              <BookmarkIcon colorTheme="black" active width={20} />
+            </View>
+            <Typography
+              font={{
+                family: 'GTAlpina',
+                weight: 'StandardLight',
+              }}
+              className="text-center text-xl mb-6"
+            >
+              You haven’t Bookmarked anything yet! Tap the Bookmark icon on work you like to build
+              your collection.
+            </Typography>
+            <Button
+              text="Start Exploring"
+              eventElementId="Profile Bookmarks Tab Empty State Start Exploring Button"
+              eventName="Pressed Profile Bookmarks Tab Empty State Start Exploring Button"
+              eventContext={contexts.Bookmarks}
+              onPress={onExplorePress}
+            />
+          </View>
+        </Tabs.ScrollView>
+      )}
     </View>
   );
 }

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
@@ -102,7 +102,8 @@ export function ProfileViewBookmarksTab({ queryRef }: Props) {
 
       if (item.kind === 'bookmark-row') {
         return (
-          <View className="flex flex-row space-x-2 w-full justify-center px-4 mb-8">
+          // If adjusting the horizontal spacing between row items, be sure to adjust the dimension calculation in ProfileViewBookmarkItem
+          <View className="flex flex-row w-full justify-center px-4 mb-6">
             {item.bookmarkedTokens[0] && (
               <ProfileViewBookmarkItem queryRef={query} tokenRef={item.bookmarkedTokens[0]} />
             )}

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
@@ -88,36 +88,37 @@ export function ProfileViewBookmarksTab({ queryRef }: Props) {
     return items;
   }, [groupedTokens]);
 
-  const renderItem = useCallback<ListRenderItem<ListItem>>(({ item }) => {
-    if (item.kind === 'header') {
-      return (
-        <View className="flex flex-row px-4 pb-4 justify-start items-start" style={{ gap: 10 }}>
-          <Typography className="text-md" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-            Bookmarks
-          </Typography>
-          <BookmarkIcon />
-        </View>
-      );
-    }
+  const renderItem = useCallback<ListRenderItem<ListItem>>(
+    ({ item }) => {
+      if (item.kind === 'header') {
+        return (
+          <View className="flex flex-row px-4 pb-4 justify-start items-center" style={{ gap: 10 }}>
+            <Typography className="text-md" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+              Bookmarks
+            </Typography>
+            <BookmarkIcon colorTheme="black" active width={20} />
+          </View>
+        );
+      }
 
-    if (item.kind === 'bookmark-row') {
-      return (
-        // <View className="flex">
-        <View className="flex flex-row space-x-2 w-full justify-center px-4 mb-4">
-          {/* {item.bookmarkedTokens.map((bookmarkedToken) => {
-            return <ProfileViewBookmarkItem queryRef={query} tokenRef={bookmarkedToken} />;
-          })} */}
+      if (item.kind === 'bookmark-row') {
+        return (
+          <View className="flex flex-row space-x-2 w-full justify-center px-4 mb-8">
+            {item.bookmarkedTokens[0] && (
+              <ProfileViewBookmarkItem queryRef={query} tokenRef={item.bookmarkedTokens[0]} />
+            )}
+            <View className="w-4" />
+            {item.bookmarkedTokens[1] && (
+              <ProfileViewBookmarkItem queryRef={query} tokenRef={item.bookmarkedTokens[1]} />
+            )}
+          </View>
+        );
+      }
 
-          <ProfileViewBookmarkItem queryRef={query} tokenRef={item.bookmarkedTokens[0]} />
-          <View className="w-4" />
-          <ProfileViewBookmarkItem queryRef={query} tokenRef={item.bookmarkedTokens[1]} />
-        </View>
-        // </View>
-      );
-    }
-
-    return null;
-  }, []);
+      return null;
+    },
+    [query]
+  );
 
   const loadMore = useCallback(() => {
     if (hasNext) {

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
@@ -106,7 +106,7 @@ export function ProfileViewBookmarksTab({ queryRef }: Props) {
 
       if (item.kind === 'bookmark-row') {
         return (
-          // If adjusting the horizontal spacing between row items, be sure to adjust the dimension calculation in ProfileViewBookmarkItem
+          // Note to dev: If you're adjusting the horizontal spacing between row items, be sure to adjust the dimension calculation in ProfileViewBookmarkItem
           <View className="flex flex-row w-full justify-center px-4 mb-6">
             {item.bookmarkedTokens[0] && (
               <ProfileViewBookmarkItem queryRef={query} tokenRef={item.bookmarkedTokens[0]} />

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
@@ -1,0 +1,131 @@
+import { ListRenderItem } from '@shopify/flash-list';
+import { useCallback, useMemo } from 'react';
+import { Text, View } from 'react-native';
+import { Tabs } from 'react-native-collapsible-tab-view';
+import { graphql, useFragment, usePaginationFragment } from 'react-relay';
+
+import { useListContentStyle } from './useListContentStyle';
+import { removeNullValues } from 'shared/relay/removeNullValues';
+import ProfileViewBookmarkItem from '../ProfileViewBookmarkItem';
+
+type Props = {
+  queryRef: ProfileViewBookmarksTabFragment$key;
+};
+
+type ListItem =
+  | { kind: 'header' }
+  | { kind: 'bookmark-row'; bookmarkedTokens: ProfileViewBookmarkItemFragment$key[] };
+
+const BOOKMARKS_PER_PAGE = 24;
+
+export function ProfileViewBookmarksTab({ queryRef }: Props) {
+  const {
+    data: query,
+    hasNext,
+    loadNext,
+  } = usePaginationFragment(
+    graphql`
+      fragment ProfileViewBookmarksTabFragment on Query
+      @refetchable(queryName: "ProfileViewBookmarksTabFragmentPaginationQuery") {
+        userByUsername(username: $username) {
+          ... on GalleryUser {
+            tokensBookmarked(first: $bookmarksFirst, after: $bookmarksAfter)
+              @connection(key: "ProfileViewBookmarksTab_tokensBookmarked") {
+              edges {
+                node {
+                  id
+                  ...ProfileViewBookmarkItemFragment
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  const contentContainerStyle = useListContentStyle();
+  const user = query.userByUsername;
+  const bookmarkedTokens = useMemo(() => {
+    const tokens = [];
+
+    for (const token of user.tokensBookmarked?.edges ?? []) {
+      if (token?.node) {
+        tokens.push(token.node);
+      }
+    }
+
+    return tokens;
+  }, [user.tokensBookmarked?.edges]);
+
+  // group tokens into rows so they can be virtualized
+  const groupedTokens = useMemo(() => {
+    const itemsPerRow = 2;
+    const result = [];
+    for (let i = 0; i < bookmarkedTokens.length; i += itemsPerRow) {
+      const row = bookmarkedTokens.slice(i, i + itemsPerRow);
+      result.push(row);
+    }
+    return result;
+  }, [bookmarkedTokens]);
+
+  const items = useMemo<ListItem[]>(() => {
+    const items: ListItem[] = [];
+    items.push({ kind: 'header' });
+    // return removeNullValues(user.tokensBookmarked);
+    groupedTokens.forEach((row) => {
+      items.push({ kind: 'bookmark-row', bookmarkedTokens: row });
+    });
+    return items;
+  }, [groupedTokens]);
+
+  const renderItem = useCallback<ListRenderItem<ListItem>>(({ item }) => {
+    if (item.kind === 'header') {
+      return (
+        <View className="flex flex-row items-center justify-center py-3" style={{ gap: 10 }}>
+          <Text>Bookmarks</Text>
+        </View>
+      );
+    }
+
+    if (item.kind === 'bookmark-row') {
+      console.log(item.bookmarkedTokens.length);
+      return (
+        // <View className="flex">
+        <View className="flex flex-row space-x-2 w-full justify-center px-4 mb-4">
+          {item.bookmarkedTokens.map((bookmarkedToken) => {
+            return <ProfileViewBookmarkItem tokenRef={bookmarkedToken} />;
+          })}
+          {/* <View className="border border-black flex flex-1">
+              <Text>test</Text>
+            </View>
+            <View className="border border-black flex flex-1">
+              <Text>test</Text>
+            </View> */}
+        </View>
+        // </View>
+      );
+    }
+
+    return null;
+  }, []);
+
+  const loadMore = useCallback(() => {
+    if (hasNext) {
+      loadNext(BOOKMARKS_PER_PAGE);
+    }
+  }, [hasNext, loadNext]);
+
+  return (
+    <View style={contentContainerStyle}>
+      <Tabs.FlashList
+        // ref={ref}
+        data={items}
+        renderItem={renderItem}
+        estimatedItemSize={100}
+        onEndReached={loadMore}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
@@ -1,16 +1,16 @@
 import { ListRenderItem } from '@shopify/flash-list';
 import { useCallback, useMemo } from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 import { Tabs } from 'react-native-collapsible-tab-view';
 import { graphql, usePaginationFragment } from 'react-relay';
+import { BookmarkIcon } from 'src/icons/BookmarkIcon';
 
+import { Typography } from '~/components/Typography';
 import { ProfileViewBookmarkItemFragment$key } from '~/generated/ProfileViewBookmarkItemFragment.graphql';
 import { ProfileViewBookmarksTabFragment$key } from '~/generated/ProfileViewBookmarksTabFragment.graphql';
 
 import ProfileViewBookmarkItem from '../ProfileViewBookmarkItem';
 import { useListContentStyle } from './useListContentStyle';
-import { Typography } from '~/components/Typography';
-import { BookmarkIcon } from 'src/icons/BookmarkIcon';
 
 type Props = {
   queryRef: ProfileViewBookmarksTabFragment$key;
@@ -37,7 +37,6 @@ export function ProfileViewBookmarksTab({ queryRef }: Props) {
               @connection(key: "ProfileViewBookmarksTab_tokensBookmarked") {
               edges {
                 node {
-                  id
                   ...ProfileViewBookmarkItemFragment
                 }
               }

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewBookmarksTab.tsx
@@ -57,6 +57,7 @@ export function ProfileViewBookmarksTab({ queryRef }: Props) {
   const user = query.userByUsername;
   const bookmarkedTokens = useMemo(() => {
     const tokens = [];
+
     if (!user || !user.tokensBookmarked) {
       return [];
     }
@@ -107,13 +108,15 @@ export function ProfileViewBookmarksTab({ queryRef }: Props) {
       if (item.kind === 'bookmark-row') {
         return (
           // Note to dev: If you're adjusting the horizontal spacing between row items, be sure to adjust the dimension calculation in ProfileViewBookmarkItem
-          <View className="flex flex-row w-full justify-center px-4 mb-6">
+          <View className="flex flex-row w-full justify-start px-4 mb-6">
             {item.bookmarkedTokens[0] && (
               <ProfileViewBookmarkItem queryRef={query} tokenRef={item.bookmarkedTokens[0]} />
             )}
             <View className="w-4" />
-            {item.bookmarkedTokens[1] && (
+            {item.bookmarkedTokens[1] ? (
               <ProfileViewBookmarkItem queryRef={query} tokenRef={item.bookmarkedTokens[1]} />
+            ) : (
+              <View className="flex flex-1" />
             )}
           </View>
         );
@@ -140,7 +143,7 @@ export function ProfileViewBookmarksTab({ queryRef }: Props) {
 
   return (
     <View style={contentContainerStyle}>
-      {items.length > 0 ? (
+      {bookmarkedTokens.length > 0 ? (
         <Tabs.FlashList
           data={items}
           renderItem={renderItem}

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewFeaturedTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewFeaturedTab.tsx
@@ -28,6 +28,7 @@ export function ProfileViewFeaturedTab({ queryRef }: ProfileViewFeaturedTabProps
             }
           }
         }
+        ...GalleryVirtualizedRowQueryFragment
       }
     `,
     queryRef
@@ -45,9 +46,12 @@ export function ProfileViewFeaturedTab({ queryRef }: ProfileViewFeaturedTabProps
     });
   }, [user?.featuredGallery]);
 
-  const renderItem = useCallback<ListRenderItem<GalleryListItemType>>(({ item }) => {
-    return <GalleryVirtualizedRow item={item} />;
-  }, []);
+  const renderItem = useCallback<ListRenderItem<GalleryListItemType>>(
+    ({ item }) => {
+      return <GalleryVirtualizedRow queryRef={query} item={item} />;
+    },
+    [query]
+  );
 
   const contentContainerStyle = useListContentStyle();
 

--- a/apps/mobile/src/components/Text.tsx
+++ b/apps/mobile/src/components/Text.tsx
@@ -1,0 +1,12 @@
+import { Typography } from './Typography';
+
+export const TitleXS = ({ children }: { children: string }) => {
+  return (
+    <Typography
+      className="text-metal text-xs leading-4 uppercase"
+      font={{ family: 'ABCDiatype', weight: 'Regular' }}
+    >
+      {children}
+    </Typography>
+  );
+};

--- a/apps/mobile/src/components/Toast/Toast.tsx
+++ b/apps/mobile/src/components/Toast/Toast.tsx
@@ -86,10 +86,10 @@ export function AnimatedToast({
 
   return (
     <Animated.View
-      className="absolute inset-x-0 z-50 justify-center items-center"
+      className="absolute inset-x-0 z-50 justify-center items-center max-w-full"
       style={[positionStyles, animatedStyles]}
     >
-      <View className="flex-row items-center p-2 space-x-2 bg-offWhite dark:bg-black-800 border border-black-800 dark:border-porcelain">
+      <View className="flex-row items-center p-2 space-x-2 bg-offWhite dark:bg-black-800 border border-black-800 dark:border-porcelain max-w-full">
         {message && (
           <Typography
             className="text-sm text-offBlack dark:text-offWhite"

--- a/apps/mobile/src/hooks/useToggleTokenAdmire.tsx
+++ b/apps/mobile/src/hooks/useToggleTokenAdmire.tsx
@@ -13,7 +13,7 @@ import { useToggleTokenAdmireAddMutation } from '~/generated/useToggleTokenAdmir
 import { useToggleTokenAdmireFragment$key } from '~/generated/useToggleTokenAdmireFragment.graphql';
 import { useToggleTokenAdmireQueryFragment$key } from '~/generated/useToggleTokenAdmireQueryFragment.graphql';
 import { useToggleTokenAdmireRemoveMutation } from '~/generated/useToggleTokenAdmireRemoveMutation.graphql';
-import { MainTabStackNavigatorProp } from '~/navigation/types';
+import { RootStackNavigatorProp } from '~/navigation/types';
 import { AdditionalContext, useReportError } from '~/shared/contexts/ErrorReportingContext';
 import { usePromisifiedMutation } from '~/shared/relay/usePromisifiedMutation';
 type Args = {
@@ -231,13 +231,19 @@ export function useToggleTokenAdmire({ tokenRef, queryRef }: Args) {
     truncatedTokenName,
   ]);
 
-  const navigation = useNavigation<MainTabStackNavigatorProp>();
+  const navigation = useNavigation<RootStackNavigatorProp>();
 
   const handleViewBookmarksPress = useCallback(() => {
     if (query.viewer?.__typename === 'Viewer' && query.viewer?.user?.username) {
-      navigation.navigate('Profile', {
-        username: query.viewer.user.username,
-        navigateToTab: 'Bookmarks',
+      navigation.navigate('MainTabs', {
+        screen: 'AccountTab',
+        params: {
+          screen: 'Profile',
+          params: {
+            username: query.viewer.user.username,
+            navigateToTab: 'Bookmarks',
+          },
+        },
       });
     }
   }, [navigation, query.viewer]);

--- a/apps/mobile/src/hooks/useToggleTokenAdmire.tsx
+++ b/apps/mobile/src/hooks/useToggleTokenAdmire.tsx
@@ -1,10 +1,11 @@
+import { useNavigation } from '@react-navigation/native';
 import { useCallback, useMemo } from 'react';
 import { Text, View } from 'react-native';
 import { trigger } from 'react-native-haptic-feedback';
 import { ConnectionHandler, graphql, useFragment } from 'react-relay';
 import { SelectorStoreUpdater } from 'relay-runtime';
-import { ButtonChip } from '~/components/ButtonChip';
 
+import { ButtonChip } from '~/components/ButtonChip';
 import { Typography } from '~/components/Typography';
 import { useToastActions } from '~/contexts/ToastContext';
 import { useToggleAdmireRemoveMutation } from '~/generated/useToggleAdmireRemoveMutation.graphql';
@@ -12,10 +13,9 @@ import { useToggleTokenAdmireAddMutation } from '~/generated/useToggleTokenAdmir
 import { useToggleTokenAdmireFragment$key } from '~/generated/useToggleTokenAdmireFragment.graphql';
 import { useToggleTokenAdmireQueryFragment$key } from '~/generated/useToggleTokenAdmireQueryFragment.graphql';
 import { useToggleTokenAdmireRemoveMutation } from '~/generated/useToggleTokenAdmireRemoveMutation.graphql';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { AdditionalContext, useReportError } from '~/shared/contexts/ErrorReportingContext';
 import { usePromisifiedMutation } from '~/shared/relay/usePromisifiedMutation';
-import { useNavigation } from '@react-navigation/native';
-import { MainTabStackNavigatorProp, RootStackNavigatorProp } from '~/navigation/types';
 type Args = {
   queryRef: useToggleTokenAdmireQueryFragment$key;
   tokenRef: useToggleTokenAdmireFragment$key;
@@ -366,10 +366,7 @@ export function useToggleTokenAdmire({ tokenRef, queryRef }: Args) {
       }
     }
   }, [
-    query.viewer?.__typename,
-    query.viewer?.user?.dbid,
-    query.viewer?.user?.id,
-    query.viewer?.user?.username,
+    query.viewer,
     token.dbid,
     token.id,
     token.definition.id,

--- a/apps/mobile/src/icons/BookmarkIcon.tsx
+++ b/apps/mobile/src/icons/BookmarkIcon.tsx
@@ -8,19 +8,6 @@ type Props = {
   colorTheme: 'white' | 'blue' | 'black';
 } & SvgProps;
 
-const colorMap = {
-  light: {
-    stroke: colors.black['DEFAULT'],
-    fill: colors.offWhite,
-    active: colors.activeBlue,
-  },
-  dark: {
-    stroke: colors.white,
-    fill: colors.black['DEFAULT'],
-    active: colors.activeBlue,
-  },
-};
-
 const COLOR_THEME = {
   white: {
     light: {

--- a/apps/mobile/src/icons/BookmarkIcon.tsx
+++ b/apps/mobile/src/icons/BookmarkIcon.tsx
@@ -4,6 +4,8 @@ import colors from 'shared/theme/colors';
 
 type Props = {
   active?: boolean;
+  width?: number;
+  colorTheme: 'white' | 'blue' | 'black';
 } & SvgProps;
 
 const colorMap = {
@@ -19,14 +21,67 @@ const colorMap = {
   },
 };
 
-export function BookmarkIcon({ active, ...props }: Props) {
+const COLOR_THEME = {
+  white: {
+    light: {
+      activeFillColor: colors.white,
+      activeStrokeColor: colors.white,
+      inactiveFillColor: 'none',
+      inactiveStrokeColor: colors.white,
+    },
+    dark: {
+      activeFillColor: colors.white,
+      activeStrokeColor: colors.white,
+      inactiveFillColor: 'none',
+      inactiveStrokeColor: colors.white,
+    },
+  },
+  blue: {
+    light: {
+      activeFillColor: colors.activeBlue,
+      activeStrokeColor: colors.activeBlue,
+      inactiveFillColor: 'none',
+      inactiveStrokeColor: colors.black['800'],
+    },
+    dark: {
+      activeFillColor: colors.darkModeBlue,
+      activeStrokeColor: colors.darkModeBlue,
+      inactiveFillColor: 'none',
+      inactiveStrokeColor: colors.black['800'],
+    },
+  },
+  black: {
+    light: {
+      activeFillColor: colors.black['800'],
+      activeStrokeColor: colors.black['800'],
+      inactiveFillColor: 'none',
+      inactiveStrokeColor: colors.black['800'],
+    },
+    dark: {
+      activeFillColor: colors.white,
+      activeStrokeColor: colors.white,
+      inactiveFillColor: 'none',
+      inactiveStrokeColor: colors.black['800'],
+    },
+  },
+};
+
+export function BookmarkIcon({ active, width, colorTheme, ...props }: Props) {
   const { colorScheme } = useColorScheme();
 
   return (
-    <Svg width={25} height={24} fill="none" {...props}>
+    <Svg width={width ?? 25} height={width ?? 24} viewBox="0 0 27 24" fill="none" {...props}>
       <Path
-        stroke={active ? colorMap[colorScheme].active : colorMap[colorScheme].stroke}
-        fill={active ? colorMap[colorScheme].active : colorMap[colorScheme].fill}
+        stroke={
+          active
+            ? COLOR_THEME[colorTheme][colorScheme].activeStrokeColor
+            : COLOR_THEME[colorTheme][colorScheme].inactiveStrokeColor
+        }
+        fill={
+          active
+            ? COLOR_THEME[colorTheme][colorScheme].activeFillColor
+            : COLOR_THEME[colorTheme][colorScheme].inactiveFillColor
+        }
         d="m19.313 20-6.5-6-6.5 6V4h13v16Z"
       />
     </Svg>

--- a/apps/mobile/src/navigation/MainTabNavigator/MainTabNavigator.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/MainTabNavigator.tsx
@@ -1,6 +1,5 @@
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import { useColorScheme } from 'nativewind';
-import { RouteProp, useRoute } from '@react-navigation/native';
 import { Suspense } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -8,7 +7,7 @@ import { ProfileViewFallback } from '~/components/ProfileView/ProfileViewFallbac
 import { MainTabNavigatorAccountScreenQuery } from '~/generated/MainTabNavigatorAccountScreenQuery.graphql';
 import { TabBar } from '~/navigation/MainTabNavigator/TabBar';
 import { MainTabStackNavigator } from '~/navigation/MainTabStackNavigator';
-import { MainTabNavigatorParamList, MainTabStackNavigatorParamList } from '~/navigation/types';
+import { MainTabNavigatorParamList } from '~/navigation/types';
 import colors from '~/shared/theme/colors';
 
 import { PostStackNavigator } from '../PostStackNavigator';

--- a/apps/mobile/src/navigation/MainTabNavigator/MainTabNavigator.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/MainTabNavigator.tsx
@@ -1,5 +1,6 @@
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import { useColorScheme } from 'nativewind';
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { Suspense } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
@@ -7,7 +8,7 @@ import { ProfileViewFallback } from '~/components/ProfileView/ProfileViewFallbac
 import { MainTabNavigatorAccountScreenQuery } from '~/generated/MainTabNavigatorAccountScreenQuery.graphql';
 import { TabBar } from '~/navigation/MainTabNavigator/TabBar';
 import { MainTabStackNavigator } from '~/navigation/MainTabStackNavigator';
-import { MainTabNavigatorParamList } from '~/navigation/types';
+import { MainTabNavigatorParamList, MainTabStackNavigatorParamList } from '~/navigation/types';
 import colors from '~/shared/theme/colors';
 
 import { PostStackNavigator } from '../PostStackNavigator';
@@ -34,7 +35,10 @@ function AccountScreenInner() {
   return (
     <MainTabStackNavigator
       initialRouteName="Profile"
-      initialProfileParams={{ username: query.viewer?.user?.username ?? '', hideBackButton: true }}
+      initialProfileParams={{
+        username: query.viewer?.user?.username ?? '',
+        hideBackButton: true,
+      }}
     />
   );
 }

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -26,7 +26,7 @@ export type RootStackNavigatorParamList = {
 
 export type ScreenWithNftSelector = 'ProfilePicture' | 'Post' | 'Community';
 export type MainTabStackNavigatorParamList = {
-  Profile: { username: string; hideBackButton?: boolean };
+  Profile: { username: string; hideBackButton?: boolean; navigateToTab?: string };
   NftDetail: {
     tokenId: string;
     collectionId: string | null;

--- a/apps/mobile/src/screens/CollectionScreen/CollectionScreen.tsx
+++ b/apps/mobile/src/screens/CollectionScreen/CollectionScreen.tsx
@@ -41,6 +41,7 @@ function CollectionScreenInner() {
         }
 
         ...GalleryProfileNavBarQueryFragment
+        ...GalleryVirtualizedRowQueryFragment
       }
     `,
     { collectionId: route.params.collectionId }
@@ -61,13 +62,16 @@ function CollectionScreenInner() {
     return createVirtualizedCollectionRows({ collectionRef: collection });
   }, [collection]);
 
-  const renderItem: ListRenderItem<ListItem> = useCallback(({ item }) => {
-    if (item.kind === 'description') {
-      return <Markdown>{item.description}</Markdown>;
-    } else {
-      return <GalleryVirtualizedRow item={item} isOnCollectionScreen />;
-    }
-  }, []);
+  const renderItem: ListRenderItem<ListItem> = useCallback(
+    ({ item }) => {
+      if (item.kind === 'description') {
+        return <Markdown>{item.description}</Markdown>;
+      } else {
+        return <GalleryVirtualizedRow queryRef={query} item={item} isOnCollectionScreen />;
+      }
+    },
+    [query]
+  );
 
   return (
     <View className="flex flex-col flex-1 bg-white dark:bg-black-900 pt-4">

--- a/apps/mobile/src/screens/GalleryScreen/GalleryScreen.tsx
+++ b/apps/mobile/src/screens/GalleryScreen/GalleryScreen.tsx
@@ -34,6 +34,7 @@ function GalleryScreenInner() {
         }
 
         ...GalleryProfileNavBarQueryFragment
+        ...GalleryVirtualizedRowQueryFragment
       }
     `,
     { galleryId: route.params.galleryId }
@@ -86,17 +87,20 @@ function GalleryScreenInner() {
     return { items, stickyIndices };
   }, [gallery]);
 
-  const renderItem: ListRenderItem<ListItem> = useCallback(({ item }) => {
-    if (item.kind === 'description') {
-      return (
-        <View className="px-4">
-          <Markdown>{item.description}</Markdown>
-        </View>
-      );
-    } else {
-      return <GalleryVirtualizedRow item={item} />;
-    }
-  }, []);
+  const renderItem: ListRenderItem<ListItem> = useCallback(
+    ({ item }) => {
+      if (item.kind === 'description') {
+        return (
+          <View className="px-4">
+            <Markdown>{item.description}</Markdown>
+          </View>
+        );
+      } else {
+        return <GalleryVirtualizedRow queryRef={query} item={item} />;
+      }
+    },
+    [query]
+  );
 
   return (
     <View className="flex flex-col flex-1 bg-white dark:bg-black-900">

--- a/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/NftDetailSection.tsx
@@ -280,7 +280,7 @@ export function NftDetailSection({ onShare, queryRef }: Props) {
         <View className="space-y-2">
           <Button
             variant="blue"
-            headerElement={<BookmarkIcon active={hasViewerBookmarkedEvent} />}
+            headerElement={<BookmarkIcon active={hasViewerBookmarkedEvent} colorTheme="blue" />}
             eventElementId={'NFT Detail Token Bookmark Button'}
             eventName={'NFT Detail Token Bookmark Button Clicked'}
             eventContext={contexts['NFT Detail']}

--- a/apps/mobile/src/screens/ProfileScreen/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen/ProfileScreen.tsx
@@ -30,6 +30,8 @@ function ProfileScreenInner() {
         $sharedCommunitiesAfter: String
         $sharedFollowersFirst: Int
         $sharedFollowersAfter: String
+        $bookmarksFirst: Int
+        $bookmarksAfter: String
       ) {
         ...ProfileScreenRefetchableFragment
       }
@@ -39,6 +41,7 @@ function ProfileScreenInner() {
       feedLast: ACTIVITY_FEED_ITEMS_PER_PAGE,
       sharedCommunitiesFirst: SHARED_COMMUNITIES_PER_PAGE,
       sharedFollowersFirst: SHARED_FOLLOWERS_PER_PAGE,
+      bookmarksFirst: 20,
     },
     { fetchPolicy: 'store-or-network', UNSTABLE_renderPolicy: 'full' }
   );


### PR DESCRIPTION
### Summary of Changes

This PR adds the Bookmarks Tab to the User Profile on mobile. same behavior as web
- added tab that shows all of your bookmarks
- tab is only visible to you
- added "View Bookmarks" button to bookmark success toast. 
- added Bookmark/Unbookmark option to press+hold context menu on nft preview
- bookmark/unbookmark updates all stored values
- empty state for mobile tab
- scrollable profile tabs if there are 5 tab items

### Demo or Before/After Pics
![CleanShot 2024-02-12 at 17 42 59@2x](https://github.com/gallery-so/gallery/assets/80802871/05c25ec6-f736-4d78-b235-43f83e9b2543)

### Edge Cases


### Testing Steps 
bookmark and unbookmark items in different places of the app
tap the "View Bookmarks" toast button from different places in the app

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
