### PR TITLE
fix announcement and seen state typo

### DIFF
--- a/apps/mobile/src/contexts/SanityAnnouncementContext.tsx
+++ b/apps/mobile/src/contexts/SanityAnnouncementContext.tsx
@@ -110,14 +110,14 @@ export const SanityAnnouncementProvider = ({ children }: { children: ReactNode[]
   // Function to dismiss an announcement
   const dismissAnnouncement = useCallback(async () => {
     if (announcement && announcement.internal_id) {
-      await AsyncStorage.setItem(`hasDismissedAnnouncement-${announcement.internal_id}`, 'true');
+      await AsyncStorage.setItem(`${announcement.internal_id}-hasDismissedAnnouncement`, 'true');
       setHasDismissedAnnouncement(true);
     }
   }, [announcement]);
 
   const markAnnouncementAsSeen = useCallback(async () => {
     if (announcement && announcement.internal_id) {
-      await AsyncStorage.setItem(`hasSeenAnnouncement-${announcement.internal_id}`, 'true');
+      await AsyncStorage.setItem(`${announcement.internal_id}-hasSeenAnnouncement`, 'true');
       setHasSeenAnnouncement(true);
     }
   }, [announcement]);


### PR DESCRIPTION
### Summary of Changes

On mobile the announcement dismissed and seen status weren't persisting because there was a typo in the storage key.

### Demo or Before/After Pics

na
### Edge Cases
na
### Testing Steps

Provide steps on how the reviewer can test the changes.

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
