### PR TITLE
profile screen skeleton loader

### DIFF
--- a/apps/web/pages/[username]/index.tsx
+++ b/apps/web/pages/[username]/index.tsx
@@ -1,12 +1,13 @@
 import { GetServerSideProps } from 'next';
 import { route } from 'nextjs-routes';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, Suspense } from 'react';
 import { loadQuery, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { graphql } from 'relay-runtime';
 import styled from 'styled-components';
 
 import breakpoints, { pageGutter } from '~/components/core/breakpoints';
 import useVerifyEmailOnPage from '~/components/Email/useVerifyEmailOnPage';
+import { ProfileScreenLoadingSkeleton } from '~/components/Profile/ProfileScreenLoadingSkeleton';
 import { GalleryNavbar } from '~/contexts/globalLayout/GlobalNavbar/GalleryNavbar/GalleryNavbar';
 import { useGlobalNavbarHeight } from '~/contexts/globalLayout/GlobalNavbar/useGlobalNavbarHeight';
 import { StandardSidebar } from '~/contexts/globalLayout/GlobalSidebar/StandardSidebar';
@@ -85,6 +86,14 @@ type UserGalleryProps = MetaTagProps & {
 };
 
 export default function UserGallery({ username, preloadedQuery }: UserGalleryProps) {
+  return (
+    <Suspense key={username} fallback={<ProfileScreenLoadingSkeleton />}>
+      <UserGalleryInner username={username} preloadedQuery={preloadedQuery} />
+    </Suspense>
+  );
+}
+
+function UserGalleryInner({ username, preloadedQuery }: UserGalleryProps) {
   const query = usePreloadedQuery<UsernameQuery>(UsernameQueryNode, preloadedQuery);
 
   useVerifyEmailOnPage(query);

--- a/apps/web/src/components/MultiShimmer/MultiShimmer.tsx
+++ b/apps/web/src/components/MultiShimmer/MultiShimmer.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  margin-bottom: 60px;
+  width: 100%;
+`;
+
+const ArtworksGridSkeleton = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-gap: 32px;
+  margin-top: 16px;
+`;
+
+const ArtworkGridItemSkeleton = styled(Skeleton)`
+  height: 300px;
+`;
+
+const SkeletoState = () => {
+  return (
+    <Wrapper>
+      <ArtworksGridSkeleton>
+        {[...Array(12)].map((_, index) => (
+          <ArtworkGridItemSkeleton key={index} />
+        ))}
+      </ArtworksGridSkeleton>
+    </Wrapper>
+  );
+};
+
+export function MultiShimmer() {
+  return <SkeletoState />;
+}

--- a/apps/web/src/components/MultiShimmer/MultiShimmer.tsx
+++ b/apps/web/src/components/MultiShimmer/MultiShimmer.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Skeleton from 'react-loading-skeleton';
 import styled from 'styled-components';
 
+import { size } from '../core/breakpoints';
+
 const Wrapper = styled.div`
   margin-bottom: 60px;
   width: 100%;
@@ -10,8 +12,13 @@ const Wrapper = styled.div`
 const ArtworksGridSkeleton = styled.div`
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-gap: 32px;
+  grid-gap: 16px;
   margin-top: 16px;
+
+  @media (max-width: ${size.tablet}px) {
+    // Adjusts to a mobile viewport
+    grid-template-columns: repeat(1, 1fr);
+  }
 `;
 
 const ArtworkGridItemSkeleton = styled(Skeleton)`

--- a/apps/web/src/components/Profile/ProfileScreenLoadingSkeleton.tsx
+++ b/apps/web/src/components/Profile/ProfileScreenLoadingSkeleton.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import Skeleton from 'react-loading-skeleton';
-import colors from 'shared/theme/colors';
 import styled from 'styled-components';
 
 import { GalleryPageSpacing } from '~/pages/[username]';
 
-import breakpoints from '../core/breakpoints';
 import { VStack } from '../core/Spacer/Stack';
 
 const GallerySkeletonWrapper = styled.div`
@@ -15,6 +13,7 @@ const GallerySkeletonWrapper = styled.div`
 
 const Wrapper = styled.div`
   padding-left: 20px;
+  margin-bottom: 60px;
 `;
 
 const TitleSkeleton = styled(Skeleton)`
@@ -52,18 +51,6 @@ const ArtworkGridItemSkeleton = styled(Skeleton)`
   height: 300px;
 `;
 
-const Divider = styled.div`
-  width: 100%;
-  height: 1px;
-  background-color: ${colors.porcelain};
-  display: none;
-  margin-top: 60px;
-
-  @media only screen and ${breakpoints.desktop} {
-    display: block;
-  }
-`;
-
 const UserGallerySkeleton = () => {
   return (
     <GalleryPageSpacing>
@@ -74,7 +61,6 @@ const UserGallerySkeleton = () => {
             <UsernameFollowsSkeleton />
             <UsernameSocialsSkeleton />
           </Wrapper>
-          <Divider />
         </GallerySkeletonWrapper>
       </VStack>
       <Wrapper>

--- a/apps/web/src/components/Profile/ProfileScreenLoadingSkeleton.tsx
+++ b/apps/web/src/components/Profile/ProfileScreenLoadingSkeleton.tsx
@@ -42,7 +42,7 @@ const UsernameSocialsSkeleton = styled(Skeleton)`
 
 const ArtworksGridSkeleton = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   grid-gap: 16px;
   margin-top: 16px;
 `;
@@ -66,7 +66,7 @@ const UserGallerySkeleton = () => {
       <Wrapper>
         <TitleSkeleton />
         <ArtworksGridSkeleton>
-          {[...Array(6)].map((_, index) => (
+          {[...Array(12)].map((_, index) => (
             <ArtworkGridItemSkeleton key={index} />
           ))}
         </ArtworksGridSkeleton>

--- a/apps/web/src/components/Profile/ProfileScreenLoadingSkeleton.tsx
+++ b/apps/web/src/components/Profile/ProfileScreenLoadingSkeleton.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { GalleryPageSpacing } from '~/pages/[username]';
 
+import { size } from '../core/breakpoints';
 import { VStack } from '../core/Spacer/Stack';
 
 const GallerySkeletonWrapper = styled.div`
@@ -13,6 +14,7 @@ const GallerySkeletonWrapper = styled.div`
 
 const Wrapper = styled.div`
   padding-left: 20px;
+  padding-right: 20px;
   margin-bottom: 60px;
 `;
 
@@ -42,9 +44,14 @@ const UsernameSocialsSkeleton = styled(Skeleton)`
 
 const ArtworksGridSkeleton = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, 1fr); // default to 4 items per row
   grid-gap: 16px;
   margin-top: 16px;
+
+  @media (max-width: ${size.tablet}px) {
+    // Adjusts to a mobile viewport
+    grid-template-columns: repeat(1, 1fr); // 1 item per row on mobile
+  }
 `;
 
 const ArtworkGridItemSkeleton = styled(Skeleton)`

--- a/apps/web/src/components/Profile/ProfileScreenLoadingSkeleton.tsx
+++ b/apps/web/src/components/Profile/ProfileScreenLoadingSkeleton.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+import colors from 'shared/theme/colors';
+import styled from 'styled-components';
+
+import { GalleryPageSpacing } from '~/pages/[username]';
+
+import breakpoints from '../core/breakpoints';
+import { VStack } from '../core/Spacer/Stack';
+
+const GallerySkeletonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Wrapper = styled.div`
+  padding-left: 20px;
+`;
+
+const TitleSkeleton = styled(Skeleton)`
+  margin-top: 20px;
+  width: 15vw;
+  height: 2vh;
+`;
+
+const UsernameSkeleton = styled(Skeleton)`
+  margin-top: 10px;
+  width: 15vw;
+  height: 2vh;
+`;
+
+const UsernameFollowsSkeleton = styled(Skeleton)`
+  margin-top: 18px;
+  width: 20vw;
+  height: 2vh;
+`;
+
+const UsernameSocialsSkeleton = styled(Skeleton)`
+  margin-top: 10px;
+  width: 10vw;
+  height: 2vh;
+`;
+
+const ArtworksGridSkeleton = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 16px;
+  margin-top: 16px;
+`;
+
+const ArtworkGridItemSkeleton = styled(Skeleton)`
+  height: 300px;
+`;
+
+const Divider = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: ${colors.porcelain};
+  display: none;
+  margin-top: 60px;
+
+  @media only screen and ${breakpoints.desktop} {
+    display: block;
+  }
+`;
+
+const UserGallerySkeleton = () => {
+  return (
+    <GalleryPageSpacing>
+      <VStack>
+        <GallerySkeletonWrapper>
+          <Wrapper>
+            <UsernameSkeleton />
+            <UsernameFollowsSkeleton />
+            <UsernameSocialsSkeleton />
+          </Wrapper>
+          <Divider />
+        </GallerySkeletonWrapper>
+      </VStack>
+      <Wrapper>
+        <TitleSkeleton />
+        <ArtworksGridSkeleton>
+          {[...Array(6)].map((_, index) => (
+            <ArtworkGridItemSkeleton key={index} />
+          ))}
+        </ArtworksGridSkeleton>
+      </Wrapper>
+    </GalleryPageSpacing>
+  );
+};
+
+export function ProfileScreenLoadingSkeleton() {
+  return <UserGallerySkeleton />;
+}

--- a/apps/web/src/contexts/globalLayout/GlobalNavbar/useGlobalNavbarHeight.tsx
+++ b/apps/web/src/contexts/globalLayout/GlobalNavbar/useGlobalNavbarHeight.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-const INITIAL_HEIGHT = 64;
+const INITIAL_HEIGHT = 56;
 
 export function useGlobalNavbarHeight() {
   const [height, setHeight] = useState(INITIAL_HEIGHT);

--- a/apps/web/src/contexts/shimmer/ShimmerContext.tsx
+++ b/apps/web/src/contexts/shimmer/ShimmerContext.tsx
@@ -1,4 +1,13 @@
-import { createContext, memo, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+import {
+  createContext,
+  memo,
+  PropsWithChildren,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 import styled from 'styled-components';
 
 import { MultiShimmer } from '~/components/MultiShimmer/MultiShimmer';
@@ -53,13 +62,17 @@ export const useMultiShimmerProvider = () => {
   return context;
 };
 
-export const MultiShimmerProvider = ({
-  children,
-  tokenIdsToLoad,
-}: {
-  children: ReactNode;
+/*
+    MultiShimmerProvider is used to show a skeleton loader for group of tokens and stop showing it
+    when X tokens were done loaded. For example, in profile screen we'll show it while the first 12
+    tokens are loading, after they're finished loading we'll show the actual tokens.
+*/
+
+type MultiShimmerProviderProps = PropsWithChildren<{
   tokenIdsToLoad: string[];
-}) => {
+}>;
+
+export const MultiShimmerProvider = ({ children, tokenIdsToLoad }: MultiShimmerProviderProps) => {
   const [waitingForTokenIds, setWaitingForTokenIds] = useState(tokenIdsToLoad);
 
   const markTokenAsLoaded = useCallback((tokenId: string) => {
@@ -72,19 +85,6 @@ export const MultiShimmerProvider = ({
     }),
     [markTokenAsLoaded]
   );
-
-  type VisibleDivProps = {
-    isVisible: boolean;
-  };
-
-  const VisibleDiv = styled.div<VisibleDivProps>`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
-  `;
 
   const isLoading = Boolean(waitingForTokenIds.length);
 
@@ -210,6 +210,19 @@ const StyledChildren = styled.div<VisibleProps>`
   justify-content: center;
   align-items: center;
   opacity: ${({ visible }) => (visible ? 1 : 0)};
+`;
+
+type VisibleDivProps = {
+  isVisible: boolean;
+};
+
+const VisibleDiv = styled.div<VisibleDivProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
 `;
 
 export default ShimmerProvider;

--- a/apps/web/src/contexts/shimmer/ShimmerContext.tsx
+++ b/apps/web/src/contexts/shimmer/ShimmerContext.tsx
@@ -1,6 +1,15 @@
-import { createContext, memo, ReactNode, useContext, useMemo, useState } from 'react';
+import {
+  createContext,
+  memo,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 import styled from 'styled-components';
 
+import { MultiShimmer } from '~/components/MultiShimmer/MultiShimmer';
 import Shimmer from '~/components/Shimmer/Shimmer';
 
 type AspectRatio = 'wide' | 'square' | 'tall' | 'unknown';
@@ -23,7 +32,7 @@ export const useContentState = (): ShimmerState => {
 
 // TODO(Terence): Fix this later
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ContentIsLoadedEvent = (event?: any) => void;
+export type ContentIsLoadedEvent = (event?: any, tokenId?: string) => void;
 
 type ShimmerAction = {
   setContentIsLoaded: ContentIsLoadedEvent;
@@ -40,12 +49,75 @@ export const useSetContentIsLoaded = (): ShimmerAction['setContentIsLoaded'] => 
   return context.setContentIsLoaded;
 };
 
+const MultiShimmerContext = createContext<
+  { markTokenAsLoaded: (tokenId: string) => void } | undefined
+>(undefined);
+
+export const useMultiShimmerProvider = () => {
+  const context = useContext(MultiShimmerContext);
+  if (!context) {
+    return null;
+  }
+  return context;
+};
+
+export const MultiShimmerProvider = ({
+  children,
+  tokenIdsToLoad,
+}: {
+  children: ReactNode;
+  tokenIdsToLoad: string[];
+}) => {
+  const [waitingForTokenIds, setWaitingForTokenIds] = useState(tokenIdsToLoad);
+
+  const markTokenAsLoaded = useCallback((tokenId: string) => {
+    setWaitingForTokenIds((prev) => prev.filter((id) => id !== tokenId));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      markTokenAsLoaded,
+    }),
+    [markTokenAsLoaded]
+  );
+
+  type VisibleDivProps = {
+    isVisible: boolean;
+  };
+
+  const VisibleDiv = styled.div<VisibleDivProps>`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
+  `;
+
+  const isLoading = Boolean(waitingForTokenIds.length);
+
+  return (
+    <MultiShimmerContext.Provider value={value}>
+      {isLoading && (
+        <Container overflowHidden={isLoading}>
+          <VisibleDiv isVisible={isLoading}>
+            <MultiShimmer />
+          </VisibleDiv>
+        </Container>
+      )}
+      {children}
+    </MultiShimmerContext.Provider>
+  );
+};
+
 type Props = { children: ReactNode | ReactNode[] };
 
 const ShimmerProvider = memo(({ children }: Props) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const [aspectRatio, setAspectRatio] = useState<null | number>(null);
   const [aspectRatioType, setAspectRatioType] = useState<null | AspectRatio>(null);
+
+  const multiShimmerContext = useMultiShimmerProvider();
 
   const state = useMemo(
     () => ({
@@ -61,7 +133,7 @@ const ShimmerProvider = memo(({ children }: Props) => {
       // such as images, videos, and iframes, each of which come with different properties.
       // This is getting fixed in a followup PR
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      setContentIsLoaded: (event?: any) => {
+      setContentIsLoaded: (event?: any, tokenId?: string) => {
         if (event) {
           // default aspect ratio to 1; if we can't determine an asset's dimensions, we'll show it in a square viewport
           let aspectRatio = 1;
@@ -89,11 +161,13 @@ const ShimmerProvider = memo(({ children }: Props) => {
             setAspectRatioType('unknown');
           }
         }
-
+        if (tokenId) {
+          multiShimmerContext?.markTokenAsLoaded(tokenId);
+        }
         setIsLoaded(true);
       },
     }),
-    []
+    [multiShimmerContext]
   );
 
   return (

--- a/apps/web/src/contexts/shimmer/ShimmerContext.tsx
+++ b/apps/web/src/contexts/shimmer/ShimmerContext.tsx
@@ -1,12 +1,4 @@
-import {
-  createContext,
-  memo,
-  ReactNode,
-  useCallback,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
+import { createContext, memo, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { MultiShimmer } from '~/components/MultiShimmer/MultiShimmer';

--- a/apps/web/src/hooks/useNftRetry.tsx
+++ b/apps/web/src/hooks/useNftRetry.tsx
@@ -30,7 +30,7 @@ export function useNftRetry({ tokenId }: useNftRetryArgs): useNftRetryResult {
 
   const handleNftLoaded = useCallback<ContentIsLoadedEvent>(
     (event) => {
-      shimmerContext?.setContentIsLoaded(event);
+      shimmerContext?.setContentIsLoaded(event, tokenId);
 
       markTokenAsLoaded(tokenId);
     },

--- a/apps/web/src/scenes/GalleryPage/GalleriesPage.tsx
+++ b/apps/web/src/scenes/GalleryPage/GalleriesPage.tsx
@@ -48,7 +48,6 @@ export default function GalleriesPage({ queryRef }: Props) {
             galleries {
               dbid
               id
-              position @required(action: NONE)
               ...GalleryFragment
             }
           }

--- a/apps/web/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -75,13 +75,14 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
     galleryRef
   );
 
-  const tokenIds = collections?.reduce((acc, collection) => {
-    const ids =
-      collection?.tokens
-        ?.map((token) => token?.token?.dbid)
-        .filter((id): id is string => id !== undefined) || [];
-    return acc.concat(ids);
-  }, [] as string[]);
+  const tokenIds = useMemo(() => {
+    return collections?.reduce<string[]>((acc, collection) => {
+      const ids = collection?.tokens?.map((token) => token?.token?.dbid) || [];
+      const nonNullIds = removeNullValues(ids);
+
+      return [...acc, ...nonNullIds];
+    }, []);
+  }, [collections]);
 
   const isAuthenticatedUsersPage = loggedInUserId === owner?.id;
 

--- a/apps/web/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
+++ b/apps/web/src/scenes/UserGalleryPage/UserGalleryCollections.tsx
@@ -205,14 +205,14 @@ function UserGalleryCollections({ galleryRef, queryRef, mobileLayout }: Props) {
 }
 
 const StyledUserGalleryCollections = styled.div`
-      width: 100%;
+  width: 100%;
 
-      padding-top: 16px;
+  padding-top: 16px;
 
-      @media only screen and ${breakpoints.tablet} {
-        padding-top: 24px;
+  @media only screen and ${breakpoints.tablet} {
+    padding-top: 24px;
   }
-      `;
+`;
 
 const StyledUserGalleryCollectionContainer = styled.div`
   padding-bottom: 48px;


### PR DESCRIPTION
### Summary of Changes

- Skeleton loaders for profile screen (web)
- Also adding a key to Suspense makes it so it retriggers the actual boundary when navigating between same routes (form profile to profiel, ie. robin -> santa)

### Demo or Before/After Pics

https://github.com/gallery-so/gallery/assets/112896251/d4a6c686-0e69-4315-aa83-06c1d13e762f


### Edge Cases

List any common edge cases that you have considered and tested.

### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
