### PR TITLE
GAL-5263 fix gallery page spacing on mobile

### DIFF
--- a/apps/web/src/scenes/UserGalleryPage/FocusedGalleryPage.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/FocusedGalleryPage.tsx
@@ -8,6 +8,8 @@ import { GalleryPageSpacing } from '~/pages/[username]';
 import { UserGalleryLayout } from '~/scenes/UserGalleryPage/UserGalleryLayout';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 
+import { MobileSpacingContainer } from './UserGallery';
+
 type FocusedGalleryPageProps = {
   queryRef: FocusedGalleryPageFragment$key;
 };
@@ -57,7 +59,9 @@ export function FocusedGalleryPage({ queryRef }: FocusedGalleryPageProps) {
         <title>{headTitle}</title>
       </Head>
       <GalleryPageSpacing>
-        <UserGalleryLayout galleryRef={query.galleryById} queryRef={query} />
+        <MobileSpacingContainer>
+          <UserGalleryLayout galleryRef={query.galleryById} queryRef={query} />
+        </MobileSpacingContainer>
       </GalleryPageSpacing>
     </>
   );


### PR DESCRIPTION
### Summary of Changes

Fix page gutter for individual gallery page on mobile



### Demo or Before/After Pics

before
![CleanShot 2024-03-07 at 15 22 43@2x](https://github.com/gallery-so/gallery/assets/80802871/bbfd8b82-e8a7-47dd-b2e6-94bc0afbf910)

after

![CleanShot 2024-03-07 at 15 22 03@2x](https://github.com/gallery-so/gallery/assets/80802871/5b76b076-2ca4-4571-baee-064b47fc7d10)



### Edge Cases

na
### Testing Steps

go an individual gallery page like http://localhost:3000/gianna/galleries/0c4e5e97fc3d407a23313aa748ff319d on mobile screen size, there should be a page gutter so the content isn't flush with the screen edge


### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
