### PR TITLE
Add blue background back for punks

### DIFF
--- a/apps/web/src/utils/token.ts
+++ b/apps/web/src/utils/token.ts
@@ -36,6 +36,7 @@ export function graphqlGetResizedNftImageUrlWithFallback(
 
 const backgroundColorOverrides: Record<string, string> = {
   '0x30cdac3871c41a63767247c8d1a2de59f5714e78': '#E0E0E0', // Obits
+  '0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb': '#648494', // Cryptopunks
 };
 
 export function getBackgroundColorOverrideForContract(contractAddress: string) {


### PR DESCRIPTION
### Summary of Changes

Add blue background back for punks now that we're re-processing them all without a background

### Demo or Before/After Pics

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="932" alt="image" src="https://github.com/gallery-so/gallery/assets/12162433/dadf60bb-fc9f-426d-b70d-122a390d4226"> | everything should have a blue background after backend reprocessing lol |

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
