### PR TITLE
be more selective about disableBookmarkOnHover and insert new edge at start of connection

### DIFF
--- a/apps/web/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
+++ b/apps/web/src/components/Feed/Events/FeedEventNftPreviewWrapper.tsx
@@ -47,7 +47,13 @@ function FeedEventNftPreviewWrapper({ queryRef, tokenRef, maxWidth, maxHeight }:
       maxHeight={maxHeight}
       onClick={(e) => e.stopPropagation()}
     >
-      <CollectionTokenPreview tokenRef={token} disableLiverender isInFeedEvent queryRef={query} />
+      <CollectionTokenPreview
+        tokenRef={token}
+        disableLiverender
+        isInFeedEvent
+        queryRef={query}
+        disableBookmarkOnHover
+      />
     </StyledNftPreviewWrapper>
   );
 }

--- a/apps/web/src/components/NftPreview/CollectionTokenPreview.tsx
+++ b/apps/web/src/components/NftPreview/CollectionTokenPreview.tsx
@@ -15,6 +15,7 @@ type Props = {
   disableLiverender?: boolean;
   columns?: number;
   isInFeedEvent?: boolean;
+  disableBookmarkOnHover?: boolean;
 };
 
 export default function CollectionTokenPreview({
@@ -23,6 +24,7 @@ export default function CollectionTokenPreview({
   disableLiverender,
   columns,
   isInFeedEvent,
+  disableBookmarkOnHover,
 }: Props) {
   const query = useFragment(
     graphql`
@@ -64,7 +66,7 @@ export default function CollectionTokenPreview({
       shouldLiveRender={shouldLiveRender}
       collectionId={collection.dbid}
       eventContext={contexts.UserCollection}
-      disableBookmarkOnHover
+      disableBookmarkOnHover={disableBookmarkOnHover}
     />
   );
 }

--- a/apps/web/src/hooks/api/posts/useAdmireToken.ts
+++ b/apps/web/src/hooks/api/posts/useAdmireToken.ts
@@ -115,7 +115,7 @@ export default function useAdmireToken() {
               newBookmarkedToken,
               'TokenBookmarkEdge'
             );
-            ConnectionHandler.insertEdgeAfter(bookmarkedTokensConnection, edge);
+            ConnectionHandler.insertEdgeBefore(bookmarkedTokensConnection, edge);
           }
         }
       };


### PR DESCRIPTION


### Summary of Changes

- Fix bug where disableBookmarkOnHover was true for gallery previews. make sure it only applies to feed event previews.
- update post-mutation store update to insert new edge at beginning of connection instead of end, now that we sort by new -> old]

### Demo or Before/After Pics

![CleanShot 2024-02-09 at 00 05 37](https://github.com/gallery-so/gallery/assets/80802871/805111f1-e2ab-47b1-81cd-e1051689beb6)


### Edge Cases
na

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
