### PR TITLE
add Email Notification Setting unsub options

### DIFF
--- a/apps/mobile/src/icons/CircleCheckIcon.tsx
+++ b/apps/mobile/src/icons/CircleCheckIcon.tsx
@@ -6,7 +6,11 @@ import colors from '~/shared/theme/colors';
 
 export function CircleCheckIcon(props: SvgProps) {
   const { colorScheme } = useColorScheme();
-  const stroke = colorScheme === 'dark' ? colors.white : colors.black['800'];
+  const stroke = props.stroke
+    ? props.stroke
+    : colorScheme === 'dark'
+    ? colors.white
+    : colors.black['800'];
   return (
     <Svg width="48" height="48" viewBox="0 0 48 48" fill="none" {...props}>
       <Path

--- a/apps/mobile/src/screens/SettingsScreen/EmailNotificationSettingsSection.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/EmailNotificationSettingsSection.tsx
@@ -1,0 +1,158 @@
+import { useColorScheme } from 'nativewind';
+import { useMemo } from 'react';
+import { View } from 'react-native';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import colors from 'shared/theme/colors';
+import { CircleCheckIcon } from 'src/icons/CircleCheckIcon';
+
+import { Toggle } from '~/components/Toggle';
+import { Typography } from '~/components/Typography';
+import { useToastActions } from '~/contexts/ToastContext';
+import { EmailNotificationSettingsSectionQuery } from '~/generated/EmailNotificationSettingsSectionQuery.graphql';
+import useUpdateEmailNotificationSettings from '~/shared/hooks/useUpdateEmailNotificationSettings';
+
+export function EmailNotificationSettingsSection() {
+  const query = useLazyLoadQuery<EmailNotificationSettingsSectionQuery>(
+    graphql`
+      query EmailNotificationSettingsSectionQuery {
+        viewer {
+          ... on Viewer {
+            user {
+              roles
+            }
+            email {
+              email
+              verificationStatus
+            }
+          }
+        }
+        ...useUpdateEmailNotificationSettingsFragment
+      }
+    `,
+    {}
+  );
+
+  const hasEarlyAccess = useMemo(() => {
+    return query.viewer?.user?.roles?.includes('EARLY_ACCESS') ?? false;
+  }, [query]);
+
+  const emailNotificationSettingData = useMemo(
+    () => [
+      {
+        key: 'notifications',
+        title: 'Notifications',
+        description: 'Weekly summary of your unread notifications',
+      },
+      {
+        key: 'marketing',
+        title: 'General Marketing',
+        description: 'Product updates, artist collabs, and airdrops',
+      },
+      ...(hasEarlyAccess
+        ? [
+            {
+              key: 'membersClub',
+              title: 'Members Club',
+              description: 'Exclusive updates for Members Club Holders',
+            },
+          ]
+        : []),
+      {
+        key: 'digest',
+        title: 'Digest',
+        description: 'Weekly digest of top interacted galleries, artists, and posts',
+      },
+    ],
+    [hasEarlyAccess]
+  );
+
+  const userEmail = query?.viewer?.email?.email;
+  const { pushToast } = useToastActions();
+  const { colorScheme } = useColorScheme();
+
+  const isEmailUnverified = useMemo(() => {
+    return DISABLED_TOGGLE_BY_EMAIL_STATUS.includes(query?.viewer?.email?.verificationStatus ?? '');
+  }, [query]);
+
+  const shouldShowEmailSettings = useMemo(
+    () => userEmail && !isEmailUnverified,
+    [userEmail, isEmailUnverified]
+  );
+
+  const { computeToggleChecked, handleToggle } = useUpdateEmailNotificationSettings({
+    queryRef: query,
+    hasEarlyAccess,
+    shouldShowEmailSettings: Boolean(shouldShowEmailSettings),
+  });
+
+  if (!shouldShowEmailSettings) {
+    return null;
+  }
+
+  return (
+    <View className="px-4 pt-8 space-y-2 flex flex-col">
+      <Typography className="text-xl" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+        Email notifications
+      </Typography>
+      <Typography className="text-md" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+        Receive weekly recaps that show your most recent admires, comments, and followers.
+      </Typography>
+      <View className="p-3 space-y-3 bg-offWhite dark:bg-black-700">
+        <View>
+          <View className="flex">
+            <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+              {userEmail}
+            </Typography>
+            <View className="flex flex-col justify-between">
+              <View className="flex flex-row items-center space-x-1">
+                <CircleCheckIcon
+                  stroke={colorScheme === 'dark' ? colors.metal : colors.shadow}
+                  width="20"
+                  height="20"
+                />
+                <Typography
+                  className="text-sm text-shadow dark:text-metal"
+                  font={{ family: 'ABCDiatype', weight: 'Regular' }}
+                >
+                  Verified
+                </Typography>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View className="bg-offWhite dark:bg-black-700">
+          {emailNotificationSettingData.map((notifSetting, idx) => (
+            <View className="space-y-3" key={idx}>
+              <View className="w-full h-px bg-porcelain dark:bg-black-500" />
+              <View className="flex flex-row justify-between items-center">
+                <View className="max-w-[280px] mb-3">
+                  <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+                    {notifSetting.title}
+                  </Typography>
+                  <Typography
+                    className="text-sm"
+                    font={{ family: 'ABCDiatype', weight: 'Regular' }}
+                  >
+                    {notifSetting.description}
+                  </Typography>
+                </View>
+                <Toggle
+                  checked={computeToggleChecked(notifSetting.key) ?? false}
+                  onToggle={() =>
+                    handleToggle({
+                      settingType: notifSetting.key,
+                      settingTitle: notifSetting.title,
+                      pushToast,
+                    })
+                  }
+                />
+              </View>
+            </View>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const DISABLED_TOGGLE_BY_EMAIL_STATUS = ['Unverified', 'Failed'];

--- a/apps/mobile/src/screens/SettingsScreen/EmailNotificationSettingsSection.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/EmailNotificationSettingsSection.tsx
@@ -19,9 +19,6 @@ export function EmailNotificationSettingsSection() {
       query EmailNotificationSettingsSectionQuery {
         viewer {
           ... on Viewer {
-            user {
-              roles
-            }
             email {
               email
               verificationStatus
@@ -32,40 +29,6 @@ export function EmailNotificationSettingsSection() {
       }
     `,
     {}
-  );
-
-  const hasEarlyAccess = useMemo(() => {
-    return query.viewer?.user?.roles?.includes('EARLY_ACCESS') ?? false;
-  }, [query]);
-
-  const emailNotificationSettingData = useMemo(
-    () => [
-      {
-        key: 'unsubscribedFromNotifications',
-        title: 'Notifications',
-        description: 'Weekly summary of your unread notifications',
-      },
-      {
-        key: 'unsubscribedFromMarketing',
-        title: 'General Marketing',
-        description: 'Product updates, artist collabs, and airdrops',
-      },
-      ...(hasEarlyAccess
-        ? [
-            {
-              key: 'unsubscribedFromMembersClub',
-              title: 'Members Club',
-              description: 'Exclusive updates for Members Club Holders',
-            },
-          ]
-        : []),
-      {
-        key: 'unsubscribedFromDigest',
-        title: 'Digest',
-        description: 'Weekly digest of top interacted galleries, artists, and posts',
-      },
-    ],
-    [hasEarlyAccess]
   );
 
   const userEmail = query?.viewer?.email?.email;
@@ -81,11 +44,11 @@ export function EmailNotificationSettingsSection() {
     [userEmail, isEmailUnverified]
   );
 
-  const { computeToggleChecked, handleToggle } = useUpdateEmailNotificationSettings({
-    queryRef: query,
-    hasEarlyAccess,
-    shouldShowEmailSettings: Boolean(shouldShowEmailSettings),
-  });
+  const { emailNotificationSettingData, computeToggleChecked, handleToggle } =
+    useUpdateEmailNotificationSettings({
+      queryRef: query,
+      shouldShowEmailSettings: Boolean(shouldShowEmailSettings),
+    });
 
   if (!shouldShowEmailSettings) {
     return null;

--- a/apps/mobile/src/screens/SettingsScreen/EmailNotificationSettingsSection.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/EmailNotificationSettingsSection.tsx
@@ -9,7 +9,9 @@ import { Toggle } from '~/components/Toggle';
 import { Typography } from '~/components/Typography';
 import { useToastActions } from '~/contexts/ToastContext';
 import { EmailNotificationSettingsSectionQuery } from '~/generated/EmailNotificationSettingsSectionQuery.graphql';
-import useUpdateEmailNotificationSettings from '~/shared/hooks/useUpdateEmailNotificationSettings';
+import useUpdateEmailNotificationSettings, {
+  EmailNotificationSettings,
+} from '~/shared/hooks/useUpdateEmailNotificationSettings';
 
 export function EmailNotificationSettingsSection() {
   const query = useLazyLoadQuery<EmailNotificationSettingsSectionQuery>(
@@ -39,26 +41,26 @@ export function EmailNotificationSettingsSection() {
   const emailNotificationSettingData = useMemo(
     () => [
       {
-        key: 'notifications',
+        key: 'unsubscribedFromNotifications',
         title: 'Notifications',
         description: 'Weekly summary of your unread notifications',
       },
       {
-        key: 'marketing',
+        key: 'unsubscribedFromMarketing',
         title: 'General Marketing',
         description: 'Product updates, artist collabs, and airdrops',
       },
       ...(hasEarlyAccess
         ? [
             {
-              key: 'membersClub',
+              key: 'unsubscribedFromMembersClub',
               title: 'Members Club',
               description: 'Exclusive updates for Members Club Holders',
             },
           ]
         : []),
       {
-        key: 'digest',
+        key: 'unsubscribedFromDigest',
         title: 'Digest',
         description: 'Weekly digest of top interacted galleries, artists, and posts',
       },
@@ -137,10 +139,13 @@ export function EmailNotificationSettingsSection() {
                   </Typography>
                 </View>
                 <Toggle
-                  checked={computeToggleChecked(notifSetting.key) ?? false}
+                  checked={
+                    computeToggleChecked(notifSetting.key as keyof EmailNotificationSettings) ??
+                    false
+                  }
                   onToggle={() =>
                     handleToggle({
-                      settingType: notifSetting.key,
+                      settingType: notifSetting.key as keyof EmailNotificationSettings,
                       settingTitle: notifSetting.title,
                       pushToast,
                     })

--- a/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
@@ -3,10 +3,13 @@ import * as Notifications from 'expo-notifications';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, Linking, View } from 'react-native';
 import { useRelayEnvironment } from 'react-relay';
+import colors from 'shared/theme/colors';
+import { CircleCheckIcon } from 'src/icons/CircleCheckIcon';
 
 import { BackButton } from '~/components/BackButton';
 import { Button } from '~/components/Button';
 import { registerNotificationToken } from '~/components/Notification/registerNotificationToken';
+import { Toggle } from '~/components/Toggle';
 import { Typography } from '~/components/Typography';
 import { contexts } from '~/shared/analytics/constants';
 
@@ -20,6 +23,42 @@ export function NotificationSettingsScreen() {
     const existingPermissions = await Notifications.getPermissionsAsync();
     setPushNotificationPermissions(existingPermissions);
   }, []);
+
+  const query = { viewer: null };
+  const hasEarlyAccess = useMemo(() => {
+    return query.viewer?.user?.roles?.includes('EARLY_ACCESS') ?? false;
+  }, [query]);
+
+  const emailNotificationSettingData = useMemo(
+    () => [
+      {
+        key: 'notifications',
+        title: 'Notifications',
+        description: 'Weekly summary of your unread notifications',
+      },
+      {
+        key: 'marketing',
+        title: 'General Marketing',
+        description: 'Product updates, artist collabs, and airdrops',
+      },
+      // Conditionally add the 'Members Club' entry if `hasEarlyAccess` is true
+      ...(hasEarlyAccess
+        ? [
+            {
+              key: 'membersClub',
+              title: 'Members Club',
+              description: 'Exclusive updates for Members Club Holders',
+            },
+          ]
+        : []),
+      {
+        key: 'digest',
+        title: 'Digest',
+        description: 'Weekly digest of top interacted galleries, artists, and posts',
+      },
+    ],
+    [hasEarlyAccess]
+  );
 
   useEffect(() => {
     checkPushNotificationPermission();
@@ -55,10 +94,67 @@ export function NotificationSettingsScreen() {
     [pushNotificationPermissions]
   );
 
+  // TODOs:
+  // fix row styling
+  // add query to get if member's club or not
+  // add logic to actually update user settings (copy from web)
+  // find out if you need to add the edit button logic
   return (
     <View className="relative pt-4 flex-1 bg-white dark:bg-black-900">
       <View className="px-4 relative mb-2">
         <BackButton />
+      </View>
+      <View className="px-4 pt-8 space-y-2 flex flex-col">
+        <Typography className="text-xl" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+          Email notifications
+        </Typography>
+        <Typography className="text-md" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+          Receive weekly recaps that show your most recent admires, comments, and followers.
+        </Typography>
+        <View className="p-3 space-y-3 bg-offWhite">
+          <View>
+            <View className="flex">
+              <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+                {'username@email.com'}
+              </Typography>
+              <View className="flex flex-col justify-between">
+                <View className="flex flex-row items-center space-x-1">
+                  <CircleCheckIcon stroke={colors.shadow} width="20" height="20" />
+                  <Typography
+                    className="text-sm text-shadow"
+                    font={{ family: 'ABCDiatype', weight: 'Regular' }}
+                  >
+                    {'verified'}
+                  </Typography>
+                </View>
+                <Button className="w-[80px]" variant="secondary" text="EDIT" onPress={() => {}} />
+              </View>
+            </View>
+          </View>
+          <View className="w-full h-px bg-porcelain" />
+          <View className="bg-offWhite">
+            {emailNotificationSettingData.map((notifSetting) => (
+              <View className="space-y-3">
+                <View className="flex flex-col">
+                  <View className="max-w-[280px]">
+                    <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+                      {notifSetting.title}
+                    </Typography>
+
+                    <Typography
+                      className="text-sm"
+                      font={{ family: 'ABCDiatype', weight: 'Regular' }}
+                    >
+                      {notifSetting.description}
+                    </Typography>
+                  </View>
+                  <Toggle checked={true} onToggle={() => {}} />
+                </View>
+                <View className="w-full h-px mb-3 bg-porcelain" />
+              </View>
+            ))}
+          </View>
+        </View>
       </View>
       <View className="px-4 pt-8 space-y-6 flex flex-col">
         <Typography className="text-xl" font={{ family: 'ABCDiatype', weight: 'Bold' }}>

--- a/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
@@ -8,6 +8,7 @@ import colors from 'shared/theme/colors';
 import { CircleCheckIcon } from 'src/icons/CircleCheckIcon';
 
 import { BackButton } from '~/components/BackButton';
+import { useColorScheme } from 'nativewind';
 import { Button } from '~/components/Button';
 import { registerNotificationToken } from '~/components/Notification/registerNotificationToken';
 import { Toggle } from '~/components/Toggle';
@@ -129,7 +130,6 @@ export function NotificationSettingsScreen() {
     return DISABLED_TOGGLE_BY_EMAIL_STATUS.includes(query?.viewer?.email?.verificationStatus ?? '');
   }, [query]);
 
-
   const currentEmailNotificationSettings = query?.viewer?.email?.emailNotificationSettings;
 
   const [emailSettings, setEmailSettings] = useState({
@@ -142,9 +142,12 @@ export function NotificationSettingsScreen() {
     // currently cannot toggle all notifs from notif setting
     all: false,
   });
-  
-  const shouldShowEmailSettings = useMemo(() => (userEmail && !isEmailUnverified), [userEmail, isEmailUnverified])
-  
+
+  const shouldShowEmailSettings = useMemo(
+    () => userEmail && !isEmailUnverified,
+    [userEmail, isEmailUnverified]
+  );
+
   const isToggleChecked = useCallback(
     (notifType: string | number) => {
       // if the user dont have an email or not verified, we want to toggle off
@@ -245,6 +248,8 @@ export function NotificationSettingsScreen() {
     ]
   );
 
+  const { colorScheme } = useColorScheme();
+
   // TODOs:
   // add query to get if member's club or not
   // add verified check to show email setting
@@ -255,60 +260,66 @@ export function NotificationSettingsScreen() {
         <BackButton />
       </View>
       {shouldShowEmailSettings && (
-      <View className="px-4 pt-8 space-y-2 flex flex-col">
-        <Typography className="text-xl" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-          Email notifications
-        </Typography>
-        <Typography className="text-md" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-          Receive weekly recaps that show your most recent admires, comments, and followers.
-        </Typography>
-        <View className="p-3 space-y-3 bg-offWhite">
-          <View>
-            <View className="flex">
-              <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-                {'username@email.com'}
-              </Typography>
-              <View className="flex flex-col justify-between">
-                <View className="flex flex-row items-center space-x-1">
-                  <CircleCheckIcon stroke={colors.shadow} width="20" height="20" />
-                  <Typography
-                    className="text-sm text-shadow"
-                    font={{ family: 'ABCDiatype', weight: 'Regular' }}
-                  >
-                    {'verified'}
-                  </Typography>
+        <View className="px-4 pt-8 space-y-2 flex flex-col">
+          <Typography className="text-xl" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+            Email notifications
+          </Typography>
+          <Typography className="text-md" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+            Receive weekly recaps that show your most recent admires, comments, and followers.
+          </Typography>
+          <View className="p-3 space-y-3 bg-offWhite dark:bg-black-700">
+            <View>
+              <View className="flex">
+                <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+                  {'username@email.com'}
+                </Typography>
+                <View className="flex flex-col justify-between">
+                  <View className="flex flex-row items-center space-x-1">
+                    <CircleCheckIcon
+                      stroke={colorScheme === 'dark' ? colors.metal : colors.shadow}
+                      width="20"
+                      height="20"
+                    />
+                    <Typography
+                      className="text-sm text-shadow dark:text-metal"
+                      font={{ family: 'ABCDiatype', weight: 'Regular' }}
+                    >
+                      verified
+                    </Typography>
+                  </View>
                 </View>
               </View>
             </View>
-          </View>
-          <View className="w-full h-px bg-porcelain" />
-          <View className="bg-offWhite">
-            {emailNotificationSettingData.map((notifSetting, idx) => (
-              <View className="space-y-3" key={idx}>
-                <View className="flex flex-row justify-between items-center">
-                  <View className="max-w-[280px]">
-                    <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-                      {notifSetting.title}
-                    </Typography>
-                    <Typography
-                      className="text-sm"
-                      font={{ family: 'ABCDiatype', weight: 'Regular' }}
-                    >
-                      {notifSetting.description}
-                    </Typography>
+            <View className="bg-offWhite dark:bg-black-700">
+              {emailNotificationSettingData.map((notifSetting, idx) => (
+                <View className="space-y-3" key={idx}>
+                  <View className="w-full h-px bg-porcelain dark:bg-shadow" />
+                  <View className="flex flex-row justify-between items-center">
+                    <View className="max-w-[280px] mb-3">
+                      <Typography
+                        className="text-sm"
+                        font={{ family: 'ABCDiatype', weight: 'Bold' }}
+                      >
+                        {notifSetting.title}
+                      </Typography>
+                      <Typography
+                        className="text-sm"
+                        font={{ family: 'ABCDiatype', weight: 'Regular' }}
+                      >
+                        {notifSetting.description}
+                      </Typography>
+                    </View>
+                    <Toggle
+                      checked={isToggleChecked(notifSetting.key)}
+                      onToggle={() => handleToggle(notifSetting.key, notifSetting.title)}
+                    />
                   </View>
-                  <Toggle
-                    checked={isToggleChecked(notifSetting.key)}
-                    onToggle={() => handleToggle(notifSetting.key, notifSetting.title)}
-                  />
                 </View>
-                <View className="w-full h-px mb-3 bg-porcelain" />
-              </View>
-            ))}
+              ))}
+            </View>
           </View>
         </View>
-      </View>)
-      }
+      )}
       <View className="px-4 pt-8 space-y-6 flex flex-col">
         <Typography className="text-xl" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
           Push notifications

--- a/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
@@ -69,7 +69,6 @@ export function NotificationSettingsScreen() {
         title: 'General Marketing',
         description: 'Product updates, artist collabs, and airdrops',
       },
-      // Conditionally add the 'Members Club' entry if `hasEarlyAccess` is true
       ...(hasEarlyAccess
         ? [
             {
@@ -160,9 +159,7 @@ export function NotificationSettingsScreen() {
 
   const updateEmailNotificationSettings = useUpdateEmailNotificationSettings();
 
-  // Adjusted toggle handler to manage multiple settings
   const handleToggle = async (settingType: string, settingTitle: string) => {
-    // Invert the current setting to reflect the change immediately in the UI
     const newSettingValue = !emailSettings[settingType];
 
     setEmailSettings((prevSettings) => ({
@@ -173,20 +170,17 @@ export function NotificationSettingsScreen() {
     try {
       await handleEmailNotificationChange(settingType, newSettingValue, settingTitle);
 
-      // Assuming success if no errors thrown
       pushToast({
         message: `Settings successfully updated. You have ${
           newSettingValue ? 'subscribed to' : 'unsubscribed from'
         } ${settingTitle}.`,
       });
     } catch (error) {
-      // On failure, revert the optimistic UI update to maintain consistency with the server state
       setEmailSettings((prevSettings) => ({
         ...prevSettings,
         [settingType]: !newSettingValue,
       }));
 
-      // Handle and report the error appropriately
       reportError('Failed to update email notification settings');
 
       pushToast({
@@ -197,15 +191,12 @@ export function NotificationSettingsScreen() {
 
   const handleEmailNotificationChange = useCallback(
     async (settingType: string, newSettingValue: boolean, settingTitle: string) => {
-      // Determine which setting is being updated and its new value
       const settingsUpdate = {
-        ...emailSettings, // Assuming emailSettings is a new state that holds all settings
+        ...emailSettings,
         [settingType]: newSettingValue,
       };
 
       try {
-        // Call the API to update the email notification settings
-        // You need to adjust the payload according to your backend requirements
         const response = await updateEmailNotificationSettings({
           unsubscribedFromNotifications: !settingsUpdate.notifications,
           unsubscribedFromDigest: !settingsUpdate.digest,
@@ -214,8 +205,6 @@ export function NotificationSettingsScreen() {
           unsubscribedFromAll: false,
         });
 
-        // Update local state based on the response
-        // Assuming response structure is similar, adjust as necessary
         if (
           response.updateEmailNotificationSettings?.viewer?.email?.emailNotificationSettings &&
           settingType in
@@ -239,22 +228,13 @@ export function NotificationSettingsScreen() {
         pushToast({
           message: 'Unfortunately, there was an error updating your notification settings.',
         });
-        // No need to explicitly revert the toggle state here if using a centralized state approach
       }
     },
-    [
-      emailSettings, // Make sure to include this in your dependencies if you're using it
-      pushToast,
-      updateEmailNotificationSettings,
-    ]
+    [emailSettings, pushToast, updateEmailNotificationSettings]
   );
 
   const { colorScheme } = useColorScheme();
 
-  // TODOs:
-  // add query to get if member's club or not
-  // add verified check to show email setting
-  // add logic to actually update user settings (copy from web)
   return (
     <View className="relative pt-4 flex-1 bg-white dark:bg-black-900">
       <View className="px-4 relative mb-2">
@@ -272,7 +252,7 @@ export function NotificationSettingsScreen() {
             <View>
               <View className="flex">
                 <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-                  {'username@email.com'}
+                  {userEmail}
                 </Typography>
                 <View className="flex flex-col justify-between">
                   <View className="flex flex-row items-center space-x-1">

--- a/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/NotificationSettingsScreen.tsx
@@ -1,48 +1,18 @@
 import * as Application from 'expo-application';
 import * as Notifications from 'expo-notifications';
-import { useColorScheme } from 'nativewind';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, Linking, View } from 'react-native';
 import { useRelayEnvironment } from 'react-relay';
-import { graphql, useLazyLoadQuery } from 'react-relay';
-import colors from 'shared/theme/colors';
-import { CircleCheckIcon } from 'src/icons/CircleCheckIcon';
 
 import { BackButton } from '~/components/BackButton';
 import { Button } from '~/components/Button';
 import { registerNotificationToken } from '~/components/Notification/registerNotificationToken';
-import { Toggle } from '~/components/Toggle';
 import { Typography } from '~/components/Typography';
-import { useToastActions } from '~/contexts/ToastContext';
-import { NotificationSettingsScreensQuery } from '~/generated/NotificationSettingsScreensQuery.graphql';
 import { contexts } from '~/shared/analytics/constants';
-import useUpdateEmailNotificationSettings from '~/shared/hooks/useUpdateEmailNotificationSettings';
+
+import { EmailNotificationSettingsSection } from './EmailNotificationSettingsSection';
 
 export function NotificationSettingsScreen() {
-  const query = useLazyLoadQuery<NotificationSettingsScreensQuery>(
-    graphql`
-      query NotificationSettingsScreensQuery {
-        viewer {
-          ... on Viewer {
-            user {
-              roles
-            }
-            email {
-              email
-              verificationStatus
-              emailNotificationSettings {
-                unsubscribedFromNotifications
-                unsubscribedFromDigest
-                unsubscribedFromMarketing
-                unsubscribedFromMembersClub
-              }
-            }
-          }
-        }
-      }
-    `,
-    {}
-  );
   const relayEnvironment = useRelayEnvironment();
 
   const [pushNotificationPermissions, setPushNotificationPermissions] =
@@ -52,40 +22,6 @@ export function NotificationSettingsScreen() {
     const existingPermissions = await Notifications.getPermissionsAsync();
     setPushNotificationPermissions(existingPermissions);
   }, []);
-
-  const hasEarlyAccess = useMemo(() => {
-    return query.viewer?.user?.roles?.includes('EARLY_ACCESS') ?? false;
-  }, [query]);
-
-  const emailNotificationSettingData = useMemo(
-    () => [
-      {
-        key: 'notifications',
-        title: 'Notifications',
-        description: 'Weekly summary of your unread notifications',
-      },
-      {
-        key: 'marketing',
-        title: 'General Marketing',
-        description: 'Product updates, artist collabs, and airdrops',
-      },
-      ...(hasEarlyAccess
-        ? [
-            {
-              key: 'membersClub',
-              title: 'Members Club',
-              description: 'Exclusive updates for Members Club Holders',
-            },
-          ]
-        : []),
-      {
-        key: 'digest',
-        title: 'Digest',
-        description: 'Weekly digest of top interacted galleries, artists, and posts',
-      },
-    ],
-    [hasEarlyAccess]
-  );
 
   useEffect(() => {
     checkPushNotificationPermission();
@@ -121,186 +57,14 @@ export function NotificationSettingsScreen() {
     [pushNotificationPermissions]
   );
 
-  const userEmail = query?.viewer?.email?.email;
-
-  const isEmailUnverified = useMemo(() => {
-    return DISABLED_TOGGLE_BY_EMAIL_STATUS.includes(query?.viewer?.email?.verificationStatus ?? '');
-  }, [query]);
-
-  const shouldShowEmailSettings = useMemo(
-    () => userEmail && !isEmailUnverified,
-    [userEmail, isEmailUnverified]
-  );
-
-  const currentEmailNotificationSettings = query?.viewer?.email?.emailNotificationSettings;
-
-  const [emailSettings, setEmailSettings] = useState<EmailNotificationSettings>({
-    notifications: !currentEmailNotificationSettings?.unsubscribedFromNotifications,
-    marketing: !currentEmailNotificationSettings?.unsubscribedFromMarketing,
-    digest: !currentEmailNotificationSettings?.unsubscribedFromDigest,
-    membersClub: hasEarlyAccess
-      ? !currentEmailNotificationSettings?.unsubscribedFromMembersClub
-      : false,
-    // currently cannot toggle all notifs from notif setting
-    all: false,
-  });
-
-  const isToggleChecked = useCallback(
-    (notifType: string | number) => {
-      // if the user dont have an email or not verified, we want to toggle off
-      if (!shouldShowEmailSettings) {
-        return false;
-      }
-      return emailSettings[notifType];
-    },
-    [shouldShowEmailSettings, emailSettings]
-  );
-  const { pushToast } = useToastActions();
-
-  const updateEmailNotificationSettings = useUpdateEmailNotificationSettings();
-
-  const handleToggle = async (settingType: string, settingTitle: string) => {
-    const newSettingValue = !emailSettings[settingType];
-
-    setEmailSettings((prevSettings) => ({
-      ...prevSettings,
-      [settingType]: newSettingValue,
-    }));
-
-    try {
-      await handleEmailNotificationChange(settingType, newSettingValue, settingTitle);
-
-      pushToast({
-        message: `Settings successfully updated. You have ${
-          newSettingValue ? 'subscribed to' : 'unsubscribed from'
-        } ${settingTitle}.`,
-      });
-    } catch (error) {
-      setEmailSettings((prevSettings) => ({
-        ...prevSettings,
-        [settingType]: !newSettingValue,
-      }));
-
-      reportError('Failed to update email notification settings');
-
-      pushToast({
-        message: 'Unfortunately, there was an error updating your notification settings.',
-      });
-    }
-  };
-
-  const handleEmailNotificationChange = useCallback(
-    async (settingType: string, newSettingValue: boolean, settingTitle: string) => {
-      const settingsUpdate = {
-        ...emailSettings,
-        [settingType]: newSettingValue,
-      };
-
-      try {
-        const response = await updateEmailNotificationSettings({
-          unsubscribedFromNotifications: !settingsUpdate.notifications,
-          unsubscribedFromDigest: !settingsUpdate.digest,
-          unsubscribedFromMarketing: !settingsUpdate.marketing,
-          unsubscribedFromMembersClub: !settingsUpdate.membersClub ?? false,
-          unsubscribedFromAll: false,
-        });
-
-        if (
-          response.updateEmailNotificationSettings?.viewer?.email?.emailNotificationSettings &&
-          settingType in
-            response.updateEmailNotificationSettings.viewer.email.emailNotificationSettings
-        ) {
-          const settings =
-            response.updateEmailNotificationSettings.viewer.email.emailNotificationSettings;
-          if (settings[settingType as keyof EmailSettings] === newSettingValue) {
-            setEmailSettings(settingsUpdate);
-            pushToast({
-              message: `Settings successfully updated. You will ${
-                settingsUpdate[settingType] ? 'no longer' : 'now'
-              } receive ${settingTitle} emails.`,
-            });
-          }
-        }
-      } catch (error) {
-        if (error instanceof Error) {
-          reportError('Failed to update email notification settings');
-        }
-        pushToast({
-          message: 'Unfortunately, there was an error updating your notification settings.',
-        });
-      }
-    },
-    [emailSettings, pushToast, updateEmailNotificationSettings]
-  );
-
-  const { colorScheme } = useColorScheme();
-
   return (
     <View className="relative pt-4 flex-1 bg-white dark:bg-black-900">
       <View className="px-4 relative mb-2">
         <BackButton />
       </View>
-      {shouldShowEmailSettings && (
-        <View className="px-4 pt-8 space-y-2 flex flex-col">
-          <Typography className="text-xl" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-            Email notifications
-          </Typography>
-          <Typography className="text-md" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-            Receive weekly recaps that show your most recent admires, comments, and followers.
-          </Typography>
-          <View className="p-3 space-y-3 bg-offWhite dark:bg-black-700">
-            <View>
-              <View className="flex">
-                <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-                  {userEmail}
-                </Typography>
-                <View className="flex flex-col justify-between">
-                  <View className="flex flex-row items-center space-x-1">
-                    <CircleCheckIcon
-                      stroke={colorScheme === 'dark' ? colors.metal : colors.shadow}
-                      width="20"
-                      height="20"
-                    />
-                    <Typography
-                      className="text-sm text-shadow dark:text-metal"
-                      font={{ family: 'ABCDiatype', weight: 'Regular' }}
-                    >
-                      Verified
-                    </Typography>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View className="bg-offWhite dark:bg-black-700">
-              {emailNotificationSettingData.map((notifSetting, idx) => (
-                <View className="space-y-3" key={idx}>
-                  <View className="w-full h-px bg-porcelain dark:bg-shadow" />
-                  <View className="flex flex-row justify-between items-center">
-                    <View className="max-w-[280px] mb-3">
-                      <Typography
-                        className="text-sm"
-                        font={{ family: 'ABCDiatype', weight: 'Bold' }}
-                      >
-                        {notifSetting.title}
-                      </Typography>
-                      <Typography
-                        className="text-sm"
-                        font={{ family: 'ABCDiatype', weight: 'Regular' }}
-                      >
-                        {notifSetting.description}
-                      </Typography>
-                    </View>
-                    <Toggle
-                      checked={isToggleChecked(notifSetting.key) ?? false}
-                      onToggle={() => handleToggle(notifSetting.key, notifSetting.title)}
-                    />
-                  </View>
-                </View>
-              ))}
-            </View>
-          </View>
-        </View>
-      )}
+      <Suspense fallback={null}>
+        <EmailNotificationSettingsSection />
+      </Suspense>
       <View className="px-4 pt-8 space-y-6 flex flex-col">
         <Typography className="text-xl" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
           Push notifications
@@ -326,22 +90,3 @@ export function NotificationSettingsScreen() {
     </View>
   );
 }
-
-const DISABLED_TOGGLE_BY_EMAIL_STATUS = ['Unverified', 'Failed'];
-
-type EmailSettings = {
-  readonly unsubscribedFromAll: boolean;
-  readonly unsubscribedFromDigest: boolean;
-  readonly unsubscribedFromMarketing: boolean;
-  readonly unsubscribedFromMembersClub: boolean;
-  readonly unsubscribedFromNotifications: boolean;
-};
-
-type EmailNotificationSettings = {
-  notifications: boolean;
-  marketing: boolean;
-  digest: boolean;
-  membersClub: boolean;
-  all: boolean;
-  [key: string]: boolean;
-};

--- a/apps/web/src/components/Email/useUpdateEmailNotificationSettings.ts
+++ b/apps/web/src/components/Email/useUpdateEmailNotificationSettings.ts
@@ -7,6 +7,8 @@ import { usePromisifiedMutation } from '~/shared/relay/usePromisifiedMutation';
 type Props = {
   unsubscribedFromNotifications: boolean;
   unsubscribedFromDigest: boolean;
+  unsubscribedFromMarketing: boolean;
+  unsubscribedFromMembersClub: boolean;
   unsubscribedFromAll: boolean;
 };
 
@@ -23,6 +25,8 @@ export default function useUpdateEmailNotificationSettings() {
                 emailNotificationSettings {
                   unsubscribedFromNotifications
                   unsubscribedFromDigest
+                  unsubscribedFromMarketing
+                  unsubscribedFromMembersClub
                   unsubscribedFromAll
                 }
               }
@@ -36,12 +40,20 @@ export default function useUpdateEmailNotificationSettings() {
     `);
 
   return useCallback(
-    ({ unsubscribedFromNotifications, unsubscribedFromDigest, unsubscribedFromAll }: Props) => {
+    ({
+      unsubscribedFromNotifications,
+      unsubscribedFromDigest,
+      unsubscribedFromMarketing,
+      unsubscribedFromMembersClub,
+      unsubscribedFromAll,
+    }: Props) => {
       return updateEmailNotificationSettings({
         variables: {
           enabledNotification: {
             unsubscribedFromNotifications,
             unsubscribedFromDigest,
+            unsubscribedFromMarketing,
+            unsubscribedFromMembersClub,
             unsubscribedFromAll,
           },
         },

--- a/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
+++ b/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
@@ -10,9 +10,7 @@ import EmailManager from '~/components/Email/EmailManager';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { ManageEmailSectionFragment$key } from '~/generated/ManageEmailSectionFragment.graphql';
 import { contexts } from '~/shared/analytics/constants';
-import useUpdateEmailNotificationSettings, {
-  EmailNotificationSettings,
-} from '~/shared/hooks/useUpdateEmailNotificationSettings';
+import useUpdateEmailNotificationSettings from '~/shared/hooks/useUpdateEmailNotificationSettings';
 import colors from '~/shared/theme/colors';
 
 import SettingsRowDescription from '../SettingsRowDescription';

--- a/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
+++ b/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
@@ -115,14 +115,10 @@ export default function ManageEmailSection({ queryRef }: Props) {
                   <SettingsRowDescription>{emailNotifSetting.description}</SettingsRowDescription>
                 </VStack>
                 <Toggle
-                  checked={
-                    computeToggleChecked(
-                      emailNotifSetting.key as keyof EmailNotificationSettings
-                    ) ?? false
-                  }
+                  checked={computeToggleChecked(emailNotifSetting.key)}
                   onChange={() =>
                     handleToggle({
-                      settingType: emailNotifSetting.key as keyof EmailNotificationSettings,
+                      settingType: emailNotifSetting.key,
                       settingTitle: emailNotifSetting.title,
                       pushToast,
                     })

--- a/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
+++ b/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
@@ -81,12 +81,12 @@ export default function ManageEmailSection({ queryRef }: Props) {
       {
         key: 'notifications',
         title: 'Notifications',
-        description: 'Weekly summary of your unread notifications',
+        description: 'Notification summary emails',
       },
       {
         key: 'marketing',
         title: 'General Marketing',
-        description: 'Product updates, artist collabs, and airdrops',
+        description: 'Product marketing emails',
       },
       // Conditionally add the 'Members Club' entry if `hasEarlyAccess` is true
       ...(hasEarlyAccess
@@ -94,14 +94,14 @@ export default function ManageEmailSection({ queryRef }: Props) {
             {
               key: 'membersClub',
               title: 'Members Club',
-              description: 'Exclusive updates for Members Club Holders',
+              description: 'Exclusively for Members Club Holders',
             },
           ]
         : []),
       {
         key: 'digest',
-        title: 'Digest',
-        description: 'Weekly digest of top interacted galleries, artists, and posts',
+        title: 'Weekly Digest',
+        description: 'Featured Galleries, Collections and more',
       },
     ],
     [hasEarlyAccess]
@@ -273,7 +273,7 @@ export default function ManageEmailSection({ queryRef }: Props) {
                 </VStack>
                 <Toggle
                   checked={isToggleChecked(emailNotifSetting.key)}
-                  isPending={isPending[emailNotifSetting.key]}
+                  isPending={isPending[emailNotifSetting.key] || isEmailUnverified}
                   onChange={() => handleToggle(emailNotifSetting.key)}
                 />
               </HStack>

--- a/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
+++ b/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
@@ -10,7 +10,9 @@ import EmailManager from '~/components/Email/EmailManager';
 import { useToastActions } from '~/contexts/toast/ToastContext';
 import { ManageEmailSectionFragment$key } from '~/generated/ManageEmailSectionFragment.graphql';
 import { contexts } from '~/shared/analytics/constants';
-import useUpdateEmailNotificationSettings from '~/shared/hooks/useUpdateEmailNotificationSettings';
+import useUpdateEmailNotificationSettings, {
+  EmailNotificationSettings,
+} from '~/shared/hooks/useUpdateEmailNotificationSettings';
 import colors from '~/shared/theme/colors';
 
 import SettingsRowDescription from '../SettingsRowDescription';
@@ -55,12 +57,12 @@ export default function ManageEmailSection({ queryRef }: Props) {
   const emailNotificationSettingData = useMemo(
     () => [
       {
-        key: 'notifications',
+        key: 'unsubscribedFromNotifications',
         title: 'Notifications',
         description: 'Notification summary emails',
       },
       {
-        key: 'marketing',
+        key: 'unsubscribedFromMarketing',
         title: 'General Marketing',
         description: 'Product marketing emails',
       },
@@ -68,14 +70,14 @@ export default function ManageEmailSection({ queryRef }: Props) {
       ...(hasEarlyAccess
         ? [
             {
-              key: 'membersClub',
+              key: 'unsubscribedFromMembersClub',
               title: 'Members Club',
               description: 'Exclusively for Members Club Holders',
             },
           ]
         : []),
       {
-        key: 'digest',
+        key: 'unsubscribedFromDigest',
         title: 'Weekly Digest',
         description: 'Featured Galleries, Collections and more',
       },
@@ -151,10 +153,14 @@ export default function ManageEmailSection({ queryRef }: Props) {
                   <SettingsRowDescription>{emailNotifSetting.description}</SettingsRowDescription>
                 </VStack>
                 <Toggle
-                  checked={computeToggleChecked(emailNotifSetting.key) ?? false}
+                  checked={
+                    computeToggleChecked(
+                      emailNotifSetting.key as keyof EmailNotificationSettings
+                    ) ?? false
+                  }
                   onChange={() =>
                     handleToggle({
-                      settingType: emailNotifSetting.key,
+                      settingType: emailNotifSetting.key as keyof EmailNotificationSettings,
                       settingTitle: emailNotifSetting.title,
                       pushToast,
                     })

--- a/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
+++ b/apps/web/src/components/Settings/ManageEmailSection/ManageEmailSection.tsx
@@ -31,9 +31,6 @@ export default function ManageEmailSection({ queryRef }: Props) {
       fragment ManageEmailSectionFragment on Query {
         viewer {
           ... on Viewer {
-            user {
-              roles
-            }
             email {
               email
               verificationStatus
@@ -49,41 +46,6 @@ export default function ManageEmailSection({ queryRef }: Props) {
   );
 
   const userEmail = query?.viewer?.email?.email;
-
-  const hasEarlyAccess = useMemo(() => {
-    return query.viewer?.user?.roles?.includes('EARLY_ACCESS');
-  }, [query]);
-
-  const emailNotificationSettingData = useMemo(
-    () => [
-      {
-        key: 'unsubscribedFromNotifications',
-        title: 'Notifications',
-        description: 'Notification summary emails',
-      },
-      {
-        key: 'unsubscribedFromMarketing',
-        title: 'General Marketing',
-        description: 'Product marketing emails',
-      },
-      // Conditionally add the 'Members Club' entry if `hasEarlyAccess` is true
-      ...(hasEarlyAccess
-        ? [
-            {
-              key: 'unsubscribedFromMembersClub',
-              title: 'Members Club',
-              description: 'Exclusively for Members Club Holders',
-            },
-          ]
-        : []),
-      {
-        key: 'unsubscribedFromDigest',
-        title: 'Weekly Digest',
-        description: 'Featured Galleries, Collections and more',
-      },
-    ],
-    [hasEarlyAccess]
-  );
 
   const { pushToast } = useToastActions();
 
@@ -110,11 +72,11 @@ export default function ManageEmailSection({ queryRef }: Props) {
     [userEmail, isEmailUnverified]
   );
 
-  const { computeToggleChecked, handleToggle } = useUpdateEmailNotificationSettings({
-    queryRef: query,
-    hasEarlyAccess: Boolean(hasEarlyAccess),
-    shouldShowEmailSettings: Boolean(shouldShowEmailSettings),
-  });
+  const { emailNotificationSettingData, computeToggleChecked, handleToggle } =
+    useUpdateEmailNotificationSettings({
+      queryRef: query,
+      shouldShowEmailSettings: Boolean(shouldShowEmailSettings),
+    });
 
   return (
     <VStack gap={16}>

--- a/packages/shared/src/hooks/useUpdateEmailNotificationSettings.ts
+++ b/packages/shared/src/hooks/useUpdateEmailNotificationSettings.ts
@@ -17,7 +17,6 @@ export default function useUpdateEmailNotificationSettings({
   hasEarlyAccess,
   shouldShowEmailSettings,
 }: useUpdateEmailNotificationSettingsProps) {
-  console.log('queryRef', queryRef);
   const query = useFragment(
     graphql`
       fragment useUpdateEmailNotificationSettingsFragment on Query {

--- a/packages/shared/src/hooks/useUpdateEmailNotificationSettings.ts
+++ b/packages/shared/src/hooks/useUpdateEmailNotificationSettings.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { graphql } from 'react-relay';
 
 import { useUpdateEmailNotificationSettingsMutation } from '~/generated/useUpdateEmailNotificationSettingsMutation.graphql';
-import { usePromisifiedMutation } from '~/shared/relay/usePromisifiedMutation';
+import { usePromisifiedMutation } from '../relay/usePromisifiedMutation';
 
 type Props = {
   unsubscribedFromNotifications: boolean;

--- a/packages/shared/src/hooks/useUpdateEmailNotificationSettings.ts
+++ b/packages/shared/src/hooks/useUpdateEmailNotificationSettings.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { graphql } from 'react-relay';
 
 import { useUpdateEmailNotificationSettingsMutation } from '~/generated/useUpdateEmailNotificationSettingsMutation.graphql';
+
 import { usePromisifiedMutation } from '../relay/usePromisifiedMutation';
 
 type Props = {

--- a/packages/shared/src/hooks/useUpdateEmailNotificationSettings.ts
+++ b/packages/shared/src/hooks/useUpdateEmailNotificationSettings.ts
@@ -60,32 +60,37 @@ export default function useUpdateEmailNotificationSettings({
   });
 
   const emailNotificationSettingData = useMemo(
-    () => [
-      {
-        key: 'unsubscribedFromNotifications',
-        title: 'Notifications',
-        description: 'Weekly summary of your unread notifications',
-      },
-      {
-        key: 'unsubscribedFromMarketing',
-        title: 'General Marketing',
-        description: 'Product updates, artist collabs, and airdrops',
-      },
-      ...(hasEarlyAccess
-        ? [
-            {
-              key: 'unsubscribedFromMembersClub',
-              title: 'Members Club',
-              description: 'Exclusive updates for Members Club Holders',
-            },
-          ]
-        : []),
-      {
-        key: 'unsubscribedFromDigest',
-        title: 'Digest',
-        description: 'Weekly digest of top interacted galleries, artists, and posts',
-      },
-    ],
+    () =>
+      [
+        {
+          key: 'unsubscribedFromNotifications',
+          title: 'Notifications',
+          description: 'Weekly summary of your unread notifications',
+        },
+        {
+          key: 'unsubscribedFromMarketing',
+          title: 'General Marketing',
+          description: 'Product updates, artist collabs, and airdrops',
+        },
+        ...(hasEarlyAccess
+          ? [
+              {
+                key: 'unsubscribedFromMembersClub',
+                title: 'Members Club',
+                description: 'Exclusive updates for Members Club Holders',
+              },
+            ]
+          : []),
+        {
+          key: 'unsubscribedFromDigest',
+          title: 'Digest',
+          description: 'Weekly digest of trending galleries, artists, and posts',
+        },
+      ] as {
+        key: keyof EmailNotificationSettings;
+        title: string;
+        description: string;
+      }[],
     [hasEarlyAccess]
   );
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -560,12 +560,16 @@ type EmailNotificationSettings {
   unsubscribedFromAll: Boolean!
   unsubscribedFromNotifications: Boolean!
   unsubscribedFromDigest: Boolean!
+  unsubscribedFromMarketing: Boolean
+  unsubscribedFromMembersClub: Boolean
 }
 
 enum EmailUnsubscriptionType {
   All
   Notifications
   Digest
+  Marketing
+  MembersClub
 }
 
 enum EmailVerificationStatus {
@@ -2202,6 +2206,8 @@ input UpdateEmailNotificationSettingsInput {
   unsubscribedFromAll: Boolean!
   unsubscribedFromNotifications: Boolean!
   unsubscribedFromDigest: Boolean!
+  unsubscribedFromMarketing: Boolean
+  unsubscribedFromMembersClub: Boolean
 }
 
 type UpdateEmailNotificationSettingsPayload {


### PR DESCRIPTION
### Summary of Changes
You can now unsubscribe to specific mailing lists from the notification settings, and when you toggle an email notification subscription, a toast is pushed when the mutation succeeds or fails.



### Demo Web

## After (video)
https://github.com/gallery-so/gallery/assets/49758803/11f07815-3f5d-4a10-8483-b43807ef614b



| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| <img width="412" alt="Screenshot 2024-03-09 at 14 19 47" src="https://github.com/gallery-so/gallery/assets/49758803/34be7c86-5a6b-4e10-90de-4a3038a576f3"> | <img width="413" alt="Screenshot 2024-03-09 at 14 05 46" src="https://github.com/gallery-so/gallery/assets/49758803/949c9da9-186c-4134-b603-fee5a4ee7e7e"> |

### Demo Mobile
## After (video)
https://github.com/gallery-so/gallery/assets/49758803/e35842b3-6484-465e-8c62-d8cecd77f63e

### Edge Cases

Dark mode
<img width="522" alt="Screenshot 2024-03-11 at 17 56 42" src="https://github.com/gallery-so/gallery/assets/49758803/7275d8a6-62c5-424e-a5cb-6bf05978b6e3">


### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
