### PR TITLE
allowlist new prohibition url for mint link

### DIFF
--- a/packages/shared/src/utils/getMintUrlWithReferrer.ts
+++ b/packages/shared/src/utils/getMintUrlWithReferrer.ts
@@ -10,7 +10,7 @@ const providers = [
   { regex: '^https://(www\\.)?zora.co/?', name: 'Zora', param: 'referrer' },
   { regex: '^https://(www\\.)?fxhash.xyz/?', name: 'FxHash' },
   {
-    regex: '^https://(www\\.)?prohibition.art/?',
+    regex: '^https://(www\\.)?(prohibition.art|daily.prohibition.art)/?',
     name: 'Prohibition',
   },
   { regex: '^https://(www\\.)?ensemble.art/?', name: 'Ensemble' },


### PR DESCRIPTION
dd prohibition art daily to allowed mint links

### Summary of Changes


Allow https://daily.prohibition.art as a valid mint link url




### Demo or Before/After Pics
before
![CleanShot 2024-05-31 at 16 27 13@2x](https://github.com/gallery-so/gallery/assets/80802871/c54cde67-9e5d-435d-b4a3-f4a61ff1e7d9)


after
![CleanShot 2024-06-06 at 23 02 42@2x](https://github.com/gallery-so/gallery/assets/80802871/71c91f6c-12e8-4c56-bdf0-3b32ebf52797)


### Edge Cases

na
### Testing Steps
try to post an nft and add a custom mint link. the new one should now be allowed 

### Checklist

Please make sure to review and check all of the following:

- [ ] I've tested the changes and all tests pass.
- [ ] (if web) I've tested the changes on various desktop screen sizes to ensure responsiveness.
- [ ] (if mobile) I've tested the changes on both light and dark modes.
