### PR TITLE
truncate long posts with gradient

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -36,6 +36,7 @@
     "expo-device": "~5.9.3",
     "expo-file-system": "~16.0.8",
     "expo-font": "~11.10.3",
+    "expo-linear-gradient": "^12.7.2",
     "expo-linking": "~6.2.2",
     "expo-notifications": "~0.27.6",
     "expo-secure-store": "~12.8.1",

--- a/apps/mobile/src/components/Feed/Posts/PostListCaption.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostListCaption.tsx
@@ -18,9 +18,9 @@ export function PostListCaption({ feedPostRef }: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [textHeight, setTextHeight] = useState(0);
 
-  const toggleExpanded = () => {
+  const toggleExpanded = useCallback(() => {
     setIsExpanded((prev) => !prev);
-  };
+  }, []);
 
   const feedPost = useFragment(
     graphql`

--- a/yarn.lock
+++ b/yarn.lock
@@ -17773,6 +17773,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-linear-gradient@npm:^12.7.2":
+  version: 12.7.2
+  resolution: "expo-linear-gradient@npm:12.7.2"
+  peerDependencies:
+    expo: "*"
+  checksum: afe4daf423dcaa02900a1252eb670a75089b9c9837bff2bd7f76199b7ad76f4b48efadaeec773b4d328456d9e8e3d56f68f9f665312681e1537adadbd97b54ff
+  languageName: node
+  linkType: hard
+
 "expo-linking@npm:~6.2.2":
   version: 6.2.2
   resolution: "expo-linking@npm:6.2.2"
@@ -24651,6 +24660,7 @@ __metadata:
     expo-device: ~5.9.3
     expo-file-system: ~16.0.8
     expo-font: ~11.10.3
+    expo-linear-gradient: ^12.7.2
     expo-linking: ~6.2.2
     expo-notifications: ~0.27.6
     expo-secure-store: ~12.8.1


### PR DESCRIPTION
### Summary of Changes

Added a check for line height and added a gradient that suggests there is more to be seen. When tapped it expands to show the whole text. Can also be tapped again to collapse

https://linear.app/galleryso/issue/GAL-4476/truncate-long-post-captions-on-mobile-app

### Demo or Before/After Pics


| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
|![Screenshot 2024-04-01 at 16 48 28](https://github.com/gallery-so/gallery/assets/112896251/04f2e82f-c1e9-4456-ab02-214706effa3c)|![Screenshot 2024-04-01 at 16 48 25](https://github.com/gallery-so/gallery/assets/112896251/44576241-ef71-4581-bdf4-56ce10480372)|


### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
