### PR TITLE
[GAL-5338] add referrer on Mint On Zora button from the NFT Detail Page

### DIFF
--- a/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailText.tsx
@@ -76,6 +76,11 @@ function NftDetailText({ queryRef, tokenRef, authenticatedUserOwnsAsset, toggleL
         owner {
           username
           dbid
+          primaryWallet {
+            chainAddress {
+              address
+            }
+          }
           ...ProfilePictureAndUserOrAddressOwnerFragment
         }
 
@@ -125,6 +130,8 @@ function NftDetailText({ queryRef, tokenRef, authenticatedUserOwnsAsset, toggleL
 
     return null;
   }, [name]);
+
+  const ownerWalletAddress = token.owner?.primaryWallet?.chainAddress?.address ?? '';
 
   const [admireToken] = useAdmireToken();
   const [removeTokenAdmire] = useRemoveTokenAdmire();
@@ -333,6 +340,7 @@ function NftDetailText({ queryRef, tokenRef, authenticatedUserOwnsAsset, toggleL
           ) : (
             <StyledMintLinkButton
               tokenRef={token}
+              referrerAddress={ownerWalletAddress}
               eventElementId="Click Mint Link Button"
               eventName="Click Mint Link"
               eventContext={contexts['NFT Detail']}


### PR DESCRIPTION
### Summary of Changes
The referrer address in the zora URL mint link is missing if visited from the 'Mint On Zora' button from the NFT Detail Page web
![Screenshot 2024-03-25 at 19 44 06](https://github.com/gallery-so/gallery/assets/49758803/a1a46b10-0ca1-40ad-9831-c71d6f17470b)

### Demo or Before/After Pics


| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| ![Screenshot 2024-03-25 at 19 43 45](https://github.com/gallery-so/gallery/assets/49758803/8323b202-b834-4e39-8237-607a769978fd) | ![Screenshot 2024-03-25 at 19 43 35](https://github.com/gallery-so/gallery/assets/49758803/babf4117-0667-4dee-b12d-e81dc8751bac) |






### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
