### PR TITLE
if primary address is non eth, check other wallets to mint to

### DIFF
--- a/apps/mobile/src/components/Mint/MintCampaign/MintCampaignPreTransaction.tsx
+++ b/apps/mobile/src/components/Mint/MintCampaign/MintCampaignPreTransaction.tsx
@@ -152,6 +152,11 @@ function MintButton({
             user {
               primaryWallet {
                 dbid
+                chain
+              }
+              wallets {
+                dbid
+                chain
               }
             }
           }
@@ -161,17 +166,35 @@ function MintButton({
     {}
   );
 
-  const recipientWalletId = query.viewer?.user?.primaryWallet?.dbid;
+  // Since the mint is only available for Ethereum addresses, look for the first connected Eth wallet starting with the primary wallet
+  const recipientWalletId = useMemo(() => {
+    const user = query.viewer?.user;
+    if (!user) {
+      return;
+    }
+    if (user.primaryWallet?.chain === 'Ethereum') {
+      return user.primaryWallet?.dbid;
+    }
+
+    return user.wallets?.find((wallet) => wallet?.chain === 'Ethereum')?.dbid;
+  }, [query.viewer?.user]);
 
   return (
-    <Button
-      text={isClamingMint ? 'Minting...' : 'Mint'}
-      eventElementId="Mint Campaign Mint Button"
-      eventName="Pressed Mint Campaign Mint Button"
-      eventContext={contexts['Mint Campaign']}
-      className="my-2"
-      onPress={() => onPress(recipientWalletId ?? '')}
-      disabled={isClamingMint || !recipientWalletId || isMintOver}
-    />
+    <>
+      <Button
+        text={isClamingMint ? 'Minting...' : 'Mint'}
+        eventElementId="Mint Campaign Mint Button"
+        eventName="Pressed Mint Campaign Mint Button"
+        eventContext={contexts['Mint Campaign']}
+        className="my-2"
+        onPress={() => onPress(recipientWalletId ?? '')}
+        disabled={isClamingMint || !recipientWalletId || isMintOver}
+      />
+      {!recipientWalletId && (
+        <BaseM classNameOverride="text-red">
+          Please connect an Ethereum address to your account to mint.
+        </BaseM>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
### Summary of Changes

Some users are unable to mint because their primary wallet is a Tezos address, which results in an error while trying to mint.
This PR checks if the primary wallet is an Eth address, and if not checks to see if any other connected wallets are eligible and uses that instead if one exists. If there are no eligible wallets, we show an error message and disable the mint button to make the issue clear.

### Demo or Before/After Pics

![CleanShot 2024-04-10 at 15 41 28](https://github.com/gallery-so/gallery/assets/80802871/a5d4e502-3914-41bb-8475-e37ee8b59b3c)



### Edge Cases
- User has a non eth address as their primary, but has an eth address connected
- User has a non eth address as their primary, and doesn't have an eth address connected



### Testing Steps
Set a non eth address as the primary, and go through the mint flow

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
