### PR TITLE
pato/fix android feed

### DIFF
--- a/apps/mobile/src/components/GalleryRefreshControl.tsx
+++ b/apps/mobile/src/components/GalleryRefreshControl.tsx
@@ -8,7 +8,7 @@ type GalleryRefreshControlProps = {
   onRefresh: () => void;
   refreshing: boolean;
 };
-export function GalleryRefreshControl({ onRefresh, refreshing }: GalleryRefreshControlProps) {
+export function GalleryRefreshControl({ onRefresh, refreshing, ...props }: GalleryRefreshControlProps) {
   const { colorScheme } = useColorScheme();
 
   return (
@@ -19,6 +19,7 @@ export function GalleryRefreshControl({ onRefresh, refreshing }: GalleryRefreshC
       colors={colorScheme === 'dark' ? [colors.white] : [colors.black.DEFAULT]}
       refreshing={refreshing}
       onRefresh={onRefresh}
+      {...props}
     />
   );
 }

--- a/apps/mobile/src/components/GalleryRefreshControl.tsx
+++ b/apps/mobile/src/components/GalleryRefreshControl.tsx
@@ -10,7 +10,11 @@ type GalleryRefreshControlProps = {
   onRefresh: () => void;
   refreshing: boolean;
 };
-export function GalleryRefreshControl({ onRefresh, refreshing, ...props }: GalleryRefreshControlProps) {
+export function GalleryRefreshControl({
+  onRefresh,
+  refreshing,
+  ...props
+}: GalleryRefreshControlProps) {
   const { colorScheme } = useColorScheme();
 
   const handleRefresh = useCallback(() => {


### PR DESCRIPTION
### Summary of Changes

Left a thorough description in slack, but basically in android there needs to be the `...props` passed to RefreshControl, in iOS it works fine without.
Tested in both android and iOS and is working fine

### Demo or Before/After Pics

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
|![Screenshot 2024-03-06 at 12 30 04](https://github.com/gallery-so/gallery/assets/112896251/756b09b8-882b-4223-b252-255fd1a84e27) | ![Screenshot 2024-03-06 at 12 28 56](https://github.com/gallery-so/gallery/assets/112896251/201db742-bf55-4d5c-a97b-ec00495aef91) |



### Checklist

Please make sure to review and check all of the following:

- [] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [] (if mobile) I've tested the changes on both light and dark modes.
