### PR TITLE
GAL-5122 dont render tooltip in IconContainer on mobile

### DIFF
--- a/apps/web/src/components/core/IconContainer.tsx
+++ b/apps/web/src/components/core/IconContainer.tsx
@@ -2,6 +2,7 @@ import React, { ForwardedRef, forwardRef } from 'react';
 import styled, { css } from 'styled-components';
 
 import { HStack } from '~/components/core/Spacer/Stack';
+import { useIsMobileWindowWidth } from '~/hooks/useWindowSize';
 import colors from '~/shared/theme/colors';
 
 import { NewTooltip } from '../Tooltip/NewTooltip';
@@ -118,6 +119,7 @@ function IconContainer(
 ) {
   const { floating, reference, getFloatingProps, getReferenceProps, floatingStyle } =
     useTooltipHover({ placement: tooltipPlacement });
+  const isMobile = useIsMobileWindowWidth();
   return (
     <div ref={ref}>
       <StyledIcon
@@ -148,7 +150,7 @@ function IconContainer(
           {icon}
         </HStack>
       </StyledIcon>
-      {tooltipLabel && (
+      {tooltipLabel && !isMobile && (
         <NewTooltip
           {...getFloatingProps()}
           style={floatingStyle}


### PR DESCRIPTION
### Summary of Changes

Dont  render tooltip in IconContainer on mobile
the tooltip isn't accessible anyway on mobile because it appears on hover, and its presence in the dom was affecting mobile window width on certain screen sizes

### Demo or Before/After Pics
before
![CleanShot 2024-02-28 at 21 26 38@2x](https://github.com/gallery-so/gallery/assets/80802871/c65052cc-9f5f-4a60-8648-7ea2258d0768)


after
![CleanShot 2024-02-28 at 21 26 11@2x](https://github.com/gallery-so/gallery/assets/80802871/66b61a48-2a34-4af4-bff0-e9e33050aab3)



### Edge Cases
na

### Testing Steps
test tooltips in general (should still appear on desktop)
and check profile pages with the Active Badge, which was causing the screen width issue on smaller devices

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
