### PR TITLE
Add tooltips for onboarding

### DIFF
--- a/apps/web/src/components/Onboarding/WelcomeNewUser.tsx
+++ b/apps/web/src/components/Onboarding/WelcomeNewUser.tsx
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useState } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import colors from 'shared/theme/colors';
+import styled from 'styled-components';
+
+import SidebarIcon from '~/contexts/globalLayout/GlobalSidebar/SidebarIcon';
+import SidebarPfp from '~/contexts/globalLayout/GlobalSidebar/SidebarPfp';
+import { useModalActions } from '~/contexts/modal/ModalContext';
+import { WelcomeNewUserFragment$key } from '~/generated/WelcomeNewUserFragment.graphql';
+import { WelcomeNewUserQueryFragment$key } from '~/generated/WelcomeNewUserQueryFragment.graphql';
+import BellIcon from '~/icons/BellIcon';
+import CogIcon from '~/icons/CogIcon';
+import HomeIcon from '~/icons/HomeIcon';
+import { PlusSquareIcon } from '~/icons/PlusSquareIcon';
+import { QuestionMarkIcon } from '~/icons/QuestionMarkIcon';
+import SearchIcon from '~/icons/SearchIcon';
+import { useClearURLQueryParams } from '~/utils/useClearURLQueryParams';
+
+import breakpoints from '../core/breakpoints';
+import { HStack, VStack } from '../core/Spacer/Stack';
+import { BaseS } from '../core/Text/Text';
+import { WelcomeNewUserModal } from './WelcomeNewUserModal';
+
+type Props = {
+  queryRef: WelcomeNewUserFragment$key;
+};
+
+export function WelcomeNewUser({ queryRef }: Props) {
+  const query = useFragment(
+    graphql`
+      fragment WelcomeNewUserFragment on Query {
+        ...WelcomeNewUserQueryFragment
+        viewer {
+          ... on Viewer {
+            user {
+              username
+            }
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  const username = query?.viewer?.user?.username ?? '';
+
+  useClearURLQueryParams(['onboarding']);
+
+  // Step 1: Welcome message
+  // Step 2: Post message
+  // Step 3: Profile message
+  const [step, setStep] = useState(1);
+
+  const { showModal, hideModal } = useModalActions();
+
+  const handleNextStep = useCallback(() => {
+    setStep((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    if (step === 1) {
+      showModal({
+        content: (
+          <WelcomeNewUserModal
+            username={username}
+            onContinue={() => {
+              setStep(2);
+              hideModal();
+            }}
+          />
+        ),
+        hideClose: true,
+        onClose: () => {
+          setStep(2);
+        },
+      });
+      return;
+    }
+  }, [hideModal, showModal, step, username]);
+
+  if (step > 3) {
+    return null;
+  }
+
+  return (
+    <StyledOverlay onClick={handleNextStep}>
+      {(step === 2 || step === 3) && (
+        <MockSidebar queryRef={query} onNextStep={handleNextStep} step={step} />
+      )}
+    </StyledOverlay>
+  );
+}
+
+const StyledOverlay = styled.div`
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 10;
+  backdrop-filter: blur(4px);
+  top: 0;
+  left: 0;
+`;
+
+type MockSidebarProps = {
+  queryRef: WelcomeNewUserQueryFragment$key;
+  step: number;
+  onNextStep: () => void;
+};
+
+function MockSidebar({ queryRef, onNextStep, step }: MockSidebarProps) {
+  const query = useFragment(
+    graphql`
+      fragment WelcomeNewUserQueryFragment on Query {
+        viewer {
+          ... on Viewer {
+            __typename
+            user {
+              ...SidebarPfpFragment
+            }
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  return (
+    <MockSidebarContainer>
+      <StyledStandardSidebar>
+        <StyledIconContainer align="center" justify="space-between">
+          <VStack gap={18}>
+            {query.viewer?.__typename === 'Viewer' && query?.viewer?.user && (
+              <SidebarPfp userRef={query.viewer.user} onClick={onNextStep} />
+            )}
+            {step === 2 && (
+              <StyledTooltip gap={10} align="center" step="profile">
+                <StyledTooltipText>This is where you can set up your own Gallery</StyledTooltipText>
+                <StyledTooltipTextProgress>1/2</StyledTooltipTextProgress>
+              </StyledTooltip>
+            )}
+          </VStack>
+          <VStack gap={24}>
+            <StyledSidebarIconContainer>
+              <StyledSidebarIcon
+                to={{ pathname: '/home' }}
+                tooltipLabel="Home"
+                onClick={onNextStep}
+                icon={<HomeIcon />}
+              />
+            </StyledSidebarIconContainer>
+            <div
+              style={{
+                position: 'relative',
+              }}
+            >
+              <StyledSidebarIconContainer>
+                <StyledSidebarIcon
+                  tooltipLabel="Create a post"
+                  onClick={onNextStep}
+                  icon={<PlusSquareIcon />}
+                />
+              </StyledSidebarIconContainer>
+
+              {step === 3 && (
+                <StyledTooltip gap={10} align="center" step="post">
+                  <StyledTooltipText>
+                    Tap here to post an item from your collection
+                  </StyledTooltipText>
+                  <StyledTooltipTextProgress>2/2</StyledTooltipTextProgress>
+                </StyledTooltip>
+              )}
+            </div>
+            <StyledSidebarIconContainer>
+              <StyledSidebarIcon tooltipLabel="Search" onClick={onNextStep} icon={<SearchIcon />} />
+            </StyledSidebarIconContainer>
+            <StyledSidebarIconContainer>
+              <StyledSidebarIcon
+                tooltipLabel="Notifications"
+                onClick={onNextStep}
+                icon={<BellIcon />}
+              />
+            </StyledSidebarIconContainer>
+          </VStack>
+          <VStack gap={24}>
+            <StyledSidebarIconContainer>
+              <StyledSidebarIcon tooltipLabel="Settings" onClick={onNextStep} icon={<CogIcon />} />
+            </StyledSidebarIconContainer>
+            <StyledSidebarIconContainer>
+              <StyledSidebarIcon
+                href="#"
+                tooltipLabel="Support/FAQ"
+                onClick={onNextStep}
+                icon={<QuestionMarkIcon color={colors.black[800]} />}
+              />
+            </StyledSidebarIconContainer>
+          </VStack>
+        </StyledIconContainer>
+      </StyledStandardSidebar>
+    </MockSidebarContainer>
+  );
+}
+
+const MockSidebarContainer = styled.div`
+  height: 100vh;
+  background: ${colors.white};
+  width: 64px;
+`;
+
+const StyledStandardSidebar = styled.div`
+  min-width: 100%;
+  height: 100%;
+
+  @media only screen and ${breakpoints.tablet} {
+    padding: 16px 0;
+  }
+`;
+const StyledSidebarIcon = styled(SidebarIcon)``;
+
+const StyledSidebarIconContainer = styled(VStack)<{ active?: boolean }>`
+  svg {
+    opacity: ${({ active }) => (active ? 1 : 0.25)};
+  }
+`;
+
+const StyledIconContainer = styled(VStack)`
+  height: 100%;
+`;
+
+const StyledTooltip = styled(HStack)<{ step: 'profile' | 'post' }>`
+  padding: 4px 8px;
+  background: ${colors.white};
+  border-radius: 1px;
+
+  position: absolute;
+
+  ${({ step }) =>
+    step === 'profile'
+      ? `
+      top: 16px;
+      left: 72px;
+    `
+      : `
+      top: 0;
+      left: 60px;
+    `}
+
+  width: max-content;
+
+  /* transition: top 1s ease, left 1s ease; */
+`;
+
+const StyledTooltipText = styled(BaseS)`
+  font-weight: 700;
+`;
+
+const StyledTooltipTextProgress = styled(BaseS)`
+  color: ${colors.shadow};
+`;

--- a/apps/web/src/components/Onboarding/WelcomeNewUser.tsx
+++ b/apps/web/src/components/Onboarding/WelcomeNewUser.tsx
@@ -8,6 +8,7 @@ import SidebarPfp from '~/contexts/globalLayout/GlobalSidebar/SidebarPfp';
 import { useModalActions } from '~/contexts/modal/ModalContext';
 import { WelcomeNewUserFragment$key } from '~/generated/WelcomeNewUserFragment.graphql';
 import { WelcomeNewUserQueryFragment$key } from '~/generated/WelcomeNewUserQueryFragment.graphql';
+import { useIsMobileOrMobileLargeWindowWidth } from '~/hooks/useWindowSize';
 import BellIcon from '~/icons/BellIcon';
 import CogIcon from '~/icons/CogIcon';
 import HomeIcon from '~/icons/HomeIcon';
@@ -19,6 +20,7 @@ import { useClearURLQueryParams } from '~/utils/useClearURLQueryParams';
 import breakpoints from '../core/breakpoints';
 import { HStack, VStack } from '../core/Spacer/Stack';
 import { BaseS } from '../core/Text/Text';
+import transitions from '../core/transitions';
 import { WelcomeNewUserModal } from './WelcomeNewUserModal';
 
 type Props = {
@@ -125,24 +127,82 @@ function MockSidebar({ queryRef, onNextStep, step }: MockSidebarProps) {
     queryRef
   );
 
+  const isMobile = useIsMobileOrMobileLargeWindowWidth();
+  if (isMobile) {
+    return (
+      <MockMobileSidebarContainer>
+        <StyledStandardSidebar>
+          <StyledMobileIconContainer align="center" justify="space-around">
+            <StyledSidebarIconContainer>
+              <SidebarIcon
+                to={{ pathname: '/home' }}
+                tooltipLabel="Home"
+                onClick={onNextStep}
+                icon={<HomeIcon />}
+              />
+            </StyledSidebarIconContainer>
+            <StyledSidebarIconContainer>
+              <SidebarIcon tooltipLabel="Search" onClick={onNextStep} icon={<SearchIcon />} />
+            </StyledSidebarIconContainer>
+            <StyledSidebarIconContainer active={step === 3}>
+              <SidebarIcon
+                tooltipLabel="Create a post"
+                onClick={onNextStep}
+                icon={<PlusSquareIcon />}
+              />
+            </StyledSidebarIconContainer>
+            <StyledSidebarIconContainer>
+              <SidebarIcon tooltipLabel="Notifications" onClick={onNextStep} icon={<BellIcon />} />
+            </StyledSidebarIconContainer>
+            <StyledSidebarIconContainer active={step === 2}>
+              {query.viewer?.__typename === 'Viewer' && query?.viewer?.user && (
+                <SidebarPfp userRef={query.viewer.user} onClick={onNextStep} />
+              )}
+            </StyledSidebarIconContainer>
+          </StyledMobileIconContainer>
+        </StyledStandardSidebar>
+
+        <StyledMobileStyledTooltipContainer
+          align="flex-end"
+          active={step === 2}
+          style={{
+            paddingRight: 8,
+          }}
+        >
+          <StyledMobileStyledTooltip gap={10} align="center">
+            <StyledTooltipText>This is where you can set up your own Gallery</StyledTooltipText>
+            <StyledTooltipTextProgress>1/2</StyledTooltipTextProgress>
+          </StyledMobileStyledTooltip>
+        </StyledMobileStyledTooltipContainer>
+
+        <StyledMobileStyledTooltipContainer align="center" active={step === 3}>
+          <StyledMobileStyledTooltip gap={10} align="center">
+            <StyledTooltipText>Tap here to post an item from your collection</StyledTooltipText>
+            <StyledTooltipTextProgress>2/2</StyledTooltipTextProgress>
+          </StyledMobileStyledTooltip>
+        </StyledMobileStyledTooltipContainer>
+      </MockMobileSidebarContainer>
+    );
+  }
+
   return (
     <MockSidebarContainer>
       <StyledStandardSidebar>
         <StyledIconContainer align="center" justify="space-between">
           <VStack gap={18}>
-            {query.viewer?.__typename === 'Viewer' && query?.viewer?.user && (
-              <SidebarPfp userRef={query.viewer.user} onClick={onNextStep} />
-            )}
-            {step === 2 && (
-              <StyledTooltip gap={10} align="center" step="profile">
-                <StyledTooltipText>This is where you can set up your own Gallery</StyledTooltipText>
-                <StyledTooltipTextProgress>1/2</StyledTooltipTextProgress>
-              </StyledTooltip>
-            )}
+            <StyledSidebarIconContainer active={step === 2}>
+              {query.viewer?.__typename === 'Viewer' && query?.viewer?.user && (
+                <SidebarPfp userRef={query.viewer.user} onClick={onNextStep} />
+              )}
+            </StyledSidebarIconContainer>
+            <StyledTooltip gap={10} align="center" step="profile" active={step === 2}>
+              <StyledTooltipText>This is where you can set up your own Gallery</StyledTooltipText>
+              <StyledTooltipTextProgress>1/2</StyledTooltipTextProgress>
+            </StyledTooltip>
           </VStack>
           <VStack gap={24}>
             <StyledSidebarIconContainer>
-              <StyledSidebarIcon
+              <SidebarIcon
                 to={{ pathname: '/home' }}
                 tooltipLabel="Home"
                 onClick={onNextStep}
@@ -154,40 +214,32 @@ function MockSidebar({ queryRef, onNextStep, step }: MockSidebarProps) {
                 position: 'relative',
               }}
             >
-              <StyledSidebarIconContainer>
-                <StyledSidebarIcon
+              <StyledSidebarIconContainer active={step === 3}>
+                <SidebarIcon
                   tooltipLabel="Create a post"
                   onClick={onNextStep}
                   icon={<PlusSquareIcon />}
                 />
               </StyledSidebarIconContainer>
 
-              {step === 3 && (
-                <StyledTooltip gap={10} align="center" step="post">
-                  <StyledTooltipText>
-                    Tap here to post an item from your collection
-                  </StyledTooltipText>
-                  <StyledTooltipTextProgress>2/2</StyledTooltipTextProgress>
-                </StyledTooltip>
-              )}
+              <StyledTooltip gap={10} align="center" step="post" active={step === 3}>
+                <StyledTooltipText>Tap here to post an item from your collection</StyledTooltipText>
+                <StyledTooltipTextProgress>2/2</StyledTooltipTextProgress>
+              </StyledTooltip>
             </div>
             <StyledSidebarIconContainer>
-              <StyledSidebarIcon tooltipLabel="Search" onClick={onNextStep} icon={<SearchIcon />} />
+              <SidebarIcon tooltipLabel="Search" onClick={onNextStep} icon={<SearchIcon />} />
             </StyledSidebarIconContainer>
             <StyledSidebarIconContainer>
-              <StyledSidebarIcon
-                tooltipLabel="Notifications"
-                onClick={onNextStep}
-                icon={<BellIcon />}
-              />
+              <SidebarIcon tooltipLabel="Notifications" onClick={onNextStep} icon={<BellIcon />} />
             </StyledSidebarIconContainer>
           </VStack>
           <VStack gap={24}>
             <StyledSidebarIconContainer>
-              <StyledSidebarIcon tooltipLabel="Settings" onClick={onNextStep} icon={<CogIcon />} />
+              <SidebarIcon tooltipLabel="Settings" onClick={onNextStep} icon={<CogIcon />} />
             </StyledSidebarIconContainer>
             <StyledSidebarIconContainer>
-              <StyledSidebarIcon
+              <SidebarIcon
                 href="#"
                 tooltipLabel="Support/FAQ"
                 onClick={onNextStep}
@@ -207,6 +259,16 @@ const MockSidebarContainer = styled.div`
   width: 64px;
 `;
 
+const MockMobileSidebarContainer = styled.div`
+  height: 100vh;
+  background: ${colors.white};
+  width: 100%;
+
+  height: 48px;
+  bottom: 0;
+  position: absolute;
+`;
+
 const StyledStandardSidebar = styled.div`
   min-width: 100%;
   height: 100%;
@@ -215,10 +277,10 @@ const StyledStandardSidebar = styled.div`
     padding: 16px 0;
   }
 `;
-const StyledSidebarIcon = styled(SidebarIcon)``;
 
 const StyledSidebarIconContainer = styled(VStack)<{ active?: boolean }>`
-  svg {
+  svg,
+  img {
     opacity: ${({ active }) => (active ? 1 : 0.25)};
   }
 `;
@@ -227,7 +289,7 @@ const StyledIconContainer = styled(VStack)`
   height: 100%;
 `;
 
-const StyledTooltip = styled(HStack)<{ step: 'profile' | 'post' }>`
+const StyledTooltip = styled(HStack)<{ step: 'profile' | 'post'; active?: boolean }>`
   padding: 4px 8px;
   background: ${colors.white};
   border-radius: 1px;
@@ -241,13 +303,30 @@ const StyledTooltip = styled(HStack)<{ step: 'profile' | 'post' }>`
       left: 72px;
     `
       : `
-      top: 0;
+      top: 4px;
       left: 60px;
     `}
 
   width: max-content;
+  opacity: ${({ active }) => (active ? 1 : 0)};
+  transition: opacity ${transitions.cubic};
+`;
 
-  /* transition: top 1s ease, left 1s ease; */
+const StyledMobileStyledTooltipContainer = styled(VStack)<{ active?: boolean }>`
+  width: 100%;
+  position: absolute;
+  top: -32px;
+  opacity: ${({ active }) => (active ? 1 : 0)};
+  transition: opacity ${transitions.cubic};
+`;
+
+const StyledMobileStyledTooltip = styled(HStack)`
+  padding: 4px 8px;
+  background: ${colors.white};
+  border-radius: 1px;
+
+  width: max-content;
+  transition: opacity ${transitions.cubic};
 `;
 
 const StyledTooltipText = styled(BaseS)`
@@ -256,4 +335,8 @@ const StyledTooltipText = styled(BaseS)`
 
 const StyledTooltipTextProgress = styled(BaseS)`
   color: ${colors.shadow};
+`;
+
+const StyledMobileIconContainer = styled(HStack)`
+  height: 100%;
 `;

--- a/apps/web/src/components/Onboarding/WelcomeNewUser.tsx
+++ b/apps/web/src/components/Onboarding/WelcomeNewUser.tsx
@@ -45,7 +45,7 @@ export function WelcomeNewUser({ queryRef }: Props) {
     queryRef
   );
 
-  const username = query?.viewer?.user?.username ?? '';
+  const username = query?.viewer?.__typename === 'Viewer' ? query.viewer.user?.username : '';
 
   useClearURLQueryParams(['onboarding']);
 
@@ -65,7 +65,7 @@ export function WelcomeNewUser({ queryRef }: Props) {
       showModal({
         content: (
           <WelcomeNewUserModal
-            username={username}
+            username={username ?? ''}
             onContinue={() => {
               setStep(2);
               hideModal();

--- a/apps/web/src/components/Onboarding/WelcomeNewUser.tsx
+++ b/apps/web/src/components/Onboarding/WelcomeNewUser.tsx
@@ -34,6 +34,7 @@ export function WelcomeNewUser({ queryRef }: Props) {
         ...WelcomeNewUserQueryFragment
         viewer {
           ... on Viewer {
+            __typename
             user {
               username
             }
@@ -80,7 +81,7 @@ export function WelcomeNewUser({ queryRef }: Props) {
     }
   }, [hideModal, showModal, step, username]);
 
-  if (step > 3) {
+  if (step > 3 || query.viewer?.__typename !== 'Viewer') {
     return null;
   }
 

--- a/apps/web/src/components/Onboarding/WelcomeNewUser.tsx
+++ b/apps/web/src/components/Onboarding/WelcomeNewUser.tsx
@@ -19,7 +19,7 @@ import { useClearURLQueryParams } from '~/utils/useClearURLQueryParams';
 
 import breakpoints from '../core/breakpoints';
 import { HStack, VStack } from '../core/Spacer/Stack';
-import { BaseS } from '../core/Text/Text';
+import { BaseM } from '../core/Text/Text';
 import transitions from '../core/transitions';
 import { WelcomeNewUserModal } from './WelcomeNewUserModal';
 
@@ -172,14 +172,12 @@ function MockSidebar({ queryRef, onNextStep, step }: MockSidebarProps) {
         >
           <StyledMobileStyledTooltip gap={10} align="center">
             <StyledTooltipText>This is where you can set up your own Gallery</StyledTooltipText>
-            <StyledTooltipTextProgress>1/2</StyledTooltipTextProgress>
           </StyledMobileStyledTooltip>
         </StyledMobileStyledTooltipContainer>
 
         <StyledMobileStyledTooltipContainer align="center" active={step === 3}>
           <StyledMobileStyledTooltip gap={10} align="center">
             <StyledTooltipText>Tap here to post an item from your collection</StyledTooltipText>
-            <StyledTooltipTextProgress>2/2</StyledTooltipTextProgress>
           </StyledMobileStyledTooltip>
         </StyledMobileStyledTooltipContainer>
       </MockMobileSidebarContainer>
@@ -316,7 +314,7 @@ const StyledTooltip = styled(HStack)<{ step: 'profile' | 'post'; active?: boolea
 const StyledMobileStyledTooltipContainer = styled(VStack)<{ active?: boolean }>`
   width: 100%;
   position: absolute;
-  top: -32px;
+  top: -36px;
   opacity: ${({ active }) => (active ? 1 : 0)};
   transition: opacity ${transitions.cubic};
 `;
@@ -330,11 +328,11 @@ const StyledMobileStyledTooltip = styled(HStack)`
   transition: opacity ${transitions.cubic};
 `;
 
-const StyledTooltipText = styled(BaseS)`
+const StyledTooltipText = styled(BaseM)`
   font-weight: 700;
 `;
 
-const StyledTooltipTextProgress = styled(BaseS)`
+const StyledTooltipTextProgress = styled(BaseM)`
   color: ${colors.shadow};
 `;
 

--- a/apps/web/src/components/Onboarding/WelcomeNewUserModal.tsx
+++ b/apps/web/src/components/Onboarding/WelcomeNewUserModal.tsx
@@ -1,0 +1,44 @@
+import { contexts } from 'shared/analytics/constants';
+import styled from 'styled-components';
+
+import { Button } from '../core/Button/Button';
+import { VStack } from '../core/Spacer/Stack';
+import { BaseM, TitleL } from '../core/Text/Text';
+
+type Props = {
+  username: string;
+  onContinue: () => void;
+};
+
+export function WelcomeNewUserModal({ username, onContinue }: Props) {
+  return (
+    <StyledWelcomeModal gap={32} align="center">
+      <TitleL>
+        Welcome to Gallery, <br />
+        {username}!
+      </TitleL>
+      <BaseM>
+        This is where you’ll see updates from other Gallery users. Toggle between your personalized
+        'For You' feed and the 'Following' feed, showing the latest updates from your connections.
+      </BaseM>
+      <StyledButton
+        onClick={onContinue}
+        eventElementId="Welcome New User Modal"
+        eventName="Click Welcome New User Modal"
+        eventContext={contexts.Onboarding}
+      >
+        Continue
+      </StyledButton>
+    </StyledWelcomeModal>
+  );
+}
+
+const StyledWelcomeModal = styled(VStack)`
+  width: 500px;
+  padding: 24px 32px;
+  text-align: center;
+`;
+
+const StyledButton = styled(Button)`
+  width: 150px;
+`;

--- a/apps/web/src/components/Onboarding/WelcomeNewUserModal.tsx
+++ b/apps/web/src/components/Onboarding/WelcomeNewUserModal.tsx
@@ -1,6 +1,7 @@
 import { contexts } from 'shared/analytics/constants';
 import styled from 'styled-components';
 
+import breakpoints from '../core/breakpoints';
 import { Button } from '../core/Button/Button';
 import { VStack } from '../core/Spacer/Stack';
 import { BaseM, TitleL } from '../core/Text/Text';
@@ -34,9 +35,13 @@ export function WelcomeNewUserModal({ username, onContinue }: Props) {
 }
 
 const StyledWelcomeModal = styled(VStack)`
-  width: 500px;
+  width: 100%;
   padding: 24px 32px;
   text-align: center;
+
+  @media only screen and ${breakpoints.tablet} {
+    width: 500px;
+  }
 `;
 
 const StyledButton = styled(Button)`

--- a/apps/web/src/scenes/Home/CuratedHomePage.tsx
+++ b/apps/web/src/scenes/Home/CuratedHomePage.tsx
@@ -1,8 +1,12 @@
 import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { graphql, useFragment } from 'react-relay';
 
 import CuratedFeed from '~/components/Feed/CuratedFeed';
 import { FeedPage } from '~/components/Feed/FeedPage';
+import { WelcomeNewUser } from '~/components/Onboarding/WelcomeNewUser';
 import { CuratedHomePageFragment$key } from '~/generated/CuratedHomePageFragment.graphql';
 
 type Props = {
@@ -14,16 +18,29 @@ export default function CuratedHomePage({ queryRef }: Props) {
     graphql`
       fragment CuratedHomePageFragment on Query {
         ...CuratedFeedFragment
+        ...WelcomeNewUserFragment
       }
     `,
     queryRef
   );
+
+  const [showWelcome, setShowWelcome] = useState(false);
+
+  const { query: urlQuery } = useRouter();
+  const { onboarding } = urlQuery;
+
+  useEffect(() => {
+    if (onboarding) {
+      setShowWelcome(true);
+    }
+  }, [onboarding]);
 
   return (
     <>
       <Head>
         <title>Gallery | Trending</title>
       </Head>
+      {showWelcome && createPortal(<WelcomeNewUser queryRef={query} />, document.body)}
       <FeedPage>
         <CuratedFeed queryRef={query} />
       </FeedPage>


### PR DESCRIPTION
### Summary of Changes

Added tooltips to welcome user after user going through onboarding

### Demo or Before/After Pics

**Desktop view**

https://github.com/gallery-so/gallery/assets/4480258/f39aa1ff-0d0b-4855-9617-31eafe514981



**Mobile view**


https://github.com/gallery-so/gallery/assets/4480258/fde4324b-6c48-4b2d-9865-290f9086ae97



### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

1. Visit `https://localhost/home?onboarding=true`

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
