### PR TITLE
pato/fix loading skeleton styles

### DIFF
--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorPickerScreen.tsx
@@ -31,9 +31,8 @@ import {
   NftSelectorFilterBottomSheet,
   NftSelectorSortView,
 } from './NftSelectorFilterBottomSheet';
+import { NftSelectorLoadingSkeleton } from './NftSelectorLoadingSkeleton';
 import { NftSelectorPickerGrid } from './NftSelectorPickerGrid';
-import { NftSelectorPickerScreenFallback } from './NftSelectorPickerScreenFallback';
-import { NftSelectorScreenFallback } from './NftSelectorScreenFallback';
 
 const NETWORKS: {
   label: string;
@@ -213,7 +212,7 @@ function InnerNftSelectorPickerScreen() {
               </View>
             </View>
             <View className="flex-grow flex-1 w-full">
-              <Suspense fallback={<NftSelectorScreenFallback />}>
+              <Suspense fallback={<NftSelectorLoadingSkeleton />}>
                 <NftSelectorPickerGrid
                   searchCriteria={{
                     searchQuery,
@@ -278,7 +277,7 @@ function CreatorBottomSheetWrapper({
 
 export function NftSelectorPickerScreen() {
   return (
-    <Suspense fallback={<NftSelectorPickerScreenFallback />}>
+    <Suspense fallback={<NftSelectorLoadingSkeleton />}>
       <InnerNftSelectorPickerScreen />
     </Suspense>
   );


### PR DESCRIPTION
### Summary of Changes
Basically changed the skeleton styles for the picker screen on load. It was fine when you refreshed but on first mount the older skeleton was still being shown.

### Demo or Before/After Pics

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
|![Screenshot 2024-03-06 at 17 17 39](https://github.com/gallery-so/gallery/assets/112896251/70627d60-4158-4d29-af53-a6102c1db631) | ![Screenshot 2024-03-06 at 17 16 46](https://github.com/gallery-so/gallery/assets/112896251/bebabce9-e324-4389-a045-71ae2fe390ba) |


### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
