### PR TITLE
tab to expand mobile and scroll in web

### DIFF
--- a/apps/mobile/src/components/Feed/Posts/PostListCaption.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostListCaption.tsx
@@ -1,17 +1,29 @@
-import { useMemo } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
+import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import ProcessedText from '~/components/ProcessedText/ProcessedText';
 import { PostListCaptionFragment$key } from '~/generated/PostListCaptionFragment.graphql';
+import { GalleryElementTrackingProps } from '~/shared/contexts/AnalyticsContext';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import { replaceUrlsWithMarkdownFormat } from '~/shared/utils/replaceUrlsWithMarkdownFormat';
 
 type Props = {
   feedPostRef: PostListCaptionFragment$key;
+  eventContext: GalleryElementTrackingProps['eventContext'];
 };
 
-export function PostListCaption({ feedPostRef }: Props) {
+export function PostListCaption({ feedPostRef, eventContext }: Props) {
+  const [showAll, setShowAll] = useState(false);
+  const ref = useRef(null);
+  const toggleText = () => {
+    if (!showAll) {
+      setShowAll(!showAll);
+    }
+  };
+
+
   const feedPost = useFragment(
     graphql`
       fragment PostListCaptionFragment on Post {
@@ -32,7 +44,19 @@ export function PostListCaption({ feedPostRef }: Props) {
 
   return (
     <View className="px-4 pb-4">
-      <ProcessedText text={captionWithMarkdownLinks} mentionsRef={nonNullMentions} />
+      <View>
+        <GalleryTouchableOpacity eventElementId="Show more lines"
+          eventName="Show more lines"
+          eventContext={eventContext}
+          onPress={toggleText}
+          withoutFeedback={true}
+          activeOpacity={0}
+          ref={ref}
+        >
+          <ProcessedText suppressHighlighting={true} numberOfLines={showAll ? undefined : 4} text={captionWithMarkdownLinks} mentionsRef={nonNullMentions} />
+
+        </GalleryTouchableOpacity>
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/components/GalleryTouchableOpacity.tsx
+++ b/apps/mobile/src/components/GalleryTouchableOpacity.tsx
@@ -13,6 +13,7 @@ import { GalleryElementTrackingProps, useTrack } from '~/shared/contexts/Analyti
 
 export type GalleryTouchableOpacityProps = {
   withoutFeedback?: boolean;
+  ref?: React.Ref<TouchableOpacity>;
 } & GalleryElementTrackingProps &
   TouchableOpacityProps;
 
@@ -25,6 +26,7 @@ export function GalleryTouchableOpacity({
   onPress,
   properties,
   withoutFeedback,
+  ref,
   ...props
 }: GalleryTouchableOpacityProps) {
   const track = useTrack();
@@ -55,7 +57,7 @@ export function GalleryTouchableOpacity({
 
   if (withoutFeedback) {
     return (
-      <TouchableWithoutFeedback {...props} onPress={handlePress}>
+      <TouchableWithoutFeedback  {...props} onPress={handlePress}>
         {children}
       </TouchableWithoutFeedback>
     );

--- a/apps/web/src/components/Feed/Posts/PostHeader.tsx
+++ b/apps/web/src/components/Feed/Posts/PostHeader.tsx
@@ -121,6 +121,8 @@ const StyledBaseM = styled(BaseM)`
   word-wrap: break-word;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  overflow: hidden;
   text-overflow: ellipsis;
+  max-height: 300px;
+  padding-right: 20px;
+  overflow-y: scroll;
 `;


### PR DESCRIPTION
### Summary of Changes

Adding the feature on mobile on touch to expand description, and scroll in web with overflow, for this we need to set a maximum height I use 300px but not sure if we want to use another value

### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| not expanding | < <video src="https://github.com/gallery-so/gallery/assets/51178245/95aac612-e431-4a90-b325-ec575045eeb3" /> 
 <video src="https://github.com/gallery-so/gallery/assets/51178245/98711ef5-47b9-4b06-88de-86b80df48853" /> 
|







### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
