### PR TITLE
Default to explore frame button

### DIFF
--- a/apps/web/pages/community/[chain]/[contractAddress]/index.tsx
+++ b/apps/web/pages/community/[chain]/[contractAddress]/index.tsx
@@ -90,7 +90,6 @@ export const getServerSideProps: GetServerSideProps<CommunityPageProps> = async 
             title: `${contractAddress} | Gallery`,
             path: `/community/${chain}/${contractAddress}`,
             isFcFrameCompatible: true,
-            buttonContent: 'Explore',
           })
         : null,
     },

--- a/apps/web/src/utils/openGraphMetaTags.ts
+++ b/apps/web/src/utils/openGraphMetaTags.ts
@@ -18,7 +18,7 @@ export const openGraphMetaTags = ({
   title,
   path,
   isFcFrameCompatible,
-  buttonContent = '→',
+  buttonContent = 'Explore',
 }: Params): Required<MetaTagProps['metaTags']> => {
   const tags = [
     { property: 'og:title', content: title },
@@ -48,6 +48,10 @@ export const openGraphMetaTags = ({
       {
         property: `fc:frame:button:1`,
         content: buttonContent,
+      },
+      {
+        property: `fc:frame:button:1:action`,
+        content: 'post',
       },
       {
         property: 'fc:frame:image',


### PR DESCRIPTION
### Summary of Changes

Frame buttons being served from our site should default to "Explore" to represent a splash screen, as opposed to a right-arrow

### Demo or Before/After Pics

- If this is a new feature, include screenshots or recordings of the feature in action.
- If this PR makes visual changes, include before and after screenshots.

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img src="https://placehold.co/500x300" /> | <img src="https://placehold.co/500x300" /> |

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
