### PR TITLE
'Featured' text is shown above the notification bug fix

### DIFF
--- a/apps/web/src/components/MultiGallery/Gallery.tsx
+++ b/apps/web/src/components/MultiGallery/Gallery.tsx
@@ -423,7 +423,7 @@ const StyledEmptyTokenPreview = styled.div`
 const StyledGalleryActionsContainer = styled.div`
   flex-shrink: 0;
   user-select: none;
-  z-index: 10;
+  z-index: 1;
 `;
 
 const StyledIconContainer = styled(IconContainer)<{ isDragging: boolean }>`


### PR DESCRIPTION
### Summary of Changes

fix z-index bug where the notifications tab is open in the /galleries view, and the 'Featured' text is shown above the notification elements.

### Before

![image (5)](https://github.com/gallery-so/gallery/assets/49758803/14ba590d-1458-4fd1-9b2b-7657a69e0991)


### After

https://github.com/gallery-so/gallery/assets/49758803/598fa732-bbfc-4ab8-a09a-2a6d34134874

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
