### PR TITLE
fix regression where all chains are disabled for collected tab

### DIFF
--- a/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarChainDropdown.tsx
+++ b/apps/web/src/components/GalleryEditor/PiecesSidebar/SidebarChainDropdown.tsx
@@ -83,7 +83,7 @@ export default function SidebarChainDropdown({
         <DropdownSection>
           {availableChains.map((chain) => {
             const isChainEnabled =
-              isAdmin || (selectedView === 'Created' && chain.hasCreatorSupport);
+              selectedView === 'Created' ? isAdmin || chain.hasCreatorSupport : true;
             return (
               <DropdownItem
                 key={chain.name}

--- a/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorFilterNetwork.tsx
+++ b/apps/web/src/components/NftSelector/NftSelectorFilter/NftSelectorFilterNetwork.tsx
@@ -100,7 +100,7 @@ export function NftSelectorFilterNetwork({
         <DropdownSection>
           {availableChains.map((chain) => {
             const isChainEnabled =
-              isAdmin || (selectedMode === 'Created' && chain.hasCreatorSupport);
+              selectedMode === 'Created' ? isAdmin || chain.hasCreatorSupport : true;
             return (
               <DropdownItem
                 key={chain.name}


### PR DESCRIPTION
### Summary of Changes

fix regression where all chains are disabled for collected tab

### Demo or Before/After Pics


Before

Non admin , collected tab
![CleanShot 2024-04-10 at 18 43 31@2x](https://github.com/gallery-so/gallery/assets/80802871/e8468b10-2eb7-4251-b7a3-d51fa42f31da)

Non admin, created tab
![CleanShot 2024-04-10 at 18 43 38@2x](https://github.com/gallery-so/gallery/assets/80802871/3837c86d-ef4d-4304-914d-4fe7a38589ab)


After
Non admin, collected tab
![CleanShot 2024-04-10 at 18 43 52@2x](https://github.com/gallery-so/gallery/assets/80802871/42434070-235e-487d-ac0b-b1f17c41205a)

Non admin, created tab
![CleanShot 2024-04-10 at 18 44 02@2x](https://github.com/gallery-so/gallery/assets/80802871/8fda6f53-22b2-4cc5-b783-0b26d4ae1a97)


Same fix for nft selector dropdown
![CleanShot 2024-04-10 at 18 45 26@2x](https://github.com/gallery-so/gallery/assets/80802871/efed6700-8604-459d-b07f-30ee14e42b3e)


### Edge Cases

- is admin user
- is not admin user

### Testing Steps

- log in as a non admin user
- go to the editor or nft selector and select the network dropdown
- you should be able to select any chain for the Collected tab
- you should see a limited selection of chains for the Created tab

- if you log in as an admin user you should see all chains enabled

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
