### PR TITLE
fix darkmode inactive color for bookmark icon

### DIFF
--- a/apps/mobile/src/icons/BookmarkIcon.tsx
+++ b/apps/mobile/src/icons/BookmarkIcon.tsx
@@ -34,7 +34,7 @@ const COLOR_THEME = {
       activeFillColor: colors.darkModeBlue,
       activeStrokeColor: colors.darkModeBlue,
       inactiveFillColor: 'none',
-      inactiveStrokeColor: colors.black['800'],
+      inactiveStrokeColor: colors.white,
     },
   },
   black: {


### PR DESCRIPTION
### Summary of Changes
Bookmark icon on detail page was not visible in dark mode when inactive



### Demo or Before/After Pics

before
![CleanShot 2024-03-12 at 10 41 31](https://github.com/gallery-so/gallery/assets/80802871/8b45daf6-9277-412b-8f3a-822c35f00e07)


after
![CleanShot 2024-03-12 at 10 41 20](https://github.com/gallery-so/gallery/assets/80802871/6e514a69-2fab-4df8-99d9-4d30c195eb16)



List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [x] (if mobile) I've tested the changes on both light and dark modes.
