### PR TITLE
fix transition to NftDetail page on web

### DIFF
--- a/apps/web/src/scenes/NftDetailPage/NftDetailAssetContainer.tsx
+++ b/apps/web/src/scenes/NftDetailPage/NftDetailAssetContainer.tsx
@@ -110,6 +110,7 @@ const StyledImage = styled.img`
   border: none;
   max-width: 100%;
   max-height: 100%;
+  object-fit: contain;
 `;
 
 const ShimmerContainer = styled.div`


### PR DESCRIPTION
### Summary of Changes

Weird stretching when you go to nft detail page from feed or a gallery. 

### Before


https://github.com/gallery-so/gallery/assets/49758803/6cfcb92d-6d61-4622-8582-caac9811a229

### After
https://github.com/gallery-so/gallery/assets/49758803/2789032c-906b-4a7b-9e61-384143c02d96



### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [x] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
