### PR TITLE
fix navigation crash after mint campaign

### DIFF
--- a/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
+++ b/apps/mobile/src/components/Notification/Notifications/AnnouncementNotification.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from '@react-navigation/native';
 import { ResizeMode } from 'expo-av';
 import { useColorScheme } from 'nativewind';
 import { useCallback, useEffect } from 'react';
@@ -12,19 +13,22 @@ import MintCampaignBottomSheet from '~/components/Mint/MintCampaign/MintCampaign
 import { BaseM } from '~/components/Text';
 import { useBottomSheetModalActions } from '~/contexts/BottomSheetModalContext';
 import { useSanityAnnouncementContext } from '~/contexts/SanityAnnouncementContext';
+import { MainTabStackNavigatorProp } from '~/navigation/types';
 
 // Displays announcement content from Sanity
 export default function AnnouncementNotification() {
   const { announcement, markAnnouncementAsSeen, dismissAnnouncement } =
     useSanityAnnouncementContext();
   const { showBottomSheetModal } = useBottomSheetModalActions();
+  const navigation = useNavigation<MainTabStackNavigatorProp>();
 
   const handlePress = useCallback(() => {
     if (!announcement) return;
     showBottomSheetModal({
       content: <MintCampaignBottomSheet projectInternalId={announcement.internal_id} />,
+      navigationContext: navigation,
     });
-  }, [announcement, showBottomSheetModal]);
+  }, [announcement, navigation, showBottomSheetModal]);
 
   const handleDismissPress = useCallback(() => {
     dismissAnnouncement();

--- a/apps/mobile/src/hooks/useNavigateToCommunityScreen.ts
+++ b/apps/mobile/src/hooks/useNavigateToCommunityScreen.ts
@@ -26,7 +26,7 @@ export function useNavigateToCommunityScreen() {
       const { chain, contractAddress, subtype, projectId } =
         extractRelevantMetadataFromCommunity(community);
 
-      if (navigationType === 'push') {
+      if (navigation.push && navigationType === 'push') {
         navigation.push('Community', {
           subtype,
           contractAddress,


### PR DESCRIPTION
### Summary of Changes

- Navigation was undefined and crashed the app. Added a check in the hook itself just in case and passed navigation to the bottom sheet context to actually fix it 

https://galleryso.slack.com/archives/C04DUEVL22U/p1715715459661029


### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
