### PR TITLE
clicking on "followers" in profile view, now defaults to followers list

### DIFF
--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewFollowersTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewFollowersTab.tsx
@@ -52,7 +52,7 @@ export function ProfileViewFollowersTab({ queryRef }: ProfileViewFollowersTabPro
 
   const user = query.userByUsername;
 
-  const [selectedTab, setSelectedTab] = useState<FollowersTabName>('Following');
+  const [selectedTab, setSelectedTab] = useState<FollowersTabName>('Followers');
 
   const items = useMemo((): ListItem[] => {
     const items: ListItem[] = [];


### PR DESCRIPTION
### Summary of Changes

clicking on "followers" in profile view, now defaults to followers list and not following list

### Before

https://github.com/gallery-so/gallery/assets/49758803/9031b86b-a8c4-44c9-9c44-267525da195f

### After
https://github.com/gallery-so/gallery/assets/49758803/7c997889-a4a5-4e80-a020-34e3d7a78820

### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
