### PR TITLE
add justify space between to nft selector sort dropdown

### DIFF
--- a/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorFilterSort.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorFilterSort.tsx
@@ -39,7 +39,12 @@ export function NftSelectorFilterSort({
 
   return (
     <Container>
-      <Selector gap={10} align="center" onClick={() => setIsDropdownOpen(true)}>
+      <Selector
+        gap={10}
+        justify="space-between"
+        align="center"
+        onClick={() => setIsDropdownOpen(true)}
+      >
         <BaseM>{selectedView}</BaseM>
         <IconContainer variant="stacked" size="sm" icon={<DoubleArrowsIcon />} />
       </Selector>


### PR DESCRIPTION
### Summary of Changes

the Sort Filter in the NFT Selector was missing justify:space-between so the arrow moved depending on label length 

### Demo or Before/After Pics

before
https://github.com/gallery-so/gallery/assets/80802871/a66052ab-1afa-4e0c-bc2c-00ab958066e1



after

https://github.com/gallery-so/gallery/assets/80802871/8dd69abc-5efa-431f-a68a-c7d0822ed272



### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
