### PR TITLE
special copy for mchx notification on web

### DIFF
--- a/apps/web/src/components/Notifications/notifications/GalleryAnnouncement.tsx
+++ b/apps/web/src/components/Notifications/notifications/GalleryAnnouncement.tsx
@@ -3,6 +3,7 @@ import { graphql, useFragment } from 'react-relay';
 import styled from 'styled-components';
 
 import { Button } from '~/components/core/Button/Button';
+import GalleryLink from '~/components/core/GalleryLink/GalleryLink';
 import { HStack, VStack } from '~/components/core/Spacer/Stack';
 import { BaseM } from '~/components/core/Text/Text';
 import { GalleryAnnouncementFragment$key } from '~/generated/GalleryAnnouncementFragment.graphql';
@@ -24,12 +25,13 @@ export function GalleryAnnouncement({ notificationRef, onClose }: Props) {
         ctaText
         ctaLink
         imageUrl
+        internalId
       }
     `,
     notificationRef
   );
 
-  const { title, description, ctaText, ctaLink, imageUrl } = notification;
+  const { title, description, ctaText, ctaLink, imageUrl, internalId } = notification;
 
   const handleClick = useCallback(() => {
     if (!ctaLink) return;
@@ -37,6 +39,37 @@ export function GalleryAnnouncement({ notificationRef, onClose }: Props) {
     onClose();
   }, [ctaLink, onClose]);
 
+  if (internalId === 'apr-2024-mchx-collab') {
+    return (
+      <GalleryLink href="https://apps.apple.com/app/gallery/id6447068892">
+        <StyledNotificationContent align="center" justify="space-between" gap={8}>
+          <HStack align="center" gap={8}>
+            <VStack>{imageUrl ? <StyledImage src={imageUrl} /> : <StyledDefaultImage />}</VStack>
+
+            <VStack>
+              <StyledTextWrapper align="center" as="span" wrap="wrap">
+                <BaseM>
+                  <strong>Gallery is now on the App Store</strong>
+                </BaseM>
+                <BaseM as="span">
+                  Download the app today to claim your free mint of Radiance by MCHX.
+                </BaseM>
+              </StyledTextWrapper>
+            </VStack>
+          </HStack>
+          <StyledButton
+            eventElementId="Cta link from gallery announcement"
+            eventName="Click cta link from gallery announcement"
+            eventContext={contexts.Notifications}
+            variant="primary"
+            onClick={handleClick}
+          >
+            Download
+          </StyledButton>
+        </StyledNotificationContent>
+      </GalleryLink>
+    );
+  }
   return (
     <StyledNotificationContent align="center" justify="space-between" gap={8}>
       <HStack align="center" gap={8}>


### PR DESCRIPTION
### Summary of Changes

we are manually showing web specific copy for the MCHX notification.

![CleanShot 2024-04-05 at 23 06 54@2x](https://github.com/gallery-so/gallery/assets/80802871/4cff1ce2-25c0-4136-9b56-20a170e7c1f3)







### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
