### PR TITLE
Refactor all bottom sheets to use BottomSheetModalContext, fix bug preventing Bottom Sheet from opening if Reduced Motion iOS setting is on

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -1,6 +1,6 @@
 import 'expo-dev-client';
 
-import { PortalHost, PortalProvider } from '@gorhom/portal';
+import { PortalProvider } from '@gorhom/portal';
 import { PrivyProvider } from '@privy-io/expo';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer, useNavigationContainerRef } from '@react-navigation/native';

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -1,6 +1,6 @@
 import 'expo-dev-client';
 
-import { PortalProvider } from '@gorhom/portal';
+import { PortalHost, PortalProvider } from '@gorhom/portal';
 import { PrivyProvider } from '@privy-io/expo';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer, useNavigationContainerRef } from '@react-navigation/native';

--- a/apps/mobile/src/components/CommunitiesList/CommunityCard.tsx
+++ b/apps/mobile/src/components/CommunitiesList/CommunityCard.tsx
@@ -39,7 +39,7 @@ export function CommunityCard({ communityRef }: CommunityCardProps) {
   return (
     <GalleryTouchableOpacity
       onPress={handlePress}
-      className="flex flex-row items-center space-x-4 py-2 px-4"
+      className="flex flex-row items-center space-x-4 py-2"
       eventElementId="Community Name"
       eventName="Community Name Clicked"
       eventContext={contexts.Community}

--- a/apps/mobile/src/components/Community/CommunityBottomSheet.tsx
+++ b/apps/mobile/src/components/Community/CommunityBottomSheet.tsx
@@ -1,19 +1,11 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
-import { ForwardedRef, forwardRef, useRef } from 'react';
+import { forwardRef } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
 import { CommunityBottomSheetFragment$key } from '~/generated/CommunityBottomSheetFragment.graphql';
 
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../GalleryBottomSheet/GalleryBottomSheetModal';
 import { Markdown } from '../Markdown';
-import { useSafeAreaPadding } from '../SafeAreaViewWithPadding';
 import { Typography } from '../Typography';
-
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
 
 const markdownStyles = {
   paragraph: {
@@ -25,10 +17,7 @@ type Props = {
   communityRef: CommunityBottomSheetFragment$key;
 };
 
-function CommunityBottomSheet(
-  { communityRef }: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
+function CommunityBottomSheet({ communityRef }: Props) {
   const community = useFragment(
     graphql`
       fragment CommunityBottomSheetFragment on Community {
@@ -39,49 +28,23 @@ function CommunityBottomSheet(
     communityRef
   );
 
-  const { bottom } = useSafeAreaPadding();
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
-
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        bottomSheetRef.current = value;
-
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          ref.current = value;
-        }
-      }}
-      snapPoints={animatedSnapPoints}
-      handleHeight={animatedHandleHeight}
-      contentHeight={animatedContentHeight}
-    >
-      <View
-        onLayout={handleContentLayout}
-        style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-6"
-      >
-        <View className="flex flex-col space-y-4">
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
-          >
-            {community.name}
-          </Typography>
-          <Typography
-            className="text-sm text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Regular' }}
-          >
-            <Markdown style={markdownStyles}>{community.description}</Markdown>
-          </Typography>
-        </View>
+    <View className="flex flex-col space-y-6">
+      <View className="flex flex-col space-y-4">
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Bold' }}
+        >
+          {community.name}
+        </Typography>
+        <Typography
+          className="text-sm text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Regular' }}
+        >
+          <Markdown style={markdownStyles}>{community.description}</Markdown>
+        </Typography>
       </View>
-    </GalleryBottomSheetModal>
+    </View>
   );
 }
 

--- a/apps/mobile/src/components/Community/CommunityCollectors/CommunityCollectorsListItem.tsx
+++ b/apps/mobile/src/components/Community/CommunityCollectors/CommunityCollectorsListItem.tsx
@@ -1,5 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import { useCallback } from 'react';
+import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
 import { UserFollowCard } from '~/components/UserFollowList/UserFollowCard';
@@ -43,5 +44,9 @@ export function CommunityCollectorsListItem({ userRef, queryRef }: Props) {
     }
   }, [navigation, user.username]);
 
-  return <UserFollowCard userRef={user} queryRef={query} onPress={handlePress} />;
+  return (
+    <View className="px-4">
+      <UserFollowCard userRef={user} queryRef={query} onPress={handlePress} />
+    </View>
+  );
 }

--- a/apps/mobile/src/components/Community/CommunityHeader.tsx
+++ b/apps/mobile/src/components/Community/CommunityHeader.tsx
@@ -1,21 +1,21 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { EditPencilIcon } from 'src/icons/EditPencilIcon';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { CommunityHeaderFragment$key } from '~/generated/CommunityHeaderFragment.graphql';
 import { CommunityHeaderQueryFragment$key } from '~/generated/CommunityHeaderQueryFragment.graphql';
 import { contexts } from '~/shared/analytics/constants';
 import { extractRelevantMetadataFromCommunity } from '~/shared/utils/extractRelevantMetadataFromCommunity';
 import { truncateAddress } from '~/shared/utils/wallet';
 
-import { GalleryBottomSheetModalType } from '../GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
 import { Markdown } from '../Markdown';
 import { CommunityProfilePicture } from '../ProfilePicture/CommunityProfilePicture';
 import { Typography } from '../Typography';
 import { CommunityBottomSheet } from './CommunityBottomSheet';
-import { CommunityMetadataFormBottomSheet } from './CommunityMetadataFormBottomSheet';
+import CommunityMetadataFormBottomSheet from './CommunityMetadataFormBottomSheet';
 
 type Props = {
   communityRef: CommunityHeaderFragment$key;
@@ -46,11 +46,15 @@ export function CommunityHeader({ communityRef, queryRef }: Props) {
   );
 
   const hasCommunityDescription = Boolean(community.description);
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+
+  const { showBottomSheetModal } = useBottomSheetModalActions();
   const handlePress = useCallback(() => {
     if (!hasCommunityDescription) return;
-    bottomSheetRef.current?.present();
-  }, [hasCommunityDescription]);
+
+    showBottomSheetModal({
+      content: <CommunityBottomSheet communityRef={community} />,
+    });
+  }, [community, hasCommunityDescription, showBottomSheetModal]);
 
   // combines description into a single paragraph by removing extra whitespace,
   //  then splitting the cleaned text into sentences using a regular expression
@@ -62,10 +66,11 @@ export function CommunityHeader({ communityRef, queryRef }: Props) {
 
   const displayName = community.name || truncateAddress(contractAddress);
 
-  const formBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
   const handleEditPress = useCallback(() => {
-    formBottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: <CommunityMetadataFormBottomSheet communityRef={community} queryRef={query} />,
+    });
+  }, [community, query, showBottomSheetModal]);
 
   return (
     <View className="mb-2">
@@ -98,12 +103,6 @@ export function CommunityHeader({ communityRef, queryRef }: Props) {
           </View>
         </GalleryTouchableOpacity>
       </View>
-      <CommunityBottomSheet ref={bottomSheetRef} communityRef={community} />
-      <CommunityMetadataFormBottomSheet
-        ref={formBottomSheetRef}
-        communityRef={community}
-        queryRef={query}
-      />
     </View>
   );
 }

--- a/apps/mobile/src/components/Community/CommunityMetadataFormBottomSheet.tsx
+++ b/apps/mobile/src/components/Community/CommunityMetadataFormBottomSheet.tsx
@@ -1,10 +1,10 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
 import clsx from 'clsx';
-import { ForwardedRef, forwardRef, useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { TextInput, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import colors from 'shared/theme/colors';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { useToastActions } from '~/contexts/ToastContext';
 import { env } from '~/env/runtime';
 import { CommunityMetadataFormBottomSheetFragment$key } from '~/generated/CommunityMetadataFormBottomSheetFragment.graphql';
@@ -12,24 +12,14 @@ import { CommunityMetadataFormBottomSheetQueryFragment$key } from '~/generated/C
 import { contexts } from '~/shared/analytics/constants';
 
 import { Button } from '../Button';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../GalleryBottomSheet/GalleryBottomSheetModal';
-import { useSafeAreaPadding } from '../SafeAreaViewWithPadding';
 import { Typography } from '../Typography';
-
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
 
 type Props = {
   communityRef: CommunityMetadataFormBottomSheetFragment$key;
   queryRef: CommunityMetadataFormBottomSheetQueryFragment$key;
 };
 
-function CommunityMetadataFormBottomSheet(
-  { communityRef, queryRef }: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
+export default function CommunityMetadataFormBottomSheet({ communityRef, queryRef }: Props) {
   const community = useFragment(
     graphql`
       fragment CommunityMetadataFormBottomSheetFragment on Community {
@@ -54,18 +44,13 @@ function CommunityMetadataFormBottomSheet(
     queryRef
   );
 
-  const { bottom } = useSafeAreaPadding();
   const { pushToast } = useToastActions();
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
   const userId = query.viewer?.user?.dbid;
 
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
-
   const [message, setMessage] = useState<string>('');
   const [status, setStatus] = useState<'SUBMITTING' | 'SUCCESS' | 'ERROR' | undefined>();
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
 
   const handleSubmitPress = useCallback(async () => {
     setStatus('SUBMITTING');
@@ -91,91 +76,68 @@ function CommunityMetadataFormBottomSheet(
         pushToast({
           message: 'Submitted successfully!',
         });
-        bottomSheetRef.current?.dismiss();
+        hideBottomSheetModal();
       } else {
         setStatus('ERROR');
       }
     } catch (error) {
       setStatus('ERROR');
     }
-  }, [community.dbid, message, pushToast, userId]);
+  }, [community.dbid, hideBottomSheetModal, message, pushToast, userId]);
 
   const isButtonDisabled = useMemo(() => {
     return status === 'SUBMITTING' || !message;
   }, [message, status]);
 
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        bottomSheetRef.current = value;
-
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          ref.current = value;
-        }
-      }}
-      snapPoints={animatedSnapPoints}
-      handleHeight={animatedHandleHeight}
-      contentHeight={animatedContentHeight}
-    >
-      <View
-        onLayout={handleContentLayout}
-        style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-6"
-      >
-        <View className="flex flex-col space-y-6">
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
-          >
-            Request changes
-          </Typography>
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Regular' }}
-          >
-            We're currently updating our editor for collection pages. Let us know what changes you’d
-            like and we'll jump on them right away!
-          </Typography>
-        </View>
-
-        <View className="space-y-8">
-          <View className="space-y-2">
-            <TextInput
-              onChange={(e) => setMessage(e.nativeEvent.text)}
-              placeholder="Update Title, Description and/or Profile Picture (include image link)"
-              className={clsx('px-3 py-2 bg-offWhite h-32 leading-5 border border-transparent', {
-                'border border-red': status === 'ERROR',
-              })}
-              placeholderTextColor={colors.metal}
-              multiline
-            />
-
-            {status === 'ERROR' && (
-              <Typography
-                className="text-sm text-red pl-2 pb-2"
-                font={{ family: 'ABCDiatype', weight: 'Regular' }}
-              >
-                Something went wrong! Please try again
-              </Typography>
-            )}
-          </View>
-
-          <Button
-            onPress={handleSubmitPress}
-            text="SUBMIT"
-            eventElementId="Community Metadata Form Submit Button"
-            eventName="Community Metadata Form Submit Press"
-            eventContext={contexts.Community}
-            disabled={isButtonDisabled}
-          />
-        </View>
+    <View className="flex flex-col space-y-6">
+      <View className="flex flex-col space-y-6">
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Bold' }}
+        >
+          Request changes
+        </Typography>
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Regular' }}
+        >
+          We're currently updating our editor for collection pages. Let us know what changes you’d
+          like and we'll jump on them right away!
+        </Typography>
       </View>
-    </GalleryBottomSheetModal>
+
+      <View className="space-y-8">
+        <View className="space-y-2">
+          <TextInput
+            onChange={(e) => setMessage(e.nativeEvent.text)}
+            placeholder="Update Title, Description and/or Profile Picture (include image link)"
+            className={clsx('px-3 py-2 bg-offWhite h-32 leading-5 border border-transparent', {
+              'border border-red': status === 'ERROR',
+            })}
+            placeholderTextColor={colors.metal}
+            multiline
+          />
+
+          {status === 'ERROR' && (
+            <Typography
+              className="text-sm text-red pl-2 pb-2"
+              font={{ family: 'ABCDiatype', weight: 'Regular' }}
+            >
+              Something went wrong! Please try again
+            </Typography>
+          )}
+        </View>
+
+        <Button
+          onPress={handleSubmitPress}
+          text="SUBMIT"
+          eventElementId="Community Metadata Form Submit Button"
+          eventName="Community Metadata Form Submit Press"
+          eventContext={contexts.Community}
+          disabled={isButtonDisabled}
+        />
+      </View>
+    </View>
   );
 }
-
-const ForwardedCommunityMetadataFormBottomSheet = forwardRef(CommunityMetadataFormBottomSheet);
-
-export { ForwardedCommunityMetadataFormBottomSheet as CommunityMetadataFormBottomSheet };

--- a/apps/mobile/src/components/Community/CommunityPostBottomSheet.tsx
+++ b/apps/mobile/src/components/Community/CommunityPostBottomSheet.tsx
@@ -1,9 +1,9 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
-import { ForwardedRef, forwardRef, useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { Text, View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { RefreshIcon } from 'src/icons/RefreshIcon';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { useSyncTokensActions } from '~/contexts/SyncTokensContext';
 import { useToastActions } from '~/contexts/ToastContext';
 import { CommunityPostBottomSheetFragment$key } from '~/generated/CommunityPostBottomSheetFragment.graphql';
@@ -11,24 +11,14 @@ import { contexts } from '~/shared/analytics/constants';
 import { extractRelevantMetadataFromCommunity } from '~/shared/utils/extractRelevantMetadataFromCommunity';
 
 import { Button } from '../Button';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../GalleryBottomSheet/GalleryBottomSheetModal';
-import { useSafeAreaPadding } from '../SafeAreaViewWithPadding';
 import { Typography } from '../Typography';
-
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
 
 type Props = {
   communityRef: CommunityPostBottomSheetFragment$key;
   onRefresh: () => void;
 };
 
-function CommunityPostBottomSheet(
-  { communityRef, onRefresh }: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
+export default function CommunityPostBottomSheet({ communityRef, onRefresh }: Props) {
   const community = useFragment(
     graphql`
       fragment CommunityPostBottomSheetFragment on Community {
@@ -39,18 +29,14 @@ function CommunityPostBottomSheet(
     communityRef
   );
 
-  const { bottom } = useSafeAreaPadding();
   const { isSyncing, syncTokens } = useSyncTokensActions();
   const { pushToast } = useToastActions();
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
 
   const closeBottomSheet = useCallback(() => {
-    bottomSheetRef.current?.close();
-  }, []);
+    hideBottomSheetModal();
+  }, [hideBottomSheetModal]);
 
   const { chain } = extractRelevantMetadataFromCommunity(community);
 
@@ -68,70 +54,47 @@ function CommunityPostBottomSheet(
   }, [closeBottomSheet, chain, onRefresh, pushToast, syncTokens]);
 
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        bottomSheetRef.current = value;
-
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          ref.current = value;
-        }
-      }}
-      snapPoints={animatedSnapPoints}
-      handleHeight={animatedHandleHeight}
-      contentHeight={animatedContentHeight}
-    >
-      <View
-        onLayout={handleContentLayout}
-        style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-6"
-      >
-        <View className="flex flex-col space-y-4">
+    <View className="flex flex-col space-y-6">
+      <View className="flex flex-col space-y-4">
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Bold' }}
+        >
+          Ownership required
+        </Typography>
+        <Text>
           <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
+            className="text-md text-black-900 dark:text-offWhite"
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
+          >
+            Only {community.name} owners can post about {community.name}. If you own this item but
+            it's not displaying try
+          </Typography>{' '}
+          <Typography
+            className="text-md text-black-900 dark:text-offWhite"
             font={{ family: 'ABCDiatype', weight: 'Bold' }}
           >
-            Ownership required
+            refreshing your collection.
           </Typography>
-          <Text>
-            <Typography
-              className="text-md text-black-900 dark:text-offWhite"
-              font={{ family: 'ABCDiatype', weight: 'Regular' }}
-            >
-              Only {community.name} owners can post about {community.name}. If you own this item but
-              it's not displaying try
-            </Typography>{' '}
-            <Typography
-              className="text-md text-black-900 dark:text-offWhite"
-              font={{ family: 'ABCDiatype', weight: 'Bold' }}
-            >
-              refreshing your collection.
-            </Typography>
-          </Text>
-          <Button
-            text="Ok"
-            onPress={closeBottomSheet}
-            eventElementId={null}
-            eventName={null}
-            eventContext={null}
-          />
-          <Button
-            text="Refresh collection"
-            variant="secondary"
-            loading={isSyncing}
-            onPress={handleSync}
-            headerElement={<RefreshIcon />}
-            eventElementId="Refresh Tokens From Community Screen Button"
-            eventName="Refresh Tokens From Community Screen"
-            eventContext={contexts.Posts}
-          />
-        </View>
+        </Text>
+        <Button
+          text="Ok"
+          onPress={closeBottomSheet}
+          eventElementId={null}
+          eventName={null}
+          eventContext={null}
+        />
+        <Button
+          text="Refresh collection"
+          variant="secondary"
+          loading={isSyncing}
+          onPress={handleSync}
+          headerElement={<RefreshIcon />}
+          eventElementId="Refresh Tokens From Community Screen Button"
+          eventName="Refresh Tokens From Community Screen"
+          eventContext={contexts.Posts}
+        />
       </View>
-    </GalleryBottomSheetModal>
+    </View>
   );
 }
-
-const ForwardedCommunityPostBottomSheet = forwardRef(CommunityPostBottomSheet);
-
-export { ForwardedCommunityPostBottomSheet as CommunityPostBottomSheet };

--- a/apps/mobile/src/components/Community/Tabs/CommunityViewPostsTab.tsx
+++ b/apps/mobile/src/components/Community/Tabs/CommunityViewPostsTab.tsx
@@ -13,9 +13,9 @@ import {
 } from '~/components/Feed/createVirtualizedFeedEventItems';
 import { FeedVirtualizedRow } from '~/components/Feed/FeedVirtualizedRow';
 import { useFailedEventTracker } from '~/components/Feed/useFailedEventTracker';
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { useListContentStyle } from '~/components/ProfileView/Tabs/useListContentStyle';
 import { Typography } from '~/components/Typography';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { CommunityViewPostsTabFragment$key } from '~/generated/CommunityViewPostsTabFragment.graphql';
 import { CommunityViewPostsTabQueryFragment$key } from '~/generated/CommunityViewPostsTabQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
@@ -23,7 +23,7 @@ import { contexts } from '~/shared/analytics/constants';
 import { extractRelevantMetadataFromCommunity } from '~/shared/utils/extractRelevantMetadataFromCommunity';
 import { noop } from '~/shared/utils/noop';
 
-import { CommunityPostBottomSheet } from '../CommunityPostBottomSheet';
+import CommunityPostBottomSheet from '../CommunityPostBottomSheet';
 
 type Props = {
   communityRef: CommunityViewPostsTabFragment$key;
@@ -127,10 +127,12 @@ export function CommunityViewPostsTab({ communityRef, queryRef }: Props) {
 
   const { contractAddress } = extractRelevantMetadataFromCommunity(community);
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const { showBottomSheetModal } = useBottomSheetModalActions();
   const handleCreatePost = useCallback(() => {
     if (!isMemberOfCommunity) {
-      bottomSheetRef.current?.present();
+      showBottomSheetModal({
+        content: <CommunityPostBottomSheet communityRef={community} onRefresh={noop} />,
+      });
       return;
     }
 
@@ -139,7 +141,7 @@ export function CommunityViewPostsTab({ communityRef, queryRef }: Props) {
       contractAddress,
       page: 'Community',
     });
-  }, [isMemberOfCommunity, contractAddress, navigation]);
+  }, [isMemberOfCommunity, contractAddress, navigation, showBottomSheetModal, community]);
 
   const loadMore = useCallback(() => {
     if (hasPrevious) {
@@ -171,12 +173,6 @@ export function CommunityViewPostsTab({ communityRef, queryRef }: Props) {
             eventElementId="Empty View Create Post Button"
             eventName="Empty View Create Post Button Press"
             eventContext={contexts.Posts}
-          />
-
-          <CommunityPostBottomSheet
-            ref={bottomSheetRef}
-            communityRef={community}
-            onRefresh={noop}
           />
         </View>
       </View>

--- a/apps/mobile/src/components/Feed/AdmireBottomSheet/AdmireBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/AdmireBottomSheet/AdmireBottomSheet.tsx
@@ -1,14 +1,9 @@
 import { useNavigation } from '@react-navigation/native';
-import { ForwardedRef, Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
-import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 import { Typography } from '~/components/Typography';
 import { UserFollowList } from '~/components/UserFollowList/UserFollowList';
 import { UserFollowListFallback } from '~/components/UserFollowList/UserFollowListFallback';
@@ -23,47 +18,24 @@ import { removeNullValues } from '~/shared/relay/removeNullValues';
 
 import { FeedItemTypes } from '../createVirtualizedFeedEventItems';
 
-const SNAP_POINTS = [350];
-
 type AdmireBottomSheetProps = {
   feedId: string;
-  bottomSheetRef: ForwardedRef<GalleryBottomSheetModalType | null>;
   type: FeedItemTypes;
 };
 
-export function AdmireBottomSheet({ bottomSheetRef, feedId, type }: AdmireBottomSheetProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const internalRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { bottom } = useSafeAreaPadding();
-
+export function AdmireBottomSheet({ feedId, type }: AdmireBottomSheetProps) {
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        internalRef.current = value;
-        if (typeof bottomSheetRef === 'function') {
-          bottomSheetRef(value);
-        } else if (bottomSheetRef) {
-          bottomSheetRef.current = value;
-        }
-      }}
-      snapPoints={SNAP_POINTS}
-      onChange={() => setIsOpen(true)}
-      android_keyboardInputMode="adjustResize"
-      keyboardBlurBehavior="restore"
-    >
-      <View style={{ paddingBottom: bottom }} className="flex flex-1 flex-col space-y-5">
-        <Typography className="text-sm px-4" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-          Admires
-        </Typography>
+    <View className="flex flex-1 flex-col space-y-5">
+      <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+        Admires
+      </Typography>
 
-        <View className="flex-grow">
-          <Suspense fallback={<UserFollowListFallback />}>
-            {isOpen && <ConnectedAdmireList type={type} feedId={feedId} />}
-          </Suspense>
-        </View>
+      <View className="flex-grow">
+        <Suspense fallback={<UserFollowListFallback />}>
+          <ConnectedAdmireList type={type} feedId={feedId} />
+        </Suspense>
       </View>
-    </GalleryBottomSheetModal>
+    </View>
   );
 }
 type ConnectedAdmireListProps = {

--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
@@ -2,6 +2,7 @@ import {
   ForwardedRef,
   Suspense,
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -44,21 +45,16 @@ type CommentsBottomSheetProps = {
   activeCommentId?: string;
   replyToComment?: OnReplyPressParams;
   feedId: string;
-  bottomSheetRef: ForwardedRef<GalleryBottomSheetModalType>;
   type: FeedItemTypes;
 };
 
 export function CommentsBottomSheet({
   activeCommentId,
-  bottomSheetRef,
   feedId,
   replyToComment,
   type,
 }: CommentsBottomSheetProps) {
-  const internalRef = useRef<GalleryBottomSheetModalType | null>(null);
   const commentBoxRef = useRef<TextInput>(null);
-
-  const [isOpen, setIsOpen] = useState(false);
 
   const { bottom } = useSafeAreaPadding();
   const isKeyboardActive = useKeyboardStatus();
@@ -77,8 +73,6 @@ export function CommentsBottomSheet({
   const { submitComment, isSubmittingComment } = useEventComment();
   const { submitComment: postComment, isSubmittingComment: isSubmittingPostComment } =
     usePostComment();
-
-  const snapPoints = [600];
 
   const {
     aliasKeyword,
@@ -162,91 +156,75 @@ export function CommentsBottomSheet({
     }
   }, [bottom, isKeyboardActive, paddingBottomValue]);
 
-  const handleDismiss = useCallback(() => {
-    resetMentions();
-    setSelectedComment(null);
-    topCommentId.current = null;
+  useEffect(() => {
+    return () => {
+      resetMentions();
+      setSelectedComment(null);
+      topCommentId.current = null;
+    };
   }, [resetMentions]);
 
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        internalRef.current = value;
-        if (typeof bottomSheetRef === 'function') {
-          bottomSheetRef(value);
-        } else if (bottomSheetRef) {
-          bottomSheetRef.current = value;
-        }
-      }}
-      snapPoints={snapPoints}
-      onChange={() => setIsOpen(true)}
-      android_keyboardInputMode="adjustResize"
-      keyboardBlurBehavior="restore"
-      onDismiss={handleDismiss}
-    >
-      <Animated.View style={paddingStyle} className="flex flex-1 flex-col space-y-5">
-        <View className="flex-grow">
-          {isSelectingMentions ? (
-            <View className="flex-1 overflow-hidden">
-              {aliasKeyword ? (
-                <Suspense fallback={<SearchResultsFallback />}>
-                  <SearchResults
-                    keyword={aliasKeyword}
-                    activeFilter="top"
-                    onChangeFilter={noop}
-                    blurInputFocus={noop}
-                    onSelect={selectMention}
-                    onlyShowTopResults
-                    isMentionSearch
-                  />
-                </Suspense>
-              ) : (
-                <SearchResultsFallback />
-              )}
+    <Animated.View style={paddingStyle} className="flex flex-1 flex-col space-y-5 min-h-[400px]">
+      <View className="flex-grow">
+        {isSelectingMentions ? (
+          <View className="flex-1 overflow-hidden">
+            {aliasKeyword ? (
+              <Suspense fallback={<SearchResultsFallback />}>
+                <SearchResults
+                  keyword={aliasKeyword}
+                  activeFilter="top"
+                  onChangeFilter={noop}
+                  blurInputFocus={noop}
+                  onSelect={selectMention}
+                  onlyShowTopResults
+                  isMentionSearch
+                />
+              </Suspense>
+            ) : (
+              <SearchResultsFallback />
+            )}
+          </View>
+        ) : (
+          <View className="flex-1 space-y-2">
+            <Typography className="text-sm px-4" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+              Comments
+            </Typography>
+            <View className="flex-grow">
+              <Suspense fallback={<CommentListFallback />}>
+                <ConnectedCommentsList
+                  type={type}
+                  feedId={feedId}
+                  activeCommentId={highlightCommentId}
+                  onReplyPress={handleReplyPress}
+                />
+              </Suspense>
             </View>
-          ) : (
-            <View className="flex-1 space-y-2">
-              <Typography className="text-sm px-4" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-                Comments
-              </Typography>
-              <View className="flex-grow">
-                <Suspense fallback={<CommentListFallback />}>
-                  {isOpen && (
-                    <ConnectedCommentsList
-                      type={type}
-                      feedId={feedId}
-                      activeCommentId={highlightCommentId}
-                      onReplyPress={handleReplyPress}
-                    />
-                  )}
-                </Suspense>
-              </View>
-            </View>
-          )}
-        </View>
+          </View>
+        )}
+      </View>
 
-        <CommentsRepliedBanner
-          username={selectedComment?.username ?? ''}
-          comment={selectedComment?.comment ?? ''}
-          onClose={() => {
-            setSelectedComment(null);
-            topCommentId.current = null;
-          }}
-        />
+      <CommentsRepliedBanner
+        username={selectedComment?.username ?? ''}
+        comment={selectedComment?.comment ?? ''}
+        onClose={() => {
+          setSelectedComment(null);
+          topCommentId.current = null;
+        }}
+      />
 
-        <CommentBox
-          value={message}
-          onChangeText={setMessage}
-          onSelectionChange={handleSelectionChange}
-          onSubmit={handleSubmit}
-          isSubmittingComment={isSubmitting}
-          onClose={noop}
-          ref={commentBoxRef}
-          mentions={mentions}
-          autoFocus={Boolean(selectedComment?.commentId)}
-        />
-      </Animated.View>
-    </GalleryBottomSheetModal>
+      <CommentBox
+        value={message}
+        onChangeText={setMessage}
+        onSelectionChange={handleSelectionChange}
+        onSubmit={handleSubmit}
+        isSubmittingComment={isSubmitting}
+        onClose={noop}
+        ref={commentBoxRef}
+        mentions={mentions}
+        autoFocus={Boolean(selectedComment?.commentId)}
+      />
+    </Animated.View>
   );
 }
 

--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
@@ -1,5 +1,4 @@
 import {
-  ForwardedRef,
   Suspense,
   useCallback,
   useEffect,
@@ -17,10 +16,6 @@ import { usePostComment } from 'src/hooks/usePostComment';
 
 import { CommentsBottomSheetList } from '~/components/Feed/CommentsBottomSheet/CommentsBottomSheetList';
 import { CommentBox } from '~/components/Feed/Socialize/CommentBox';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 import { SearchResultsFallback } from '~/components/Search/SearchResultFallback';
 import { SearchResults } from '~/components/Search/SearchResults';

--- a/apps/mobile/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
+++ b/apps/mobile/src/components/Feed/Events/UserFollowedUsersFeedEvent.tsx
@@ -1,16 +1,13 @@
 import { useNavigation } from '@react-navigation/native';
-import { Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { useFragment, useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { UserFollowList } from '~/components/UserFollowList/UserFollowList';
 import { UserFollowListFallback } from '~/components/UserFollowList/UserFollowListFallback';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { UserFollowedUsersFeedEventFollowersFragment$key } from '~/generated/UserFollowedUsersFeedEventFollowersFragment.graphql';
 import { UserFollowedUsersFeedEventFollowListQuery } from '~/generated/UserFollowedUsersFeedEventFollowListQuery.graphql';
 import { UserFollowedUsersFeedEventFragment$key } from '~/generated/UserFollowedUsersFeedEventFragment.graphql';
@@ -70,22 +67,20 @@ export function UserFollowedUsersFeedEvent({
     }
   }, [followeeUsername, navigation]);
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const { showBottomSheetModal } = useBottomSheetModalActions();
 
-  const [opened, setOpened] = useState(false);
   const handleOthersPress = useCallback(() => {
-    setOpened(true);
-    bottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: (
+        <Suspense fallback={<UserFollowListFallback />}>
+          <FollowList userRefs={followedUsers} />
+        </Suspense>
+      ),
+    });
+  }, [followedUsers, showBottomSheetModal]);
 
   return (
     <View className="flex flex-row justify-between items-center px-3">
-      <GalleryBottomSheetModal ref={bottomSheetRef} snapPoints={[320]}>
-        <Suspense fallback={<UserFollowListFallback />}>
-          {opened && <FollowList userRefs={followedUsers} />}
-        </Suspense>
-      </GalleryBottomSheetModal>
-
       <View className="flex flex-row space-x-1">
         <GalleryTouchableOpacity
           onPress={handleFollowerPress}

--- a/apps/mobile/src/components/Feed/Posts/DeletePostBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/Posts/DeletePostBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 

--- a/apps/mobile/src/components/Feed/Posts/DeletePostBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/Posts/DeletePostBottomSheet.tsx
@@ -14,7 +14,7 @@ type Props = {
   postRef: DeletePostBottomSheetFragment$key;
 };
 
-function DeletePostBottomSheet({ postRef }: Props) {
+export default function DeletePostBottomSheet({ postRef }: Props) {
   const post = useFragment(
     graphql`
       fragment DeletePostBottomSheetFragment on Post {
@@ -55,11 +55,7 @@ function DeletePostBottomSheet({ postRef }: Props) {
   }, [deletePost, hideBottomSheetModal, post.dbid]);
 
   return (
-    <View
-      // onLayout={handleContentLayout}
-
-      className="flex flex-col space-y-6"
-    >
+    <View className="flex flex-col space-y-6">
       <View className="flex flex-col space-y-4">
         <Typography
           className="text-lg text-black-900 dark:text-offWhite"
@@ -95,7 +91,3 @@ function DeletePostBottomSheet({ postRef }: Props) {
     </View>
   );
 }
-
-const ForwardedDeletePostBottomSheet = forwardRef(DeletePostBottomSheet);
-
-export { ForwardedDeletePostBottomSheet as DeletePostBottomSheet };

--- a/apps/mobile/src/components/Feed/Posts/FeedPostSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Posts/FeedPostSocializeSection.tsx
@@ -1,10 +1,10 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { useTogglePostAdmire } from 'src/hooks/useTogglePostAdmire';
 
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { FeedPostSocializeSectionFragment$key } from '~/generated/FeedPostSocializeSectionFragment.graphql';
 import { FeedPostSocializeSectionQueryFragment$key } from '~/generated/FeedPostSocializeSectionQueryFragment.graphql';
 import { MainTabStackNavigatorParamList } from '~/navigation/types';
@@ -107,10 +107,20 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef }: Props) {
 
   const totalAdmires = post.admires?.pageInfo?.total ?? 0;
 
-  const commentsBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const { showBottomSheetModal } = useBottomSheetModalActions();
   const handleOpenCommentBottomSheet = useCallback(() => {
-    commentsBottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: (
+        <CommentsBottomSheet
+          type="Post"
+          feedId={post.dbid}
+          activeCommentId={route.params?.commentId}
+          replyToComment={route.params?.replyToComment}
+        />
+      ),
+      noPadding: true,
+    });
+  }, [post.dbid, route.params?.commentId, route.params?.replyToComment, showBottomSheetModal]);
 
   useEffect(() => {
     if (route.params?.commentId) {
@@ -144,13 +154,6 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef }: Props) {
           onCommentPress={handleOpenCommentBottomSheet}
         />
       </View>
-      <CommentsBottomSheet
-        type="Post"
-        feedId={post.dbid}
-        bottomSheetRef={commentsBottomSheetRef}
-        activeCommentId={route.params?.commentId}
-        replyToComment={route.params?.replyToComment}
-      />
     </>
   );
 }

--- a/apps/mobile/src/components/Feed/Posts/FirstTimePosterBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/Posts/FirstTimePosterBottomSheet.tsx
@@ -1,76 +1,37 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
-import { ForwardedRef, forwardRef, useRef } from 'react';
 import { View } from 'react-native';
 
 import { Button } from '~/components/Button';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
-import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 import { Typography } from '~/components/Typography';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { contexts } from '~/shared/analytics/constants';
 
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
-
-// eslint-disable-next-line @typescript-eslint/ban-types
-type Props = {};
-
-function FirstTimePosterBottomSheet(props: Props, ref: ForwardedRef<GalleryBottomSheetModalType>) {
-  const { bottom } = useSafeAreaPadding();
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
+export default function FirstTimePosterBottomSheet() {
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
 
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        bottomSheetRef.current = value;
-
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          ref.current = value;
-        }
-      }}
-      snapPoints={animatedSnapPoints}
-      handleHeight={animatedHandleHeight}
-      contentHeight={animatedContentHeight}
-    >
-      <View
-        onLayout={handleContentLayout}
-        style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-6"
-      >
-        <View className="flex flex-col space-y-4">
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
-          >
-            First-time poster
-          </Typography>
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Regular' }}
-          >
-            This is my first post—gm!
-          </Typography>
-        </View>
-
-        <Button
-          onPress={() => bottomSheetRef.current?.dismiss()}
-          text="CLOSE"
-          eventElementId={null}
-          eventName={null}
-          eventContext={contexts.Posts}
-        />
+    <View className="flex flex-col space-y-6">
+      <View className="flex flex-col space-y-4">
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Bold' }}
+        >
+          First-time poster
+        </Typography>
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Regular' }}
+        >
+          This is my first post—gm!
+        </Typography>
       </View>
-    </GalleryBottomSheetModal>
+
+      <Button
+        onPress={hideBottomSheetModal}
+        text="CLOSE"
+        eventElementId={null}
+        eventName={null}
+        eventContext={contexts.Posts}
+      />
+    </View>
   );
 }
-
-const ForwardedFirstTimePosterBottomSheet = forwardRef(FirstTimePosterBottomSheet);
-
-export { ForwardedFirstTimePosterBottomSheet as FirstTimePosterBottomSheet };

--- a/apps/mobile/src/components/Feed/Posts/PostBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostBottomSheet.tsx
@@ -1,15 +1,10 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
 import { useNavigation } from '@react-navigation/native';
-import { ForwardedRef, forwardRef, useCallback, useMemo, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
 import { BottomSheetRow } from '~/components/BottomSheetRow';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
-import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { PostBottomSheetFragment$key } from '~/generated/PostBottomSheetFragment.graphql';
 import { PostBottomSheetQueryFragment$key } from '~/generated/PostBottomSheetQueryFragment.graphql';
 import { PostBottomSheetUserFragment$key } from '~/generated/PostBottomSheetUserFragment.graphql';
@@ -22,8 +17,6 @@ import useUnfollowUser from '~/shared/relay/useUnfollowUser';
 import { DeletePostBottomSheet } from './DeletePostBottomSheet';
 import ReportPost from './ReportPost';
 
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
-
 type Props = {
   isOwnPost: boolean;
   postRef: PostBottomSheetFragment$key;
@@ -32,10 +25,7 @@ type Props = {
   onShare: () => void;
 };
 
-function PostBottomSheet(
-  { isOwnPost, postRef, queryRef, userRef, onShare }: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
+function PostBottomSheet({ isOwnPost, postRef, queryRef, userRef, onShare }: Props) {
   const post = useFragment(
     graphql`
       fragment PostBottomSheetFragment on Post {
@@ -91,20 +81,14 @@ function PostBottomSheet(
 
   const navigation = useNavigation<MainTabStackNavigatorProp>();
 
-  const { bottom } = useSafeAreaPadding();
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const deletePostBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
-
   const username = post?.author?.username;
+  const { showBottomSheetModal } = useBottomSheetModalActions();
 
   const handleDeletePost = useCallback(() => {
-    deletePostBottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: <DeletePostBottomSheet postRef={post} />,
+    });
+  }, [post, showBottomSheetModal]);
 
   const followingList = loggedInUserQuery.viewer?.user?.following;
 
@@ -145,10 +129,12 @@ function PostBottomSheet(
     });
   }, [imageUrl, navigation, token.dbid]);
 
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
+
   const handleShare = useCallback(() => {
-    bottomSheetRef.current?.dismiss();
+    hideBottomSheetModal();
     onShare();
-  }, [onShare]);
+  }, [hideBottomSheetModal, onShare]);
 
   const [showReportPostForm, setShowReportPostForm] = useState(false);
 
@@ -158,10 +144,6 @@ function PostBottomSheet(
 
   const handleResetState = useCallback(() => {
     setShowReportPostForm(false);
-  }, []);
-
-  const handleDismissBottomSheet = useCallback(() => {
-    bottomSheetRef.current?.dismiss();
   }, []);
 
   const inner = useMemo(() => {
@@ -240,41 +222,21 @@ function PostBottomSheet(
     username,
   ]);
 
+  useEffect(() => {
+    return () => {
+      handleResetState();
+    };
+  }, [handleResetState]);
+
   return (
     <>
-      <GalleryBottomSheetModal
-        ref={(value) => {
-          bottomSheetRef.current = value;
-
-          if (typeof ref === 'function') {
-            ref(value);
-          } else if (ref) {
-            ref.current = value;
-          }
-        }}
-        snapPoints={animatedSnapPoints}
-        handleHeight={animatedHandleHeight}
-        contentHeight={animatedContentHeight}
-        onDismiss={handleResetState}
-      >
-        <View
-          onLayout={handleContentLayout}
-          style={{ paddingBottom: bottom }}
-          className="p-4 flex flex-col space-y-6"
-        >
-          {showReportPostForm ? (
-            <ReportPost postId={post.dbid} onDismiss={handleDismissBottomSheet} />
-          ) : (
-            <View className="flex flex-col space-y-2">{inner}</View>
-          )}
-        </View>
-      </GalleryBottomSheetModal>
-
-      <DeletePostBottomSheet
-        ref={deletePostBottomSheetRef}
-        postRef={post}
-        onDeleted={handleDismissBottomSheet}
-      />
+      <View className="flex flex-col space-y-6">
+        {showReportPostForm ? (
+          <ReportPost postId={post.dbid} onDismiss={hideBottomSheetModal} />
+        ) : (
+          <View className="flex flex-col space-y-2">{inner}</View>
+        )}
+      </View>
     </>
   );
 }

--- a/apps/mobile/src/components/Feed/Posts/PostBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostBottomSheet.tsx
@@ -14,7 +14,7 @@ import useFollowUser from '~/shared/relay/useFollowUser';
 import { useGetSinglePreviewImage } from '~/shared/relay/useGetPreviewImages';
 import useUnfollowUser from '~/shared/relay/useUnfollowUser';
 
-import { DeletePostBottomSheet } from './DeletePostBottomSheet';
+import DeletePostBottomSheet from './DeletePostBottomSheet';
 import ReportPost from './ReportPost';
 
 type Props = {

--- a/apps/mobile/src/components/Feed/Posts/PostListSectionHeader.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostListSectionHeader.tsx
@@ -11,15 +11,16 @@ import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/Gal
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { Typography } from '~/components/Typography';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { PostListSectionHeaderFragment$key } from '~/generated/PostListSectionHeaderFragment.graphql';
 import { PostListSectionHeaderQueryFragment$key } from '~/generated/PostListSectionHeaderQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
-import { SharePostBottomSheet } from '~/screens/PostScreen/SharePostBottomSheet';
+import SharePostBottomSheet from '~/screens/PostScreen/SharePostBottomSheet';
 import { contexts } from '~/shared/analytics/constants';
 import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
 import { getTimeSince } from '~/shared/utils/time';
 
-import { FirstTimePosterBottomSheet } from './FirstTimePosterBottomSheet';
+import FirstTimePosterBottomSheet from './FirstTimePosterBottomSheet';
 import { PostBottomSheet } from './PostBottomSheet';
 
 type PostListSectionHeaderProps = {
@@ -77,8 +78,6 @@ export function PostListSectionHeader({ feedPostRef, queryRef }: PostListSection
   const navigation = useNavigation<MainTabStackNavigatorProp>();
 
   const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-  const sharePostBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-  const firstTimePosterBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
   const token = feedPost?.tokens?.[0];
   const loggedInUserId = useLoggedInUserId(query);
@@ -88,15 +87,49 @@ export function PostListSectionHeader({ feedPostRef, queryRef }: PostListSection
     return feedPost.author?.badges?.find((badge) => badge?.name === 'Top Member');
   }, [feedPost.author?.badges]);
 
+  const { showBottomSheetModal } = useBottomSheetModalActions();
+
+  const handleSharePost = useCallback(() => {
+    showBottomSheetModal({
+      content: (
+        // TODO add fallback loading state for Share Bottom Sheet
+        <Suspense fallback={null}>
+          <SharePostBottomSheet
+            title="Share Post"
+            postId={feedPost.dbid}
+            creatorName={token?.definition?.community?.creator?.username ?? ''}
+          />
+        </Suspense>
+      ),
+    });
+  }, [feedPost.dbid, showBottomSheetModal, token?.definition?.community?.creator?.username]);
+
   const handleMenuPress = useCallback(() => {
-    bottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: (
+        <PostBottomSheet
+          ref={bottomSheetRef}
+          isOwnPost={isOwnPost}
+          postRef={feedPost}
+          queryRef={query}
+          userRef={feedPost.author}
+          onShare={handleSharePost}
+        />
+      ),
+    });
+  }, [feedPost, handleSharePost, isOwnPost, query, showBottomSheetModal]);
 
   const handleUsernamePress = useCallback(() => {
     if (feedPost.author?.username) {
       navigation.push('Profile', { username: feedPost.author?.username });
     }
   }, [feedPost.author?.username, navigation]);
+
+  const handleLeafIconPress = useCallback(() => {
+    showBottomSheetModal({
+      content: <FirstTimePosterBottomSheet />,
+    });
+  }, [showBottomSheetModal]);
 
   return (
     <View className="flex flex-row items-center justify-between bg-white dark:bg-black-900  px-4">
@@ -128,7 +161,7 @@ export function PostListSectionHeader({ feedPostRef, queryRef }: PostListSection
               {feedPost.isFirstPost && (
                 <GalleryTouchableOpacity
                   className="flex"
-                  onPress={() => firstTimePosterBottomSheetRef.current?.present()}
+                  onPress={handleLeafIconPress}
                   eventElementId="First Time Poster Leaf Icon Button"
                   eventName="First Time Poster Leaf Icon Button Clicked"
                   eventContext={contexts.Posts}
@@ -157,24 +190,6 @@ export function PostListSectionHeader({ feedPostRef, queryRef }: PostListSection
           </GalleryTouchableOpacity>
         </View>
       </View>
-      <FirstTimePosterBottomSheet ref={firstTimePosterBottomSheetRef} />
-      <PostBottomSheet
-        ref={bottomSheetRef}
-        isOwnPost={isOwnPost}
-        postRef={feedPost}
-        queryRef={query}
-        userRef={feedPost.author}
-        onShare={() => sharePostBottomSheetRef.current?.present()}
-      />
-
-      <Suspense fallback={null}>
-        <SharePostBottomSheet
-          ref={sharePostBottomSheetRef}
-          title="Share Post"
-          postId={feedPost.dbid}
-          creatorName={token?.definition?.community?.creator?.username ?? ''}
-        />
-      </Suspense>
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/Posts/WarningLinkBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/Posts/WarningLinkBottomSheet.tsx
@@ -1,95 +1,60 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
-import { ForwardedRef, forwardRef, useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { Linking, View } from 'react-native';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { contexts } from '~/shared/analytics/constants';
 
 import { Button } from '../../Button';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../../GalleryBottomSheet/GalleryBottomSheetModal';
-import { useSafeAreaPadding } from '../../SafeAreaViewWithPadding';
 import { Typography } from '../../Typography';
-
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
 
 type Props = {
   redirectUrl: string;
 };
 
-function WarningLinkBottomSheet(props: Props, ref: ForwardedRef<GalleryBottomSheetModalType>) {
-  const { bottom } = useSafeAreaPadding();
+export default function WarningLinkBottomSheet(props: Props) {
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
-
-  const handleCancel = useCallback(() => bottomSheetRef.current?.dismiss(), []);
+  const handleCancel = useCallback(() => hideBottomSheetModal(), [hideBottomSheetModal]);
 
   const handleContinue = useCallback(() => Linking.openURL(props.redirectUrl), [props.redirectUrl]);
 
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        bottomSheetRef.current = value;
-
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          ref.current = value;
-        }
-      }}
-      snapPoints={animatedSnapPoints}
-      handleHeight={animatedHandleHeight}
-      contentHeight={animatedContentHeight}
-    >
-      <View
-        onLayout={handleContentLayout}
-        style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-6"
-      >
-        <View className="flex flex-col space-y-4">
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
-          >
-            Leaving Gallery
+    <View className="flex flex-col space-y-6">
+      <View className="flex flex-col space-y-4">
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Bold' }}
+        >
+          Leaving Gallery
+        </Typography>
+        <Typography
+          className="text-md text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Regular' }}
+        >
+          You are going to{' '}
+          <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+            {props.redirectUrl}
           </Typography>
-          <Typography
-            className="text-md text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Regular' }}
-          >
-            You are going to{' '}
-            <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-              {props.redirectUrl}
-            </Typography>
-          </Typography>
-        </View>
-
-        <View className="pb-1.5 flex flex-col space-y-2.5">
-          <Button
-            onPress={handleContinue}
-            text="CONTINUE"
-            eventElementId="External URL Confirmation Continue Button"
-            eventName="Pressed External URL Confirmation Continue Button"
-            eventContext={contexts.Posts}
-          />
-          <Button
-            variant="secondary"
-            onPress={handleCancel}
-            text="CANCEL"
-            eventElementId="External URL Confirmation Cancel Button"
-            eventName="Pressed External URL Confirmation Cancel Button"
-            eventContext={contexts.Posts}
-          />
-        </View>
+        </Typography>
       </View>
-    </GalleryBottomSheetModal>
+
+      <View className="pb-1.5 flex flex-col space-y-2.5">
+        <Button
+          onPress={handleContinue}
+          text="CONTINUE"
+          eventElementId="External URL Confirmation Continue Button"
+          eventName="Pressed External URL Confirmation Continue Button"
+          eventContext={contexts.Posts}
+        />
+        <Button
+          variant="secondary"
+          onPress={handleCancel}
+          text="CANCEL"
+          eventElementId="External URL Confirmation Cancel Button"
+          eventName="Pressed External URL Confirmation Cancel Button"
+          eventContext={contexts.Posts}
+        />
+      </View>
+    </View>
   );
 }
-
-const ForwardedWarningLinkBottomSheet = forwardRef(WarningLinkBottomSheet);
-
-export { ForwardedWarningLinkBottomSheet as WarningLinkBottomSheet };

--- a/apps/mobile/src/components/Feed/Socialize/Admires.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/Admires.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
@@ -33,13 +33,13 @@ export function Admires({ type, feedId, admireRefs, totalAdmires, onAdmirePress 
     admireRefs
   );
 
-  const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
+  const { showBottomSheetModal } = useBottomSheetModalActions();
 
   const handleSeeAllAdmires = useCallback(() => {
     showBottomSheetModal({
-      content: <AdmireBottomSheet type={type} feedId={feedId} onClose={hideBottomSheetModal} />,
+      content: <AdmireBottomSheet type={type} feedId={feedId} />,
     });
-  }, [feedId, hideBottomSheetModal, showBottomSheetModal, type]);
+  }, [feedId, showBottomSheetModal, type]);
 
   const admireUsers = useMemo(() => {
     const users = [];

--- a/apps/mobile/src/components/Feed/Socialize/Admires.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/Admires.tsx
@@ -4,8 +4,8 @@ import { graphql, useFragment } from 'react-relay';
 
 import { AdmireBottomSheet } from '~/components/Feed/AdmireBottomSheet/AdmireBottomSheet';
 import { AdmireLine } from '~/components/Feed/Socialize/AdmireLine';
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { ProfilePictureBubblesWithCount } from '~/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { AdmiresFragment$key } from '~/generated/AdmiresFragment.graphql';
 import { contexts } from '~/shared/analytics/constants';
 
@@ -33,9 +33,13 @@ export function Admires({ type, feedId, admireRefs, totalAdmires, onAdmirePress 
     admireRefs
   );
 
+  const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
+
   const handleSeeAllAdmires = useCallback(() => {
-    admiresBottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: <AdmireBottomSheet type={type} feedId={feedId} onClose={hideBottomSheetModal} />,
+    });
+  }, [feedId, hideBottomSheetModal, showBottomSheetModal, type]);
 
   const admireUsers = useMemo(() => {
     const users = [];
@@ -46,8 +50,6 @@ export function Admires({ type, feedId, admireRefs, totalAdmires, onAdmirePress 
     }
     return users;
   }, [admires]);
-
-  const admiresBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
   return (
     <View className="flex flex-col space-y-2">
@@ -70,8 +72,6 @@ export function Admires({ type, feedId, admireRefs, totalAdmires, onAdmirePress 
           onAdmirePress={onAdmirePress}
         />
       </View>
-
-      <AdmireBottomSheet type={type} feedId={feedId} bottomSheetRef={admiresBottomSheetRef} />
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { useToggleAdmire } from 'src/hooks/useToggleAdmire';
 
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { FeedEventSocializeSectionFragment$key } from '~/generated/FeedEventSocializeSectionFragment.graphql';
 import { FeedEventSocializeSectionQueryFragment$key } from '~/generated/FeedEventSocializeSectionQueryFragment.graphql';
 
@@ -107,11 +107,13 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
 
   const totalAdmires = event.admires?.pageInfo?.total ?? 0;
 
-  const commentsBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const { showBottomSheetModal } = useBottomSheetModalActions();
   const handleOpenCommentBottomSheet = useCallback(() => {
-    commentsBottomSheetRef.current?.present();
+    showBottomSheetModal({
+      content: <CommentsBottomSheet type="FeedEvent" feedId={event.dbid} />,
+    });
     onCommentPress();
-  }, [onCommentPress]);
+  }, [event.dbid, onCommentPress, showBottomSheetModal]);
 
   if (event.eventData?.__typename === 'UserFollowedUsersFeedEventData') {
     return <View className="pb-6" />;
@@ -143,11 +145,6 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
           onCommentPress={handleOpenCommentBottomSheet}
         />
       </View>
-      <CommentsBottomSheet
-        type="FeedEvent"
-        feedId={event.dbid}
-        bottomSheetRef={commentsBottomSheetRef}
-      />
     </>
   );
 }

--- a/apps/mobile/src/components/GalleryBottomSheet/GalleryBottomSheetModal.tsx
+++ b/apps/mobile/src/components/GalleryBottomSheet/GalleryBottomSheetModal.tsx
@@ -8,6 +8,11 @@ import { ReduceMotion, SharedValue } from 'react-native-reanimated';
 import { GalleryBottomSheetBackdrop } from '~/components/GalleryBottomSheet/GalleryBottomSheetBackdrop';
 import { GalleryBottomSheetBackground } from '~/components/GalleryBottomSheet/GalleryBottomSheetBackground';
 import { GalleryBottomSheetHandle } from '~/components/GalleryBottomSheet/GalleryBottomSheetHandle';
+import {
+  BottomSheetModalActionsContext,
+  useBottomSheetModalActions,
+} from '~/contexts/BottomSheetModalContext';
+import SyncTokensProvider from '~/contexts/SyncTokensContext';
 
 export type GalleryBottomSheetModalType = BottomSheetModal;
 
@@ -46,6 +51,8 @@ function GalleryBottomSheetModal(
     reduceMotion: ReduceMotion.Never,
   };
 
+  const bottomSheetModalActions = useBottomSheetModalActions();
+
   return (
     <BottomSheetModal
       animationConfigs={Platform.OS === 'android' ? androidAnimationConfigs : undefined}
@@ -70,8 +77,12 @@ function GalleryBottomSheetModal(
       {/* all of the context that its parent did. We may need to do more of this in the future */}
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
       <NavigationContext.Provider value={navigation as any}>
-        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-        {children as any}
+        <BottomSheetModalActionsContext.Provider value={bottomSheetModalActions}>
+          <SyncTokensProvider>
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+            {children as any}
+          </SyncTokensProvider>
+        </BottomSheetModalActionsContext.Provider>
       </NavigationContext.Provider>
     </BottomSheetModal>
   );

--- a/apps/mobile/src/components/Login/SignInBottomSheet.tsx
+++ b/apps/mobile/src/components/Login/SignInBottomSheet.tsx
@@ -1,77 +1,45 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
 import { useNavigation } from '@react-navigation/native';
-import { ForwardedRef, forwardRef, useCallback, useRef } from 'react';
+import { forwardRef, useCallback } from 'react';
 import { View } from 'react-native';
 import { EmailIcon } from 'src/icons/EmailIcon';
 import { FarcasterOutlineIcon } from 'src/icons/FarcasterOutlineIcon';
 import { QRCodeIcon } from 'src/icons/QRCodeIcon';
 import { WalletIcon } from 'src/icons/WalletIcon';
 
-import { OpenManageWalletProps, useManageWalletActions } from '~/contexts/ManageWalletContext';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
+import { OpenManageWalletProps } from '~/contexts/ManageWalletContext';
 import { LoginStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 
 import { BottomSheetRow } from '../BottomSheetRow';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../GalleryBottomSheet/GalleryBottomSheetModal';
-import { useSafeAreaPadding } from '../SafeAreaViewWithPadding';
 import { Typography } from '../Typography';
 import { useLoginWithFarcaster } from './AuthProvider/Farcaster/FarcasterAuthProvider';
 
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
-
 type Props = {
   onQrCodePress: () => void;
-  onClose: () => void;
   openManageWallet: (o: OpenManageWalletProps) => void;
 };
 
-function SignInBottomSheet({ onClose, onQrCodePress, openManageWallet }: Props) {
-  const { bottom } = useSafeAreaPadding();
-  // const { openManageWallet } = useManageWalletActions();
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
+function SignInBottomSheet({ onQrCodePress, openManageWallet }: Props) {
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
   const navigation = useNavigation<LoginStackNavigatorProp>();
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
 
   const handleEmailPress = useCallback(() => {
+    hideBottomSheetModal();
     navigation.navigate('OnboardingEmail', {
       authMethod: 'Privy',
     });
-  }, [navigation]);
+  }, [hideBottomSheetModal, navigation]);
 
   const handleConnectWallet = useCallback(() => {
-    // bottomSheetRef.current?.dismiss();
-    onClose();
+    hideBottomSheetModal();
     openManageWallet({ method: 'auth' });
-  }, [onClose, openManageWallet]);
+  }, [hideBottomSheetModal, openManageWallet]);
 
   const { open: handleConnectFarcaster } = useLoginWithFarcaster();
 
   return (
-    // <GalleryBottomSheetModal
-    //   ref={(value) => {
-    //     bottomSheetRef.current = value;
-
-    //     if (typeof ref === 'function') {
-    //       ref(value);
-    //     } else if (ref) {
-    //       ref.current = value;
-    //     }
-    //   }}
-    //   snapPoints={animatedSnapPoints}
-    //   handleHeight={animatedHandleHeight}
-    //   contentHeight={animatedContentHeight}
-    // >
-    <View
-      onLayout={handleContentLayout}
-      style={{ paddingBottom: bottom }}
-      className="p-4 flex flex-col space-y-6"
-    >
+    <View className="flex flex-col space-y-6">
       <View className="flex flex-col space-y-4">
         <Typography
           className="text-lg text-black-900 dark:text-offWhite"

--- a/apps/mobile/src/components/Login/SignInBottomSheet.tsx
+++ b/apps/mobile/src/components/Login/SignInBottomSheet.tsx
@@ -7,7 +7,7 @@ import { FarcasterOutlineIcon } from 'src/icons/FarcasterOutlineIcon';
 import { QRCodeIcon } from 'src/icons/QRCodeIcon';
 import { WalletIcon } from 'src/icons/WalletIcon';
 
-import { useManageWalletActions } from '~/contexts/ManageWalletContext';
+import { OpenManageWalletProps, useManageWalletActions } from '~/contexts/ManageWalletContext';
 import { LoginStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 
@@ -24,14 +24,13 @@ const SNAP_POINTS = ['CONTENT_HEIGHT'];
 
 type Props = {
   onQrCodePress: () => void;
+  onClose: () => void;
+  openManageWallet: (o: OpenManageWalletProps) => void;
 };
 
-function SignInBottomSheet(
-  { onQrCodePress }: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
+function SignInBottomSheet({ onClose, onQrCodePress, openManageWallet }: Props) {
   const { bottom } = useSafeAreaPadding();
-  const { openManageWallet } = useManageWalletActions();
+  // const { openManageWallet } = useManageWalletActions();
 
   const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
@@ -46,73 +45,73 @@ function SignInBottomSheet(
   }, [navigation]);
 
   const handleConnectWallet = useCallback(() => {
-    bottomSheetRef.current?.dismiss();
+    // bottomSheetRef.current?.dismiss();
+    onClose();
     openManageWallet({ method: 'auth' });
-  }, [openManageWallet]);
+  }, [onClose, openManageWallet]);
 
   const { open: handleConnectFarcaster } = useLoginWithFarcaster();
 
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        bottomSheetRef.current = value;
+    // <GalleryBottomSheetModal
+    //   ref={(value) => {
+    //     bottomSheetRef.current = value;
 
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          ref.current = value;
-        }
-      }}
-      snapPoints={animatedSnapPoints}
-      handleHeight={animatedHandleHeight}
-      contentHeight={animatedContentHeight}
+    //     if (typeof ref === 'function') {
+    //       ref(value);
+    //     } else if (ref) {
+    //       ref.current = value;
+    //     }
+    //   }}
+    //   snapPoints={animatedSnapPoints}
+    //   handleHeight={animatedHandleHeight}
+    //   contentHeight={animatedContentHeight}
+    // >
+    <View
+      onLayout={handleContentLayout}
+      style={{ paddingBottom: bottom }}
+      className="p-4 flex flex-col space-y-6"
     >
-      <View
-        onLayout={handleContentLayout}
-        style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-6"
-      >
-        <View className="flex flex-col space-y-4">
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
-          >
-            Sign in or sign up
-          </Typography>
-        </View>
-
-        <View className="flex flex-col space-y-2">
-          <BottomSheetRow
-            icon={<EmailIcon />}
-            text="Email"
-            onPress={handleEmailPress}
-            eventContext={contexts.Authentication}
-            fontWeight="Bold"
-          />
-          <BottomSheetRow
-            icon={<WalletIcon />}
-            text="Wallet"
-            onPress={handleConnectWallet}
-            eventContext={contexts.Authentication}
-            fontWeight="Bold"
-          />
-          <BottomSheetRow
-            icon={<FarcasterOutlineIcon />}
-            text="Farcaster"
-            onPress={handleConnectFarcaster}
-            eventContext={contexts.Authentication}
-            fontWeight="Bold"
-          />
-          <BottomSheetRow
-            icon={<QRCodeIcon width={24} height={24} />}
-            text="Sign in via Desktop"
-            onPress={onQrCodePress}
-            eventContext={contexts.Authentication}
-            fontWeight="Bold"
-          />
-        </View>
+      <View className="flex flex-col space-y-4">
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Bold' }}
+        >
+          Sign in or sign up
+        </Typography>
       </View>
-    </GalleryBottomSheetModal>
+
+      <View className="flex flex-col space-y-2">
+        <BottomSheetRow
+          icon={<EmailIcon />}
+          text="Email"
+          onPress={handleEmailPress}
+          eventContext={contexts.Authentication}
+          fontWeight="Bold"
+        />
+        <BottomSheetRow
+          icon={<WalletIcon />}
+          text="Wallet"
+          onPress={handleConnectWallet}
+          eventContext={contexts.Authentication}
+          fontWeight="Bold"
+        />
+        <BottomSheetRow
+          icon={<FarcasterOutlineIcon />}
+          text="Farcaster"
+          onPress={handleConnectFarcaster}
+          eventContext={contexts.Authentication}
+          fontWeight="Bold"
+        />
+        <BottomSheetRow
+          icon={<QRCodeIcon width={24} height={24} />}
+          text="Sign in via Desktop"
+          onPress={onQrCodePress}
+          eventContext={contexts.Authentication}
+          fontWeight="Bold"
+        />
+      </View>
+    </View>
   );
 }
 

--- a/apps/mobile/src/components/Login/WalletSelectorBottomSheet.tsx
+++ b/apps/mobile/src/components/Login/WalletSelectorBottomSheet.tsx
@@ -1,6 +1,5 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
 import clsx from 'clsx';
-import { ForwardedRef, forwardRef, useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { View, ViewProps } from 'react-native';
 import { SignerVariables } from 'shared/hooks/useAuthPayloadQuery';
 import { CoinbaseWalletIcon } from 'src/icons/CoinbaseWalletIcon';
@@ -12,17 +11,11 @@ import { WalletConnectIcon } from 'src/icons/WalletConnectIcon';
 import { contexts } from '~/shared/analytics/constants';
 
 import { BottomSheetRow } from '../BottomSheetRow';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../GalleryBottomSheet/GalleryBottomSheetModal';
 import { useSafeAreaPadding } from '../SafeAreaViewWithPadding';
 import { Typography } from '../Typography';
 import { useCoinbaseWallet } from './AuthProvider/CoinbaseWallet/useCoinbaseWallet';
 import { useWalletConnect } from './AuthProvider/WalletConnect/useWallectConnect';
 import { WalletConnectProvider } from './AuthProvider/WalletConnect/WalletConnectProvider';
-
-const SNAP_POINTS = [300, 'CONTENT_HEIGHT'];
 
 type Props = {
   title?: string;
@@ -34,16 +27,14 @@ type Props = {
 
 type WalletSupport = 'WalletConnect' | 'CoinbaseWallet';
 
-function WalletSelectorBottomSheet(
-  { onDismiss, title = 'Network', onSignedIn, isSigningIn, setIsSigningIn }: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
+export default function WalletSelectorBottomSheet({
+  onDismiss,
+  title = 'Network',
+  onSignedIn,
+  isSigningIn,
+  setIsSigningIn,
+}: Props) {
   const { bottom } = useSafeAreaPadding();
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
 
   const handleOnSignedIn: Props['onSignedIn'] = useCallback(
     (props) => {
@@ -76,40 +67,17 @@ function WalletSelectorBottomSheet(
 
   return (
     <>
-      <GalleryBottomSheetModal
-        ref={(value) => {
-          bottomSheetRef.current = value;
-          if (typeof ref === 'function') {
-            ref(value);
-          } else if (ref) {
-            ref.current = value;
-          }
-        }}
-        snapPoints={animatedSnapPoints}
-        handleHeight={animatedHandleHeight}
-        contentHeight={animatedContentHeight}
-        onDismiss={onDismiss}
-      >
-        <View
-          onLayout={handleContentLayout}
-          style={{ paddingBottom: bottom }}
-          className="p-4 flex flex-col space-y-6"
-        >
-          {isSigningIn ? (
-            <SignedInWalletMessage />
-          ) : (
-            <WalletOptions title={title} onSelect={handleSelectWallet} />
-          )}
-        </View>
-      </GalleryBottomSheetModal>
+      <View style={{ paddingBottom: bottom }} className="p-4 flex flex-col space-y-6">
+        {isSigningIn ? (
+          <SignedInWalletMessage />
+        ) : (
+          <WalletOptions title={title} onSelect={handleSelectWallet} />
+        )}
+      </View>
       <WalletConnectProvider />
     </>
   );
 }
-
-const ForwardedWalletSelectorBottomSheet = forwardRef(WalletSelectorBottomSheet);
-
-export { ForwardedWalletSelectorBottomSheet as WalletSelectorBottomSheet };
 
 function IconWrapper({
   children,

--- a/apps/mobile/src/components/MarfaCheckIn/MarfaCheckInSheet.tsx
+++ b/apps/mobile/src/components/MarfaCheckIn/MarfaCheckInSheet.tsx
@@ -1,5 +1,5 @@
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import { useCallback, useEffect, useRef } from 'react';
+// import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+// import { useCallback, useEffect } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { MARFA_2023_SUBMITTED_FORM_KEY } from 'src/constants/storageKeys';
@@ -8,22 +8,17 @@ import { CircleCheckIcon } from 'src/icons/CircleCheckIcon';
 
 import { Button } from '~/components/Button';
 import { MarfaCheckInSheetFragment$key } from '~/generated/MarfaCheckInSheetFragment.graphql';
-import { FeedTabNavigatorParamList, FeedTabNavigatorProp } from '~/navigation/types';
 
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../GalleryBottomSheet/GalleryBottomSheetModal';
+// import { FeedTabNavigatorParamList, FeedTabNavigatorProp } from '~/navigation/types';
 import { useSafeAreaPadding } from '../SafeAreaViewWithPadding';
 import { Typography } from '../Typography';
 import CheckInForm from './CheckInForm';
 type Props = {
   viewerRef: MarfaCheckInSheetFragment$key;
+  onClose: () => void;
 };
 
-const SNAP_POINTS = [360];
-
-export function MarfaCheckInSheet({ viewerRef }: Props) {
+export function MarfaCheckInSheet({ viewerRef, onClose }: Props) {
   const viewer = useFragment(
     graphql`
       fragment MarfaCheckInSheetFragment on Viewer {
@@ -33,70 +28,54 @@ export function MarfaCheckInSheet({ viewerRef }: Props) {
     viewerRef
   );
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType>(null);
-  useEffect(() => bottomSheetRef.current?.present(), []);
-
   const [formSubmitted] = usePersistedState(MARFA_2023_SUBMITTED_FORM_KEY, '');
   const userAlreadySubmittedForm = formSubmitted === 'true';
 
   const { bottom } = useSafeAreaPadding();
 
-  const navigation = useNavigation<FeedTabNavigatorProp>();
-  const route = useRoute<RouteProp<FeedTabNavigatorParamList, 'For You'>>();
+  // const navigation = useNavigation<FeedTabNavigatorProp>();
+  // const route = useRoute<RouteProp<FeedTabNavigatorParamList, 'For You'>>();
 
-  const handleOnDimiss = useCallback(() => {
-    // update route param so the sheet can be retrigered by re-scanning the QR code
-    if (route.params && route.params.showMarfaCheckIn) {
-      // @ts-expect-error - showMarfaCheckIn is a valid route param for the FeedTabNavigator
-      navigation.setParams({ ...route.params, showMarfaCheckIn: false });
-    }
-  }, [navigation, route.params]);
-
-  const closeSheet = useCallback(() => {
-    bottomSheetRef.current?.dismiss();
-  }, []);
+  // const handleOnDimiss = useCallback(() => {
+  //   // update route param so the sheet can be retrigered by re-scanning the QR code
+  //   if (route.params && route.params.showMarfaCheckIn) {
+  //     // @ts-expect-error - showMarfaCheckIn is a valid route param for the FeedTabNavigator
+  //     navigation.setParams({ ...route.params, showMarfaCheckIn: false });
+  //   }
+  // }, [navigation, route.params]);
 
   return (
-    <GalleryBottomSheetModal
-      ref={bottomSheetRef}
-      index={0}
-      snapPoints={SNAP_POINTS}
-      onDismiss={handleOnDimiss}
-      android_keyboardInputMode="adjustResize"
-      keyboardBlurBehavior="restore"
-    >
-      <View className="px-4 pt-2" style={{ paddingBottom: bottom }}>
-        {userAlreadySubmittedForm ? (
-          <View className="flex flex-col items-center h-full justify-between ">
-            <View>
-              <Typography
-                className="text-lg text-center mb-2"
-                font={{ family: 'ABCDiatype', weight: 'Bold' }}
-              >
-                You’re in the draw!
-              </Typography>
-              <Typography
-                className="text-sm text-center mx-5"
-                font={{ family: 'ABCDiatype', weight: 'Regular' }}
-              >
-                Looks like you’ve already entered this draw. Note that there is only one entry per
-                user permitted for this allowlist.
-              </Typography>
-            </View>
-            <CircleCheckIcon />
-            <Button
-              className="w-full"
-              onPress={closeSheet}
-              text="Close"
-              eventElementId="Marfa Check In: Already Submitted View Close Button"
-              eventName="Pressed Marfa Check In: Already Submitted View Close Button"
-              eventContext={null}
-            />
+    <View className="px-4 pt-2" style={{ paddingBottom: bottom }}>
+      {userAlreadySubmittedForm ? (
+        <View className="flex flex-col items-center h-full justify-between ">
+          <View>
+            <Typography
+              className="text-lg text-center mb-2"
+              font={{ family: 'ABCDiatype', weight: 'Bold' }}
+            >
+              You’re in the draw!
+            </Typography>
+            <Typography
+              className="text-sm text-center mx-5"
+              font={{ family: 'ABCDiatype', weight: 'Regular' }}
+            >
+              Looks like you’ve already entered this draw. Note that there is only one entry per
+              user permitted for this allowlist.
+            </Typography>
           </View>
-        ) : (
-          <CheckInForm viewerRef={viewer} closeSheet={closeSheet} />
-        )}
-      </View>
-    </GalleryBottomSheetModal>
+          <CircleCheckIcon />
+          <Button
+            className="w-full"
+            onPress={onClose}
+            text="Close"
+            eventElementId="Marfa Check In: Already Submitted View Close Button"
+            eventName="Pressed Marfa Check In: Already Submitted View Close Button"
+            eventContext={null}
+          />
+        </View>
+      ) : (
+        <CheckInForm viewerRef={viewer} closeSheet={onClose} />
+      )}
+    </View>
   );
 }

--- a/apps/mobile/src/components/NftSelector/NftSelectorToolbar.tsx
+++ b/apps/mobile/src/components/NftSelector/NftSelectorToolbar.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { View, ViewProps } from 'react-native';
 import { contexts } from 'shared/analytics/constants';
 import { chains } from 'shared/utils/chains';
 import { SlidersIcon } from 'src/icons/SlidersIcon';
 import { getChainIconComponent } from 'src/utils/getChainIconComponent';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { SearchIcon } from '~/navigation/MainTabNavigator/SearchIcon';
 import {
   NetworkChoice,
@@ -14,7 +15,6 @@ import {
 
 import { AnimatedRefreshIcon } from '../AnimatedRefreshIcon';
 import { FadedInput } from '../FadedInput';
-import { GalleryBottomSheetModalType } from '../GalleryBottomSheet/GalleryBottomSheetModal';
 import { IconContainer } from '../IconContainer';
 import { Select } from '../Select';
 
@@ -61,11 +61,20 @@ export function NftSelectorToolbar({
   handleSync,
   style,
 }: Props) {
-  const filterBottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
+  const { showBottomSheetModal } = useBottomSheetModalActions();
   const handleSettingsPress = useCallback(() => {
-    filterBottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: (
+        <NftSelectorFilterBottomSheet
+          ownerFilter={ownershipTypeFilter}
+          onOwnerFilterChange={setFilter}
+          sortView={sortView}
+          onSortViewChange={setSortView}
+          selectedNetwork={networkFilter}
+        />
+      ),
+    });
+  }, [networkFilter, ownershipTypeFilter, setFilter, setSortView, showBottomSheetModal, sortView]);
 
   const decoratedNetworks = useMemo(() => {
     return NETWORKS.map((network) => {
@@ -121,15 +130,6 @@ export function NftSelectorToolbar({
             eventElementId="NftSelectorSelectorSettingsButton"
             eventName="NftSelectorSelectorSettingsButton pressed"
             eventContext={contexts.Posts}
-          />
-
-          <NftSelectorFilterBottomSheet
-            ref={filterBottomSheetRef}
-            ownerFilter={ownershipTypeFilter}
-            onOwnerFilterChange={setFilter}
-            sortView={sortView}
-            onSortViewChange={setSortView}
-            selectedNetwork={networkFilter}
           />
         </View>
       </View>

--- a/apps/mobile/src/components/Notification/NotificationBottomSheetUserList.tsx
+++ b/apps/mobile/src/components/Notification/NotificationBottomSheetUserList.tsx
@@ -1,20 +1,16 @@
 import { BottomSheetModalProps } from '@gorhom/bottom-sheet';
-import { ForwardedRef, forwardRef, Suspense, useCallback, useState } from 'react';
+import { Suspense } from 'react';
 import { View } from 'react-native';
 import { useLazyLoadQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { UserFollowList } from '~/components/UserFollowList/UserFollowList';
 import { UserFollowListFallback } from '~/components/UserFollowList/UserFollowListFallback';
 import { NotificationBottomSheetUserListQuery } from '~/generated/NotificationBottomSheetUserListQuery.graphql';
 import { UserFollowListFragment$key } from '~/generated/UserFollowListFragment.graphql';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 
-export const NotificationBottomSheetUserListQueryNode = graphql`
+const NotificationBottomSheetUserListQueryNode = graphql`
   query NotificationBottomSheetUserListQuery($notificationId: ID!) {
     node(id: $notificationId) {
       ... on SomeoneViewedYourGalleryNotification {
@@ -107,7 +103,7 @@ function NotificationBottomSheetUserListInner({
   }
 
   return (
-    <View className="flex-1 bg-white dark:bg-black-900">
+    <View className="flex-1 bg-white dark:bg-black-900 min-h-[180px]">
       <UserFollowList userRefs={users} queryRef={query} onUserPress={onUserPress} />
     </View>
   );
@@ -116,43 +112,16 @@ function NotificationBottomSheetUserListInner({
 type NotificationBottomSheetUserListProps = NotificationBottomSheetUserListInnerProps &
   Omit<BottomSheetModalProps, 'children' | 'snapPoints'>;
 
-function NotificationBottomSheetUserList(
-  { onUserPress, notificationId, ...rest }: NotificationBottomSheetUserListProps,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
-  const [showing, setShowing] = useState(false);
-
-  // This is to ensure the lazy query doesn't start until the modal is presented
-  const handleAnimate = useCallback(
-    (fromIndex: number, toIndex: number) => {
-      if (fromIndex === -1) {
-        setShowing(true);
-      }
-
-      rest?.onAnimate?.(fromIndex, toIndex);
-    },
-    [rest]
-  );
-
+export default function NotificationBottomSheetUserList({
+  onUserPress,
+  notificationId,
+}: NotificationBottomSheetUserListProps) {
   return (
-    <GalleryBottomSheetModal snapPoints={[320]} {...rest} onAnimate={handleAnimate} ref={ref}>
-      <Suspense fallback={<UserFollowListFallback />}>
-        {showing ? (
-          <NotificationBottomSheetUserListInner
-            onUserPress={onUserPress}
-            notificationId={notificationId}
-          />
-        ) : (
-          <UserFollowListFallback />
-        )}
-      </Suspense>
-    </GalleryBottomSheetModal>
+    <Suspense fallback={<UserFollowListFallback />}>
+      <NotificationBottomSheetUserListInner
+        onUserPress={onUserPress}
+        notificationId={notificationId}
+      />
+    </Suspense>
   );
 }
-
-const ForwardedNotificationBottomSheetUserList = forwardRef<
-  GalleryBottomSheetModalType,
-  NotificationBottomSheetUserListProps
->(NotificationBottomSheetUserList);
-
-export { ForwardedNotificationBottomSheetUserList as NotificationBottomSheetUserList };

--- a/apps/mobile/src/components/Notification/Notifications/SomeoneAdmiredYourComment.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/SomeoneAdmiredYourComment.tsx
@@ -146,11 +146,6 @@ export function SomeoneAdmiredYourComment({ notificationRef, queryRef }: Someone
                   ? firstAdmirer?.username
                   : 'Someone'}
               </Typography>
-              {/* <NotificationBottomSheetUserList
-                ref={bottomSheetRef}
-                onUserPress={handleUserPress}
-                notificationId={notification.id}
-              /> */}
             </Text>
           </GalleryTouchableOpacity>
           <Text>

--- a/apps/mobile/src/components/Notification/Notifications/SomeoneFollowedYouBack.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/SomeoneFollowedYouBack.tsx
@@ -1,13 +1,13 @@
 import { useNavigation } from '@react-navigation/native';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Text } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
-import { NotificationBottomSheetUserList } from '~/components/Notification/NotificationBottomSheetUserList';
+import NotificationBottomSheetUserList from '~/components/Notification/NotificationBottomSheetUserList';
 import { NotificationSkeleton } from '~/components/Notification/NotificationSkeleton';
 import { Typography } from '~/components/Typography';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { SomeoneFollowedYouBackFragment$key } from '~/generated/SomeoneFollowedYouBackFragment.graphql';
 import { SomeoneFollowedYouBackQueryFragment$key } from '~/generated/SomeoneFollowedYouBackQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
@@ -59,22 +59,37 @@ export function SomeoneFollowedYouBack({ notificationRef, queryRef }: SomeoneFol
 
   const navigation = useNavigation<MainTabStackNavigatorProp>();
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-  const handlePress = useCallback(() => {
-    if (count > 1) {
-      bottomSheetRef.current?.present();
-    } else if (lastFollower?.username) {
-      navigation.navigate('Profile', { username: lastFollower.username });
-    }
-  }, [count, lastFollower?.username, navigation]);
+  const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
 
   const handleUserPress = useCallback(
     (username: string) => {
-      bottomSheetRef.current?.dismiss();
+      hideBottomSheetModal();
       navigation.navigate('Profile', { username });
     },
-    [navigation]
+    [hideBottomSheetModal, navigation]
   );
+
+  const handlePress = useCallback(() => {
+    if (count > 1) {
+      showBottomSheetModal({
+        content: (
+          <NotificationBottomSheetUserList
+            onUserPress={handleUserPress}
+            notificationId={notification.id}
+          />
+        ),
+      });
+    } else if (lastFollower?.username) {
+      navigation.navigate('Profile', { username: lastFollower.username });
+    }
+  }, [
+    count,
+    handleUserPress,
+    lastFollower?.username,
+    navigation,
+    notification.id,
+    showBottomSheetModal,
+  ]);
 
   return (
     <NotificationSkeleton
@@ -95,12 +110,6 @@ export function SomeoneFollowedYouBack({ notificationRef, queryRef }: SomeoneFol
         </Typography>{' '}
         followed you back
       </Text>
-
-      <NotificationBottomSheetUserList
-        ref={bottomSheetRef}
-        onUserPress={handleUserPress}
-        notificationId={notification.id}
-      />
     </NotificationSkeleton>
   );
 }

--- a/apps/mobile/src/components/Onboarding/WelcomeNewUser.tsx
+++ b/apps/mobile/src/components/Onboarding/WelcomeNewUser.tsx
@@ -1,14 +1,10 @@
-import { BlurView } from 'expo-blur';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback } from 'react';
 import { View } from 'react-native';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { contexts } from '~/shared/analytics/constants';
 
 import { Button } from '../Button';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../GalleryBottomSheet/GalleryBottomSheetModal';
 import { Typography } from '../Typography';
 
 type Props = {
@@ -17,57 +13,44 @@ type Props = {
 };
 
 export function WelcomeNewUser({ username, onContinue }: Props) {
-  const snapPoints = useMemo(() => [360], []);
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType>(null);
-  useEffect(() => bottomSheetRef.current?.present(), []);
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
 
   const handleContinue = useCallback(() => {
-    bottomSheetRef.current?.dismiss();
+    hideBottomSheetModal();
     onContinue();
-  }, [onContinue]);
+  }, [hideBottomSheetModal, onContinue]);
 
   return (
-    <GalleryBottomSheetModal
-      ref={bottomSheetRef}
-      index={0}
-      snapPoints={snapPoints}
-      backdropComponent={BackdropComponent}
-    >
-      <View className="flex flex-column space-y-8 mx-4 mt-2">
-        <View className="space-y-6">
-          <View>
-            <Typography
-              className="text-3xl text-center"
-              font={{ family: 'GTAlpina', weight: 'StandardLight' }}
-            >
-              Welcome to Gallery,
-            </Typography>
-            <Typography
-              className="text-3xl text-center"
-              font={{ family: 'GTAlpina', weight: 'StandardLight' }}
-            >
-              {username}!
-            </Typography>
-          </View>
-          <Typography className="text-center" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-            This is where you’ll see updates from other Gallery users. Toggle between your
-            personalized For 'You feed' and the 'Following' feed, showing the latest updates from
-            your connections
+    <View className="flex flex-column space-y-8 ">
+      <View className="space-y-6">
+        <View>
+          <Typography
+            className="text-3xl text-center"
+            font={{ family: 'GTAlpina', weight: 'StandardLight' }}
+          >
+            Welcome to Gallery,
+          </Typography>
+          <Typography
+            className="text-3xl text-center"
+            font={{ family: 'GTAlpina', weight: 'StandardLight' }}
+          >
+            {username}!
           </Typography>
         </View>
-
-        <Button
-          onPress={handleContinue}
-          text="continue"
-          eventElementId="Welcome New User Bottom Sheet"
-          eventName="Welcome New User Continue Clicked"
-          eventContext={contexts.Onboarding}
-        />
+        <Typography className="text-center" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+          This is where you’ll see updates from other Gallery users. Toggle between your
+          personalized For 'You feed' and the 'Following' feed, showing the latest updates from your
+          connections
+        </Typography>
       </View>
-    </GalleryBottomSheetModal>
-  );
-}
 
-function BackdropComponent() {
-  return <BlurView intensity={4} className="absolute h-full w-full top-0 bg-black/50 "></BlurView>;
+      <Button
+        onPress={handleContinue}
+        text="continue"
+        eventElementId="Welcome New User Bottom Sheet"
+        eventName="Welcome New User Continue Clicked"
+        eventContext={contexts.Onboarding}
+      />
+    </View>
+  );
 }

--- a/apps/mobile/src/components/Onboarding/WelcomeNewUserOnboarding.tsx
+++ b/apps/mobile/src/components/Onboarding/WelcomeNewUserOnboarding.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { contexts } from 'shared/analytics/constants';
 import colors from 'shared/theme/colors';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { GLogo } from '~/navigation/MainTabNavigator/GLogo';
 import { NotificationsIcon } from '~/navigation/MainTabNavigator/NotificationsIcon';
 import { PostIcon } from '~/navigation/MainTabNavigator/PostIcon';
@@ -24,6 +25,7 @@ type Props = {
 
 export function WelcomeNewUserOnboarding({ username, onComplete }: Props) {
   const { colorScheme } = useColorScheme();
+  const { showBottomSheetModal } = useBottomSheetModalActions();
 
   // Step 1: Welcome message
   // Step 2: Post message
@@ -57,7 +59,11 @@ export function WelcomeNewUserOnboarding({ username, onComplete }: Props) {
   }
 
   if (step === 1) {
-    return <WelcomeNewUser username={username} onContinue={nextStep} />;
+    showBottomSheetModal({
+      content: <WelcomeNewUser username={username} onContinue={nextStep} />,
+      blurBackground: true,
+    });
+    return null;
   }
 
   return (

--- a/apps/mobile/src/components/PfpPicker/PfpBottomSheet.tsx
+++ b/apps/mobile/src/components/PfpPicker/PfpBottomSheet.tsx
@@ -8,6 +8,7 @@ import { graphql } from 'relay-runtime';
 import { CollectionGridIcon } from 'src/icons/CollectionGridIcon';
 import { TrashIcon } from 'src/icons/TrashIcon';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { PfpBottomSheetFragment$key } from '~/generated/PfpBottomSheetFragment.graphql';
 import {
   PfpBottomSheetRemoveProfileImageMutation,
@@ -26,10 +27,9 @@ import { Typography } from '../Typography';
 
 type PfpBottomSheetProps = {
   queryRef: PfpBottomSheetFragment$key;
-  onClose: () => void;
 };
 
-export default function PfpBottomSheet({ queryRef, onClose }: PfpBottomSheetProps) {
+export default function PfpBottomSheet({ queryRef }: PfpBottomSheetProps) {
   const query = useFragment(
     graphql`
       fragment PfpBottomSheetFragment on Query {
@@ -88,6 +88,7 @@ export default function PfpBottomSheet({ queryRef, onClose }: PfpBottomSheetProp
 
   const ensAddress = user?.potentialEnsProfileImage?.wallet?.chainAddress;
 
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
   const handleEnsPress = useCallback(() => {
     if (!ensAddress) return;
 
@@ -97,15 +98,16 @@ export default function PfpBottomSheet({ queryRef, onClose }: PfpBottomSheetProp
     })
       .catch(reportError)
       .then(() => {
-        onClose();
+        hideBottomSheetModal();
       });
-  }, [ensAddress, onClose, reportError, setEnsProfileImage]);
+  }, [ensAddress, hideBottomSheetModal, reportError, setEnsProfileImage]);
 
   const handleChooseFromCollectionPress = useCallback(() => {
+    hideBottomSheetModal();
     navigation.navigate('NftSelector', {
       page: 'ProfilePicture',
     });
-  }, [navigation]);
+  }, [hideBottomSheetModal, navigation]);
 
   const handleRemovePress = useCallback(() => {
     let optimisticResponse: PfpBottomSheetRemoveProfileImageMutation$rawResponse | undefined =
@@ -131,9 +133,15 @@ export default function PfpBottomSheet({ queryRef, onClose }: PfpBottomSheetProp
     })
       .catch(reportError)
       .then(() => {
-        onClose();
+        hideBottomSheetModal();
       });
-  }, [onClose, query.viewer?.id, query.viewer?.user?.id, removeProfileImage, reportError]);
+  }, [
+    hideBottomSheetModal,
+    query.viewer?.id,
+    query.viewer?.user?.id,
+    removeProfileImage,
+    reportError,
+  ]);
 
   const hasProfilePictureSet = Boolean(query.viewer?.user?.profileImage?.__typename);
   const potentialEnsProfileImageUrl =

--- a/apps/mobile/src/components/Post/PostMintLinkInput.tsx
+++ b/apps/mobile/src/components/Post/PostMintLinkInput.tsx
@@ -1,19 +1,19 @@
 import clsx from 'clsx';
 import { useColorScheme } from 'nativewind';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { TextInput, View, ViewProps } from 'react-native';
 import { AlertIcon } from 'src/icons/AlertIcon';
 import { InfoCircleIcon } from 'src/icons/InfoCircleIcon';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { contexts } from '~/shared/analytics/constants';
 import colors from '~/shared/theme/colors';
 import { checkValidMintUrl } from '~/shared/utils/getMintUrlWithReferrer';
 
-import { GalleryBottomSheetModalType } from '../GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
 import { Toggle } from '../Toggle';
 import { Typography } from '../Typography';
-import { SupportedMintLinkBottomSheet } from './SupportedMintLinkBottomSheet';
+import SupportedMintLinkBottomSheet from './SupportedMintLinkBottomSheet';
 
 type Props = {
   value: string;
@@ -42,8 +42,6 @@ export function PostMintLinkInput({
   const { colorScheme } = useColorScheme();
   const [isInputFocused, setIsInputFocused] = useState(false);
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
   const handleTextChange = useCallback(
     (text: string) => {
       setValue(text);
@@ -65,9 +63,13 @@ export function PostMintLinkInput({
     setIncludeMintLink(newValue);
   }, [defaultValue, handleTextChange, includeMintLink, setIncludeMintLink]);
 
+  const { showBottomSheetModal } = useBottomSheetModalActions();
+
   const handleOpenBottomSheet = useCallback(() => {
-    bottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: <SupportedMintLinkBottomSheet />,
+    });
+  }, [showBottomSheetModal]);
 
   return (
     <View className="space-y-2" style={style}>
@@ -157,8 +159,6 @@ export function PostMintLinkInput({
           )}
         </View>
       )}
-
-      <SupportedMintLinkBottomSheet ref={bottomSheetRef} />
     </View>
   );
 }

--- a/apps/mobile/src/components/Post/SupportedMintLinkBottomSheet.tsx
+++ b/apps/mobile/src/components/Post/SupportedMintLinkBottomSheet.tsx
@@ -1,113 +1,68 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
-import { ForwardedRef, forwardRef, useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { Linking, View } from 'react-native';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { contexts } from '~/shared/analytics/constants';
 
 import { Button } from '../Button';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
-import { useSafeAreaPadding } from '../SafeAreaViewWithPadding';
 import { Typography } from '../Typography';
 
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
-
-// eslint-disable-next-line @typescript-eslint/ban-types
-type Props = {};
-
-function SupportedMintLinkBottomSheet(
-  props: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
-  const { bottom } = useSafeAreaPadding();
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
-
-  const handleClose = useCallback(() => {
-    bottomSheetRef.current?.dismiss();
-  }, []);
-
+export default function SupportedMintLinkBottomSheet() {
   const handlePress = useCallback(() => {
     Linking.openURL(
       'https://gallery-so.notion.site/Supported-Mint-Link-Domains-b4420f096413498d8aa24d857561817b'
     );
   }, []);
 
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
+
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        bottomSheetRef.current = value;
-
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          ref.current = value;
-        }
-      }}
-      snapPoints={animatedSnapPoints}
-      handleHeight={animatedHandleHeight}
-      contentHeight={animatedContentHeight}
-    >
-      <View
-        onLayout={handleContentLayout}
-        style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-6"
-      >
-        <View className="flex flex-col space-y-4">
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
+    <View className="flex flex-col space-y-6">
+      <View className="flex flex-col space-y-4">
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Bold' }}
+        >
+          Mint links
+        </Typography>
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Regular' }}
+        >
+          Gallery automatically adds your primary wallet address in mint links, ensuring you get
+          100% of referral rewards on supported platforms.
+        </Typography>
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Regular' }}
+        >
+          View our supported platforms{' '}
+          <GalleryTouchableOpacity
+            onPress={handlePress}
+            eventElementId="Supported Mint Link Bottom Sheet"
+            eventName="Press Supported Mint Link Bottom Sheet"
+            eventContext={contexts.Posts}
+            withoutFeedback
           >
-            Mint links
-          </Typography>
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Regular' }}
-          >
-            Gallery automatically adds your primary wallet address in mint links, ensuring you get
-            100% of referral rewards on supported platforms.
-          </Typography>
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Regular' }}
-          >
-            View our supported platforms{' '}
-            <GalleryTouchableOpacity
-              onPress={handlePress}
-              eventElementId="Supported Mint Link Bottom Sheet"
-              eventName="Press Supported Mint Link Bottom Sheet"
-              eventContext={contexts.Posts}
-              withoutFeedback
+            <Typography
+              className="text-lg text-black-900 dark:text-offWhite"
+              font={{ family: 'ABCDiatype', weight: 'Bold' }}
             >
-              <Typography
-                className="text-lg text-black-900 dark:text-offWhite"
-                font={{ family: 'ABCDiatype', weight: 'Bold' }}
-              >
-                here
-              </Typography>
-            </GalleryTouchableOpacity>
-            .
-          </Typography>
-        </View>
-
-        <Button
-          onPress={handleClose}
-          text="close"
-          eventElementId="Close Supported Mint Link Bottom Sheet"
-          eventName="Close Supported Mint Link Bottom Sheet"
-          eventContext={contexts.Posts}
-        />
+              here
+            </Typography>
+          </GalleryTouchableOpacity>
+          .
+        </Typography>
       </View>
-    </GalleryBottomSheetModal>
+
+      <Button
+        onPress={hideBottomSheetModal}
+        text="close"
+        eventElementId="Close Supported Mint Link Bottom Sheet"
+        eventName="Close Supported Mint Link Bottom Sheet"
+        eventContext={contexts.Posts}
+      />
+    </View>
   );
 }
-
-const ForwardedSupportedMintLinkBottomSheet = forwardRef(SupportedMintLinkBottomSheet);
-
-export { ForwardedSupportedMintLinkBottomSheet as SupportedMintLinkBottomSheet };

--- a/apps/mobile/src/components/Post/WarningPostBottomSheet.tsx
+++ b/apps/mobile/src/components/Post/WarningPostBottomSheet.tsx
@@ -1,85 +1,48 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
 import { useNavigation } from '@react-navigation/native';
-import { ForwardedRef, forwardRef, useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { View } from 'react-native';
 
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { contexts } from '~/shared/analytics/constants';
 
 import { Button } from '../Button';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../GalleryBottomSheet/GalleryBottomSheetModal';
-import { useSafeAreaPadding } from '../SafeAreaViewWithPadding';
 import { Typography } from '../Typography';
 
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
-
-// eslint-disable-next-line @typescript-eslint/ban-types
-type Props = {};
-
-function WarningPostBottomSheet(props: Props, ref: ForwardedRef<GalleryBottomSheetModalType>) {
+export default function WarningPostBottomSheet() {
   const navigation = useNavigation();
 
-  const { bottom } = useSafeAreaPadding();
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
 
   const handleBack = useCallback(() => {
-    bottomSheetRef.current?.dismiss();
+    hideBottomSheetModal();
+
     navigation.goBack();
-  }, [navigation]);
+  }, [hideBottomSheetModal, navigation]);
 
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        bottomSheetRef.current = value;
-
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          ref.current = value;
-        }
-      }}
-      snapPoints={animatedSnapPoints}
-      handleHeight={animatedHandleHeight}
-      contentHeight={animatedContentHeight}
-    >
-      <View
-        onLayout={handleContentLayout}
-        style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-6"
-      >
-        <View className="flex flex-col space-y-4">
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
-          >
-            Are you sure?
-          </Typography>
-          <Typography
-            className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Regular' }}
-          >
-            If you go back now, this post will be discarded.
-          </Typography>
-        </View>
-
-        <Button
-          onPress={handleBack}
-          text="DISCARD POST"
-          eventElementId="Discard Post Button"
-          eventName="Discard Post"
-          eventContext={contexts.Posts}
-        />
+    <View className=" flex flex-col space-y-6">
+      <View className="flex flex-col space-y-4">
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Bold' }}
+        >
+          Are you sure?
+        </Typography>
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Regular' }}
+        >
+          If you go back now, this post will be discarded.
+        </Typography>
       </View>
-    </GalleryBottomSheetModal>
+
+      <Button
+        onPress={handleBack}
+        text="DISCARD POST"
+        eventElementId="Discard Post Button"
+        eventName="Discard Post"
+        eventContext={contexts.Posts}
+      />
+    </View>
   );
 }
-
-const ForwardedWarningPostBottomSheet = forwardRef(WarningPostBottomSheet);
-
-export { ForwardedWarningPostBottomSheet as WarningPostBottomSheet };

--- a/apps/mobile/src/components/ProcessedText/elements/LinkComponent.tsx
+++ b/apps/mobile/src/components/ProcessedText/elements/LinkComponent.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { Text } from 'react-native';
 
-import { WarningLinkBottomSheet } from '~/components/Feed/Posts/WarningLinkBottomSheet';
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
+import WarningLinkBottomSheet from '~/components/Feed/Posts/WarningLinkBottomSheet';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 
 type Props = {
   value?: string;
@@ -10,17 +10,16 @@ type Props = {
 };
 
 export function LinkComponent({ url, value }: Props) {
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const { showBottomSheetModal } = useBottomSheetModalActions();
   const handleLinkPress = useCallback(() => {
-    bottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: <WarningLinkBottomSheet redirectUrl={url} />,
+    });
+  }, [showBottomSheetModal, url]);
 
   return (
-    <>
-      <Text className="text-shadow" onPress={handleLinkPress}>
-        {value ?? url}
-      </Text>
-      <WarningLinkBottomSheet redirectUrl={url} ref={bottomSheetRef} />
-    </>
+    <Text className="text-shadow" onPress={handleLinkPress}>
+      {value ?? url}
+    </Text>
   );
 }

--- a/apps/mobile/src/components/ProfileView/BadgeProfileBottomSheet.tsx
+++ b/apps/mobile/src/components/ProfileView/BadgeProfileBottomSheet.tsx
@@ -1,23 +1,17 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
-import { ForwardedRef, forwardRef, useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { contexts } from '~/shared/analytics/constants';
 
 import { Button } from '../Button';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '../GalleryBottomSheet/GalleryBottomSheetModal';
 import { Markdown } from '../Markdown';
-import { useSafeAreaPadding } from '../SafeAreaViewWithPadding';
-import { Typography } from '../Typography';
 
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
+import { Typography } from '../Typography';
 
 type Props = {
   title: string;
   description: string;
+  onClose: () => void;
 };
 
 const markdownStyles = StyleSheet.create({
@@ -32,71 +26,38 @@ const markdownStyles = StyleSheet.create({
   },
 });
 
-function BadgeProfileBottomSheet(
-  { title, description }: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
-  const { bottom } = useSafeAreaPadding();
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
-
+export default function BadgeProfileBottomSheet({ title, description, onClose }: Props) {
   const handleClose = useCallback(() => {
-    bottomSheetRef.current?.dismiss();
-  }, []);
+    onClose();
+  }, [onClose]);
 
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        bottomSheetRef.current = value;
-
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          ref.current = value;
-        }
-      }}
-      snapPoints={animatedSnapPoints}
-      handleHeight={animatedHandleHeight}
-      contentHeight={animatedContentHeight}
-    >
-      <View
-        onLayout={handleContentLayout}
-        style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-6"
-      >
-        <View className="flex flex-col space-y-4">
+    <View className="flex flex-col space-y-6">
+      <View className="flex flex-col space-y-4">
+        <Typography
+          className="text-lg text-black-900 dark:text-offWhite"
+          font={{ family: 'ABCDiatype', weight: 'Bold' }}
+        >
+          {title}
+        </Typography>
+        {description && (
           <Typography
             className="text-lg text-black-900 dark:text-offWhite"
-            font={{ family: 'ABCDiatype', weight: 'Bold' }}
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
           >
-            {title}
+            <Markdown style={markdownStyles}>{description}</Markdown>
           </Typography>
-          {description && (
-            <Typography
-              className="text-lg text-black-900 dark:text-offWhite"
-              font={{ family: 'ABCDiatype', weight: 'Regular' }}
-            >
-              <Markdown style={markdownStyles}>{description}</Markdown>
-            </Typography>
-          )}
-        </View>
-
-        <Button
-          onPress={handleClose}
-          text="CLOSE"
-          eventElementId="Close badge details"
-          eventName="Close badge"
-          eventContext={contexts.Badge}
-          variant="secondary"
-        />
+        )}
       </View>
-    </GalleryBottomSheetModal>
+
+      <Button
+        onPress={handleClose}
+        text="CLOSE"
+        eventElementId="Close badge details"
+        eventName="Close badge"
+        eventContext={contexts.Badge}
+        variant="secondary"
+      />
+    </View>
   );
 }
-
-const ForwardedBadgeProfileBottomSheet = forwardRef(BadgeProfileBottomSheet);
-
-export { ForwardedBadgeProfileBottomSheet as BadgeProfileBottomSheet };

--- a/apps/mobile/src/components/ProfileView/BadgeProfileBottomSheet.tsx
+++ b/apps/mobile/src/components/ProfileView/BadgeProfileBottomSheet.tsx
@@ -5,7 +5,6 @@ import { contexts } from '~/shared/analytics/constants';
 
 import { Button } from '../Button';
 import { Markdown } from '../Markdown';
-
 import { Typography } from '../Typography';
 
 type Props = {

--- a/apps/mobile/src/components/ProfileView/GalleryProfileNavBar.tsx
+++ b/apps/mobile/src/components/ProfileView/GalleryProfileNavBar.tsx
@@ -1,5 +1,5 @@
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { Share, View, ViewProps } from 'react-native';
 import { useFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
@@ -9,6 +9,7 @@ import { SettingsIcon } from 'src/icons/SettingsIcon';
 import { BackButton } from '~/components/BackButton';
 import { DarkModeToggle } from '~/components/DarkModeToggle';
 import { IconContainer } from '~/components/IconContainer';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { GalleryProfileNavBarFragment$key } from '~/generated/GalleryProfileNavBarFragment.graphql';
 import { GalleryProfileNavBarQueryFragment$key } from '~/generated/GalleryProfileNavBarQueryFragment.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
@@ -17,8 +18,7 @@ import { useLoggedInUserId } from '~/shared/relay/useLoggedInUserId';
 
 import { QRCodeIcon } from '../../icons/QRCodeIcon';
 import { ShareIcon } from '../../icons/ShareIcon';
-import { GalleryBottomSheetModalType } from '../GalleryBottomSheet/GalleryBottomSheetModal';
-import { GalleryProfileMoreOptionsBottomSheet } from './GalleryProfileMoreOptionsBottomSheet';
+import GalleryProfileMoreOptionsBottomSheet from './GalleryProfileMoreOptionsBottomSheet';
 
 type ScreenName = 'Profile' | 'Gallery' | 'Collection';
 type RouteParams = {
@@ -101,11 +101,12 @@ export function GalleryProfileNavBar({
     navigation.navigate('Settings');
   }, [navigation]);
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
+  const { showBottomSheetModal } = useBottomSheetModalActions();
   const handleMoreOptionsPress = useCallback(async () => {
-    bottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: <GalleryProfileMoreOptionsBottomSheet queryRef={query} userRef={user} />,
+    });
+  }, [query, showBottomSheetModal, user]);
 
   return (
     <View style={style} className="flex flex-row justify-between bg-white dark:bg-black-900">
@@ -155,7 +156,6 @@ export function GalleryProfileNavBar({
           </>
         )}
       </View>
-      <GalleryProfileMoreOptionsBottomSheet ref={bottomSheetRef} queryRef={query} userRef={user} />
     </View>
   );
 }

--- a/apps/mobile/src/components/ProfileView/ProfileView.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileView.tsx
@@ -31,7 +31,6 @@ import GalleryViewEmitter from '~/shared/components/GalleryViewEmitter';
 import { BADGE_ENABLED_COMMUNITY_ADDRESSES } from '~/shared/utils/communities';
 
 import { FollowButton } from '../FollowButton';
-import { GalleryBottomSheetModalType } from '../GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryTabsContainer } from '../GalleryTabs/GalleryTabsContainer';
 import { GalleryTouchableOpacity } from '../GalleryTouchableOpacity';
 import PfpBottomSheet from '../PfpPicker/PfpBottomSheet';
@@ -361,10 +360,9 @@ function ConnectedProfilePicture({ queryRef }: ConnectedProfilePictureProps) {
       query.viewer?.user?.dbid === query.userByUsername?.dbid
   );
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
   const { openManageWallet } = useManageWalletActions();
   const userHasWallet = query.viewer?.user?.primaryWallet?.__typename === 'Wallet';
-  const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
+  const { showBottomSheetModal } = useBottomSheetModalActions();
   const handlePress = useCallback(() => {
     if (!isLoggedInUser) {
       return;
@@ -374,7 +372,7 @@ function ConnectedProfilePicture({ queryRef }: ConnectedProfilePictureProps) {
       openManageWallet({
         onSuccess: () => {
           showBottomSheetModal({
-            content: <PfpBottomSheet onClose={hideBottomSheetModal} queryRef={query} />,
+            content: <PfpBottomSheet queryRef={query} />,
           });
         },
       });
@@ -382,16 +380,9 @@ function ConnectedProfilePicture({ queryRef }: ConnectedProfilePictureProps) {
     }
 
     showBottomSheetModal({
-      content: <PfpBottomSheet onClose={hideBottomSheetModal} queryRef={query} />,
+      content: <PfpBottomSheet queryRef={query} />,
     });
-  }, [
-    hideBottomSheetModal,
-    isLoggedInUser,
-    openManageWallet,
-    query,
-    showBottomSheetModal,
-    userHasWallet,
-  ]);
+  }, [isLoggedInUser, openManageWallet, query, showBottomSheetModal, userHasWallet]);
 
   return (
     <View className="mr-2">

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
@@ -1,15 +1,15 @@
 import clsx from 'clsx';
 import { useColorScheme } from 'nativewind';
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { View, ViewProps } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 import { useNavigateToCommunityScreen } from 'src/hooks/useNavigateToCommunityScreen';
 
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryLink } from '~/components/GalleryLink';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { CommunityProfilePicture } from '~/components/ProfilePicture/CommunityProfilePicture';
 import { Typography } from '~/components/Typography';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { ProfileViewSharedCommunitiesBubblesFragment$key } from '~/generated/ProfileViewSharedCommunitiesBubblesFragment.graphql';
 import { ProfileViewSharedCommunitiesFragment$key } from '~/generated/ProfileViewSharedCommunitiesFragment.graphql';
 import { ProfileViewSharedCommunitiesHoldsTextFragment$key } from '~/generated/ProfileViewSharedCommunitiesHoldsTextFragment.graphql';
@@ -18,7 +18,7 @@ import { GalleryElementTrackingProps } from '~/shared/contexts/AnalyticsContext'
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import colors from '~/shared/theme/colors';
 
-import { ProfileViewSharedCommunitiesSheet } from './ProfileViewSharedCommunitiesSheet';
+import ProfileViewSharedCommunitiesSheet from './ProfileViewSharedCommunitiesSheet';
 
 type Props = {
   userRef: ProfileViewSharedCommunitiesFragment$key;
@@ -58,10 +58,13 @@ export default function ProfileViewSharedCommunities({ userRef }: Props) {
 
   const totalSharedCommunities = user.sharedCommunities?.pageInfo?.total ?? 0;
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const { showBottomSheetModal } = useBottomSheetModalActions();
+
   const handleSeeAllPress = useCallback(() => {
-    bottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: <ProfileViewSharedCommunitiesSheet userRef={user} />,
+    });
+  }, [showBottomSheetModal, user]);
 
   if (totalSharedCommunities === 0) {
     return null;
@@ -83,8 +86,6 @@ export default function ProfileViewSharedCommunities({ userRef }: Props) {
         communityRefs={sharedCommunities}
         totalCount={totalSharedCommunities}
       />
-
-      <ProfileViewSharedCommunitiesSheet ref={bottomSheetRef} userRef={user} />
     </View>
   );
 }

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunitiesSheet.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunitiesSheet.tsx
@@ -1,22 +1,14 @@
-import { ForwardedRef, forwardRef, useCallback, useMemo } from 'react';
-import { View } from 'react-native';
+import { useCallback, useMemo } from 'react';
+import { Dimensions, View } from 'react-native';
 import { graphql, usePaginationFragment } from 'react-relay';
 
 import { CommunityList } from '~/components/CommunitiesList/CommunityList';
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { Typography } from '~/components/Typography';
 import { ProfileViewSharedCommunitiesSheetFragment$key } from '~/generated/ProfileViewSharedCommunitiesSheetFragment.graphql';
-
-import { useListContentStyle } from '../Tabs/useListContentStyle';
 
 type Props = {
   userRef: ProfileViewSharedCommunitiesSheetFragment$key;
 };
-
-const snapPoints = ['50%'];
 
 export const SHARED_COMMUNITIES_PER_PAGE = 20;
 export type ContractAddress = {
@@ -24,10 +16,7 @@ export type ContractAddress = {
   chain: string | null;
 };
 
-function ProfileViewSharedCommunitiesSheet(
-  props: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
+export default function ProfileViewSharedCommunitiesSheet(props: Props) {
   const { data, loadNext, hasNext } = usePaginationFragment(
     graphql`
       fragment ProfileViewSharedCommunitiesSheetFragment on GalleryUser
@@ -61,19 +50,19 @@ function ProfileViewSharedCommunitiesSheet(
     return communities;
   }, [data.sharedCommunities?.edges]);
 
-  const contentContainerStyle = useListContentStyle();
-
   const loadMore = useCallback(() => {
     if (hasNext) {
       loadNext(SHARED_COMMUNITIES_PER_PAGE);
     }
   }, [hasNext, loadNext]);
 
+  const screenHeight = Dimensions.get('window').height;
+
   return (
-    <GalleryBottomSheetModal ref={ref} index={0} snapPoints={snapPoints}>
-      <View style={contentContainerStyle}>
+    <View className="flex bg-white dark:bg-black-900">
+      <View className={`max-h-[${screenHeight * 0.5}px]`}>
         <Typography
-          className="text-sm mb-4 px-4 flex flex-row items-center "
+          className="text-sm mb-4  flex flex-row items-center "
           font={{
             family: 'ABCDiatype',
             weight: 'Bold',
@@ -82,16 +71,10 @@ function ProfileViewSharedCommunitiesSheet(
           Items you both own
         </Typography>
 
-        <View className="flex-grow">
+        <View className="flex-grow h-full">
           <CommunityList onLoadMore={loadMore} communityRefs={nonNullCommunities} />
         </View>
       </View>
-    </GalleryBottomSheetModal>
+    </View>
   );
 }
-
-const ForwardedProfileViewSharedCommunitiesSheet = forwardRef<GalleryBottomSheetModalType, Props>(
-  ProfileViewSharedCommunitiesSheet
-);
-
-export { ForwardedProfileViewSharedCommunitiesSheet as ProfileViewSharedCommunitiesSheet };

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers.tsx
@@ -1,16 +1,16 @@
 import { useNavigation } from '@react-navigation/native';
 import clsx from 'clsx';
 import { useColorScheme } from 'nativewind';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { View, ViewProps } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
 
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { GalleryLink } from '~/components/GalleryLink';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { RawProfilePictureProps } from '~/components/ProfilePicture/RawProfilePicture';
 import { Typography } from '~/components/Typography';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { ProfileViewSharedFollowersBubblesFragment$key } from '~/generated/ProfileViewSharedFollowersBubblesFragment.graphql';
 import { ProfileViewSharedFollowersFollowingTextFragment$key } from '~/generated/ProfileViewSharedFollowersFollowingTextFragment.graphql';
 import { ProfileViewSharedFollowersFragment$key } from '~/generated/ProfileViewSharedFollowersFragment.graphql';
@@ -20,7 +20,7 @@ import { GalleryElementTrackingProps } from '~/shared/contexts/AnalyticsContext'
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 import colors from '~/shared/theme/colors';
 
-import { ProfileViewSharedFollowersSheet } from './ProfileViewSharedFollowersSheet';
+import ProfileViewSharedFollowersSheet from './ProfileViewSharedFollowersSheet';
 export const SHARED_FOLLOWERS_PER_PAGE = 20;
 
 type Props = {
@@ -60,11 +60,14 @@ export default function ProfileViewSharedFollowers({ userRef }: Props) {
   }, [user.sharedFollowers?.edges]);
 
   const totalSharedFollowers = user.sharedFollowers?.pageInfo?.total ?? 0;
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+
+  const { showBottomSheetModal } = useBottomSheetModalActions();
 
   const handleSeeAllPress = useCallback(() => {
-    bottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: <ProfileViewSharedFollowersSheet userRef={user} />,
+    });
+  }, [showBottomSheetModal, user]);
 
   if (totalSharedFollowers === 0) {
     return null;
@@ -86,8 +89,6 @@ export default function ProfileViewSharedFollowers({ userRef }: Props) {
         userRefs={sharedFollowers}
         totalCount={totalSharedFollowers}
       />
-
-      <ProfileViewSharedFollowersSheet ref={bottomSheetRef} userRef={user} />
     </View>
   );
 }

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowersSheet.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowersSheet.tsx
@@ -1,30 +1,19 @@
 import { useNavigation } from '@react-navigation/native';
-import { ForwardedRef, forwardRef, useCallback, useMemo } from 'react';
-import { View } from 'react-native';
+import { useCallback, useMemo } from 'react';
+import { Dimensions, View } from 'react-native';
 import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { Typography } from '~/components/Typography';
 import { UserFollowList } from '~/components/UserFollowList/UserFollowList';
 import { ProfileViewSharedFollowersSheetFragment$key } from '~/generated/ProfileViewSharedFollowersSheetFragment.graphql';
 import { ProfileViewSharedFollowersSheetQuery } from '~/generated/ProfileViewSharedFollowersSheetQuery.graphql';
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 
-import { useListContentStyle } from '../Tabs/useListContentStyle';
-
 type Props = {
   userRef: ProfileViewSharedFollowersSheetFragment$key;
 };
 
-const snapPoints = ['50%'];
-
-function ProfileViewSharedFollowersSheet(
-  props: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
+export default function ProfileViewSharedFollowersSheet(props: Props) {
   const { data, loadNext, hasNext } = usePaginationFragment(
     graphql`
       fragment ProfileViewSharedFollowersSheetFragment on GalleryUser
@@ -54,6 +43,8 @@ function ProfileViewSharedFollowersSheet(
     {}
   );
 
+  const screenHeight = Dimensions.get('window').height;
+
   const nonNullUsers = useMemo(() => {
     const users = [];
 
@@ -72,8 +63,6 @@ function ProfileViewSharedFollowersSheet(
     }
   }, [hasNext, loadNext]);
 
-  const contentContainerStyle = useListContentStyle();
-
   const navigation = useNavigation<MainTabStackNavigatorProp>();
 
   const handleUserPress = useCallback(
@@ -82,11 +71,12 @@ function ProfileViewSharedFollowersSheet(
     },
     [navigation]
   );
+
   return (
-    <GalleryBottomSheetModal ref={ref} index={0} snapPoints={snapPoints}>
-      <View style={contentContainerStyle}>
+    <View className="flex bg-white dark:bg-black-900">
+      <View className={`max-h-[${screenHeight * 0.5}px]`}>
         <Typography
-          className="text-sm mb-4 px-4"
+          className="text-sm mb-4"
           font={{
             family: 'ABCDiatype',
             weight: 'Bold',
@@ -95,7 +85,7 @@ function ProfileViewSharedFollowersSheet(
           Followers
         </Typography>
 
-        <View className="flex-grow">
+        <View className="flex-grow h-full">
           <UserFollowList
             onUserPress={handleUserPress}
             onLoadMore={handleLoadMore}
@@ -104,12 +94,6 @@ function ProfileViewSharedFollowersSheet(
           />
         </View>
       </View>
-    </GalleryBottomSheetModal>
+    </View>
   );
 }
-
-const ForwardedProfileViewSharedFollowersSheet = forwardRef<GalleryBottomSheetModalType, Props>(
-  ProfileViewSharedFollowersSheet
-);
-
-export { ForwardedProfileViewSharedFollowersSheet as ProfileViewSharedFollowersSheet };

--- a/apps/mobile/src/components/ProfileView/Tabs/ProfileViewFollowersTab.tsx
+++ b/apps/mobile/src/components/ProfileView/Tabs/ProfileViewFollowersTab.tsx
@@ -90,7 +90,9 @@ export function ProfileViewFollowersTab({ queryRef }: ProfileViewFollowersTabPro
     ({ item }) => {
       if (item.kind === 'user') {
         return (
-          <UserFollowCard userRef={item.user} queryRef={item.query} onPress={handleUserPress} />
+          <View className="px-4">
+            <UserFollowCard userRef={item.user} queryRef={item.query} onPress={handleUserPress} />
+          </View>
         );
       } else if (item.kind === 'tab-bar') {
         return <FollowersTabBar activeRoute={item.selectedTab} onRouteChange={setSelectedTab} />;

--- a/apps/mobile/src/components/UserFollowList/UserFollowCard.tsx
+++ b/apps/mobile/src/components/UserFollowList/UserFollowCard.tsx
@@ -60,7 +60,7 @@ export function UserFollowCard({
   }, [onPress, user.username]);
 
   return (
-    <View className={clsx('flex w-full flex-row items-center space-x-8 overflow-hidden px-4')}>
+    <View className={clsx('flex w-full flex-row items-center space-x-8 overflow-hidden')}>
       <GalleryTouchableOpacity
         onPress={handlePress}
         disabled={isPresentational}

--- a/apps/mobile/src/contexts/BottomSheetModalContext.tsx
+++ b/apps/mobile/src/contexts/BottomSheetModalContext.tsx
@@ -1,5 +1,6 @@
 import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
 import { BottomSheetModalProvider as GorhomBottomSheetModalProvider } from '@gorhom/bottom-sheet';
+import clsx from 'clsx';
 import React, {
   createContext,
   memo,
@@ -11,6 +12,7 @@ import React, {
   useState,
 } from 'react';
 import { View } from 'react-native';
+import { useReducedMotion } from 'react-native-reanimated';
 
 import {
   GalleryBottomSheetModal,
@@ -56,6 +58,7 @@ type BottomSheetModalProviderProps = {
 
 type BottomSheetModal = {
   content: React.ReactNode;
+  noPadding?: boolean;
   onDismiss?: () => void;
 };
 
@@ -98,6 +101,8 @@ function BottomSheetModalProvider({ children }: BottomSheetModalProviderProps) {
     bottomSheetModalRef?.current?.present();
   }, [bottomSheetModal]);
 
+  const reducedMotion = useReducedMotion();
+
   return (
     <GorhomBottomSheetModalProvider>
       <BottomSheetModalActionsContext.Provider value={actions}>
@@ -108,13 +113,19 @@ function BottomSheetModalProvider({ children }: BottomSheetModalProviderProps) {
             handleHeight={animatedHandleHeight}
             contentHeight={animatedContentHeight}
             onDismiss={handleDismissBottomSheetModal}
+            animateOnMount={!reducedMotion}
             index={0}
             ref={bottomSheetModalRef}
+            android_keyboardInputMode="adjustResize"
+            keyboardBlurBehavior="restore"
           >
             <View
               onLayout={handleContentLayout}
-              style={{ paddingBottom: bottom }}
-              className="p-4 flex flex-col space-y-6"
+              style={{ paddingBottom: !bottomSheetModal.noPadding ? bottom : 0 }}
+              className={clsx(
+                'flex flex-col space-y-6',
+                !bottomSheetModal.noPadding && 'px-4 py-2'
+              )}
             >
               {bottomSheetModal.content}
             </View>

--- a/apps/mobile/src/contexts/BottomSheetModalContext.tsx
+++ b/apps/mobile/src/contexts/BottomSheetModalContext.tsx
@@ -1,6 +1,7 @@
 import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
 import { BottomSheetModalProvider as GorhomBottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import clsx from 'clsx';
+import { BlurView } from 'expo-blur';
 import React, {
   createContext,
   memo,
@@ -40,7 +41,7 @@ type BottomSheetModalActions = {
   hideBottomSheetModal: () => void;
 };
 
-const BottomSheetModalActionsContext = createContext<BottomSheetModalActions | undefined>(
+export const BottomSheetModalActionsContext = createContext<BottomSheetModalActions | undefined>(
   undefined
 );
 
@@ -60,6 +61,7 @@ type BottomSheetModal = {
   content: React.ReactNode;
   noPadding?: boolean;
   onDismiss?: () => void;
+  blurBackground?: boolean;
 };
 
 function BottomSheetModalProvider({ children }: BottomSheetModalProviderProps) {
@@ -118,6 +120,7 @@ function BottomSheetModalProvider({ children }: BottomSheetModalProviderProps) {
             ref={bottomSheetModalRef}
             android_keyboardInputMode="adjustResize"
             keyboardBlurBehavior="restore"
+            backdropComponent={bottomSheetModal.blurBackground ? BluredBackdrop : null}
           >
             <View
               onLayout={handleContentLayout}
@@ -127,7 +130,7 @@ function BottomSheetModalProvider({ children }: BottomSheetModalProviderProps) {
                 !bottomSheetModal.noPadding && 'px-4 py-2'
               )}
             >
-              {bottomSheetModal.content}
+              <BottomSheetWrapper content={bottomSheetModal.content} />
             </View>
           </GalleryBottomSheetModal>
         )}
@@ -137,3 +140,11 @@ function BottomSheetModalProvider({ children }: BottomSheetModalProviderProps) {
 }
 
 export default memo(BottomSheetModalProvider);
+
+function BottomSheetWrapper({ content }: { content: React.ReactNode }) {
+  return <View>{content}</View>;
+}
+
+function BluredBackdrop() {
+  return <BlurView intensity={4} className="absolute h-full w-full top-0 bg-black/50 "></BlurView>;
+}

--- a/apps/mobile/src/contexts/ManageWalletContext.tsx
+++ b/apps/mobile/src/contexts/ManageWalletContext.tsx
@@ -12,24 +12,24 @@ import {
 import { SignerVariables } from 'shared/hooks/useAuthPayloadQuery';
 import { useLogin } from 'src/hooks/useLogin';
 
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
-import { WalletSelectorBottomSheet } from '~/components/Login/WalletSelectorBottomSheet';
+import WalletSelectorBottomSheet from '~/components/Login/WalletSelectorBottomSheet';
 import { LoginStackNavigatorProp } from '~/navigation/types';
 import { navigateToNotificationUpsellOrHomeScreen } from '~/screens/Login/navigateToNotificationUpsellOrHomeScreen';
 import { useTrack } from '~/shared/contexts/AnalyticsContext';
 import useAddWallet from '~/shared/hooks/useAddWallet';
 import { noop } from '~/shared/utils/noop';
 
+import { useBottomSheetModalActions } from './BottomSheetModalContext';
 import { useSyncTokensActions } from './SyncTokensContext';
 
-type openManageWalletProps = {
+export type OpenManageWalletProps = {
   title?: string;
   method?: 'auth' | 'add-wallet';
   onSuccess?: () => void;
 };
 
 type ManageWalletActions = {
-  openManageWallet: (o: openManageWalletProps) => void;
+  openManageWallet: (o: OpenManageWalletProps) => void;
   dismissManageWallet: () => void;
   isSigningIn: boolean;
   signature?: string;
@@ -50,7 +50,6 @@ export const useManageWalletActions = (): ManageWalletActions => {
 type Props = { children: ReactNode };
 
 const ManageWalletProvider = memo(({ children }: Props) => {
-  const bottomSheet = useRef<GalleryBottomSheetModalType | null>(null);
   const addWallet = useAddWallet();
   const navigation = useNavigation<LoginStackNavigatorProp>();
 
@@ -65,26 +64,11 @@ const ManageWalletProvider = memo(({ children }: Props) => {
   const onSuccessRef = useRef<(() => void) | null>(null);
   const methodRef = useRef<'auth' | 'add-wallet'>('add-wallet');
 
-  const openManageWallet = useCallback(
-    ({ title, onSuccess = noop, method = 'add-wallet' }: openManageWalletProps) => {
-      if (title) {
-        setTitle(title);
-      }
-
-      if (onSuccess) {
-        onSuccessRef.current = onSuccess;
-      }
-
-      methodRef.current = method;
-
-      bottomSheet.current?.present();
-    },
-    []
-  );
+  const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
 
   const dismissManageWallet = useCallback(() => {
-    bottomSheet.current?.dismiss();
-  }, []);
+    hideBottomSheetModal();
+  }, [hideBottomSheetModal]);
 
   const handleOnSignedIn = useCallback(
     async ({
@@ -161,6 +145,33 @@ const ManageWalletProvider = memo(({ children }: Props) => {
     [addWallet, isSyncing, login, navigation, syncTokens, track, methodRef]
   );
 
+  const openManageWallet = useCallback(
+    ({ title, onSuccess = noop, method = 'add-wallet' }: OpenManageWalletProps) => {
+      if (title) {
+        setTitle(title);
+      }
+
+      if (onSuccess) {
+        onSuccessRef.current = onSuccess;
+      }
+
+      methodRef.current = method;
+
+      showBottomSheetModal({
+        content: (
+          <WalletSelectorBottomSheet
+            title={title}
+            onDismiss={dismissManageWallet}
+            onSignedIn={handleOnSignedIn}
+            isSigningIn={isSigningIn}
+            setIsSigningIn={setIsSigningIn}
+          />
+        ),
+      });
+    },
+    [dismissManageWallet, handleOnSignedIn, isSigningIn, showBottomSheetModal]
+  );
+
   const value = useMemo(
     () => ({
       dismissManageWallet,
@@ -173,14 +184,6 @@ const ManageWalletProvider = memo(({ children }: Props) => {
 
   return (
     <ManageWalletActionsContext.Provider value={value}>
-      <WalletSelectorBottomSheet
-        title={value.title}
-        ref={bottomSheet}
-        onDismiss={dismissManageWallet}
-        onSignedIn={handleOnSignedIn}
-        isSigningIn={isSigningIn}
-        setIsSigningIn={setIsSigningIn}
-      />
       {children}
     </ManageWalletActionsContext.Provider>
   );

--- a/apps/mobile/src/screens/CommunityScreen/CommunityScreen.tsx
+++ b/apps/mobile/src/screens/CommunityScreen/CommunityScreen.tsx
@@ -18,8 +18,6 @@ import { CommunityScreenRefetchableFragment$key } from '~/generated/CommunityScr
 import { CommunityScreenRefetchableFragmentQuery } from '~/generated/CommunityScreenRefetchableFragmentQuery.graphql';
 import { MainTabStackNavigatorParamList } from '~/navigation/types';
 
-import { SharePostBottomSheet } from '../PostScreen/SharePostBottomSheet';
-
 /**
  * How this screen works:
  * 1) using params, decide whether we're going to render a ContractCommunity vs ArtBlocksCommunity
@@ -29,7 +27,7 @@ import { SharePostBottomSheet } from '../PostScreen/SharePostBottomSheet';
  */
 export function CommunityScreen() {
   const route = useRoute<RouteProp<MainTabStackNavigatorParamList, 'Community'>>();
-  const { subtype, chain, contractAddress, projectId, postId, creatorName } = route.params;
+  const { subtype, chain, contractAddress, projectId } = route.params;
 
   const inner = useMemo(() => {
     if (subtype === 'ContractCommunity') {
@@ -50,11 +48,6 @@ export function CommunityScreen() {
   return (
     <View className="flex-1 bg-white dark:bg-black-900">
       <Suspense fallback={<CommunityViewFallback />}>{inner}</Suspense>
-      {postId && (
-        <Suspense fallback={null}>
-          <SharePostBottomSheet postId={postId} creatorName={creatorName} />
-        </Suspense>
-      )}
     </View>
   );
 }

--- a/apps/mobile/src/screens/HomeScreen/CuratedScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen/CuratedScreen.tsx
@@ -3,7 +3,6 @@ import { RouteProp, useRoute } from '@react-navigation/native';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 
-import { MarfaCheckInSheet } from '~/components/MarfaCheckIn/MarfaCheckInSheet';
 import { WelcomeNewUserOnboarding } from '~/components/Onboarding/WelcomeNewUserOnboarding';
 import { CuratedScreenFragment$key } from '~/generated/CuratedScreenFragment.graphql';
 import { CuratedScreenQuery } from '~/generated/CuratedScreenQuery.graphql';
@@ -13,7 +12,6 @@ import { removeNullValues } from '~/shared/relay/removeNullValues';
 
 import { FeedList } from '../../components/Feed/FeedList';
 import { LoadingFeedList } from '../../components/Feed/LoadingFeedList';
-import { SharePostBottomSheet } from '../PostScreen/SharePostBottomSheet';
 
 type CuratedScreenInnerProps = {
   queryRef: CuratedScreenFragment$key;
@@ -45,7 +43,7 @@ function CuratedScreenInner({ queryRef }: CuratedScreenInnerProps) {
             user {
               username
             }
-            ...MarfaCheckInSheetFragment
+            # ...MarfaCheckInSheetFragment
           }
         }
         ...FeedListQueryFragment
@@ -55,8 +53,8 @@ function CuratedScreenInner({ queryRef }: CuratedScreenInnerProps) {
   );
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  const { params: routeParams } = useRoute<RouteProp<FeedTabNavigatorParamList, 'For You'>>();
-  const showMarfaCheckIn = routeParams?.showMarfaCheckIn ?? false;
+  // const { params: routeParams } = useRoute<RouteProp<FeedTabNavigatorParamList, 'For You'>>();
+  // const showMarfaCheckIn = routeParams?.showMarfaCheckIn ?? false;
 
   const curatedFeed = query.data.curatedFeed;
 
@@ -126,14 +124,8 @@ function CuratedScreenInner({ queryRef }: CuratedScreenInnerProps) {
           />
         </Portal>
       )}
-      {showMarfaCheckIn && <MarfaCheckInSheet viewerRef={query.data.viewer} />}
-      <Suspense fallback={null}>
-        <SharePostBottomSheet
-          shouldShowSheet
-          postId={routeParams?.postId ?? ''}
-          creatorName={routeParams?.postId ?? ''}
-        />
-      </Suspense>
+      {/* Keeping for next time we run a similar campaign */}
+      {/* {showMarfaCheckIn && <MarfaCheckInSheet viewerRef={query.data.viewer} />} */}
     </>
   );
 }

--- a/apps/mobile/src/screens/Login/LandingScreen.tsx
+++ b/apps/mobile/src/screens/Login/LandingScreen.tsx
@@ -1,15 +1,11 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useNavigation } from '@react-navigation/native';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { View } from 'react-native';
 
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
+import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { SignInBottomSheet } from '~/components/Login/SignInBottomSheet';
-import { SafeAreaViewWithPadding, useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
+import { SafeAreaViewWithPadding } from '~/components/SafeAreaViewWithPadding';
 import { OrderedListItem, Typography } from '~/components/Typography';
 import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { useManageWalletActions } from '~/contexts/ManageWalletContext';
@@ -22,10 +18,8 @@ import { LandingLogo } from './LandingLogo';
 import { QRCodeIcon } from './QRCodeIcon';
 
 export function LandingScreen() {
-  const { bottom } = useSafeAreaPadding();
   const navigation = useNavigation<LoginStackNavigatorProp>();
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -36,100 +30,39 @@ export function LandingScreen() {
     });
   }, [navigation]);
 
-  const initialSnapPoints = useMemo(() => ['CONTENT_HEIGHT'], []);
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(initialSnapPoints);
-
   const qrCodeSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
-  const handleQrCodePress = useCallback(() => {
-    qrCodeSheetRef.current?.present();
-  }, []);
-
+  const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
   const handleBottomSheetQRCodePress = useCallback(() => {
     setError('');
 
-    qrCodeSheetRef.current?.dismiss();
+    hideBottomSheetModal();
 
     navigation.navigate('QRCode', {
       onError: (message) => {
         setError(message);
       },
     });
-  }, [navigation]);
+  }, [hideBottomSheetModal, navigation]);
 
-  const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
+  const handleQrCodePress = useCallback(() => {
+    qrCodeSheetRef.current?.present();
+    showBottomSheetModal({
+      content: <QrCodeBottomSheet handleBottomSheetQRCodePress={handleBottomSheetQRCodePress} />,
+    });
+  }, [handleBottomSheetQRCodePress, showBottomSheetModal]);
 
   const { openManageWallet } = useManageWalletActions();
   const showSignInBottomSheet = useCallback(() => {
-    bottomSheetRef.current?.present();
     showBottomSheetModal({
       content: (
-        <SignInBottomSheet
-          onClose={hideBottomSheetModal}
-          onQrCodePress={handleQrCodePress}
-          openManageWallet={openManageWallet}
-        />
+        <SignInBottomSheet onQrCodePress={handleQrCodePress} openManageWallet={openManageWallet} />
       ),
     });
-  }, [handleQrCodePress, hideBottomSheetModal, openManageWallet, showBottomSheetModal]);
+  }, [handleQrCodePress, openManageWallet, showBottomSheetModal]);
 
   return (
     <SafeAreaViewWithPadding className="flex h-full flex-col justify-end bg-white dark:bg-black-900">
-      <GalleryBottomSheetModal
-        ref={qrCodeSheetRef}
-        snapPoints={animatedSnapPoints}
-        handleHeight={animatedHandleHeight}
-        contentHeight={animatedContentHeight}
-      >
-        <View
-          onLayout={handleContentLayout}
-          style={{ paddingBottom: bottom }}
-          className="px-8 flex flex-col space-y-8"
-        >
-          <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
-            If you’re signed in on Gallery elsewhere, you can sign in instantly via QR code.
-          </Typography>
-
-          <View className="flex flex-col space-y-2">
-            <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }}>Scan QR Code</Typography>
-
-            <View className="flex flex-col">
-              <OrderedListItem
-                number={1}
-                className="text-sm leading-loose"
-                font={{ family: 'ABCDiatype', weight: 'Regular' }}
-              >
-                Open gallery.so/settings on a different device.
-              </OrderedListItem>
-              <OrderedListItem
-                number={2}
-                className="text-sm leading-loose"
-                font={{ family: 'ABCDiatype', weight: 'Regular' }}
-              >
-                Click "QR Code for Login"
-              </OrderedListItem>
-              <OrderedListItem
-                number={3}
-                className="text-sm leading-loose"
-                font={{ family: 'ABCDiatype', weight: 'Regular' }}
-              >
-                Scan the QR Code.
-              </OrderedListItem>
-            </View>
-          </View>
-
-          <Button
-            eventElementId="Scan QR Code Button"
-            eventName="Scan QR Code Button Clicked"
-            eventContext={contexts.Authentication}
-            onPress={handleBottomSheetQRCodePress}
-            headerElement={<QRCodeIcon />}
-            text="SCAN QR CODE"
-          />
-        </View>
-      </GalleryBottomSheetModal>
-
       <View className="flex flex-grow flex-col items-center space-y-12 justify-between">
         <View className="pt-32">
           <LandingLogo />
@@ -145,8 +78,6 @@ export function LandingScreen() {
               eventName="Get Started Button Clicked"
               eventContext={contexts.Authentication}
             />
-
-            {/* <SignInBottomSheet ref={bottomSheetRef} onQrCodePress={handleQrCodePress} /> */}
           </View>
           {error && (
             <Typography
@@ -159,5 +90,56 @@ export function LandingScreen() {
         </View>
       </View>
     </SafeAreaViewWithPadding>
+  );
+}
+
+function QrCodeBottomSheet({
+  handleBottomSheetQRCodePress,
+}: {
+  handleBottomSheetQRCodePress: () => void;
+}) {
+  return (
+    <View className="flex flex-col space-y-8">
+      <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Regular' }}>
+        If you’re signed in on Gallery elsewhere, you can sign in instantly via QR code.
+      </Typography>
+
+      <View className="flex flex-col space-y-2">
+        <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }}>Scan QR Code</Typography>
+
+        <View className="flex flex-col">
+          <OrderedListItem
+            number={1}
+            className="text-sm leading-loose"
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
+          >
+            Open gallery.so/settings on a different device.
+          </OrderedListItem>
+          <OrderedListItem
+            number={2}
+            className="text-sm leading-loose"
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
+          >
+            Click "QR Code for Login"
+          </OrderedListItem>
+          <OrderedListItem
+            number={3}
+            className="text-sm leading-loose"
+            font={{ family: 'ABCDiatype', weight: 'Regular' }}
+          >
+            Scan the QR Code.
+          </OrderedListItem>
+        </View>
+      </View>
+
+      <Button
+        eventElementId="Scan QR Code Button"
+        eventName="Scan QR Code Button Clicked"
+        eventContext={contexts.Authentication}
+        onPress={handleBottomSheetQRCodePress}
+        headerElement={<QRCodeIcon />}
+        text="SCAN QR CODE"
+      />
+    </View>
   );
 }

--- a/apps/mobile/src/screens/Login/LandingScreen.tsx
+++ b/apps/mobile/src/screens/Login/LandingScreen.tsx
@@ -11,6 +11,8 @@ import {
 import { SignInBottomSheet } from '~/components/Login/SignInBottomSheet';
 import { SafeAreaViewWithPadding, useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 import { OrderedListItem, Typography } from '~/components/Typography';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
+import { useManageWalletActions } from '~/contexts/ManageWalletContext';
 import { LoginStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 
@@ -56,9 +58,21 @@ export function LandingScreen() {
     });
   }, [navigation]);
 
-  const toggleOption = useCallback(() => {
+  const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
+
+  const { openManageWallet } = useManageWalletActions();
+  const showSignInBottomSheet = useCallback(() => {
     bottomSheetRef.current?.present();
-  }, []);
+    showBottomSheetModal({
+      content: (
+        <SignInBottomSheet
+          onClose={hideBottomSheetModal}
+          onQrCodePress={handleQrCodePress}
+          openManageWallet={openManageWallet}
+        />
+      ),
+    });
+  }, [handleQrCodePress, hideBottomSheetModal, openManageWallet, showBottomSheetModal]);
 
   return (
     <SafeAreaViewWithPadding className="flex h-full flex-col justify-end bg-white dark:bg-black-900">
@@ -124,7 +138,7 @@ export function LandingScreen() {
         <View className="flex flex-col space-y-4 w-8/12">
           <View className="w-[200px] space-y-2 self-center">
             <Button
-              onPress={toggleOption}
+              onPress={showSignInBottomSheet}
               variant="primary"
               text="get started"
               eventElementId="Get Started Button"
@@ -132,7 +146,7 @@ export function LandingScreen() {
               eventContext={contexts.Authentication}
             />
 
-            <SignInBottomSheet ref={bottomSheetRef} onQrCodePress={handleQrCodePress} />
+            {/* <SignInBottomSheet ref={bottomSheetRef} onQrCodePress={handleQrCodePress} /> */}
           </View>
           {error && (
             <Typography

--- a/apps/mobile/src/screens/NftDetailScreen/AdmireBottomSheet.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/AdmireBottomSheet.tsx
@@ -1,14 +1,9 @@
 import { useNavigation } from '@react-navigation/native';
-import { ForwardedRef, Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 import { graphql } from 'relay-runtime';
 
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
-import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 import { Typography } from '~/components/Typography';
 import { UserFollowList } from '~/components/UserFollowList/UserFollowList';
 import { UserFollowListFallback } from '~/components/UserFollowList/UserFollowListFallback';
@@ -18,45 +13,23 @@ import { AdmireBottomSheetConnectedTokenAdmireListQuery } from '~/generated/Admi
 import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
 
-const SNAP_POINTS = [350];
-
 type AdmireBottomSheetProps = {
   tokenId: string;
-  bottomSheetRef: ForwardedRef<GalleryBottomSheetModalType | null>;
 };
 
-export function AdmireBottomSheet({ bottomSheetRef, tokenId }: AdmireBottomSheetProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const internalRef = useRef<GalleryBottomSheetModalType | null>(null);
-  const { bottom } = useSafeAreaPadding();
-
+export function AdmireBottomSheet({ tokenId }: AdmireBottomSheetProps) {
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        internalRef.current = value;
-        if (typeof bottomSheetRef === 'function') {
-          bottomSheetRef(value);
-        } else if (bottomSheetRef) {
-          bottomSheetRef.current = value;
-        }
-      }}
-      snapPoints={SNAP_POINTS}
-      onChange={() => setIsOpen(true)}
-      android_keyboardInputMode="adjustResize"
-      keyboardBlurBehavior="restore"
-    >
-      <View style={{ paddingBottom: bottom }} className="flex flex-1 flex-col space-y-5">
-        <Typography className="text-sm px-4" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
-          Admires
-        </Typography>
+    <View className="flex flex-1 flex-col space-y-5">
+      <Typography className="text-sm px-4" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
+        Admires
+      </Typography>
 
-        <View className="flex-grow">
-          <Suspense fallback={<UserFollowListFallback />}>
-            {isOpen && <ConnectedTokenAdmireList tokenId={tokenId} />}
-          </Suspense>
-        </View>
+      <View className="flex-grow">
+        <Suspense fallback={<UserFollowListFallback />}>
+          <ConnectedTokenAdmireList tokenId={tokenId} />
+        </Suspense>
       </View>
-    </GalleryBottomSheetModal>
+    </View>
   );
 }
 

--- a/apps/mobile/src/screens/NftSelectorScreen/NftSelectorFilterBottomSheet.tsx
+++ b/apps/mobile/src/screens/NftSelectorScreen/NftSelectorFilterBottomSheet.tsx
@@ -1,17 +1,10 @@
-import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
-import { ForwardedRef, forwardRef, useCallback, useMemo, useRef } from 'react';
+import { forwardRef, useCallback, useMemo } from 'react';
 import { View, ViewProps } from 'react-native';
 
-import {
-  GalleryBottomSheetModal,
-  GalleryBottomSheetModalType,
-} from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
-import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
 import { Options, Section } from '~/components/Select';
 import { Typography } from '~/components/Typography';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { ChainMetadata, isSupportedChainForCreators } from '~/shared/utils/chains';
-
-const SNAP_POINTS = ['CONTENT_HEIGHT'];
 
 const OWNER_OPTIONS: { label: string; id: 'Collected' | 'Created' }[] = [
   { id: 'Collected', label: 'Collected' },
@@ -37,20 +30,17 @@ type Props = {
 export type NetworkChoice = ChainMetadata['name'];
 export type NftSelectorSortView = 'Recently added' | 'Oldest' | 'Alphabetical';
 
-function NftSelectorFilterBottomSheet(
-  { ownerFilter, onOwnerFilterChange, sortView, onSortViewChange, selectedNetwork }: Props,
-  ref: ForwardedRef<GalleryBottomSheetModalType>
-) {
-  const { bottom } = useSafeAreaPadding();
-
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
-
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(SNAP_POINTS);
-
+function NftSelectorFilterBottomSheet({
+  ownerFilter,
+  onOwnerFilterChange,
+  sortView,
+  onSortViewChange,
+  selectedNetwork,
+}: Props) {
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
   const handleClose = useCallback(() => {
-    bottomSheetRef.current?.close();
-  }, []);
+    hideBottomSheetModal();
+  }, [hideBottomSheetModal]);
 
   const handleOwnerFilterChange = useCallback(
     (filter: 'Created' | 'Collected') => {
@@ -81,52 +71,33 @@ function NftSelectorFilterBottomSheet(
   }, [selectedNetwork]);
 
   return (
-    <GalleryBottomSheetModal
-      ref={(value) => {
-        bottomSheetRef.current = value;
-
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          ref.current = value;
-        }
-      }}
-      snapPoints={animatedSnapPoints}
-      handleHeight={animatedHandleHeight}
-      contentHeight={animatedContentHeight}
-    >
-      <View
-        onLayout={handleContentLayout}
-        style={{ paddingBottom: bottom }}
-        className="p-4 flex flex-col space-y-6"
-      >
-        <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }} className="text-lg">
-          Filters
-        </Typography>
-        <View className="flex flex-col space-y-4">
-          <FilterSection title="Type">
-            <Section>
-              <Options
-                onChange={handleOwnerFilterChange}
-                selected={ownerFilter}
-                options={decoratedOwnerOptions}
-                eventElementId="Owner filter"
-              />
-            </Section>
-          </FilterSection>
-          <FilterSection title="Sort by">
-            <Section>
-              <Options
-                onChange={handleSortViewChange}
-                selected={sortView}
-                options={SORT_VIEWS}
-                eventElementId="Sort by filter"
-              />
-            </Section>
-          </FilterSection>
-        </View>
+    <View className="flex flex-col space-y-6">
+      <Typography font={{ family: 'ABCDiatype', weight: 'Bold' }} className="text-lg">
+        Filters
+      </Typography>
+      <View className="flex flex-col space-y-4">
+        <FilterSection title="Type">
+          <Section>
+            <Options
+              onChange={handleOwnerFilterChange}
+              selected={ownerFilter}
+              options={decoratedOwnerOptions}
+              eventElementId="Owner filter"
+            />
+          </Section>
+        </FilterSection>
+        <FilterSection title="Sort by">
+          <Section>
+            <Options
+              onChange={handleSortViewChange}
+              selected={sortView}
+              options={SORT_VIEWS}
+              eventElementId="Sort by filter"
+            />
+          </Section>
+        </FilterSection>
       </View>
-    </GalleryBottomSheetModal>
+    </View>
   );
 }
 

--- a/apps/mobile/src/screens/PostScreen/PostComposerScreen.tsx
+++ b/apps/mobile/src/screens/PostScreen/PostComposerScreen.tsx
@@ -1,6 +1,6 @@
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import clsx from 'clsx';
-import { Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useMemo, useState } from 'react';
 import { Keyboard, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
@@ -9,16 +9,16 @@ import { useNavigateToCommunityScreen } from 'src/hooks/useNavigateToCommunitySc
 import { InfoCircleIcon } from 'src/icons/InfoCircleIcon';
 
 import { BackButton } from '~/components/BackButton';
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { GallerySkeleton } from '~/components/GallerySkeleton';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import { PostInput } from '~/components/Post/PostInput';
 import { PostMintLinkInput } from '~/components/Post/PostMintLinkInput';
 import { PostTokenPreview } from '~/components/Post/PostTokenPreview';
-import { WarningPostBottomSheet } from '~/components/Post/WarningPostBottomSheet';
+import WarningPostBottomSheet from '~/components/Post/WarningPostBottomSheet';
 import { SearchResultsFallback } from '~/components/Search/SearchResultFallback';
 import { SearchResults } from '~/components/Search/SearchResults';
 import { Typography } from '~/components/Typography';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { PostComposerScreenQuery } from '~/generated/PostComposerScreenQuery.graphql';
 import { PostComposerScreenTokenFragment$key } from '~/generated/PostComposerScreenTokenFragment.graphql';
 import {
@@ -125,7 +125,7 @@ function PostComposerScreenInner() {
     handleSelectionChange,
   } = useMentionableMessage();
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
+  const { showBottomSheetModal } = useBottomSheetModalActions();
   const handleBackPress = useCallback(() => {
     if (!message) {
       navigation.goBack();
@@ -133,8 +133,10 @@ function PostComposerScreenInner() {
     }
     Keyboard.dismiss();
 
-    bottomSheetRef.current?.present();
-  }, [message, navigation]);
+    showBottomSheetModal({
+      content: <WarningPostBottomSheet />,
+    });
+  }, [message, navigation, showBottomSheetModal]);
 
   const navigateToCommunity = useNavigateToCommunityScreen();
 
@@ -298,7 +300,6 @@ function PostComposerScreenInner() {
           )}
         </View>
       </View>
-      <WarningPostBottomSheet ref={bottomSheetRef} />
     </View>
   );
 }

--- a/apps/mobile/src/screens/SettingsProfileScreen.tsx
+++ b/apps/mobile/src/screens/SettingsProfileScreen.tsx
@@ -1,13 +1,13 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 import { BackButton } from '~/components/BackButton';
-import { GalleryBottomSheetModalType } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { Markdown } from '~/components/Markdown';
-import { PfpBottomSheet } from '~/components/PfpPicker/PfpBottomSheet';
+import PfpBottomSheet from '~/components/PfpPicker/PfpBottomSheet';
 import { ProfilePicture } from '~/components/ProfilePicture/ProfilePicture';
 import { Typography } from '~/components/Typography';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { useManageWalletActions } from '~/contexts/ManageWalletContext';
 import { SettingsProfileScreenQuery } from '~/generated/SettingsProfileScreenQuery.graphql';
 import colors from '~/shared/theme/colors';
@@ -38,22 +38,28 @@ export function SettingsProfileScreen() {
 
   const user = query.viewer?.user;
 
-  const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
   const { openManageWallet } = useManageWalletActions();
   const userHasWallet = query.viewer?.user?.primaryWallet?.__typename === 'Wallet';
+
+  const { showBottomSheetModal } = useBottomSheetModalActions();
+  const openPfpBottomSheet = useCallback(() => {
+    showBottomSheetModal({
+      content: <PfpBottomSheet queryRef={query} />,
+    });
+  }, [query, showBottomSheetModal]);
 
   const handlePress = useCallback(() => {
     if (!userHasWallet) {
       openManageWallet({
         onSuccess: () => {
-          bottomSheetRef.current?.present();
+          openPfpBottomSheet();
         },
       });
       return;
     }
 
-    bottomSheetRef.current?.present();
-  }, [openManageWallet, userHasWallet]);
+    openPfpBottomSheet();
+  }, [openManageWallet, openPfpBottomSheet, userHasWallet]);
 
   if (!user) {
     return null;
@@ -78,8 +84,6 @@ export function SettingsProfileScreen() {
 
         <View className="flex items-center justify-center px-4">
           <ProfilePicture userRef={user} size="xl" isEditable onPress={handlePress} />
-
-          <PfpBottomSheet ref={bottomSheetRef} queryRef={query} />
         </View>
 
         <View className="px-3 py-4 bg-offWhite dark:bg-black-800 flex flex-row justify-between mx-4">


### PR DESCRIPTION
### Summary of Changes

Migrate all usages of Bottom Sheets to use the BottomSheetModal Provider / Actions, so that we open bottom sheets using `showBottomSheetModal()`

We've wanted to use the bottom sheet modal provider for every bottom sheet to consolidate the bottom sheet logic but it was tech debt that we never needed to pay.

The motivation to do this now was to resolve a bug where the bottom sheet logic needed to make an exception if the user device had the reduced motion setting enabled. 


The other change is  to fix the specific bug for the reduced motion setting by disabling the animateOnMount prop on the bottom sheet if the setting is on.
`animateOnMount={!reducedMotion}`
https://github.com/gorhom/react-native-bottom-sheet/issues/1560

### Demo or Before/After Pics
too many changes to capture in pics

### Edge Cases
Need to test each bottom sheet

### Testing Steps
test every bottom sheet in the app



### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
