### PR TITLE
refactor explore page data loading to prevent featured user query from blocking the whole page

### DIFF
--- a/apps/web/pages/explore.tsx
+++ b/apps/web/pages/explore.tsx
@@ -6,41 +6,10 @@ import { exploreQuery } from '~/generated/exploreQuery.graphql';
 import GalleryRoute from '~/scenes/_Router/GalleryRoute';
 import ExplorePage from '~/scenes/Home/ExploreHomePage';
 
-// [GAL-3763] Revive this if / when elon lets us import twitter follower graphs again
-//
-// export default function Explore() {
-//   const query = useLazyLoadQuery<exploreQuery>(
-//     graphql`
-//       query exploreQuery($twitterListFirst: Int!, $twitterListAfter: String) {
-//         ...ExploreHomePageFragment
-//         ...HomeNavbarFragment
-//         ...StandardSidebarFragment
-
-//         ...useOpenTwitterFollowingModalFragment
-//       }
-//     `,
-//     {
-//       twitterListFirst: USER_PER_PAGE,
-//       twitterListAfter: null,
-//     }
-//   );
-
-//   useOpenTwitterFollowingModal(query);
-
-//   return (
-//     <GalleryRoute
-//       navbar={<HomeNavbar queryRef={query} />}
-//       sidebar={<StandardSidebar queryRef={query} />}
-//       element={<ExplorePage queryRef={query} />}
-//     />
-//   );
-// }
-
 export default function Explore() {
   const query = useLazyLoadQuery<exploreQuery>(
     graphql`
       query exploreQuery {
-        ...ExploreHomePageFragment
         ...HomeNavbarFragment
         ...StandardSidebarFragment
       }

--- a/apps/web/pages/explore.tsx
+++ b/apps/web/pages/explore.tsx
@@ -21,7 +21,7 @@ export default function Explore() {
     <GalleryRoute
       navbar={<HomeNavbar queryRef={query} />}
       sidebar={<StandardSidebar queryRef={query} />}
-      element={<ExplorePage queryRef={query} />}
+      element={<ExplorePage />}
     />
   );
 }

--- a/apps/web/src/components/Explore/Explore.tsx
+++ b/apps/web/src/components/Explore/Explore.tsx
@@ -1,94 +1,17 @@
-import { graphql, useFragment } from 'react-relay';
+import { Suspense } from 'react';
 import styled from 'styled-components';
 
-import { ExploreFragment$key } from '~/generated/ExploreFragment.graphql';
-
 import { VStack } from '../core/Spacer/Stack';
+import FeaturedUsers, { FeaturedUsersLoadingSkeleton } from './FeaturedUsers';
 import GallerySelects from './GallerySelects';
-import SuggestedSection from './SuggestedSection';
-import TrendingSection from './TrendingSection';
 
-type Props = {
-  queryRef: ExploreFragment$key;
-};
-
-export default function Explore({ queryRef }: Props) {
-  const query = useFragment(
-    graphql`
-      fragment ExploreFragment on Query {
-        trendingUsers5Days: trendingUsers(input: { report: LAST_5_DAYS }) {
-          ... on TrendingUsersPayload {
-            __typename
-            ...TrendingSectionFragment
-          }
-        }
-        trendingUsersAllTime: trendingUsers(input: { report: ALL_TIME }) {
-          ... on TrendingUsersPayload {
-            __typename
-            ...TrendingSectionFragment
-          }
-        }
-
-        viewer {
-          __typename
-          # [GAL-3763] Revive this if / when elon lets us import twitter follower graphs again
-          # ... on Viewer {
-          # socialAccounts @required(action: THROW) {
-          #   twitter {
-          #     __typename
-          #   }
-          # }
-          # }
-        }
-        # ...TwitterSectionQueryFragment
-
-        ...TrendingSectionQueryFragment
-        ...SuggestedSectionQueryFragment
-      }
-    `,
-    queryRef
-  );
-
+export default function Explore() {
   return (
     <StyledExplorePage gap={48}>
       <GallerySelects />
-      {query.viewer?.__typename === 'Viewer' && (
-        <>
-          {
-            // [GAL-3763] Revive this if / when elon lets us import twitter follower graphs again
-            // query.viewer.socialAccounts?.twitter?.__typename && (
-            //   <ReportingErrorBoundary fallback={null}>
-            //     <TwitterSection
-            //       title="Twitter Friends"
-            //       subTitle="Curators you know from Twitter"
-            //       queryRef={query}
-            //     />
-            //   </ReportingErrorBoundary>
-            // )
-          }
-          <SuggestedSection
-            title="In your orbit"
-            subTitle="Curators you may enjoy based on your activity"
-            queryRef={query}
-          />
-        </>
-      )}
-      {query.trendingUsers5Days?.__typename === 'TrendingUsersPayload' && (
-        <TrendingSection
-          title="Weekly Leaderboard"
-          subTitle="Trending curators this week"
-          trendingUsersRef={query.trendingUsers5Days}
-          queryRef={query}
-        />
-      )}
-      {query.trendingUsersAllTime?.__typename === 'TrendingUsersPayload' && (
-        <TrendingSection
-          title="Hall of Fame"
-          subTitle="Top curators with the most all-time views"
-          trendingUsersRef={query.trendingUsersAllTime}
-          queryRef={query}
-        />
-      )}
+      <Suspense fallback={<FeaturedUsersLoadingSkeleton />}>
+        <FeaturedUsers />
+      </Suspense>
     </StyledExplorePage>
   );
 }

--- a/apps/web/src/components/Explore/FeaturedUsers.tsx
+++ b/apps/web/src/components/Explore/FeaturedUsers.tsx
@@ -1,0 +1,101 @@
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+import { FeaturedUsersQuery } from '~/generated/FeaturedUsersQuery.graphql';
+
+import SuggestedSection from './SuggestedSection';
+import TrendingSection, { TrendingSectionLoadingState } from './TrendingSection';
+
+export default function FeaturedUsers() {
+  const query = useLazyLoadQuery<FeaturedUsersQuery>(
+    graphql`
+      query FeaturedUsersQuery {
+        trendingUsers5Days: trendingUsers(input: { report: LAST_5_DAYS }) {
+          ... on TrendingUsersPayload {
+            __typename
+            ...TrendingSectionFragment
+          }
+        }
+        trendingUsersAllTime: trendingUsers(input: { report: ALL_TIME }) {
+          ... on TrendingUsersPayload {
+            __typename
+            ...TrendingSectionFragment
+          }
+        }
+
+        viewer {
+          __typename
+          # [GAL-3763] Revive this if / when elon lets us import twitter follower graphs again
+          # ... on Viewer {
+          # socialAccounts @required(action: THROW) {
+          #   twitter {
+          #     __typename
+          #   }
+          # }
+          # }
+        }
+        # ...TwitterSectionQueryFragment
+
+        ...TrendingSectionQueryFragment
+        ...SuggestedSectionQueryFragment
+      }
+    `,
+    {}
+  );
+
+  return (
+    <>
+      {query.viewer?.__typename === 'Viewer' && (
+        <>
+          {
+            // [GAL-3763] Revive this if / when elon lets us import twitter follower graphs again
+            // query.viewer.socialAccounts?.twitter?.__typename && (
+            //   <ReportingErrorBoundary fallback={null}>
+            //     <TwitterSection
+            //       title="Twitter Friends"
+            //       subTitle="Curators you know from Twitter"
+            //       queryRef={query}
+            //     />
+            //   </ReportingErrorBoundary>
+            // )
+          }
+          <SuggestedSection
+            title="In your orbit"
+            subTitle="Curators you may enjoy based on your activity"
+            queryRef={query}
+          />
+        </>
+      )}
+      {query.trendingUsers5Days?.__typename === 'TrendingUsersPayload' && (
+        <TrendingSection
+          title="Weekly Leaderboard"
+          subTitle="Trending curators this week"
+          trendingUsersRef={query.trendingUsers5Days}
+          queryRef={query}
+        />
+      )}
+      {query.trendingUsersAllTime?.__typename === 'TrendingUsersPayload' && (
+        <TrendingSection
+          title="Hall of Fame"
+          subTitle="Top curators with the most all-time views"
+          trendingUsersRef={query.trendingUsersAllTime}
+          queryRef={query}
+        />
+      )}{' '}
+    </>
+  );
+}
+
+export function FeaturedUsersLoadingSkeleton() {
+  return (
+    <>
+      <TrendingSectionLoadingState
+        title="Weekly Leaderboard"
+        subTitle="Trending curators this week"
+      />
+      <TrendingSectionLoadingState
+        title="Hall of Fame"
+        subTitle="Top curators with the most all-time views"
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/Explore/TrendingSection.tsx
+++ b/apps/web/src/components/Explore/TrendingSection.tsx
@@ -1,3 +1,4 @@
+import Skeleton from 'react-loading-skeleton';
 import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
@@ -5,6 +6,7 @@ import { TrendingSectionFragment$key } from '~/generated/TrendingSectionFragment
 import { TrendingSectionQueryFragment$key } from '~/generated/TrendingSectionQueryFragment.graphql';
 import colors from '~/shared/theme/colors';
 
+import breakpoints from '../core/breakpoints';
 import { VStack } from '../core/Spacer/Stack';
 import { TitleDiatypeL } from '../core/Text/Text';
 import ExploreList from './ExploreList';
@@ -48,10 +50,52 @@ export default function TrendingSection({ trendingUsersRef, queryRef, title, sub
   );
 }
 
+export function TrendingSectionLoadingState({
+  title,
+  subTitle,
+}: {
+  title: string;
+  subTitle: string;
+}) {
+  return (
+    <StyledTrendingSection gap={32}>
+      <VStack gap={4}>
+        <Title>{title}</Title>
+        <TitleDiatypeL color={colors.metal}>{subTitle}</TitleDiatypeL>
+      </VStack>
+      <StyledCardContainer>
+        {[...Array(4)].map((_, index) => (
+          <UserCardPlaceholder key={index}>
+            <Skeleton height={'100%'} />
+          </UserCardPlaceholder>
+        ))}
+      </StyledCardContainer>
+    </StyledTrendingSection>
+  );
+}
+
 const StyledTrendingSection = styled(VStack)`
   width: 100%;
 `;
 
 const Title = styled(TitleDiatypeL)`
   font-size: 24px;
+`;
+
+const StyledCardContainer = styled.div`
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0px, 1fr));
+  grid-template-rows: repeat(2, minmax(0px, 1fr));
+
+  @media only screen and (${breakpoints.tablet}) {
+    grid-template-columns: repeat(4, minmax(0px, 1fr));
+    grid-template-rows: repeat(1, minmax(0px, 1fr));
+  }
+`;
+
+const UserCardPlaceholder = styled.div`
+  width: 100%;
+  height: 100%;
+  aspect-ratio: 1.5;
 `;

--- a/apps/web/src/scenes/Home/ExploreHomePage.tsx
+++ b/apps/web/src/scenes/Home/ExploreHomePage.tsx
@@ -1,26 +1,11 @@
 import Head from 'next/head';
-import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import breakpoints, { pageGutter } from '~/components/core/breakpoints';
 import Explore from '~/components/Explore/Explore';
 import { useGlobalNavbarHeight } from '~/contexts/globalLayout/GlobalNavbar/useGlobalNavbarHeight';
-import { ExploreHomePageFragment$key } from '~/generated/ExploreHomePageFragment.graphql';
 
-type Props = {
-  queryRef: ExploreHomePageFragment$key;
-};
-
-export default function ExploreHomePage({ queryRef }: Props) {
-  const query = useFragment(
-    graphql`
-      fragment ExploreHomePageFragment on Query {
-        ...ExploreFragment
-      }
-    `,
-    queryRef
-  );
-
+export default function ExploreHomePage() {
   const navbarHeight = useGlobalNavbarHeight();
 
   return (
@@ -29,7 +14,7 @@ export default function ExploreHomePage({ queryRef }: Props) {
         <title>Gallery | Explore</title>
       </Head>
       <StyledPage navbarHeight={navbarHeight}>
-        <Explore queryRef={query} />
+        <Explore />
       </StyledPage>
     </>
   );


### PR DESCRIPTION

### Summary of Changes
The explore is slow to load. This is because the query to retrieve featured/trending users takes a while to resolve. 
Currently the request blocks the whole page from loading, which makes it look super slow.

This PR separates the trending users query into its own lazy loaded query and wraps it in a suspense so that the rest of the Explore page can load first.


### Demo or Before/After Pics
before:
https://github.com/gallery-so/gallery/assets/80802871/8a50f759-d431-4976-a340-955fc0a1f887

after
https://github.com/gallery-so/gallery/assets/80802871/cb2960f1-f72e-44e0-ba58-b485fa18d207




### Edge Cases

na

### Testing Steps

go to /explore
you should see the page load fairly quickly and a loading skeleton state for the users sections

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
