### PR TITLE
hide deleted comment if no replies

### DIFF
--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetLine.tsx
@@ -50,6 +50,7 @@ type CommentLineProps = {
   footerElement?: React.ReactNode;
   isReply?: boolean;
   queryRef: CommentsBottomSheetLineQueryFragment$key;
+  hasReplies?: boolean;
 };
 
 export function CommentsBottomSheetLine({
@@ -59,6 +60,7 @@ export function CommentsBottomSheetLine({
   footerElement,
   isReply,
   queryRef,
+  hasReplies,
 }: CommentLineProps) {
   const query = useFragment(
     graphql`
@@ -188,6 +190,10 @@ export function CommentsBottomSheetLine({
   }, [toggleAdmire]);
 
   if (!comment.comment) {
+    return null;
+  }
+
+  if (comment.deleted && !hasReplies) {
     return null;
   }
 

--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetSection.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheetSection.tsx
@@ -105,10 +105,13 @@ export function CommentsBottomSheetSection({
     return null;
   }
 
+  const hasReplies = replies.length > 0;
+
   return (
     <View className="flex space-x-2">
       <View className="space-y-1">
         <CommentsBottomSheetLine
+          hasReplies={hasReplies}
           activeCommentId={activeCommentId}
           commentRef={comment}
           queryRef={query}
@@ -121,6 +124,7 @@ export function CommentsBottomSheetSection({
 
       {replies.map((reply) => (
         <CommentsBottomSheetLine
+          hasReplies={hasReplies}
           key={reply.dbid}
           activeCommentId={activeCommentId}
           commentRef={reply}

--- a/apps/web/src/components/Feed/Socialize/CommentsModal/CommentNote.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentsModal/CommentNote.tsx
@@ -38,6 +38,7 @@ type CommentNoteProps = {
   isReply?: boolean;
   footerElement?: React.ReactNode;
   onReplyClick: (params: OnReplyClickParams) => void;
+  hasReplies?: boolean;
 };
 
 export function CommentNote({
@@ -47,6 +48,7 @@ export function CommentNote({
   isReply,
   onReplyClick,
   queryRef,
+  hasReplies,
 }: CommentNoteProps) {
   const comment = useFragment(
     graphql`
@@ -128,6 +130,10 @@ export function CommentNote({
   // END TEMPORARY FIX
 
   const isCommentActive = activeCommentId === comment.dbid;
+
+  if (comment.deleted && !hasReplies) {
+    return null;
+  }
 
   return (
     <StyledListItem

--- a/apps/web/src/components/Feed/Socialize/CommentsModal/CommentNoteSection.tsx
+++ b/apps/web/src/components/Feed/Socialize/CommentsModal/CommentNoteSection.tsx
@@ -109,9 +109,12 @@ export function CommentNoteSection({
     [comment?.dbid, onReplyClick]
   );
 
+  const hasReplies = replies.length > 0;
+
   return (
     <VStack>
       <CommentNote
+        hasReplies={hasReplies}
         commentRef={comment}
         queryRef={query}
         onReplyClick={handleReplyClickWithTopCommentId}
@@ -120,6 +123,7 @@ export function CommentNoteSection({
 
       {replies.map((reply) => (
         <CommentNote
+          hasReplies={hasReplies}
           key={reply.dbid}
           commentRef={reply}
           onReplyClick={handleReplyClickWithTopCommentId}


### PR DESCRIPTION
### Summary of Changes

If the comment that has been deleted has no replies then hide that comment.
Made the changes for both web and mobile

### Demo or Before/After Pics


| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| ![Screenshot 2024-03-27 at 13 13 06](https://github.com/gallery-so/gallery/assets/112896251/3cb17329-85b9-4afb-84b3-20c73af74a63) | ![Screenshot 2024-03-27 at 17 54 17](https://github.com/gallery-so/gallery/assets/112896251/4066602b-fb3b-4aef-8bf9-d30b9a4b8322) |

More pics:
![Screenshot 2024-03-27 at 13 12 49](https://github.com/gallery-so/gallery/assets/112896251/f8365fcf-2a01-4895-ab8c-40a63ef406c9)

![Screenshot 2024-03-27 at 17 53 24](https://github.com/gallery-so/gallery/assets/112896251/9bb0c431-98e5-4879-97a4-70499f075c6f)

### Edge Cases

I'd just like to note the fact that if the post has 1 comment (that is deleted) then the condition to show "No comments yet" is not fulfilled and thus just shows a blank screen as in the screenshot. 
I tried fixing this but am unsure how to get the comments replies in the parent component's query. It currently just checks if there are comments without ever checking if its deleted or not

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
