### PR TITLE
Kaito/bottom sheet regression

### DIFF
--- a/apps/mobile/src/components/Feed/AdmireBottomSheet/AdmireBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/AdmireBottomSheet/AdmireBottomSheet.tsx
@@ -25,16 +25,14 @@ type AdmireBottomSheetProps = {
 
 export function AdmireBottomSheet({ feedId, type }: AdmireBottomSheetProps) {
   return (
-    <View className="flex flex-1 flex-col space-y-5">
+    <View className="flex h-full">
       <Typography className="text-sm" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
         Admires
       </Typography>
 
-      <View className="flex-grow">
-        <Suspense fallback={<UserFollowListFallback />}>
-          <ConnectedAdmireList type={type} feedId={feedId} />
-        </Suspense>
-      </View>
+      <Suspense fallback={<UserFollowListFallback />}>
+        <ConnectedAdmireList type={type} feedId={feedId} />
+      </Suspense>
     </View>
   );
 }

--- a/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/CommentsBottomSheet/CommentsBottomSheet.tsx
@@ -160,7 +160,7 @@ export function CommentsBottomSheet({
   }, [resetMentions]);
 
   return (
-    <Animated.View style={paddingStyle} className="flex flex-1 flex-col space-y-5 min-h-[400px]">
+    <Animated.View style={paddingStyle} className="flex flex-grow flex-col space-y-5 min-h-[400px]">
       <View className="flex-grow">
         {isSelectingMentions ? (
           <View className="flex-1 overflow-hidden">

--- a/apps/mobile/src/components/Feed/Posts/FeedPostSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Posts/FeedPostSocializeSection.tsx
@@ -1,4 +1,4 @@
-import { RouteProp, useRoute } from '@react-navigation/native';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { useCallback, useEffect, useMemo } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
@@ -7,7 +7,7 @@ import { useTogglePostAdmire } from 'src/hooks/useTogglePostAdmire';
 import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { FeedPostSocializeSectionFragment$key } from '~/generated/FeedPostSocializeSectionFragment.graphql';
 import { FeedPostSocializeSectionQueryFragment$key } from '~/generated/FeedPostSocializeSectionQueryFragment.graphql';
-import { MainTabStackNavigatorParamList } from '~/navigation/types';
+import { MainTabStackNavigatorParamList, MainTabStackNavigatorProp } from '~/navigation/types';
 
 import { CommentsBottomSheet } from '../CommentsBottomSheet/CommentsBottomSheet';
 import { AdmireButton } from '../Socialize/AdmireButton';
@@ -106,7 +106,7 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef }: Props) {
   }, [post.admires?.edges]);
 
   const totalAdmires = post.admires?.pageInfo?.total ?? 0;
-
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
   const { showBottomSheetModal } = useBottomSheetModalActions();
   const handleOpenCommentBottomSheet = useCallback(() => {
     showBottomSheetModal({
@@ -119,8 +119,15 @@ export function FeedPostSocializeSection({ feedPostRef, queryRef }: Props) {
         />
       ),
       noPadding: true,
+      navigationContext: navigation,
     });
-  }, [post.dbid, route.params?.commentId, route.params?.replyToComment, showBottomSheetModal]);
+  }, [
+    navigation,
+    post.dbid,
+    route.params?.commentId,
+    route.params?.replyToComment,
+    showBottomSheetModal,
+  ]);
 
   useEffect(() => {
     if (route.params?.commentId) {

--- a/apps/mobile/src/components/Feed/Posts/PostBottomSheet.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostBottomSheet.tsx
@@ -132,9 +132,8 @@ function PostBottomSheet({ isOwnPost, postRef, queryRef, userRef, onShare }: Pro
   const { hideBottomSheetModal } = useBottomSheetModalActions();
 
   const handleShare = useCallback(() => {
-    hideBottomSheetModal();
     onShare();
-  }, [hideBottomSheetModal, onShare]);
+  }, [onShare]);
 
   const [showReportPostForm, setShowReportPostForm] = useState(false);
 

--- a/apps/mobile/src/components/Feed/Posts/PostListSectionHeader.tsx
+++ b/apps/mobile/src/components/Feed/Posts/PostListSectionHeader.tsx
@@ -116,8 +116,9 @@ export function PostListSectionHeader({ feedPostRef, queryRef }: PostListSection
           onShare={handleSharePost}
         />
       ),
+      navigationContext: navigation,
     });
-  }, [feedPost, handleSharePost, isOwnPost, query, showBottomSheetModal]);
+  }, [feedPost, handleSharePost, isOwnPost, navigation, query, showBottomSheetModal]);
 
   const handleUsernamePress = useCallback(() => {
     if (feedPost.author?.username) {

--- a/apps/mobile/src/components/Feed/Socialize/Admires.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/Admires.tsx
@@ -10,6 +10,7 @@ import { AdmiresFragment$key } from '~/generated/AdmiresFragment.graphql';
 import { contexts } from '~/shared/analytics/constants';
 
 import { FeedItemTypes } from '../createVirtualizedFeedEventItems';
+import { useNavigation } from '@react-navigation/native';
 
 type Props = {
   type: FeedItemTypes;

--- a/apps/mobile/src/components/Feed/Socialize/Admires.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/Admires.tsx
@@ -10,7 +10,6 @@ import { AdmiresFragment$key } from '~/generated/AdmiresFragment.graphql';
 import { contexts } from '~/shared/analytics/constants';
 
 import { FeedItemTypes } from '../createVirtualizedFeedEventItems';
-import { useNavigation } from '@react-navigation/native';
 
 type Props = {
   type: FeedItemTypes;

--- a/apps/mobile/src/components/Feed/Socialize/Admires.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/Admires.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from '@react-navigation/native';
 import { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
@@ -7,6 +8,7 @@ import { AdmireLine } from '~/components/Feed/Socialize/AdmireLine';
 import { ProfilePictureBubblesWithCount } from '~/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers';
 import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { AdmiresFragment$key } from '~/generated/AdmiresFragment.graphql';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 
 import { FeedItemTypes } from '../createVirtualizedFeedEventItems';
@@ -35,11 +37,13 @@ export function Admires({ type, feedId, admireRefs, totalAdmires, onAdmirePress 
 
   const { showBottomSheetModal } = useBottomSheetModalActions();
 
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
   const handleSeeAllAdmires = useCallback(() => {
     showBottomSheetModal({
       content: <AdmireBottomSheet type={type} feedId={feedId} />,
+      navigationContext: navigation,
     });
-  }, [feedId, showBottomSheetModal, type]);
+  }, [feedId, navigation, showBottomSheetModal, type]);
 
   const admireUsers = useMemo(() => {
     const users = [];

--- a/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
+++ b/apps/mobile/src/components/Feed/Socialize/FeedEventSocializeSection.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from '@react-navigation/native';
 import { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
@@ -6,6 +7,7 @@ import { useToggleAdmire } from 'src/hooks/useToggleAdmire';
 import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { FeedEventSocializeSectionFragment$key } from '~/generated/FeedEventSocializeSectionFragment.graphql';
 import { FeedEventSocializeSectionQueryFragment$key } from '~/generated/FeedEventSocializeSectionQueryFragment.graphql';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
 
 import { CommentsBottomSheet } from '../CommentsBottomSheet/CommentsBottomSheet';
 import { AdmireButton } from './AdmireButton';
@@ -106,14 +108,15 @@ export function FeedEventSocializeSection({ feedEventRef, queryRef, onCommentPre
   }, [event.admires?.edges]);
 
   const totalAdmires = event.admires?.pageInfo?.total ?? 0;
-
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
   const { showBottomSheetModal } = useBottomSheetModalActions();
   const handleOpenCommentBottomSheet = useCallback(() => {
     showBottomSheetModal({
       content: <CommentsBottomSheet type="FeedEvent" feedId={event.dbid} />,
+      navigationContext: navigation,
     });
     onCommentPress();
-  }, [event.dbid, onCommentPress, showBottomSheetModal]);
+  }, [event.dbid, navigation, onCommentPress, showBottomSheetModal]);
 
   if (event.eventData?.__typename === 'UserFollowedUsersFeedEventData') {
     return <View className="pb-6" />;

--- a/apps/mobile/src/components/FeedbackBottomSheetModal.tsx
+++ b/apps/mobile/src/components/FeedbackBottomSheetModal.tsx
@@ -15,7 +15,7 @@ export default function FeedbackBottomSheetModal() {
   }, []);
 
   return (
-    <View className="flex flex-column space-y-2 mx-4">
+    <View className="flex flex-column space-y-2">
       <Typography className="text-xl" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
         Got Feedback?
       </Typography>

--- a/apps/mobile/src/components/GalleryBottomSheet/GalleryBottomSheetBackground.tsx
+++ b/apps/mobile/src/components/GalleryBottomSheet/GalleryBottomSheetBackground.tsx
@@ -2,5 +2,5 @@ import { BottomSheetBackgroundProps } from '@gorhom/bottom-sheet';
 import { View } from 'react-native';
 
 export function GalleryBottomSheetBackground(props: BottomSheetBackgroundProps) {
-  return <View className="bg-white dark:bg-black-900" {...props}></View>;
+  return <View className="bg-white dark:bg-black-900 border border-blue" {...props}></View>;
 }

--- a/apps/mobile/src/components/GalleryBottomSheet/GalleryBottomSheetBackground.tsx
+++ b/apps/mobile/src/components/GalleryBottomSheet/GalleryBottomSheetBackground.tsx
@@ -2,5 +2,5 @@ import { BottomSheetBackgroundProps } from '@gorhom/bottom-sheet';
 import { View } from 'react-native';
 
 export function GalleryBottomSheetBackground(props: BottomSheetBackgroundProps) {
-  return <View className="bg-white dark:bg-black-900 border border-blue" {...props}></View>;
+  return <View className="bg-white dark:bg-black-900" {...props}></View>;
 }

--- a/apps/mobile/src/components/GalleryBottomSheet/GalleryBottomSheetModal.tsx
+++ b/apps/mobile/src/components/GalleryBottomSheet/GalleryBottomSheetModal.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import { ANIMATION_CONFIGS, BottomSheetModal, BottomSheetModalProps } from '@gorhom/bottom-sheet';
-import { NavigationContext, useNavigation } from '@react-navigation/native';
+import { NavigationContext } from '@react-navigation/native';
 import { ForwardedRef, forwardRef, useEffect, useRef } from 'react';
 import { Keyboard, Platform } from 'react-native';
 import { ReduceMotion, SharedValue } from 'react-native-reanimated';
@@ -8,16 +8,13 @@ import { ReduceMotion, SharedValue } from 'react-native-reanimated';
 import { GalleryBottomSheetBackdrop } from '~/components/GalleryBottomSheet/GalleryBottomSheetBackdrop';
 import { GalleryBottomSheetBackground } from '~/components/GalleryBottomSheet/GalleryBottomSheetBackground';
 import { GalleryBottomSheetHandle } from '~/components/GalleryBottomSheet/GalleryBottomSheetHandle';
-import {
-  BottomSheetModalActionsContext,
-  useBottomSheetModalActions,
-} from '~/contexts/BottomSheetModalContext';
 import SyncTokensProvider from '~/contexts/SyncTokensContext';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
 
 export type GalleryBottomSheetModalType = BottomSheetModal;
 
 type GalleryBottomSheetModalProps = {
-  navigationContext?: any;
+  navigationContext?: MainTabStackNavigatorProp;
   children: React.ReactNode;
   snapPoints:
     | Readonly<{ value: (string | number)[] }>
@@ -31,30 +28,28 @@ function GalleryBottomSheetModal(
 ) {
   const { snapPoints, backdropComponent, ...rest } = props;
 
-  // const navigation = useNavigation();
-
   const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
-  // useEffect(
-  //   function closeBottomSheetWhenNavigating() {
-  //     const removeListener = navigation.addListener('blur', () => {
-  //       Keyboard.dismiss();
-  //       bottomSheetRef.current?.dismiss();
-  //     });
+  useEffect(
+    function closeBottomSheetWhenNavigating() {
+      if (!navigationContext) {
+        return;
+      }
 
-  //     return removeListener;
-  //   },
-  //   [navigation]
-  // );
+      const removeListener = navigationContext.addListener('blur', () => {
+        Keyboard.dismiss();
+        bottomSheetRef.current?.dismiss();
+      });
 
-  console.log({ navigationContext });
+      return removeListener;
+    },
+    [navigationContext]
+  );
 
   const androidAnimationConfigs = {
     ...ANIMATION_CONFIGS,
     reduceMotion: ReduceMotion.Never,
   };
-
-  const bottomSheetModalActions = useBottomSheetModalActions();
 
   return (
     <BottomSheetModal
@@ -80,12 +75,10 @@ function GalleryBottomSheetModal(
       {/* all of the context that its parent did. We may need to do more of this in the future */}
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
       <NavigationContext.Provider value={navigationContext as any}>
-        <BottomSheetModalActionsContext.Provider value={bottomSheetModalActions}>
-          <SyncTokensProvider>
-            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-            {children as any}
-          </SyncTokensProvider>
-        </BottomSheetModalActionsContext.Provider>
+        <SyncTokensProvider>
+          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+          {children as any}
+        </SyncTokensProvider>
       </NavigationContext.Provider>
     </BottomSheetModal>
   );

--- a/apps/mobile/src/components/GalleryBottomSheet/GalleryBottomSheetModal.tsx
+++ b/apps/mobile/src/components/GalleryBottomSheet/GalleryBottomSheetModal.tsx
@@ -17,6 +17,7 @@ import SyncTokensProvider from '~/contexts/SyncTokensContext';
 export type GalleryBottomSheetModalType = BottomSheetModal;
 
 type GalleryBottomSheetModalProps = {
+  navigationContext?: any;
   children: React.ReactNode;
   snapPoints:
     | Readonly<{ value: (string | number)[] }>
@@ -25,26 +26,28 @@ type GalleryBottomSheetModalProps = {
 } & Omit<BottomSheetModalProps, 'snapPoints'>;
 
 function GalleryBottomSheetModal(
-  { children, ...props }: GalleryBottomSheetModalProps,
+  { navigationContext, children, ...props }: GalleryBottomSheetModalProps,
   ref: ForwardedRef<GalleryBottomSheetModalType>
 ) {
   const { snapPoints, backdropComponent, ...rest } = props;
 
-  const navigation = useNavigation();
+  // const navigation = useNavigation();
 
   const bottomSheetRef = useRef<GalleryBottomSheetModalType | null>(null);
 
-  useEffect(
-    function closeBottomSheetWhenNavigating() {
-      const removeListener = navigation.addListener('blur', () => {
-        Keyboard.dismiss();
-        bottomSheetRef.current?.dismiss();
-      });
+  // useEffect(
+  //   function closeBottomSheetWhenNavigating() {
+  //     const removeListener = navigation.addListener('blur', () => {
+  //       Keyboard.dismiss();
+  //       bottomSheetRef.current?.dismiss();
+  //     });
 
-      return removeListener;
-    },
-    [navigation]
-  );
+  //     return removeListener;
+  //   },
+  //   [navigation]
+  // );
+
+  console.log({ navigationContext });
 
   const androidAnimationConfigs = {
     ...ANIMATION_CONFIGS,
@@ -76,7 +79,7 @@ function GalleryBottomSheetModal(
       {/* Pass the parent's navigation down to this bottom sheet so it has */}
       {/* all of the context that its parent did. We may need to do more of this in the future */}
       {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <NavigationContext.Provider value={navigation as any}>
+      <NavigationContext.Provider value={navigationContext as any}>
         <BottomSheetModalActionsContext.Provider value={bottomSheetModalActions}>
           <SyncTokensProvider>
             {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}

--- a/apps/mobile/src/components/Notification/NotificationBottomSheetUserList.tsx
+++ b/apps/mobile/src/components/Notification/NotificationBottomSheetUserList.tsx
@@ -103,7 +103,7 @@ function NotificationBottomSheetUserListInner({
   }
 
   return (
-    <View className="flex-1 bg-white dark:bg-black-900 min-h-[180px]">
+    <View className="flex h-full bg-white dark:bg-black-900 min-h-[180px]">
       <UserFollowList userRefs={users} queryRef={query} onUserPress={onUserPress} />
     </View>
   );

--- a/apps/mobile/src/components/ProfileView/ProfileView.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileView.tsx
@@ -257,31 +257,21 @@ export function ProfileViewUsername({ queryRef, style }: ProfileViewUsernameProp
     });
   }, [query.userByUsername?.badges]);
 
-  const [selectedBadge, setSelectedBadge] = useState<{
-    name: string;
-    description: string;
-  } | null>(null);
-
   const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
 
   const handlePress = useCallback(
     (badgeName: string) => {
-      setSelectedBadge({
-        name: badgeName,
-        description: BADGE_DESCRIPTIONS[badgeName] ?? '',
-      });
-
       showBottomSheetModal({
         content: (
           <BadgeProfileBottomSheet
             onClose={hideBottomSheetModal}
-            title={selectedBadge?.name ?? ''}
-            description={selectedBadge?.description ?? ''}
+            title={badgeName}
+            description={BADGE_DESCRIPTIONS[badgeName] ?? ''}
           />
         ),
       });
     },
-    [hideBottomSheetModal, selectedBadge?.description, selectedBadge?.name, showBottomSheetModal]
+    [hideBottomSheetModal, showBottomSheetModal]
   );
 
   return (

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
@@ -14,6 +14,7 @@ import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { ProfileViewSharedCommunitiesBubblesFragment$key } from '~/generated/ProfileViewSharedCommunitiesBubblesFragment.graphql';
 import { ProfileViewSharedCommunitiesFragment$key } from '~/generated/ProfileViewSharedCommunitiesFragment.graphql';
 import { ProfileViewSharedCommunitiesHoldsTextFragment$key } from '~/generated/ProfileViewSharedCommunitiesHoldsTextFragment.graphql';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
 import { contexts } from '~/shared/analytics/constants';
 import { GalleryElementTrackingProps } from '~/shared/contexts/AnalyticsContext';
 import { removeNullValues } from '~/shared/relay/removeNullValues';
@@ -60,7 +61,7 @@ export default function ProfileViewSharedCommunities({ userRef }: Props) {
   const totalSharedCommunities = user.sharedCommunities?.pageInfo?.total ?? 0;
 
   const { showBottomSheetModal } = useBottomSheetModalActions();
-  const navigation = useNavigation();
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
 
   const handleSeeAllPress = useCallback(() => {
     showBottomSheetModal({

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunities.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from '@react-navigation/native';
 import clsx from 'clsx';
 import { useColorScheme } from 'nativewind';
 import React, { useCallback, useMemo } from 'react';
@@ -59,12 +60,14 @@ export default function ProfileViewSharedCommunities({ userRef }: Props) {
   const totalSharedCommunities = user.sharedCommunities?.pageInfo?.total ?? 0;
 
   const { showBottomSheetModal } = useBottomSheetModalActions();
+  const navigation = useNavigation();
 
   const handleSeeAllPress = useCallback(() => {
     showBottomSheetModal({
       content: <ProfileViewSharedCommunitiesSheet userRef={user} />,
+      navigationContext: navigation,
     });
-  }, [showBottomSheetModal, user]);
+  }, [navigation, showBottomSheetModal, user]);
 
   if (totalSharedCommunities === 0) {
     return null;

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunitiesSheet.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedCommunitiesSheet.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { Dimensions, View } from 'react-native';
+import { View } from 'react-native';
 import { graphql, usePaginationFragment } from 'react-relay';
 
 import { CommunityList } from '~/components/CommunitiesList/CommunityList';
@@ -56,24 +56,20 @@ export default function ProfileViewSharedCommunitiesSheet(props: Props) {
     }
   }, [hasNext, loadNext]);
 
-  const screenHeight = Dimensions.get('window').height;
-
   return (
-    <View className="flex bg-white dark:bg-black-900">
-      <View className={`max-h-[${screenHeight * 0.5}px]`}>
-        <Typography
-          className="text-sm mb-4  flex flex-row items-center "
-          font={{
-            family: 'ABCDiatype',
-            weight: 'Bold',
-          }}
-        >
-          Items you both own
-        </Typography>
+    <View className="flex pb-8">
+      <Typography
+        className="text-sm mb-4 flex flex-row items-center "
+        font={{
+          family: 'ABCDiatype',
+          weight: 'Bold',
+        }}
+      >
+        Items you both own
+      </Typography>
 
-        <View className="flex-grow h-full">
-          <CommunityList onLoadMore={loadMore} communityRefs={nonNullCommunities} />
-        </View>
+      <View className="flex-grow h-full">
+        <CommunityList onLoadMore={loadMore} communityRefs={nonNullCommunities} />
       </View>
     </View>
   );

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowers.tsx
@@ -62,12 +62,14 @@ export default function ProfileViewSharedFollowers({ userRef }: Props) {
   const totalSharedFollowers = user.sharedFollowers?.pageInfo?.total ?? 0;
 
   const { showBottomSheetModal } = useBottomSheetModalActions();
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
 
   const handleSeeAllPress = useCallback(() => {
     showBottomSheetModal({
       content: <ProfileViewSharedFollowersSheet userRef={user} />,
+      navigationContext: navigation,
     });
-  }, [showBottomSheetModal, user]);
+  }, [navigation, showBottomSheetModal, user]);
 
   if (totalSharedFollowers === 0) {
     return null;

--- a/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowersSheet.tsx
+++ b/apps/mobile/src/components/ProfileView/ProfileViewSharedInfo/ProfileViewSharedFollowersSheet.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import { useCallback, useMemo } from 'react';
-import { Dimensions, View } from 'react-native';
+import { View } from 'react-native';
 import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
 
 import { Typography } from '~/components/Typography';
@@ -43,8 +43,6 @@ export default function ProfileViewSharedFollowersSheet(props: Props) {
     {}
   );
 
-  const screenHeight = Dimensions.get('window').height;
-
   const nonNullUsers = useMemo(() => {
     const users = [];
 
@@ -73,26 +71,24 @@ export default function ProfileViewSharedFollowersSheet(props: Props) {
   );
 
   return (
-    <View className="flex bg-white dark:bg-black-900">
-      <View className={`max-h-[${screenHeight * 0.5}px]`}>
-        <Typography
-          className="text-sm mb-4"
-          font={{
-            family: 'ABCDiatype',
-            weight: 'Bold',
-          }}
-        >
-          Followers
-        </Typography>
+    <View className="flex pb-8">
+      <Typography
+        className="text-sm mb-4"
+        font={{
+          family: 'ABCDiatype',
+          weight: 'Bold',
+        }}
+      >
+        Followers
+      </Typography>
 
-        <View className="flex-grow h-full">
-          <UserFollowList
-            onUserPress={handleUserPress}
-            onLoadMore={handleLoadMore}
-            userRefs={nonNullUsers}
-            queryRef={query}
-          />
-        </View>
+      <View className="flex-grow h-full">
+        <UserFollowList
+          onUserPress={handleUserPress}
+          onLoadMore={handleLoadMore}
+          userRefs={nonNullUsers}
+          queryRef={query}
+        />
       </View>
     </View>
   );

--- a/apps/mobile/src/contexts/BottomSheetModalContext.tsx
+++ b/apps/mobile/src/contexts/BottomSheetModalContext.tsx
@@ -1,6 +1,5 @@
 import { useBottomSheetDynamicSnapPoints } from '@gorhom/bottom-sheet';
 import { BottomSheetModalProvider as GorhomBottomSheetModalProvider } from '@gorhom/bottom-sheet';
-import { Portal } from '@gorhom/portal';
 import clsx from 'clsx';
 import { BlurView } from 'expo-blur';
 import React, {
@@ -21,6 +20,7 @@ import {
   GalleryBottomSheetModalType,
 } from '~/components/GalleryBottomSheet/GalleryBottomSheetModal';
 import { useSafeAreaPadding } from '~/components/SafeAreaViewWithPadding';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
 
 const SNAP_POINTS = ['CONTENT_HEIGHT']; // Example snap points, adjust based on your needs
 
@@ -63,7 +63,7 @@ type BottomSheetModal = {
   noPadding?: boolean;
   onDismiss?: () => void;
   blurBackground?: boolean;
-  navigationContext?: any;
+  navigationContext?: MainTabStackNavigatorProp;
 };
 
 function BottomSheetModalProvider({ children }: BottomSheetModalProviderProps) {
@@ -84,8 +84,7 @@ function BottomSheetModalProvider({ children }: BottomSheetModalProviderProps) {
     if (bottomSheetModal?.onDismiss) {
       bottomSheetModal.onDismiss();
     }
-    hideBottomSheetModal();
-  }, [bottomSheetModal, hideBottomSheetModal]);
+  }, [bottomSheetModal]);
 
   const { bottom } = useSafeAreaPadding(); // Use this for handling safe area, if necessary
 
@@ -111,9 +110,9 @@ function BottomSheetModalProvider({ children }: BottomSheetModalProviderProps) {
 
   return (
     <BottomSheetModalActionsContext.Provider value={actions}>
+      {children}
       <GorhomBottomSheetModalProvider>
-        {children}
-        <Portal hostName="bottomSheetPortal">
+        {bottomSheetModal && (
           <GalleryBottomSheetModal
             snapPoints={animatedSnapPoints}
             handleHeight={animatedHandleHeight}
@@ -127,20 +126,15 @@ function BottomSheetModalProvider({ children }: BottomSheetModalProviderProps) {
             backdropComponent={bottomSheetModal?.blurBackground ? BluredBackdrop : null}
             navigationContext={bottomSheetModal?.navigationContext}
           >
-            {bottomSheetModal && (
-              <View
-                onLayout={handleContentLayout}
-                style={{ paddingBottom: !bottomSheetModal.noPadding ? bottom : 0 }}
-                className={clsx(
-                  'flex flex-col space-y-6',
-                  !bottomSheetModal.noPadding && 'px-4 py-2'
-                )}
-              >
-                {bottomSheetModal.content}
-              </View>
-            )}
+            <View
+              onLayout={handleContentLayout}
+              style={{ paddingBottom: !bottomSheetModal.noPadding ? bottom : 0, maxHeight: 700 }}
+              className={clsx('flex ', !bottomSheetModal.noPadding && 'px-4 py-2')}
+            >
+              {bottomSheetModal.content}
+            </View>
           </GalleryBottomSheetModal>
-        </Portal>
+        )}
       </GorhomBottomSheetModalProvider>
     </BottomSheetModalActionsContext.Provider>
   );

--- a/apps/mobile/src/contexts/BottomSheetModalContext.tsx
+++ b/apps/mobile/src/contexts/BottomSheetModalContext.tsx
@@ -63,6 +63,7 @@ type BottomSheetModal = {
   noPadding?: boolean;
   onDismiss?: () => void;
   blurBackground?: boolean;
+  // If we want to use navigation in the bottom sheet, we need to pass in the navigation context from where the bottom sheet is being opened from.
   navigationContext?: MainTabStackNavigatorProp;
 };
 

--- a/apps/mobile/src/navigation/RootStackNavigator.tsx
+++ b/apps/mobile/src/navigation/RootStackNavigator.tsx
@@ -9,7 +9,6 @@ import { useMaintenanceContext } from 'shared/contexts/MaintenanceStatusContext'
 import { ClaimMintUpsellBanner } from '~/components/ClaimMintUpsellBanner';
 import { ConnectWalletUpsellBanner } from '~/components/ConnectWalletUpsellBanner';
 import { MaintenanceNoticeBottomSheetWrapper } from '~/components/MaintenanceScreen';
-import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { RootStackNavigatorFragment$key } from '~/generated/RootStackNavigatorFragment.graphql';
 import { RootStackNavigatorQuery } from '~/generated/RootStackNavigatorQuery.graphql';
 import { LoginStackNavigator } from '~/navigation/LoginStackNavigator';
@@ -61,8 +60,6 @@ export function RootStackNavigator({ navigationContainerRef }: Props) {
     return unsubscribe;
   }, [navigationContainerRef, track]);
 
-  const { hideBottomSheetModal } = useBottomSheetModalActions();
-
   return (
     <>
       {upcomingMaintenanceNoticeContent?.isActive && (
@@ -71,15 +68,6 @@ export function RootStackNavigator({ navigationContainerRef }: Props) {
       <Stack.Navigator
         screenOptions={{ header: Empty }}
         initialRouteName={isLoggedIn ? 'MainTabs' : 'Login'}
-        screenListeners={{
-          state: (e) => {
-            // Do something with the state
-            // if (isBottomSheetModalVisible) {
-            hideBottomSheetModal();
-            // }
-            console.log('state changed', e.data);
-          },
-        }}
       >
         <Stack.Screen name="Login" component={LoginStackNavigator} />
 
@@ -113,7 +101,7 @@ export function RootStackNavigator({ navigationContainerRef }: Props) {
         <Stack.Screen name="DesignSystemButtons" component={DesignSystemButtonsScreen} />
         <Stack.Screen name="Debugger" component={Debugger} />
       </Stack.Navigator>
-      <View className="flex border border-red">
+      <View className="flex">
         <PortalHost name="bottomSheetPortal" />
       </View>
     </>

--- a/apps/mobile/src/navigation/RootStackNavigator.tsx
+++ b/apps/mobile/src/navigation/RootStackNavigator.tsx
@@ -1,3 +1,4 @@
+import { PortalHost } from '@gorhom/portal';
 import { NavigationContainerRefWithCurrent } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Suspense, useEffect } from 'react';
@@ -8,6 +9,7 @@ import { useMaintenanceContext } from 'shared/contexts/MaintenanceStatusContext'
 import { ClaimMintUpsellBanner } from '~/components/ClaimMintUpsellBanner';
 import { ConnectWalletUpsellBanner } from '~/components/ConnectWalletUpsellBanner';
 import { MaintenanceNoticeBottomSheetWrapper } from '~/components/MaintenanceScreen';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { RootStackNavigatorFragment$key } from '~/generated/RootStackNavigatorFragment.graphql';
 import { RootStackNavigatorQuery } from '~/generated/RootStackNavigatorQuery.graphql';
 import { LoginStackNavigator } from '~/navigation/LoginStackNavigator';
@@ -59,6 +61,8 @@ export function RootStackNavigator({ navigationContainerRef }: Props) {
     return unsubscribe;
   }, [navigationContainerRef, track]);
 
+  const { hideBottomSheetModal } = useBottomSheetModalActions();
+
   return (
     <>
       {upcomingMaintenanceNoticeContent?.isActive && (
@@ -67,6 +71,15 @@ export function RootStackNavigator({ navigationContainerRef }: Props) {
       <Stack.Navigator
         screenOptions={{ header: Empty }}
         initialRouteName={isLoggedIn ? 'MainTabs' : 'Login'}
+        screenListeners={{
+          state: (e) => {
+            // Do something with the state
+            // if (isBottomSheetModalVisible) {
+            hideBottomSheetModal();
+            // }
+            console.log('state changed', e.data);
+          },
+        }}
       >
         <Stack.Screen name="Login" component={LoginStackNavigator} />
 
@@ -100,6 +113,9 @@ export function RootStackNavigator({ navigationContainerRef }: Props) {
         <Stack.Screen name="DesignSystemButtons" component={DesignSystemButtonsScreen} />
         <Stack.Screen name="Debugger" component={Debugger} />
       </Stack.Navigator>
+      <View className="flex border border-red">
+        <PortalHost name="bottomSheetPortal" />
+      </View>
     </>
   );
 }

--- a/apps/mobile/src/screens/HomeScreen/UserSuggestionListScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen/UserSuggestionListScreen.tsx
@@ -65,7 +65,7 @@ export function InnerUserSuggestionListScreen({ queryRef }: Props) {
   );
 
   return (
-    <View className="flex flex-1 flex-col">
+    <View className="flex flex-1 flex-col m-4">
       <Typography
         font={{
           family: 'ABCDiatype',

--- a/apps/mobile/src/screens/NftDetailScreen/AdmireBottomSheet.tsx
+++ b/apps/mobile/src/screens/NftDetailScreen/AdmireBottomSheet.tsx
@@ -19,16 +19,14 @@ type AdmireBottomSheetProps = {
 
 export function AdmireBottomSheet({ tokenId }: AdmireBottomSheetProps) {
   return (
-    <View className="flex flex-1 flex-col space-y-5">
+    <View className="flex h-full">
       <Typography className="text-sm px-4" font={{ family: 'ABCDiatype', weight: 'Bold' }}>
         Admires
       </Typography>
 
-      <View className="flex-grow">
-        <Suspense fallback={<UserFollowListFallback />}>
-          <ConnectedTokenAdmireList tokenId={tokenId} />
-        </Suspense>
-      </View>
+      <Suspense fallback={<UserFollowListFallback />}>
+        <ConnectedTokenAdmireList tokenId={tokenId} />
+      </Suspense>
     </View>
   );
 }
@@ -98,11 +96,13 @@ export function ConnectedTokenAdmireList({ tokenId }: { tokenId: string }) {
   );
 
   return (
+    // <View className="flex-grow h-full">
     <UserFollowList
       onLoadMore={handleLoadMore}
       userRefs={admirers}
       queryRef={query}
       onUserPress={handleUserPress}
     />
+    // </View>
   );
 }


### PR DESCRIPTION
### Summary of Changes

Fixed regression where using navigation.push inside Bottom Sheets crashes the app.
also fixed regressions and issues with certain bottom sheets not opening, or having wrong heights.

### Demo or Before/After Pics

https://github.com/gallery-so/gallery/assets/80802871/5ec9afbc-ef6e-4c55-a3d6-28fb10a4847b



### Edge Cases
- every bottom sheet

### Testing Steps
- Go to a bottom sheet that has a list of users (ie shared followers list on user profile, or admires on a post) 
- Tap on a username in the bottom sheet list
- you should be navigated to the user profile, without the app crashing


- Test other bottom sheets in the app to ensure they open as expected

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
