### PR TITLE
Mobile: Add pinned announcement notification powered by Sanity + Make Mint Flow configurable via Sanity

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -37,6 +37,7 @@ import ToastProvider from './contexts/ToastContext';
 import { TokenStateManagerProvider } from './contexts/TokenStateManagerContext';
 import { magic } from './magic';
 import { useCacheIntroVideo } from './screens/Onboarding/useCacheIntroVideo';
+import SanityDataProvider from './contexts/SanityDataContext';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -157,28 +158,30 @@ export default function App() {
                           <magic.Relayer />
                           <SearchProvider>
                             <NavigationContainer ref={navigationRef}>
-                              <ToastProvider>
-                                <TokenStateManagerProvider>
-                                  <PortalProvider>
-                                    <BottomSheetModalProvider>
-                                      <SyncTokensProvider>
-                                        <ManageWalletProvider>
-                                          <AnnouncementProvider>
-                                            {/* Register the user's push token if one exists (does not prompt the user) */}
-                                            <NotificationRegistrar />
-                                            <DevMenuItems />
-                                            <DeepLinkRegistrar />
-                                            <RootStackNavigator
-                                              navigationContainerRef={navigationRef}
-                                            />
-                                          </AnnouncementProvider>
-                                        </ManageWalletProvider>
-                                      </SyncTokensProvider>
-                                      <PortalHost name="app-context" />
-                                    </BottomSheetModalProvider>
-                                  </PortalProvider>
-                                </TokenStateManagerProvider>
-                              </ToastProvider>
+                              <SanityDataProvider>
+                                <ToastProvider>
+                                  <TokenStateManagerProvider>
+                                    <PortalProvider>
+                                      <BottomSheetModalProvider>
+                                        <SyncTokensProvider>
+                                          <ManageWalletProvider>
+                                            <AnnouncementProvider>
+                                              {/* Register the user's push token if one exists (does not prompt the user) */}
+                                              <NotificationRegistrar />
+                                              <DevMenuItems />
+                                              <DeepLinkRegistrar />
+                                              <RootStackNavigator
+                                                navigationContainerRef={navigationRef}
+                                              />
+                                            </AnnouncementProvider>
+                                          </ManageWalletProvider>
+                                        </SyncTokensProvider>
+                                        <PortalHost name="app-context" />
+                                      </BottomSheetModalProvider>
+                                    </PortalProvider>
+                                  </TokenStateManagerProvider>
+                                </ToastProvider>
+                              </SanityDataProvider>
                             </NavigationContainer>
                           </SearchProvider>
                         </SafeAreaProvider>

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -29,9 +29,9 @@ import { DevMenuItems } from './components/DevMenuItems';
 import { LoadingView } from './components/LoadingView';
 import { CheckMaintenanceOnAppForeground, MaintenanceScreen } from './components/MaintenanceScreen';
 import SearchProvider from './components/Search/SearchContext';
-import { AnnouncementProvider } from './contexts/AnnouncementContext';
 import BottomSheetModalProvider from './contexts/BottomSheetModalContext';
 import ManageWalletProvider from './contexts/ManageWalletContext';
+import { SanityAnnouncementProvider } from './contexts/SanityAnnouncementContext';
 import SanityDataProvider from './contexts/SanityDataContext';
 import SyncTokensProvider from './contexts/SyncTokensContext';
 import ToastProvider from './contexts/ToastContext';
@@ -165,7 +165,7 @@ export default function App() {
                                       <BottomSheetModalProvider>
                                         <SyncTokensProvider>
                                           <ManageWalletProvider>
-                                            <AnnouncementProvider>
+                                            <SanityAnnouncementProvider>
                                               {/* Register the user's push token if one exists (does not prompt the user) */}
                                               <NotificationRegistrar />
                                               <DevMenuItems />
@@ -173,7 +173,7 @@ export default function App() {
                                               <RootStackNavigator
                                                 navigationContainerRef={navigationRef}
                                               />
-                                            </AnnouncementProvider>
+                                            </SanityAnnouncementProvider>
                                           </ManageWalletProvider>
                                         </SyncTokensProvider>
                                         <PortalHost name="app-context" />

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -29,6 +29,7 @@ import { DevMenuItems } from './components/DevMenuItems';
 import { LoadingView } from './components/LoadingView';
 import { CheckMaintenanceOnAppForeground, MaintenanceScreen } from './components/MaintenanceScreen';
 import SearchProvider from './components/Search/SearchContext';
+import { AnnouncementProvider } from './contexts/AnnouncementContext';
 import BottomSheetModalProvider from './contexts/BottomSheetModalContext';
 import ManageWalletProvider from './contexts/ManageWalletContext';
 import SyncTokensProvider from './contexts/SyncTokensContext';
@@ -162,13 +163,15 @@ export default function App() {
                                     <BottomSheetModalProvider>
                                       <SyncTokensProvider>
                                         <ManageWalletProvider>
-                                          {/* Register the user's push token if one exists (does not prompt the user) */}
-                                          <NotificationRegistrar />
-                                          <DevMenuItems />
-                                          <DeepLinkRegistrar />
-                                          <RootStackNavigator
-                                            navigationContainerRef={navigationRef}
-                                          />
+                                          <AnnouncementProvider>
+                                            {/* Register the user's push token if one exists (does not prompt the user) */}
+                                            <NotificationRegistrar />
+                                            <DevMenuItems />
+                                            <DeepLinkRegistrar />
+                                            <RootStackNavigator
+                                              navigationContainerRef={navigationRef}
+                                            />
+                                          </AnnouncementProvider>
                                         </ManageWalletProvider>
                                       </SyncTokensProvider>
                                       <PortalHost name="app-context" />

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -32,12 +32,12 @@ import SearchProvider from './components/Search/SearchContext';
 import { AnnouncementProvider } from './contexts/AnnouncementContext';
 import BottomSheetModalProvider from './contexts/BottomSheetModalContext';
 import ManageWalletProvider from './contexts/ManageWalletContext';
+import SanityDataProvider from './contexts/SanityDataContext';
 import SyncTokensProvider from './contexts/SyncTokensContext';
 import ToastProvider from './contexts/ToastContext';
 import { TokenStateManagerProvider } from './contexts/TokenStateManagerContext';
 import { magic } from './magic';
 import { useCacheIntroVideo } from './screens/Onboarding/useCacheIntroVideo';
-import SanityDataProvider from './contexts/SanityDataContext';
 
 SplashScreen.preventAutoHideAsync();
 

--- a/apps/mobile/src/components/ClaimMintUpsellBanner.tsx
+++ b/apps/mobile/src/components/ClaimMintUpsellBanner.tsx
@@ -49,7 +49,14 @@ export function ClaimMintUpsellBanner({ queryRef }: Props) {
   }, [setIsUpsellMintBannerDismissed]);
 
   const handleClaimPress = useCallback(() => {
-    showBottomSheetModal({ content: <MintCampaignBottomSheet onClose={hideBottomSheetModal} /> });
+    showBottomSheetModal({
+      content: (
+        <MintCampaignBottomSheet
+          onClose={hideBottomSheetModal}
+          projectInternalId="mchx-app-store-2024"
+        />
+      ),
+    });
   }, [hideBottomSheetModal, showBottomSheetModal]);
 
   const user = query.viewer?.user;

--- a/apps/mobile/src/components/ClaimMintUpsellBanner.tsx
+++ b/apps/mobile/src/components/ClaimMintUpsellBanner.tsx
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
 import { View } from 'react-native';
 import { graphql, useFragment } from 'react-relay';
-import { MCHX_CLAIM_CODE_KEY } from 'src/constants/storageKeys';
 import usePersistedState from 'src/hooks/usePersistedState';
 import { XMarkIcon } from 'src/icons/XMarkIcon';
 
 import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
+import { useSanityAnnouncementContext } from '~/contexts/SanityAnnouncementContext';
 import { ClaimMintUpsellBannerFragment$key } from '~/generated/ClaimMintUpsellBannerFragment.graphql';
 import { contexts } from '~/shared/analytics/constants';
 import colors from '~/shared/theme/colors';
@@ -17,9 +17,10 @@ import { Typography } from './Typography';
 
 type Props = {
   queryRef: ClaimMintUpsellBannerFragment$key;
+  projectInternalId: string;
 };
 
-export function ClaimMintUpsellBanner({ queryRef }: Props) {
+export function ClaimMintUpsellBanner({ queryRef, projectInternalId }: Props) {
   const query = useFragment(
     graphql`
       fragment ClaimMintUpsellBannerFragment on Query {
@@ -37,10 +38,10 @@ export function ClaimMintUpsellBanner({ queryRef }: Props) {
 
   const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
 
-  const [claimCode] = usePersistedState(MCHX_CLAIM_CODE_KEY, '');
+  const [claimCode] = usePersistedState(`${projectInternalId}-claim-code`, '');
 
   const [isUpsellMintBannerDismissed, setIsUpsellMintBannerDismissed] = usePersistedState(
-    'isUpsellMintBannerDismissed',
+    `${projectInternalId}-isUpsellMintBannerDismissed`,
     false
   );
 
@@ -53,15 +54,17 @@ export function ClaimMintUpsellBanner({ queryRef }: Props) {
       content: (
         <MintCampaignBottomSheet
           onClose={hideBottomSheetModal}
-          projectInternalId="mchx-app-store-2024"
+          projectInternalId={projectInternalId}
         />
       ),
     });
-  }, [hideBottomSheetModal, showBottomSheetModal]);
+  }, [hideBottomSheetModal, projectInternalId, showBottomSheetModal]);
+
+  const { announcement } = useSanityAnnouncementContext();
 
   const user = query.viewer?.user;
 
-  if (!user || claimCode || isUpsellMintBannerDismissed) {
+  if (!user || !announcement || claimCode || isUpsellMintBannerDismissed) {
     return <View className="bg-white dark:bg-black-900" />;
   }
 
@@ -78,7 +81,7 @@ export function ClaimMintUpsellBanner({ queryRef }: Props) {
           font={{ family: 'ABCDiatype', weight: 'Regular' }}
           className="text-offWhite text-xs"
         >
-          Claim your free generative work by MCHX
+          {announcement.description}
         </Typography>
       </View>
       <View className="flex-row items-center space-x-2">

--- a/apps/mobile/src/components/Mint/MintCampaign/MintCampaignBottomSheet.tsx
+++ b/apps/mobile/src/components/Mint/MintCampaign/MintCampaignBottomSheet.tsx
@@ -1,18 +1,48 @@
-import { MCHX_CLAIM_CODE_KEY } from 'src/constants/storageKeys';
+import { useMemo } from 'react';
 import usePersistedState from 'src/hooks/usePersistedState';
+
+import { useSanityDataContext } from '~/contexts/SanityDataContext';
 
 import MintCampaignPostTransaction from './MintCampaignPostTransaction';
 import MintCampaignPreTransaction from './MintCampaignPreTransaction';
 
-export default function MintCampaignBottomSheet({ onClose }: { onClose: () => void }) {
+type Props = {
+  onClose?: () => void;
+  projectInternalId?: string;
+};
+
+export default function MintCampaignBottomSheet({ onClose, projectInternalId }: Props) {
   // claimCode is the identifer used to poll for the status of the mint
   // Once we kick off the mint, the backend returns a claim code from Highlight that we can use to check the status of the mint
 
-  const [claimCode, setClaimCode] = usePersistedState(MCHX_CLAIM_CODE_KEY, '');
+  const [claimCode, setClaimCode] = usePersistedState(`${projectInternalId}_claim_code`, '');
 
-  if (claimCode) {
-    return <MintCampaignPostTransaction claimCode={claimCode} onClose={onClose} />;
+  const { data } = useSanityDataContext();
+  const projectData = useMemo(() => {
+    return data?.mintProjects.find((document) => document.internalId === projectInternalId);
+  }, [data, projectInternalId]);
+  console.log({ projectData });
+
+  if (!projectData) {
+    // TODO decide best way to handle missing data
+    return null;
   }
 
-  return <MintCampaignPreTransaction setClaimCode={setClaimCode} />;
+  if (claimCode) {
+    return (
+      <MintCampaignPostTransaction
+        claimCode={claimCode}
+        onClose={onClose}
+        projectData={projectData}
+      />
+    );
+  }
+
+  return (
+    <MintCampaignPreTransaction
+      setClaimCode={setClaimCode}
+      projectInternalId={projectInternalId}
+      projectData={projectData}
+    />
+  );
 }

--- a/apps/mobile/src/components/Mint/MintCampaign/MintCampaignBottomSheet.tsx
+++ b/apps/mobile/src/components/Mint/MintCampaign/MintCampaignBottomSheet.tsx
@@ -8,7 +8,7 @@ import MintCampaignPreTransaction from './MintCampaignPreTransaction';
 
 type Props = {
   onClose?: () => void;
-  projectInternalId?: string;
+  projectInternalId: string;
 };
 
 export default function MintCampaignBottomSheet({ onClose, projectInternalId }: Props) {
@@ -21,7 +21,6 @@ export default function MintCampaignBottomSheet({ onClose, projectInternalId }: 
   const projectData = useMemo(() => {
     return data?.mintProjects.find((document) => document.internalId === projectInternalId);
   }, [data, projectInternalId]);
-  console.log({ projectData });
 
   if (!projectData) {
     // TODO decide best way to handle missing data

--- a/apps/mobile/src/components/Mint/MintCampaign/MintCampaignPostTransaction.tsx
+++ b/apps/mobile/src/components/Mint/MintCampaign/MintCampaignPostTransaction.tsx
@@ -203,18 +203,6 @@ export default function MintCampaignPostTransaction({
   );
 }
 
-// const COPY = [
-//   'Anton Dubrovin, aka MCHX, was born in Kazakhstan and is currently based in Georgia.',
-//   'Anton is a digital artist known for experimenting with colors and form.',
-//   'Anton uses color as a universal channel of emotional connection and self-exploration.',
-//   'For this project, MCHX created over 60 unique color modes and used a circle as the central object due to its universal symbolism of unity and integrity.',
-//   'This work leverages Javascript, GLSL, and Display P3 wide-gamut to explore emotional connection through color.',
-//   "Anton's diverse inspiration comes from 20th-century abstraction, Abstract Expressionism, Color Field artists, nature, music, and the internet.",
-//   'In his free time, Anton enjoys taking walks, reading, and watching Japanese anime and dramas.',
-//   'Anton has been creating art since 2016, but entered the NFT and Web3 space in 2020.',
-//   'Anton believes in the exchange of energy inherent in blockchain interactions and his work carries imprints of his emotional states or needs at the time of creation.',
-// ];
-
 const FADE_DURATION = 250;
 const TEXT_DURATION = 8000;
 

--- a/apps/mobile/src/components/Mint/MintCampaign/MintCampaignPostTransaction.tsx
+++ b/apps/mobile/src/components/Mint/MintCampaign/MintCampaignPostTransaction.tsx
@@ -15,6 +15,7 @@ import { SpinnerIcon } from 'src/icons/SpinnerIcon';
 
 import { Button } from '~/components/Button';
 import { BaseM, TitleS } from '~/components/Text';
+import { MintProject } from '~/contexts/SanityDataContext';
 import {
   HighlightTxStatus,
   MintCampaignPostTransactionMintStatusQuery,
@@ -26,9 +27,11 @@ import { NftDetailAsset } from '../../../screens/NftDetailScreen/NftDetailAsset/
 export default function MintCampaignPostTransaction({
   claimCode,
   onClose,
+  projectData,
 }: {
   claimCode: string;
-  onClose: () => void;
+  onClose?: () => void;
+  projectData: MintProject;
 }) {
   const [state, setState] = useState<HighlightTxStatus>('TX_PENDING');
   // TODO: Fix any - prioritizing merging atm
@@ -119,7 +122,9 @@ export default function MintCampaignPostTransaction({
       });
     }
 
-    onClose();
+    if (onClose) {
+      onClose();
+    }
 
     // close bottom sheet
   }, [navigation, onClose, token?.dbid]);
@@ -129,7 +134,9 @@ export default function MintCampaignPostTransaction({
     if (token?.definition?.community) {
       navigateToCommunity(token?.definition?.community);
     }
-    onClose();
+    if (onClose) {
+      onClose();
+    }
   }, [navigateToCommunity, onClose, token?.definition?.community]);
 
   if (state === 'TOKEN_SYNCED' && token) {
@@ -137,7 +144,12 @@ export default function MintCampaignPostTransaction({
       <View>
         <View className="mb-1">
           <TitleS>Congratulations!</TitleS>
-          <TitleS>You collected {`${token?.definition?.name ?? 'Radiance'} by MCHX`}</TitleS>
+          <TitleS>
+            You collected{' '}
+            {`${token?.definition?.name ?? projectData.collectionName} by ${
+              projectData.artistName
+            }`}
+          </TitleS>
         </View>
         <BaseM>
           Thank you for using the Gallery mobile app. Share your unique piece with others below!
@@ -173,7 +185,7 @@ export default function MintCampaignPostTransaction({
       <BaseM>
         {state === 'TX_PENDING'
           ? 'Your new artwork is being minted onchain. This should take less than a minute.'
-          : 'Revealing your unique artwork. It will be ready to view in a moment!'}
+          : 'Revealing your artwork. It will be ready to view in a moment!'}
       </BaseM>
 
       <View className="my-4 flex justify-center items-center bg-faint dark:bg-black-700 w-full aspect-square ">
@@ -183,7 +195,7 @@ export default function MintCampaignPostTransaction({
             size="s"
             colorOverride={{ lightMode: colors.shadow, darkMode: colors.shadow }}
           />
-          <LoadingStateMessage />
+          <LoadingStateMessage funFacts={projectData.funFacts} />
         </View>
       </View>
       {error && <BaseM classNameOverride="text-red">{error}</BaseM>}
@@ -191,22 +203,22 @@ export default function MintCampaignPostTransaction({
   );
 }
 
-const COPY = [
-  'Anton Dubrovin, aka MCHX, was born in Kazakhstan and is currently based in Georgia.',
-  'Anton is a digital artist known for experimenting with colors and form.',
-  'Anton uses color as a universal channel of emotional connection and self-exploration.',
-  'For this project, MCHX created over 60 unique color modes and used a circle as the central object due to its universal symbolism of unity and integrity.',
-  'This work leverages Javascript, GLSL, and Display P3 wide-gamut to explore emotional connection through color.',
-  "Anton's diverse inspiration comes from 20th-century abstraction, Abstract Expressionism, Color Field artists, nature, music, and the internet.",
-  'In his free time, Anton enjoys taking walks, reading, and watching Japanese anime and dramas.',
-  'Anton has been creating art since 2016, but entered the NFT and Web3 space in 2020.',
-  'Anton believes in the exchange of energy inherent in blockchain interactions and his work carries imprints of his emotional states or needs at the time of creation.',
-];
+// const COPY = [
+//   'Anton Dubrovin, aka MCHX, was born in Kazakhstan and is currently based in Georgia.',
+//   'Anton is a digital artist known for experimenting with colors and form.',
+//   'Anton uses color as a universal channel of emotional connection and self-exploration.',
+//   'For this project, MCHX created over 60 unique color modes and used a circle as the central object due to its universal symbolism of unity and integrity.',
+//   'This work leverages Javascript, GLSL, and Display P3 wide-gamut to explore emotional connection through color.',
+//   "Anton's diverse inspiration comes from 20th-century abstraction, Abstract Expressionism, Color Field artists, nature, music, and the internet.",
+//   'In his free time, Anton enjoys taking walks, reading, and watching Japanese anime and dramas.',
+//   'Anton has been creating art since 2016, but entered the NFT and Web3 space in 2020.',
+//   'Anton believes in the exchange of energy inherent in blockchain interactions and his work carries imprints of his emotional states or needs at the time of creation.',
+// ];
 
 const FADE_DURATION = 250;
 const TEXT_DURATION = 8000;
 
-function LoadingStateMessage() {
+function LoadingStateMessage({ funFacts }: { funFacts: string[] }) {
   const [index, setIndex] = useState(0);
 
   const fadeInOpacity = useSharedValue(1);
@@ -235,18 +247,18 @@ function LoadingStateMessage() {
     const updateDisplayedMessage = async () => {
       fadeOut();
       await new Promise((resolve) => setTimeout(resolve, FADE_DURATION));
-      setIndex((index) => (index + 1) % COPY.length);
+      setIndex((index) => (index + 1) % funFacts.length);
       fadeIn();
     };
 
     const interval = setInterval(updateDisplayedMessage, TEXT_DURATION);
 
     return () => clearInterval(interval);
-  }, [fadeIn, fadeOut]);
+  }, [fadeIn, fadeOut, funFacts.length]);
   return (
     <View className="text-center h-32">
       <Animated.View style={[animatedStyle]}>
-        <BaseM classNameOverride="text-shadow text-center ">{COPY[index]}</BaseM>
+        <BaseM classNameOverride="text-shadow text-center ">{funFacts[index]}</BaseM>
       </Animated.View>
     </View>
   );

--- a/apps/mobile/src/components/Mint/MintCampaign/MintCampaignPreTransaction.tsx
+++ b/apps/mobile/src/components/Mint/MintCampaign/MintCampaignPreTransaction.tsx
@@ -54,7 +54,7 @@ export default function MintCampaignPreTransaction({
 
   const { claimMint, isClamingMint } = useHighlightClaimMint();
 
-  const [, setClaimCodeLocalStorage] = usePersistedState(`${projectInternalId}_claim_code`, '');
+  const [, setClaimCodeLocalStorage] = usePersistedState(`${projectInternalId}-claim-code`, '');
 
   const handlePress = useCallback(
     async (recipientWalletId: string) => {

--- a/apps/mobile/src/components/MintLinkButton.tsx
+++ b/apps/mobile/src/components/MintLinkButton.tsx
@@ -148,7 +148,14 @@ export function MintLinkButton({
 
   const handlePress = useCallback(() => {
     if (isRadiance) {
-      showBottomSheetModal({ content: <MintCampaignBottomSheet onClose={hideBottomSheetModal} /> });
+      showBottomSheetModal({
+        content: (
+          <MintCampaignBottomSheet
+            projectInternalId="mchx-app-store-2024"
+            onClose={hideBottomSheetModal}
+          />
+        ),
+      });
     } else {
       Linking.openURL(mintURL);
     }

--- a/apps/mobile/src/components/Notification/NotificationList.tsx
+++ b/apps/mobile/src/components/Notification/NotificationList.tsx
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 import { graphql, usePaginationFragment } from 'react-relay';
 
 import { GalleryRefreshControl } from '~/components/GalleryRefreshControl';
-import { useAnnouncementContext } from '~/contexts/AnnouncementContext';
+import { useSanityAnnouncementContext } from '~/contexts/SanityAnnouncementContext';
 import { NotificationFragment$key } from '~/generated/NotificationFragment.graphql';
 import { NotificationListFragment$key } from '~/generated/NotificationListFragment.graphql';
 import { NotificationQueryFragment$key } from '~/generated/NotificationQueryFragment.graphql';
@@ -69,7 +69,8 @@ export function NotificationList({ queryRef }: Props) {
     queryRef
   );
 
-  const { announcement, fetchAnnouncement, hasDismissedAnnouncement } = useAnnouncementContext();
+  const { announcement, fetchAnnouncement, hasDismissedAnnouncement } =
+    useSanityAnnouncementContext();
 
   const clearNotifications = useMobileClearNotifications();
   const { isRefreshing, handleRefresh } = useRefreshHandle(refetch);
@@ -83,7 +84,7 @@ export function NotificationList({ queryRef }: Props) {
       }
     }
 
-    if (announcement && announcement.active && !hasDismissedAnnouncement) {
+    if (announcement?.active && !hasDismissedAnnouncement) {
       notifications.push({ id: 'announcement', kind: 'announcement' });
     }
 
@@ -100,12 +101,12 @@ export function NotificationList({ queryRef }: Props) {
 
   const renderItem = useCallback<ListRenderItem<NotificationListItem>>(({ item }) => {
     if (item.kind === 'announcement') {
-      return <AnnouncementNotification></AnnouncementNotification>;
+      return <AnnouncementNotification />;
     }
     return <Notification key={item.id} queryRef={item.query} notificationRef={item.notification} />;
   }, []);
 
-  const handleRefreshAndFetchAnnouncement = useCallback(async () => {
+  const handleRefreshAndFetchAnnouncement = useCallback(() => {
     fetchAnnouncement();
     handleRefresh();
   }, [fetchAnnouncement, handleRefresh]);

--- a/apps/mobile/src/components/Notification/NotificationList.tsx
+++ b/apps/mobile/src/components/Notification/NotificationList.tsx
@@ -69,7 +69,7 @@ export function NotificationList({ queryRef }: Props) {
     queryRef
   );
 
-  const { announcement, fetchAnnouncement } = useAnnouncementContext();
+  const { announcement, fetchAnnouncement, hasDismissedAnnouncement } = useAnnouncementContext();
 
   const clearNotifications = useMobileClearNotifications();
   const { isRefreshing, handleRefresh } = useRefreshHandle(refetch);
@@ -83,14 +83,14 @@ export function NotificationList({ queryRef }: Props) {
       }
     }
 
-    if (announcement && announcement.active) {
+    if (announcement && announcement.active && !hasDismissedAnnouncement) {
       notifications.push({ id: 'announcement', kind: 'announcement' });
     }
 
     notifications.reverse();
 
     return notifications;
-  }, [announcement, query]);
+  }, [announcement, hasDismissedAnnouncement, query]);
 
   const loadMore = useCallback(() => {
     if (hasPrevious) {

--- a/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
@@ -3,16 +3,27 @@ import { useCallback, useEffect } from 'react';
 import { View } from 'react-native';
 import FastImage from 'react-native-fast-image';
 import { contexts } from 'shared/analytics/constants';
+import colors from 'shared/theme/colors';
+import { XMarkIcon } from 'src/icons/XMarkIcon';
 
-import { Button } from '~/components/Button';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
+import MintCampaignBottomSheet from '~/components/Mint/MintCampaign/MintCampaignBottomSheet';
 import { BaseM } from '~/components/Text';
 import { useAnnouncementContext } from '~/contexts/AnnouncementContext';
+import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 
-// display announcement content from Sanity
+// Displays announcement content from Sanity
 export default function AnnouncementNotification() {
-  const { announcement, markAnnouncementAsSeen } = useAnnouncementContext();
-  const handlePress = useCallback(() => {}, []);
+  const { announcement, markAnnouncementAsSeen, dismissAnnouncement } = useAnnouncementContext();
+  const { showBottomSheetModal } = useBottomSheetModalActions();
+  const handlePress = useCallback(() => {
+    showBottomSheetModal({
+      content: <MintCampaignBottomSheet projectInternalId={announcement?.internal_id} />,
+    });
+  }, [announcement?.internal_id, showBottomSheetModal]);
+  const handleDismissPress = useCallback(() => {
+    dismissAnnouncement();
+  }, [dismissAnnouncement]);
 
   useEffect(() => {
     markAnnouncementAsSeen();
@@ -25,10 +36,10 @@ export default function AnnouncementNotification() {
   }
 
   return (
-    <View className="flex flex-row items-center m-2">
+    <View className="flex flex-row  m-2">
       <GalleryTouchableOpacity
         onPress={handlePress}
-        className="flex-row flex-1 items-center space-x-2 border border-blue-700 p-3"
+        className="flex-row flex-1 items-start space-x-2 border border-activeBlue p-3"
         eventElementId="Announcement Notification"
         eventName="Announcement Notification Pressed"
         eventContext={contexts.Notifications}
@@ -39,21 +50,19 @@ export default function AnnouncementNotification() {
           source={{ uri: announcement.imageUrl }}
         />
         <View className="flex flex-col flex-1 ">
-          <BaseM weight="Bold">{announcement.title}</BaseM>
-          <BaseM>{announcement.description}</BaseM>
+          <BaseM weight="Bold" classNameOverride="text-activeBlue">
+            {announcement.title}
+          </BaseM>
+          <BaseM classNameOverride="text-activeBlue">{announcement.description}</BaseM>
         </View>
-        {announcement.ctaText && (
-          <Button
-            text={announcement.ctaText}
-            eventElementId={null}
-            eventName={null}
-            eventContext={null}
-            textClassName="normal-case"
-            size="xs"
-            fontWeight="Bold"
-            className="w-20"
-          />
-        )}
+        <GalleryTouchableOpacity
+          onPress={handleDismissPress}
+          eventElementId="Dismiss Announcement Button"
+          eventName="Pressed Dismiss Announcement Button"
+          eventContext={contexts.Notifications}
+        >
+          <XMarkIcon color={colors.activeBlue} />
+        </GalleryTouchableOpacity>
       </GalleryTouchableOpacity>
     </View>
   );

--- a/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
@@ -17,10 +17,11 @@ export default function AnnouncementNotification() {
   const { announcement, markAnnouncementAsSeen, dismissAnnouncement } = useAnnouncementContext();
   const { showBottomSheetModal } = useBottomSheetModalActions();
   const handlePress = useCallback(() => {
+    if (!announcement) return;
     showBottomSheetModal({
-      content: <MintCampaignBottomSheet projectInternalId={announcement?.internal_id} />,
+      content: <MintCampaignBottomSheet projectInternalId={announcement.internal_id} />,
     });
-  }, [announcement?.internal_id, showBottomSheetModal]);
+  }, [announcement, showBottomSheetModal]);
   const handleDismissPress = useCallback(() => {
     dismissAnnouncement();
   }, [dismissAnnouncement]);

--- a/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
@@ -9,19 +9,22 @@ import { XMarkIcon } from 'src/icons/XMarkIcon';
 import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
 import MintCampaignBottomSheet from '~/components/Mint/MintCampaign/MintCampaignBottomSheet';
 import { BaseM } from '~/components/Text';
-import { useAnnouncementContext } from '~/contexts/AnnouncementContext';
 import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
+import { useSanityAnnouncementContext } from '~/contexts/SanityAnnouncementContext';
 
 // Displays announcement content from Sanity
 export default function AnnouncementNotification() {
-  const { announcement, markAnnouncementAsSeen, dismissAnnouncement } = useAnnouncementContext();
+  const { announcement, markAnnouncementAsSeen, dismissAnnouncement } =
+    useSanityAnnouncementContext();
   const { showBottomSheetModal } = useBottomSheetModalActions();
+
   const handlePress = useCallback(() => {
     if (!announcement) return;
     showBottomSheetModal({
       content: <MintCampaignBottomSheet projectInternalId={announcement.internal_id} />,
     });
   }, [announcement, showBottomSheetModal]);
+
   const handleDismissPress = useCallback(() => {
     dismissAnnouncement();
   }, [dismissAnnouncement]);
@@ -37,7 +40,7 @@ export default function AnnouncementNotification() {
   }
 
   return (
-    <View className="flex flex-row  m-2">
+    <View className="flex flex-row m-2">
       <GalleryTouchableOpacity
         onPress={handlePress}
         className="flex-row flex-1 items-start space-x-2 border border-activeBlue p-3"
@@ -45,16 +48,18 @@ export default function AnnouncementNotification() {
         eventName="Announcement Notification Pressed"
         eventContext={contexts.Notifications}
       >
-        <FastImage
-          style={{ width: 56, height: 56 }}
-          resizeMode={ResizeMode.COVER}
-          source={{ uri: announcement.imageUrl }}
-        />
-        <View className="flex flex-col flex-1 ">
-          <BaseM weight="Bold" classNameOverride="text-activeBlue">
-            {announcement.title}
-          </BaseM>
-          <BaseM classNameOverride="text-activeBlue">{announcement.description}</BaseM>
+        <View className="flex-row flex-1 items-center space-x-2">
+          <FastImage
+            style={{ width: 56, height: 56 }}
+            resizeMode={ResizeMode.COVER}
+            source={{ uri: announcement.imageUrl }}
+          />
+          <View className="flex flex-col flex-1 ">
+            <BaseM weight="Bold" classNameOverride="text-activeBlue">
+              {announcement.title}
+            </BaseM>
+            <BaseM classNameOverride="text-activeBlue">{announcement.description}</BaseM>
+          </View>
         </View>
         <GalleryTouchableOpacity
           onPress={handleDismissPress}

--- a/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
@@ -1,0 +1,60 @@
+import { ResizeMode } from 'expo-av';
+import { useCallback, useEffect } from 'react';
+import { View } from 'react-native';
+import FastImage from 'react-native-fast-image';
+import { contexts } from 'shared/analytics/constants';
+
+import { Button } from '~/components/Button';
+import { GalleryTouchableOpacity } from '~/components/GalleryTouchableOpacity';
+import { BaseM } from '~/components/Text';
+import { useAnnouncementContext } from '~/contexts/AnnouncementContext';
+
+// display announcement content from Sanity
+export default function AnnouncementNotification() {
+  const { announcement, markAnnouncementAsSeen } = useAnnouncementContext();
+  const handlePress = useCallback(() => {}, []);
+
+  useEffect(() => {
+    markAnnouncementAsSeen();
+    // Only run once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!announcement) {
+    return null;
+  }
+
+  return (
+    <View className="flex flex-row items-center m-2">
+      <GalleryTouchableOpacity
+        onPress={handlePress}
+        className="flex-row flex-1 items-center space-x-2 border border-blue-700 p-3"
+        eventElementId="Announcement Notification"
+        eventName="Announcement Notification Pressed"
+        eventContext={contexts.Notifications}
+      >
+        <FastImage
+          style={{ width: 56, height: 56 }}
+          resizeMode={ResizeMode.COVER}
+          source={{ uri: announcement.imageUrl }}
+        />
+        <View className="flex flex-col flex-1 ">
+          <BaseM weight="Bold">{announcement.title}</BaseM>
+          <BaseM>{announcement.description}</BaseM>
+        </View>
+        {announcement.ctaText && (
+          <Button
+            text={announcement.ctaText}
+            eventElementId={null}
+            eventName={null}
+            eventContext={null}
+            textClassName="normal-case"
+            size="xs"
+            fontWeight="Bold"
+            className="w-20"
+          />
+        )}
+      </GalleryTouchableOpacity>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
@@ -1,4 +1,5 @@
 import { ResizeMode } from 'expo-av';
+import { useColorScheme } from 'nativewind';
 import { useCallback, useEffect } from 'react';
 import { View } from 'react-native';
 import FastImage from 'react-native-fast-image';
@@ -35,6 +36,8 @@ export default function AnnouncementNotification() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const { colorScheme } = useColorScheme();
+
   if (!announcement) {
     return null;
   }
@@ -43,7 +46,7 @@ export default function AnnouncementNotification() {
     <View className="flex flex-row m-2">
       <GalleryTouchableOpacity
         onPress={handlePress}
-        className="flex-row flex-1 items-start space-x-2 border border-activeBlue p-3"
+        className="flex-row flex-1 items-start space-x-2 border border-activeBlue dark:border-darkModeBlue p-3"
         eventElementId="Announcement Notification"
         eventName="Announcement Notification Pressed"
         eventContext={contexts.Notifications}
@@ -55,10 +58,12 @@ export default function AnnouncementNotification() {
             source={{ uri: announcement.imageUrl }}
           />
           <View className="flex flex-col flex-1 ">
-            <BaseM weight="Bold" classNameOverride="text-activeBlue">
+            <BaseM weight="Bold" classNameOverride="text-activeBlue dark:text-darkModeBlue">
               {announcement.title}
             </BaseM>
-            <BaseM classNameOverride="text-activeBlue">{announcement.description}</BaseM>
+            <BaseM classNameOverride="text-activeBlue dark:text-darkModeBlue">
+              {announcement.description}
+            </BaseM>
           </View>
         </View>
         <GalleryTouchableOpacity
@@ -67,7 +72,7 @@ export default function AnnouncementNotification() {
           eventName="Pressed Dismiss Announcement Button"
           eventContext={contexts.Notifications}
         >
-          <XMarkIcon color={colors.activeBlue} />
+          <XMarkIcon color={colorScheme === 'dark' ? colors.darkModeBlue : colors.activeBlue} />
         </GalleryTouchableOpacity>
       </GalleryTouchableOpacity>
     </View>

--- a/apps/mobile/src/components/Notification/Notifications/GalleryAnnouncement.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/GalleryAnnouncement.tsx
@@ -49,7 +49,14 @@ export function GalleryAnnouncement({ queryRef, notificationRef }: Props) {
   const { showBottomSheetModal, hideBottomSheetModal } = useBottomSheetModalActions();
   const handlePress = useCallback(() => {
     if (internalId === 'apr-2024-mchx-collab') {
-      showBottomSheetModal({ content: <MintCampaignBottomSheet onClose={hideBottomSheetModal} /> });
+      showBottomSheetModal({
+        content: (
+          <MintCampaignBottomSheet
+            onClose={hideBottomSheetModal}
+            projectInternalId="mchx-app-store-2024"
+          />
+        ),
+      });
       return;
     }
     if (!ctaLink) return;

--- a/apps/mobile/src/contexts/AnnouncementContext.tsx
+++ b/apps/mobile/src/contexts/AnnouncementContext.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { useReportError } from 'shared/contexts/ErrorReportingContext';
 import { fetchSanityContent } from 'src/utils/sanity';
+import { useEffectOnAppForeground } from 'src/utils/useEffectOnAppForeground';
 
 type Announcement = {
   internal_id: string;
@@ -26,7 +27,9 @@ type AnnouncementContextType = {
   announcement: Announcement | null;
   fetchAnnouncement: () => void;
   hasSeenAnnouncement: boolean;
+  hasDismissedAnnouncement: boolean;
   markAnnouncementAsSeen: () => void;
+  dismissAnnouncement: () => void;
 };
 
 const AnnouncementContext = createContext<AnnouncementContextType | undefined>(undefined);
@@ -81,7 +84,6 @@ export const AnnouncementProvider = ({ children }: { children: ReactNode[] }) =>
               title,
               description,
               "imageUrl": image.asset->url,
-              ctaText,
               platform,
               min_mobile_version
             } | order(_createdAt desc)[0]`
@@ -99,6 +101,8 @@ export const AnnouncementProvider = ({ children }: { children: ReactNode[] }) =>
       }
     }
   }, [checkDismissalStatus, checkSeenStatus, reportError]);
+
+  useEffectOnAppForeground(fetchAnnouncement);
 
   // Function to dismiss an announcement
   const dismissAnnouncement = useCallback(async () => {

--- a/apps/mobile/src/contexts/AnnouncementContext.tsx
+++ b/apps/mobile/src/contexts/AnnouncementContext.tsx
@@ -1,0 +1,143 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useReportError } from 'shared/contexts/ErrorReportingContext';
+import { fetchSanityContent } from 'src/utils/sanity';
+
+type Announcement = {
+  internal_id: string;
+  active: boolean;
+  title: string;
+  description: string;
+  imageUrl: string;
+  platform: string;
+  min_mobile_version: number;
+  ctaText?: string;
+};
+
+type AnnouncementContextType = {
+  announcement: Announcement | null;
+  fetchAnnouncement: () => void;
+  hasSeenAnnouncement: boolean;
+  markAnnouncementAsSeen: () => void;
+};
+
+const AnnouncementContext = createContext<AnnouncementContextType | undefined>(undefined);
+
+export function useAnnouncementContext() {
+  const value = useContext(AnnouncementContext);
+
+  if (!value) {
+    throw new Error('Tried to use AnnouncementContext without a Provider');
+  }
+
+  return value;
+}
+
+export const AnnouncementProvider = ({ children }: { children: ReactNode[] }) => {
+  const [announcement, setAnnouncement] = useState<Announcement | null>(null);
+  const [hasDismissedAnnouncement, setHasDismissedAnnouncement] = useState(false);
+  const [hasSeenAnnouncement, setHasSeenAnnouncement] = useState(false);
+
+  const reportError = useReportError();
+
+  const checkDismissalStatus = useCallback(
+    async (internalId: string) => {
+      try {
+        const dismissed = await AsyncStorage.getItem(`hasDismissedAnnouncement-${internalId}`);
+        setHasDismissedAnnouncement(dismissed === 'true');
+      } catch (error) {
+        reportError('An error occurred while checking announcement dismissal status');
+      }
+    },
+    [reportError]
+  );
+
+  const checkSeenStatus = useCallback(
+    async (internalId: string) => {
+      try {
+        const seen = await AsyncStorage.getItem(`hasSeenAnnouncement-${internalId}`);
+        setHasSeenAnnouncement(seen === 'true');
+      } catch (error) {
+        reportError('An error occurred while checking announcement seen status');
+      }
+    },
+    [reportError]
+  );
+
+  const fetchAnnouncement = useCallback(async () => {
+    try {
+      const result = await fetchSanityContent(
+        `*[_type == "announcementNotification" && active == true] {
+              internal_id,
+              active,
+              title,
+              description,
+              "imageUrl": image.asset->url,
+              ctaText,
+              platform,
+              min_mobile_version
+            } | order(_createdAt desc)[0]`
+      );
+      if (result) {
+        setAnnouncement(result);
+        checkDismissalStatus(result.internal_id);
+        checkSeenStatus(result.internal_id);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        reportError(error);
+      } else {
+        reportError('An error occurred while fetching announcement from Sanity');
+      }
+    }
+  }, [checkDismissalStatus, checkSeenStatus, reportError]);
+
+  // Function to dismiss an announcement
+  const dismissAnnouncement = useCallback(async () => {
+    if (announcement && announcement.internal_id) {
+      await AsyncStorage.setItem(`hasDismissedAnnouncement-${announcement.internal_id}`, 'true');
+      setHasDismissedAnnouncement(true);
+    }
+  }, [announcement]);
+
+  const markAnnouncementAsSeen = useCallback(async () => {
+    if (announcement && announcement.internal_id) {
+      await AsyncStorage.setItem(`hasSeenAnnouncement-${announcement.internal_id}`, 'true');
+      setHasSeenAnnouncement(true);
+    }
+  }, [announcement]);
+
+  useEffect(() => {
+    fetchAnnouncement();
+    // Only run once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const value = useMemo(() => {
+    return {
+      announcement,
+      fetchAnnouncement,
+      hasDismissedAnnouncement,
+      dismissAnnouncement,
+      hasSeenAnnouncement,
+      markAnnouncementAsSeen,
+    };
+  }, [
+    announcement,
+    dismissAnnouncement,
+    fetchAnnouncement,
+    hasDismissedAnnouncement,
+    hasSeenAnnouncement,
+    markAnnouncementAsSeen,
+  ]);
+
+  return <AnnouncementContext.Provider value={value}>{children}</AnnouncementContext.Provider>;
+};

--- a/apps/mobile/src/contexts/AnnouncementContext.tsx
+++ b/apps/mobile/src/contexts/AnnouncementContext.tsx
@@ -78,7 +78,7 @@ export const AnnouncementProvider = ({ children }: { children: ReactNode[] }) =>
   const fetchAnnouncement = useCallback(async () => {
     try {
       const result = await fetchSanityContent(
-        `*[_type == "announcementNotification" && active == true] {
+        `*[_type == "announcementNotification" && active == true && (platform == "Mobile" || platform == "All")] {
               internal_id,
               active,
               title,

--- a/apps/mobile/src/contexts/SanityAnnouncementContext.tsx
+++ b/apps/mobile/src/contexts/SanityAnnouncementContext.tsx
@@ -23,7 +23,7 @@ type Announcement = {
   ctaText?: string;
 };
 
-type AnnouncementContextType = {
+type SanityAnnouncementContextType = {
   announcement: Announcement | null;
   fetchAnnouncement: () => void;
   hasSeenAnnouncement: boolean;
@@ -32,19 +32,21 @@ type AnnouncementContextType = {
   dismissAnnouncement: () => void;
 };
 
-const AnnouncementContext = createContext<AnnouncementContextType | undefined>(undefined);
+const SanityAnnouncementContext = createContext<SanityAnnouncementContextType | undefined>(
+  undefined
+);
 
-export function useAnnouncementContext() {
-  const value = useContext(AnnouncementContext);
+export function useSanityAnnouncementContext() {
+  const value = useContext(SanityAnnouncementContext);
 
   if (!value) {
-    throw new Error('Tried to use AnnouncementContext without a Provider');
+    throw new Error('Tried to use SanityAnnouncementContext without a Provider');
   }
 
   return value;
 }
 
-export const AnnouncementProvider = ({ children }: { children: ReactNode[] }) => {
+export const SanityAnnouncementProvider = ({ children }: { children: ReactNode[] }) => {
   const [announcement, setAnnouncement] = useState<Announcement | null>(null);
   const [hasDismissedAnnouncement, setHasDismissedAnnouncement] = useState(false);
   const [hasSeenAnnouncement, setHasSeenAnnouncement] = useState(false);
@@ -54,7 +56,7 @@ export const AnnouncementProvider = ({ children }: { children: ReactNode[] }) =>
   const checkDismissalStatus = useCallback(
     async (internalId: string) => {
       try {
-        const dismissed = await AsyncStorage.getItem(`hasDismissedAnnouncement-${internalId}`);
+        const dismissed = await AsyncStorage.getItem(`${internalId}-hasDismissedAnnouncement`);
         setHasDismissedAnnouncement(dismissed === 'true');
       } catch (error) {
         reportError('An error occurred while checking announcement dismissal status');
@@ -66,7 +68,7 @@ export const AnnouncementProvider = ({ children }: { children: ReactNode[] }) =>
   const checkSeenStatus = useCallback(
     async (internalId: string) => {
       try {
-        const seen = await AsyncStorage.getItem(`hasSeenAnnouncement-${internalId}`);
+        const seen = await AsyncStorage.getItem(`${internalId}-hasSeenAnnouncement`);
         setHasSeenAnnouncement(seen === 'true');
       } catch (error) {
         reportError('An error occurred while checking announcement seen status');
@@ -88,8 +90,9 @@ export const AnnouncementProvider = ({ children }: { children: ReactNode[] }) =>
               min_mobile_version
             } | order(_createdAt desc)[0]`
       );
+
+      setAnnouncement(result);
       if (result) {
-        setAnnouncement(result);
         checkDismissalStatus(result.internal_id);
         checkSeenStatus(result.internal_id);
       }
@@ -143,5 +146,9 @@ export const AnnouncementProvider = ({ children }: { children: ReactNode[] }) =>
     markAnnouncementAsSeen,
   ]);
 
-  return <AnnouncementContext.Provider value={value}>{children}</AnnouncementContext.Provider>;
+  return (
+    <SanityAnnouncementContext.Provider value={value}>
+      {children}
+    </SanityAnnouncementContext.Provider>
+  );
 };

--- a/apps/mobile/src/contexts/SanityDataContext.tsx
+++ b/apps/mobile/src/contexts/SanityDataContext.tsx
@@ -1,0 +1,89 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { fetchSanityContent } from 'src/utils/sanity';
+import { useEffectOnAppForeground } from 'src/utils/useEffectOnAppForeground';
+
+export type MintProject = {
+  name: string;
+  internalId: string;
+  startDate: string;
+  endDate: string;
+  highlightProjectId: string;
+  previewImageUrl: string;
+  artistName: string;
+  collectionName: string;
+  title: string;
+  description: string;
+  funFacts: string[];
+  active: boolean;
+};
+
+type sanityDocumentTypes = {
+  mintProjects: MintProject[];
+};
+
+type SanityDataContextType = {
+  data: sanityDocumentTypes | null;
+};
+
+const SanityDataContext = createContext<SanityDataContextType | undefined>(undefined);
+
+export function useSanityDataContext() {
+  const value = useContext(SanityDataContext);
+  if (!value) {
+    throw new Error('Tried to use SanityDataContext without a Provider');
+  }
+  return value;
+}
+
+export default function SanityDataProvider({ children }: { children: ReactNode }) {
+  const [data, setData] = useState<sanityDocumentTypes | null>(null);
+  const fetchData = useCallback(async () => {
+    console.log('fetching');
+    try {
+      const result = await fetchSanityContent(`
+      *[_type == "mintProject"] {
+          name,
+          internalId,
+          startDate,
+          endDate,
+          highlightProjectId,
+          "previewImageUrl": previewImage.asset->url,
+          artistName,
+          collectionName,
+          title,
+          description,
+          funFacts,
+          active
+        }`);
+      if (result) {
+        setData({ mintProjects: result });
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
+  useEffectOnAppForeground(fetchData);
+
+  useEffect(() => {
+    fetchData();
+    // Only run once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const value = useMemo(() => {
+    return {
+      data,
+    };
+  }, [data]);
+
+  return <SanityDataContext.Provider value={value}>{children}</SanityDataContext.Provider>;
+}

--- a/apps/mobile/src/contexts/SanityDataContext.tsx
+++ b/apps/mobile/src/contexts/SanityDataContext.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { useReportError } from 'shared/contexts/ErrorReportingContext';
 import { fetchSanityContent } from 'src/utils/sanity';
 import { useEffectOnAppForeground } from 'src/utils/useEffectOnAppForeground';
 
@@ -45,8 +46,8 @@ export function useSanityDataContext() {
 
 export default function SanityDataProvider({ children }: { children: ReactNode }) {
   const [data, setData] = useState<sanityDocumentTypes | null>(null);
+  const reportError = useReportError();
   const fetchData = useCallback(async () => {
-    console.log('fetching');
     try {
       const result = await fetchSanityContent(`
       *[_type == "mintProject"] {
@@ -67,9 +68,12 @@ export default function SanityDataProvider({ children }: { children: ReactNode }
         setData({ mintProjects: result });
       }
     } catch (error) {
-      console.error(error);
+      if (error instanceof Error) {
+        reportError(error);
+      }
+      reportError('An error occurred while fetching sanity data');
     }
-  }, []);
+  }, [reportError]);
 
   useEffectOnAppForeground(fetchData);
 

--- a/apps/mobile/src/navigation/MainTabNavigator/NotificationBlueDot.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/NotificationBlueDot.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native';
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
 import { useIntervalEffectOnAppForeground } from 'src/utils/useIntervalEffectOnAppForeground';
 
+import { useAnnouncementContext } from '~/contexts/AnnouncementContext';
 import { NotificationBlueDotFragment$key } from '~/generated/NotificationBlueDotFragment.graphql';
 import { NotificationBlueDotQuery } from '~/generated/NotificationBlueDotQuery.graphql';
 import { RefetchableNotificationBlueDotFragmentQuery } from '~/generated/RefetchableNotificationBlueDotFragmentQuery.graphql';
@@ -55,6 +56,8 @@ function BlueDot({ queryRef }: BlueDotProps) {
     queryRef
   );
 
+  const { announcement, hasSeenAnnouncement } = useAnnouncementContext();
+
   const handleNotificationRefresh = useCallback(() => {
     refetch({}, { fetchPolicy: 'network-only' });
   }, [refetch]);
@@ -62,12 +65,15 @@ function BlueDot({ queryRef }: BlueDotProps) {
   useIntervalEffectOnAppForeground(handleNotificationRefresh);
 
   const hasUnreadNotifications = useMemo(() => {
+    if (announcement && announcement.active && !hasSeenAnnouncement) {
+      return true;
+    }
     if (query.viewer && query.viewer.__typename === 'Viewer') {
       return (query.viewer?.notifications?.unseenCount ?? 0) > 0;
     }
 
     return false;
-  }, [query.viewer]);
+  }, [announcement, hasSeenAnnouncement, query.viewer]);
 
   if (hasUnreadNotifications) {
     return (

--- a/apps/mobile/src/navigation/MainTabNavigator/NotificationBlueDot.tsx
+++ b/apps/mobile/src/navigation/MainTabNavigator/NotificationBlueDot.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from 'react-relay';
 import { useIntervalEffectOnAppForeground } from 'src/utils/useIntervalEffectOnAppForeground';
 
-import { useAnnouncementContext } from '~/contexts/AnnouncementContext';
+import { useSanityAnnouncementContext } from '~/contexts/SanityAnnouncementContext';
 import { NotificationBlueDotFragment$key } from '~/generated/NotificationBlueDotFragment.graphql';
 import { NotificationBlueDotQuery } from '~/generated/NotificationBlueDotQuery.graphql';
 import { RefetchableNotificationBlueDotFragmentQuery } from '~/generated/RefetchableNotificationBlueDotFragmentQuery.graphql';
@@ -56,7 +56,7 @@ function BlueDot({ queryRef }: BlueDotProps) {
     queryRef
   );
 
-  const { announcement, hasSeenAnnouncement } = useAnnouncementContext();
+  const { announcement, hasSeenAnnouncement } = useSanityAnnouncementContext();
 
   const handleNotificationRefresh = useCallback(() => {
     refetch({}, { fetchPolicy: 'network-only' });
@@ -65,7 +65,7 @@ function BlueDot({ queryRef }: BlueDotProps) {
   useIntervalEffectOnAppForeground(handleNotificationRefresh);
 
   const hasUnreadNotifications = useMemo(() => {
-    if (announcement && announcement.active && !hasSeenAnnouncement) {
+    if (announcement?.active && !hasSeenAnnouncement) {
       return true;
     }
     if (query.viewer && query.viewer.__typename === 'Viewer') {

--- a/apps/mobile/src/navigation/RootStackNavigator.tsx
+++ b/apps/mobile/src/navigation/RootStackNavigator.tsx
@@ -9,6 +9,7 @@ import { useMaintenanceContext } from 'shared/contexts/MaintenanceStatusContext'
 import { ClaimMintUpsellBanner } from '~/components/ClaimMintUpsellBanner';
 import { ConnectWalletUpsellBanner } from '~/components/ConnectWalletUpsellBanner';
 import { MaintenanceNoticeBottomSheetWrapper } from '~/components/MaintenanceScreen';
+import { useSanityAnnouncementContext } from '~/contexts/SanityAnnouncementContext';
 import { RootStackNavigatorFragment$key } from '~/generated/RootStackNavigatorFragment.graphql';
 import { RootStackNavigatorQuery } from '~/generated/RootStackNavigatorQuery.graphql';
 import { LoginStackNavigator } from '~/navigation/LoginStackNavigator';
@@ -132,11 +133,15 @@ function MainScreen({ queryRef }: MainScreenProps) {
     queryRef
   );
 
+  const { announcement } = useSanityAnnouncementContext();
+
   return (
     <View className="flex-1">
       <Suspense fallback={<View />}>
         <ConnectWalletUpsellBanner queryRef={query} />
-        <ClaimMintUpsellBanner queryRef={query} />
+        {announcement && (
+          <ClaimMintUpsellBanner queryRef={query} projectInternalId={announcement.internal_id} />
+        )}
       </Suspense>
       <MainTabNavigator />
     </View>

--- a/apps/mobile/src/screens/SettingsScreen/DebugBottomSheetModal.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/DebugBottomSheetModal.tsx
@@ -23,7 +23,11 @@ export default function DebugBottomSheetModal() {
   }, []);
 
   const handleClearStorage = useCallback(() => {
-    AsyncStorage.multiRemove([MARFA_2023_SUBMITTED_FORM_KEY, MCHX_CLAIM_CODE_KEY]);
+    AsyncStorage.multiRemove([
+      MARFA_2023_SUBMITTED_FORM_KEY,
+      MCHX_CLAIM_CODE_KEY,
+      `hasSeenAnnouncement-oxen-farcon-2024`,
+    ]);
   }, []);
   return (
     <View className="flex flex-column space-y-1 mx-4">

--- a/apps/mobile/src/screens/SettingsScreen/DebugBottomSheetModal.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/DebugBottomSheetModal.tsx
@@ -23,7 +23,11 @@ export default function DebugBottomSheetModal() {
   }, []);
 
   const handleClearStorage = useCallback(() => {
-    AsyncStorage.multiRemove([MARFA_2023_SUBMITTED_FORM_KEY, MCHX_CLAIM_CODE_KEY]);
+    AsyncStorage.multiRemove([
+      MARFA_2023_SUBMITTED_FORM_KEY,
+      MCHX_CLAIM_CODE_KEY,
+      'mchx-app-store-2024-hasDismissedAnnouncement',
+    ]);
   }, []);
   return (
     <View className="flex flex-column space-y-1 mx-4">

--- a/apps/mobile/src/screens/SettingsScreen/DebugBottomSheetModal.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/DebugBottomSheetModal.tsx
@@ -27,6 +27,7 @@ export default function DebugBottomSheetModal() {
       MARFA_2023_SUBMITTED_FORM_KEY,
       MCHX_CLAIM_CODE_KEY,
       `hasSeenAnnouncement-oxen-farcon-2024`,
+      `hasDismissedAnnouncement-oxen-farcon-2024`,
     ]);
   }, []);
   return (

--- a/apps/mobile/src/screens/SettingsScreen/DebugBottomSheetModal.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/DebugBottomSheetModal.tsx
@@ -23,12 +23,7 @@ export default function DebugBottomSheetModal() {
   }, []);
 
   const handleClearStorage = useCallback(() => {
-    AsyncStorage.multiRemove([
-      MARFA_2023_SUBMITTED_FORM_KEY,
-      MCHX_CLAIM_CODE_KEY,
-      `hasSeenAnnouncement-oxen-farcon-2024`,
-      `hasDismissedAnnouncement-oxen-farcon-2024`,
-    ]);
+    AsyncStorage.multiRemove([MARFA_2023_SUBMITTED_FORM_KEY, MCHX_CLAIM_CODE_KEY]);
   }, []);
   return (
     <View className="flex flex-column space-y-1 mx-4">

--- a/apps/mobile/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -76,7 +76,14 @@ export function SettingsScreen() {
   }, [navigation]);
 
   const handleDebugMintPress = useCallback(() => {
-    showBottomSheetModal({ content: <MintCampaignBottomSheet onClose={hideBottomSheetModal} /> });
+    showBottomSheetModal({
+      content: (
+        <MintCampaignBottomSheet
+          onClose={hideBottomSheetModal}
+          projectInternalId="mchx-app-store-2024"
+        />
+      ),
+    });
   }, [hideBottomSheetModal, showBottomSheetModal]);
 
   const [logout, isLoggingOut] = useLogout();


### PR DESCRIPTION
### Summary of Changes


Announcement
- [x] Add schema for Announcement Notification to sanity
- [x] Display announcement at top of notifications if active
- [x] Announcement data can be refresh via pull-down-to-refresh
- [x] Announcement data is loaded on app start
- [x] Unread dot is shown if announcement has not been seen
- [x] Announcement can be dismissed and state it saved locally

Mint Flow
- [x] Mint Flow can be configured via Sanity
- [x] Supports multiple mint projects at once
- [x] Backwards compatible with ongoing MCHX mint

### Demo or Before/After Pics

Demo on slack

### Edge Cases
- Backwards compatibility with ongoing mint
- sanity data not loading

### Testing Steps

Watch Loom on slack
- turn on announcement (active === true) in Sanity and verify it appears as expected in the app

### Checklist

Please make sure to review and check all of the following:

- [x] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
