### PR TITLE
gltf fix

### DIFF
--- a/apps/web/src/components/NftPreview/NftPreview.tsx
+++ b/apps/web/src/components/NftPreview/NftPreview.tsx
@@ -203,6 +203,13 @@ function NftPreview({
     return <NftPreviewAsset onLoad={onNftLoad} tokenRef={token} />;
   }, [disableLiverender, shouldLiveRender, token, isIFrameLiveDisplay, onNftLoad, fullHeight]);
 
+  const isInteractive = useMemo(
+    () =>
+      (shouldLiveRender && token.definition.media?.__typename === 'GltfMedia') ||
+      isIFrameLiveDisplay,
+    [isIFrameLiveDisplay, shouldLiveRender, token.definition.media?.__typename]
+  );
+
   // [GAL-4229] TODO: leave this un-throwing until we wrap a proper boundary around it
   const imageUrl = useGetSinglePreviewImage({ tokenRef: token, size: 'large', shouldThrow: false });
 
@@ -234,12 +241,7 @@ function NftPreview({
       }
     >
       <StyledContainer className={className}>
-        <LinkToFullPageNftDetailModal
-          username={ownerUsername ?? ''}
-          collectionId={collectionId}
-          tokenId={token.dbid}
-          eventContext={eventContext}
-        >
+        {isInteractive ? (
           <StyledNftPreview
             backgroundColorOverride={backgroundColorOverride}
             fullWidth={fullWidth}
@@ -248,7 +250,23 @@ function NftPreview({
           >
             {PreviewAsset}
           </StyledNftPreview>
-        </LinkToFullPageNftDetailModal>
+        ) : (
+          <LinkToFullPageNftDetailModal
+            username={ownerUsername ?? ''}
+            collectionId={collectionId}
+            tokenId={token.dbid}
+            eventContext={eventContext}
+          >
+            <StyledNftPreview
+              backgroundColorOverride={backgroundColorOverride}
+              fullWidth={fullWidth}
+              fullHeight={fullHeight}
+              data-tokenid={token.dbid}
+            >
+              {PreviewAsset}
+            </StyledNftPreview>
+          </LinkToFullPageNftDetailModal>
+        )}
         {isMobileOrLargeMobile || disableBookmarkOnHover ? null : (
           <StyledNftHeader>
             <StyledBookmarkLabel tokenRef={token} queryRef={query} />

--- a/apps/web/src/scenes/NftDetailPage/NftDetailModel.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailModel.tsx
@@ -58,6 +58,7 @@ function NftDetailModel({ mediaRef, onLoad, fullHeight }: Props) {
         style={{
           width: '100%',
           height: fullHeight ? '100%' : undefined,
+          aspectRatio: fullHeight ? 1 : undefined,
         }}
       />
     </StyledNftDetailModel>


### PR DESCRIPTION
### Summary of Changes

gltf media isn't appearing on web desktop screen sizes because the model-viewer component had a height of zero even though it had height: 100%. I set the aspect-ratio to 1 so that they are able to expand according to its width.

also removed the a tag wrapping nft previews that navigate to the detail page if the displayed media is interactive (iframe or gltf)




### Demo or Before/After Pics
Before
![CleanShot 2024-03-20 at 18 31 15@2x](https://github.com/gallery-so/gallery/assets/80802871/231e9e2a-ad84-4407-8a44-1535923a1daa)

After
https://github.com/gallery-so/gallery/assets/80802871/dc21394f-a9d0-4d99-802c-96d434989378


### Edge Cases



### Testing Steps

go to these example gltfs
https://gallery.so/post/2dvJBXvnKBLg7uP8R9mZfxBTqeq
https://gallery.so/post/2duzQqLZLHexRdIKXDneen1Tmb1 
and confirm they load as expected on all screen sizes

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
