### PR TITLE
Add Share button to dropdown of Gallery on Multi Gallery tab

### DIFF
--- a/apps/web/src/components/MultiGallery/Gallery.tsx
+++ b/apps/web/src/components/MultiGallery/Gallery.tsx
@@ -21,6 +21,7 @@ import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
 import colors from '~/shared/theme/colors';
 import { noop } from '~/shared/utils/noop';
 
+import CopyToClipboard from '../CopyToClipboard/CopyToClipboard';
 import { DropdownItem } from '../core/Dropdown/DropdownItem';
 import { DropdownSection } from '../core/Dropdown/DropdownSection';
 import SettingsDropdown from '../core/Dropdown/SettingsDropdown';
@@ -203,6 +204,10 @@ export default function Gallery({
     query: { username: gallery.owner.username, galleryId: gallery.dbid },
   };
 
+  const galleryUrl = useMemo(() => {
+    return `${window.location.origin}/${gallery?.owner?.username}/galleries/${gallery.dbid}`;
+  }, [gallery.dbid, gallery.owner.username]);
+
   const galleryEditLink: Route = useMemo(
     () => ({
       pathname: '/gallery/[galleryId]/edit',
@@ -304,6 +309,15 @@ export default function Gallery({
                               label="Hide"
                             />
                           </>
+                        )}
+                        {!hidden && (
+                          <CopyToClipboard textToCopy={galleryUrl}>
+                            <DropdownItem
+                              name="Share Gallery"
+                              eventContext={contexts.Editor}
+                              label="Share"
+                            />
+                          </CopyToClipboard>
                         )}
                         <DropdownItem
                           onClick={handleDeleteGallery}


### PR DESCRIPTION
### Summary of Changes

Add Share button to dropdown of Gallery on Multi Gallery tab (if gallery isn't hidden)

### Demo or Before/After Pics

![CleanShot 2024-03-01 at 18 48 20@2x](https://github.com/gallery-so/gallery/assets/80802871/9e32c3c3-d30f-4b20-8e29-92440ae376bc)



### Edge Cases

na

### Testing Steps

go to Galleries tab on your profile and click dropdown of a gallery. you should see a Share option and it should copy the gallery url.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
